### PR TITLE
UI: register GITHUB_VALIDATE integration + EXTERNAL_VALIDATION output event

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -422,6 +422,30 @@
                                                     <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Optional Parameters" path="clientPayload">
                                                         <n-input v-model:value="outputTrigger.clientPayload" placeholder="Enter Optional Parameters (JSON)" />
                                                     </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Choose Validation Integration" path="integration">
+                                                        <n-select
+                                                            v-model:value="outputTrigger.integration"
+                                                            placeholder="Select GitHub Validate Integration"
+                                                            :options="validationIntegrationsForSelect" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="VCS Repository" path="vcs">
+                                                        <span v-if="!selectNewIntegrationRepo && outputTrigger.vcs">{{ getVcsRepoObjById(outputTrigger.vcs).uri }} </span>
+                                                        <span v-if="!selectNewIntegrationRepo && !outputTrigger.vcs">Not Set</span>
+                                                        <n-select v-if="selectNewIntegrationRepo" :options="vcsRepos" required v-model:value="outputTrigger.vcs" />
+                                                        <n-icon v-if="!selectNewIntegrationRepo" class="clickable" @click="async () => {selectNewIntegrationRepo = true;}" title="Select VCS Repository" size="20"><Edit /></n-icon>
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
+                                                        <n-select v-model:value="outputTrigger.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Optional Output JSON (title / summary / text)" path="clientPayload">
+                                                        <n-input v-model:value="outputTrigger.clientPayload" placeholder='{"title":"...","summary":"...","text":"..."}' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
+                                                    </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Users to notify" path="users">
                                                         <n-select v-model:value="outputTrigger.users" tag multiple required :options="users" />
                                                     </n-form-item>
@@ -900,8 +924,18 @@ const genApiKey = function (type : string) {
 }
 
 const ciIntegrations: Ref<any[]> = ref([])
+// INTEGRATION_TRIGGER picker — exclude GITHUB_VALIDATE since those are
+// only valid targets for the EXTERNAL_VALIDATION event type.
 const ciIntegrationsForSelect: ComputedRef<any[]> = computed((): any => {
-    return ciIntegrations.value.map((x: any) => {return {label: x.note, value: x.uuid}})
+    return ciIntegrations.value
+        .filter((x: any) => x.type !== 'GITHUB_VALIDATE')
+        .map((x: any) => {return {label: x.note, value: x.uuid}})
+})
+// EXTERNAL_VALIDATION picker — only GITHUB_VALIDATE integrations.
+const validationIntegrationsForSelect: ComputedRef<any[]> = computed((): any => {
+    return ciIntegrations.value
+        .filter((x: any) => x.type === 'GITHUB_VALIDATE')
+        .map((x: any) => {return {label: x.note, value: x.uuid}})
 })
 const selectedCiIntegration: ComputedRef<any> = computed((): any => {
     return ciIntegrations.value.find((x: any) => x.uuid === outputTrigger.value.integration)
@@ -1419,9 +1453,18 @@ const outputTriggerTypeOptions = [
     {label: 'Release Lifecycle Change', value: 'RELEASE_LIFECYCLE_CHANGE'},
     {label: 'Marketing Release Lifecycle Change', value: 'MARKETING_RELEASE_LIFECYCLE_CHANGE'},
     {label: 'External Integration', value: 'INTEGRATION_TRIGGER'},
+    {label: 'External Validation', value: 'EXTERNAL_VALIDATION'},
     {label: 'Email Notification', value: 'EMAIL_NOTIFICATION'},
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'}
+]
+
+const externalValidationConclusionOptions = [
+    {label: 'Success', value: 'success'},
+    {label: 'Failure', value: 'failure'},
+    {label: 'Neutral', value: 'neutral'},
+    {label: 'Skipped', value: 'skipped'},
+    {label: 'Cancelled', value: 'cancelled'}
 ]
 
 // Global Input Event Refs management

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -175,19 +175,20 @@
                             <n-form-item label="CI Type" path="createIntegrationObject.type">
                                 <n-radio-group v-model:value="createIntegrationObject.type" name="ciIntegrationType">
                                     <n-radio-button label="GitHub" value="GITHUB" />
+                                    <n-radio-button label="GitHub Validate" value="GITHUB_VALIDATE" />
                                     <n-radio-button label="GitLab" value="GITLAB" />
                                     <n-radio-button label="Jenkins" value="JENKINS" />
                                     <n-radio-button label="Azure DevOps" value="ADO" />
                                 </n-radio-group>
                             </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key DER Base64"
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key DER Base64"
                                 label-for="org_settings_create_github_integration_secret"
                                 description="GitHub Private Key DER Base64">
                                 <n-input type="textarea" id="org_settings_create_github_integration_secret"
                                     v-model:value="createIntegrationObject.secret" required
                                     placeholder="Enter GitHub Private Key Base64, use 'openssl pkcs8 -topk8 -inform PEM -outform DER -in private-key.pem -out key.der -nocrypt | base64 -w 0 key.der' to obtain" />
                             </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
                                 label-for="org_settings_create_github_integration_appid"
                                 description="GitHub Application ID">
                                 <n-input type="number" id="org_settings_create_github_integration_appid"
@@ -620,6 +621,21 @@
                                     </n-form-item>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER' && selectedGlobalCiIntegration && selectedGlobalCiIntegration.type === 'ADO'" label="Optional Parameters" path="clientPayload">
                                         <n-input v-model:value="globalOutputEvent.clientPayload" placeholder="Enter Optional Parameters (JSON)" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Choose Validation Integration" path="integration">
+                                        <n-select v-model:value="globalOutputEvent.integration" placeholder="Select GitHub Validate Integration" :options="validationIntegrationsForGlobalSelect" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
+                                        <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
+                                        <n-select v-model:value="globalOutputEvent.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Optional Output JSON (title / summary / text)" path="clientPayload">
+                                        <n-input v-model:value="globalOutputEvent.clientPayload" placeholder='{"title":"...","summary":"...","text":"..."}' />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
+                                        <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
                                     </n-form-item>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER'" label="Dynamic client payload (CEL string expression)" path="celClientPayload">
                                         <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"refs/tags/" + release.version' />
@@ -5454,9 +5470,18 @@ const outputTriggerTypeOptions = [
     {label: 'Release Lifecycle Change', value: 'RELEASE_LIFECYCLE_CHANGE'},
     {label: 'Marketing Release Lifecycle Change', value: 'MARKETING_RELEASE_LIFECYCLE_CHANGE'},
     {label: 'External Integration', value: 'INTEGRATION_TRIGGER'},
+    {label: 'External Validation', value: 'EXTERNAL_VALIDATION'},
     {label: 'Email Notification', value: 'EMAIL_NOTIFICATION'},
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'}
+]
+
+const externalValidationConclusionOptions = [
+    {label: 'Success', value: 'success'},
+    {label: 'Failure', value: 'failure'},
+    {label: 'Neutral', value: 'neutral'},
+    {label: 'Skipped', value: 'skipped'},
+    {label: 'Cancelled', value: 'cancelled'}
 ]
 
 const outputTriggerLifecycleOptions = constants.LifecycleValueOptions
@@ -5464,9 +5489,19 @@ const outputTriggerLifecycleOptions = constants.LifecycleValueOptions
 const lifecycleOptions = constants.LifecycleOptions.map((lo: any) => {return {label: lo.label, value: lo.key}})
 
 const ciIntegrationsForGlobalSelect = computed((): any => {
-    return ciIntegrations.value.map((ci: any) => {
-        return { label: ci.note + ' (' + ci.type + ')', value: ci.uuid }
-    })
+    return ciIntegrations.value
+        .filter((ci: any) => ci.type !== 'GITHUB_VALIDATE')
+        .map((ci: any) => {
+            return { label: ci.note + ' (' + ci.type + ')', value: ci.uuid }
+        })
+})
+
+const validationIntegrationsForGlobalSelect = computed((): any => {
+    return ciIntegrations.value
+        .filter((ci: any) => ci.type === 'GITHUB_VALIDATE')
+        .map((ci: any) => {
+            return { label: ci.note, value: ci.uuid }
+        })
 })
 
 const selectedGlobalCiIntegration = computed((): any => {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -181,12 +181,21 @@
                                     <n-radio-button label="Azure DevOps" value="ADO" />
                                 </n-radio-group>
                             </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key DER Base64"
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key"
                                 label-for="org_settings_create_github_integration_secret"
-                                description="GitHub Private Key DER Base64">
-                                <n-input type="textarea" id="org_settings_create_github_integration_secret"
-                                    v-model:value="createIntegrationObject.secret" required
-                                    placeholder="Enter GitHub Private Key Base64, use 'openssl pkcs8 -topk8 -inform PEM -outform DER -in private-key.pem -out key.der -nocrypt | base64 -w 0 key.der' to obtain" />
+                                description="Paste the .pem GitHub provides, upload the file directly, or paste a pre-converted DER base64 blob. Backend normalizes all three.">
+                                <n-space vertical>
+                                    <n-radio-group v-model:value="secretInputMode" name="githubSecretInputMode">
+                                        <n-radio-button label="Paste" value="paste" />
+                                        <n-radio-button label="Upload .pem" value="upload" />
+                                    </n-radio-group>
+                                    <n-input v-if="secretInputMode === 'paste'" type="textarea" id="org_settings_create_github_integration_secret"
+                                        v-model:value="createIntegrationObject.secret" required
+                                        placeholder="Paste the contents of the .pem file (-----BEGIN RSA PRIVATE KEY----- ...) or DER base64." />
+                                    <n-upload v-else :default-upload="false" :max="1" accept=".pem,.txt,.key" @change="onSecretFileChange">
+                                        <n-button>Choose .pem file</n-button>
+                                    </n-upload>
+                                </n-space>
                             </n-form-item>
                             <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
                                 label-for="org_settings_create_github_integration_appid"
@@ -1832,6 +1841,19 @@ const createIntegrationObject: Ref<any> = ref({
     client: '',
     schedule: ''
 })
+
+// Toggles between pasting the GitHub App private key into a textarea
+// and uploading the .pem file GitHub provides directly. Default is
+// 'paste' so the form looks the same as before for keyboard users.
+// Backend normalizes PEM and DER-base64 to the same canonical form.
+const secretInputMode: Ref<'paste' | 'upload'> = ref('paste')
+
+async function onSecretFileChange (options: any) {
+    const fileInfo = options.file
+    if (fileInfo && fileInfo.file) {
+        createIntegrationObject.value.secret = await fileInfo.file.text()
+    }
+}
 
 function resetCreateIntegrationObject() {
     createIntegrationObject.value = {


### PR DESCRIPTION
## Summary
- New \`GitHub Validate\` radio option in **Org Settings → CI Integrations** that registers a `GITHUB_VALIDATE` integration. Reuses the same App-style fields as `GITHUB`: private-key DER base64 + App ID.
- New \`External Validation\` (`EXTERNAL_VALIDATION`) entry in the output-event type dropdown, wired in both:
  - **Per-component** form (`ComponentView.vue`)
  - **Policy-wide global** form (`OrgSettings.vue`)
- EXTERNAL_VALIDATION fields: integration picker (filtered to GITHUB_VALIDATE), VCS repo (per-component only — global form has no VCS picker today, matching how INTEGRATION_TRIGGER global behaves), Installation ID, conclusion dropdown (success/failure/neutral/skipped/cancelled — backend rejects anything else), optional output JSON, optional CEL output.
- Integration pickers filtered so the regular \`External Integration\` (`INTEGRATION_TRIGGER`) flow does **not** list GITHUB_VALIDATE integrations, and EXTERNAL_VALIDATION only lists those.

## Test plan
- [ ] **Verified locally**: `vite build` passes clean.
- [ ] **Not verified visually** — I cannot drive a browser. Please smoke-test:
  - [ ] Org Settings → add a CI integration with type \`GitHub Validate\` → form shows the GitHub fields → save succeeds.
  - [ ] Component → Output Events → Add → type \`External Validation\` → integration dropdown shows only GITHUB_VALIDATE entries; conclusion is a dropdown.
  - [ ] Component → Output Events → Add → type \`External Integration\` → integration dropdown does **not** include GITHUB_VALIDATE entries.
  - [ ] Approval Policy → Policy-Wide Output Events → Add → type \`External Validation\` shows the same fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)