### PR TITLE
ui: expose VERSION_FEATURESET permission function

### DIFF
--- a/ui/src/utils/commonFunctions.ts
+++ b/ui/src/utils/commonFunctions.ts
@@ -24,6 +24,7 @@ function translateFunctionName(fn: string): string {
         case 'SBOM_PROBING': return 'SBOM Probing'
         case 'DEVOPS_READ': return 'DevOps Read'
         case 'DEVOPS_WRITE': return 'DevOps Write'
+        case 'VERSION_FEATURESET': return 'Version Feature Set'
         default: return fn
     }
 }

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -162,7 +162,12 @@ const PERMISSION_FUNCTIONS: string[] = [
     // keys keep their object-bound semantics and don't need
     // function-level grants.
     'DEVOPS_READ',
-    'DEVOPS_WRITE'
+    'DEVOPS_WRITE',
+    // Authorises a FREEFORM key (or user) to spin up a new feature
+    // set on a PRODUCT with selected dependency-branch overrides
+    // applied on top of the BASE feature set's dep config. Granted
+    // at PermissionScope.COMPONENT on the product.
+    'VERSION_FEATURESET'
 ]
 const ARTIFACT_COVERAGE_TYPES = [
     {label: 'Dev', value: 'DEV'},


### PR DESCRIPTION
## Summary
Mirrors the backend addition of \`VERSION_FEATURESET\` in [rearm-saas#8](https://github.com/relizaio/rearm-saas/pull/8). Adds the new function to \`PERMISSION_FUNCTIONS\` so it shows as a checkbox in the permission editor (user, user group, FREEFORM key — at every scope ScopedPermissions exposes), and to \`translateFunctionName\` so the label reads "Version Feature Set".

## Test plan
- [x] \`npm run build\` green
- [x] Visual: open user-edit modal → "Version Feature Set" checkbox appears in the org-wide functions group and in per-product / per-component / etc. scoped function groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)