### PR TITLE
feat(ui): show 'Scan pending' badge when release firstScanned is null

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -603,8 +603,13 @@
                         <Icon @click="showExportSBOMModal=true" class="clickable" style="margin-left:10px;" size="16" title="Export Release xBOM" ><Download/></Icon>
                     </n-gi>
                     <n-gi span="2">
-                        <n-space :size="1" v-if="updatedRelease.metrics.lastScanned">
-                            <span title="Criticial Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.critical }}</span>    
+                        <span
+                            v-if="releaseScanStatus.kind !== 'ready'"
+                            :title="releaseScanStatus.title"
+                            :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', background: releaseScanStatus.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
+                        >{{ releaseScanStatus.label }}</span>
+                        <n-space :size="1" v-else>
+                            <span title="Criticial Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.critical }}</span>
                             <span title="High Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.HIGH, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'HIGH', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.high }}</span>
                             <span title="Medium Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.MEDIUM, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'MEDIUM', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.medium }}</span>
                             <span title="Low Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.LOW, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'LOW', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.low }}</span>
@@ -1150,6 +1155,7 @@ import { useStore } from 'vuex'
 import constants from '@/utils/constants'
 import { DownloadLink} from '@/utils/commonTypes'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
+import { getReleaseScanStatus, isDtrackConfiguredForOrg } from '@/utils/releaseScanStatus'
 import { processMetricsData } from '@/utils/metrics'
 import { exportFindingsToPdf } from '@/utils/pdfExport'
 import { PackageURL } from 'packageurl-js'
@@ -2472,6 +2478,10 @@ async function loadDtrackConfigured () {
         console.error('Could not load configured integrations', err)
     }
 }
+
+// Drives the header circles vs. "Scan pending"/"Enriching"/"DTrack pending"
+// badge: ready means firstScanned is set and no per-artifact stage is mid-flight.
+const releaseScanStatus = computed(() => getReleaseScanStatus(updatedRelease.value, dtrackConfigured.value))
 
 // Background poll while either the per-release SBOM reconcile or any artifact
 // is still pending — keeps the status pills live without forcing the user to

--- a/ui/src/utils/releaseScanStatus.ts
+++ b/ui/src/utils/releaseScanStatus.ts
@@ -34,7 +34,7 @@ export async function isDtrackConfiguredForOrg (orgUuid: string): Promise<boolea
     }
 }
 
-export type ReleaseScanStatusKind = 'enrichment-pending' | 'dtrack-pending' | 'ready'
+export type ReleaseScanStatusKind = 'enrichment-pending' | 'dtrack-pending' | 'scan-pending' | 'ready'
 
 export interface ReleaseScanStatus {
     kind: ReleaseScanStatusKind
@@ -49,7 +49,11 @@ export interface ReleaseScanStatus {
  *  enrichment-pending  any BOM artifact still being enriched in rebom
  *  dtrack-pending      DTrack is configured but at least one BOM artifact
  *                      hasn't been submitted yet (no project UUID, no failure)
- *  ready               nothing pending — caller renders the existing circles
+ *  scan-pending        no firstScanned on the release yet — initial scan has
+ *                      not completed across all scannable inputs (artifacts +
+ *                      child releases for products). Catches PENDING-lifecycle
+ *                      releases and product releases waiting on a child.
+ *  ready               firstScanned is set — caller renders the existing circles
  */
 export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): ReleaseScanStatus {
     const artifacts: any[] = collectArtifactsForStatus(release)
@@ -69,6 +73,13 @@ export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): 
                 label: 'DTrack pending',
                 title: 'Awaiting Dependency-Track submission for at least one BOM'
             }
+        }
+    }
+    if (!release?.metrics?.firstScanned) {
+        return {
+            kind: 'scan-pending',
+            label: 'Scan pending',
+            title: 'Initial scan has not completed for this release yet'
         }
     }
     return { kind: 'ready', label: '', title: '' }


### PR DESCRIPTION
## Summary

- New `scan-pending` kind in `releaseScanStatus.ts` triggers when `metrics.firstScanned` is null — covers PENDING-lifecycle releases, BOMs not yet scanned by Dependency-Track, and product releases waiting on a child (paired with relizaio/rearm-saas#<paired>).
- `ReleaseView.vue` header now renders the badge instead of zeroed circles when scan-pending; branch view and most-recent-releases widget pick the new kind up automatically through the shared helper.
- The new state slots in beneath the existing `enrichment-pending` and `dtrack-pending` diagnostics so more-specific badges still win.

## Test plan
- [x] `npm run build` clean
- [x] Sandbox UI rolled to `2026-04-scan-pending-badge.0` against the matching backend
- [x] Smoke-tested via the integration suite (release/branch flows touch the same components)
- [ ] Manual UI sanity-check on a product release whose child has no firstScanned: header should show "Scan pending" instead of circles

🤖 Generated with [Claude Code](https://claude.com/claude-code)