### PR TITLE
fix(ui): two-row default for approval comment textarea

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -4484,7 +4484,7 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                 'onUpdate:value': (v: string) => { approvalRowComments.value[row.uuid] = v },
                 type: 'textarea',
                 placeholder: 'Optional comment (sanitised, ≤4000 chars)',
-                autosize: { minRows: 1, maxRows: 4 },
+                autosize: { minRows: 2, maxRows: 4 },
                 maxlength: 4000,
                 showCount: true
             })


### PR DESCRIPTION
## Summary
Bumps the approval-comment textarea's `autosize.minRows` from 1 → 2 so the show-count overlay no longer overlaps the placeholder / first line of typed text.

Same maxRows (4), same maxlength (4000) — only the resting height changes.

## Test plan
- [ ] Open the approval matrix on a release with at least one pending change → comment textarea opens at two rows
- [ ] Counter (`0/4000`) sits below the text instead of over it
- [ ] Type past one line of content → grows up to 4 rows as before, then scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)