### PR TITLE
feat(ui): check-name override on EXTERNAL_VALIDATION events

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -446,6 +446,9 @@
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
                                                         <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
                                                     </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
+                                                        <n-input v-model:value="outputTrigger.checkName" :placeholder="'Defaults to rearm/' + (updatedComponent.name || '<component>')" />
+                                                    </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Users to notify" path="users">
                                                         <n-select v-model:value="outputTrigger.users" tag multiple required :options="users" />
                                                     </n-form-item>
@@ -1366,6 +1369,7 @@ const outputTrigger = ref({
     snapshotApprovalEntry: null as string | null,
     snapshotLifecycle: null as string | null,
     approvedEnvironment: null as string | null,
+    checkName: null as string | null,
 })
 const snapshotMode = ref<'NONE' | 'APPROVAL' | 'LIFECYCLE'>('NONE')
 
@@ -1387,6 +1391,7 @@ function resetOutputTrigger () {
         snapshotApprovalEntry: null,
         snapshotLifecycle: null,
         approvedEnvironment: null,
+        checkName: null,
     }
     snapshotMode.value = 'NONE'
 }

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -653,6 +653,9 @@
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
                                         <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
                                     </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
+                                        <n-input v-model:value="globalOutputEvent.checkName" placeholder="Defaults to rearm/<componentName>; override e.g. rearm/policy" />
+                                    </n-form-item>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER'" label="Dynamic client payload (CEL string expression)" path="celClientPayload">
                                         <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"refs/tags/" + release.version' />
                                     </n-form-item>
@@ -5480,7 +5483,8 @@ const globalOutputEvent = ref({
     celClientPayload: '' as string | null,
     snapshotApprovalEntry: null as string | null,
     snapshotLifecycle: null as string | null,
-    approvedEnvironment: null as string | null
+    approvedEnvironment: null as string | null,
+    checkName: null as string | null
 })
 
 const globalSnapshotMode = ref<'NONE' | 'APPROVAL' | 'LIFECYCLE'>('NONE')
@@ -5502,7 +5506,8 @@ function resetGlobalOutputEvent () {
         celClientPayload: '',
         snapshotApprovalEntry: null,
         snapshotLifecycle: null,
-        approvedEnvironment: null
+        approvedEnvironment: null,
+        checkName: null
     }
     globalSnapshotMode.value = 'NONE'
 }
@@ -5646,6 +5651,7 @@ async function fetchApprovalPolicies () {
                         snapshotApprovalEntry
                         snapshotLifecycle
                         approvedEnvironment
+                        checkName
                     }
                 }
             }`,
@@ -5697,7 +5703,8 @@ async function saveGlobalOutputEvents () {
                 celClientPayload: e.celClientPayload || undefined,
                 snapshotApprovalEntry: e.snapshotApprovalEntry || undefined,
                 snapshotLifecycle: e.snapshotLifecycle || undefined,
-                approvedEnvironment: e.approvedEnvironment || undefined
+                approvedEnvironment: e.approvedEnvironment || undefined,
+                checkName: e.checkName || undefined
             }
             return ev
         })
@@ -5722,6 +5729,8 @@ async function saveGlobalOutputEvents () {
                             celClientPayload
                             snapshotApprovalEntry
                             snapshotLifecycle
+                            approvedEnvironment
+                            checkName
                         }
                     }
                 }`,

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -702,6 +702,7 @@ const COMPONENT_FULL_DATA = `
             snapshotApprovalEntry
             snapshotLifecycle
             approvedEnvironment
+            checkName
             scope
         }
     }
@@ -721,6 +722,7 @@ const COMPONENT_FULL_DATA = `
         snapshotApprovalEntry
         snapshotLifecycle
         approvedEnvironment
+        checkName
         scope
     }
     releaseInputTriggers {

--- a/ui/src/utils/triggerTypes.ts
+++ b/ui/src/utils/triggerTypes.ts
@@ -24,4 +24,5 @@ export type OutputTriggerEvent = {
     snapshotApprovalEntry?: string | null;
     snapshotLifecycle?: string | null;
     approvedEnvironment?: string | null;
+    checkName?: string | null;
 }


### PR DESCRIPTION
## Summary
- Adds an optional **Override Check Name** input to the EXTERNAL_VALIDATION output-event editor — both per-component (ComponentView) and policy-wide (OrgSettings)
- Wires `checkName` through GraphQL queries/mutations and the shared trigger types

## Why
GitHub branch protection's required-checks list matches by exact string (no wildcards), so converging multiple components on one required-check entry needs each EXTERNAL_VALIDATION output event to report under the same name. Default behaviour (when left empty) is unchanged: `rearm/<componentName>`.

## Pairs with
- Backend PR: [relizaio/rearm-saas#32](https://github.com/relizaio/rearm-saas/pull/32)

## Test plan
- [ ] Open a component → Output Events → add/edit an EXTERNAL_VALIDATION event; the new field appears only for that type
- [ ] Save with override set; verify it round-trips through the GraphQL fetch
- [ ] Save with override empty; verify backend uses `rearm/<componentName>`
- [ ] Repeat for Org Settings → policy-wide global output events

🤖 Generated with [Claude Code](https://claude.com/claude-code)