### PR TITLE
fix(backend): drop @Transactional on getNewVersionWrapper

### DIFF
--- a/backend/src/main/java/io/reliza/service/ReleaseVersionService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseVersionService.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import io.reliza.common.CommonVariables.VersionResponse;
 import io.reliza.common.Utils;
@@ -60,8 +59,16 @@ public class ReleaseVersionService {
 	
 	@Autowired
     private GetSourceCodeEntryService getSourceCodeEntryService;
-	
-	@Transactional
+
+	/**
+	 * Intentionally NOT @Transactional. The branch may be auto-created during
+	 * resolution (when getversion is called with a brand-new branch name), and
+	 * {@link VersionAssignmentService#getSetNewVersion} runs in REQUIRES_NEW —
+	 * an outer transaction here would leave the branch insert pending, so the
+	 * inner REQUIRES_NEW transaction could not see it and version assignment
+	 * would fail with "Failed to retrieve next version" → "Not authorized".
+	 * Each underlying step manages its own transaction.
+	 */
 	public VersionResponse getNewVersionWrapper(GetNewVersionDto getNewVersionDto, WhoUpdated wu) throws Exception{
 		VersionResponse vr = null;
 		UUID projectId = getNewVersionDto.project();


### PR DESCRIPTION
## Summary
- Mirror of relizaio/rearm-saas#10 for ReARM CE.
- Brand-new branches passed to `getversion` failed with "Not authorized" when auto-creation kicked in. The branch insert was pending in the outer transaction while `VersionAssignmentService.getSetNewVersion` ran in REQUIRES_NEW, so the inner transaction could not see the branch and version assignment returned empty, surfacing as `AccessDeniedException("Failed to retrieve next version")` → "Not authorized".

## Fix
- Remove `@Transactional` from `ReleaseVersionService.getNewVersionWrapper`. Each underlying step manages its own transaction; the branch is committed before getSetNewVersion runs.

## Test plan
- [ ] Verified by upstream rearm-saas integration run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)