### PR TITLE
fix(ui): strip scope/__typename on every component save path

### DIFF
--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -941,6 +941,31 @@ const storeObject : any = {
                     .map((s: any) => (s ?? '').toString().trim())
                     .filter((s: string) => s.length > 0)
                 : null
+            // The read query returns `scope` and Apollo adds `__typename` to triggers;
+            // neither field exists on the matching Input types, so the mutation rejects
+            // with 400 if we send them through. Strip on every save path here, not just
+            // in saveTriggers, so non-trigger updates (e.g. assigning an approval policy
+            // while local triggers exist) don't fail.
+            const stripTriggerFields = (triggers: any[]) => {
+                if (!Array.isArray(triggers)) return triggers
+                return triggers.map((t: any) => {
+                    const c: any = { ...t }
+                    delete c.__typename
+                    delete c.scope
+                    // Client-side `temp-…` UUIDs track unsaved triggers; server assigns real ones.
+                    if (typeof c.uuid === 'string' && c.uuid.startsWith('temp-')) c.uuid = ''
+                    if (Array.isArray(c.outputEvents)) {
+                        c.outputEvents = c.outputEvents.map((oe: any) => {
+                            if (typeof oe === 'string') return oe
+                            const co = { ...oe }
+                            delete co.__typename
+                            delete co.scope
+                            return co
+                        })
+                    }
+                    return c
+                })
+            }
             const compUpdObject = {
                 uuid: component.uuid,
                 name: component.name,
@@ -953,8 +978,8 @@ const storeObject : any = {
                 versionType: component.versionType,
                 branchSuffixMode: component.branchSuffixMode || 'INHERIT',
                 approvalPolicy: component.approvalPolicy,
-                outputTriggers: component.outputTriggers,
-                releaseInputTriggers: component.releaseInputTriggers,
+                outputTriggers: stripTriggerFields(component.outputTriggers),
+                releaseInputTriggers: stripTriggerFields(component.releaseInputTriggers),
                 globalInputEventRefs: component.globalInputEventRefs?.map(({ uuid, overrideOutputEventsLocally, outputEventsOverride }: any) => ({ uuid, overrideOutputEventsLocally, outputEventsOverride })),
                 identifiers: component.identifiers?.map(({ idType, idValue }: any) => ({ idType, idValue })),
                 authentication: component.authentication ? { login: component.authentication.login, password: component.authentication.password, type: component.authentication.type } : null,


### PR DESCRIPTION
## Summary
The component read query returns `scope` on `outputTriggers` and `releaseInputTriggers`, and Apollo adds `__typename` to all responses. Neither field exists on the matching Input types, so when the `updateComponent` mutation includes a triggers array verbatim the backend rejects with **400** before any handler logs.

`saveTriggers` already stripped these before save; the regular `save()` path used for non-trigger updates (e.g. assigning an approval policy while local triggers exist) did not — so that path 400'd silently with nothing in backend logs.

## Repro (before this PR)
1. Add a local output event (e.g. EXTERNAL_VALIDATION) on a component with no approval policy → saves OK
2. Set an approval policy and save → 400, no backend log
3. Remove the local output event, save again → succeeds
4. Re-add the same event → succeeds

## Fix
Strip `scope` / `__typename` (and the client-side `temp-…` UUIDs) from `outputTriggers` and `releaseInputTriggers` inside `store.updateComponent` so every save path is safe — not just `saveTriggers`.

## Test plan
- [ ] Repro steps above now succeed in step 2
- [ ] Existing trigger save flow still works (saveTriggers also went through updateComponent)
- [ ] Regular component metadata edits (name/vcs/etc.) still save when local triggers exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)