### PR TITLE
feat(ui): gate 'DTrack done' badge on metrics.firstScanned

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -4662,8 +4662,11 @@ function renderDtrackPill (row: any): any {
         const reason = m.dtrackSubmissionFailureReason ? `: ${m.dtrackSubmissionFailureReason}` : ''
         return h(NTag, { type: 'error', size: 'small', round: true, title: `DependencyTrack submission failed${reason}` }, () => 'DTrack failed')
     }
+    if (m.firstScanned) {
+        return h(NTag, { type: 'success', size: 'small', round: true, title: 'Dependency-Track scan complete' }, () => 'DTrack done')
+    }
     if (m.dependencyTrackFullUri) {
-        return h(NTag, { type: 'success', size: 'small', round: true, title: 'Submitted to Dependency-Track' }, () => 'DTrack done')
+        return h(NTag, { type: 'warning', size: 'small', round: true, title: 'Submitted to Dependency-Track, awaiting scan results' }, () => 'DTrack scanning…')
     }
     return h(NTag, { type: 'warning', size: 'small', round: true, title: 'Awaiting Dependency-Track submission' }, () => 'DTrack pending')
 }

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -279,6 +279,7 @@ const ARTIFACT_DETAIL_DATA_SINGLE = `
     metrics {
         dependencyTrackFullUri
         lastScanned
+        firstScanned
         dtrackSubmissionFailed
         dtrackSubmissionAttempts
         dtrackSubmissionFailureReason


### PR DESCRIPTION
## Summary

The artifact-row 'DTrack done' badge fires on `metrics.dependencyTrackFullUri` alone, which only confirms the BOM has been *submitted* to Dependency-Track — not that DT has finished analyzing or returned findings. The tooltip already concedes this ("Submitted to Dependency-Track"). Combined with the now-removed release-level firstScanned fallback (rearm-saas#25), this contributed to the false-positive 'scan complete' surface where releases showed zeroed circles for BOMs that hadn't actually been scanned.

This PR splits the post-submission state in two:

| `metrics` shape | Badge |
|---|---|
| `dtrackSubmissionFailed=true` | "DTrack failed" (error) — unchanged |
| `firstScanned` set | "DTrack done" (success) — real scan complete |
| `dependencyTrackFullUri` set, `firstScanned` null | "DTrack scanning…" (warning) — submitted, awaiting findings |
| neither set | "DTrack pending" (warning) — unchanged |

Adds `firstScanned` to the artifact-level metrics GraphQL fragment so the new check has data to pivot on.

## Test plan
- [x] `npm run build` clean
- [ ] On dev with rearm-saas#25 deployed: card-shuffle mafia-helm (or mafia-vue / mafia-express on next push) shows "DTrack scanning…" while `firstScanned` is null, transitions to "DTrack done" once DT returns findings
- [ ] Failure path ("DTrack failed") still surfaces with the original styling on a BOM that DT rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)