### PR TITLE
feat(ui+docs): templates + inline help for EXTERNAL_VALIDATION output fields

### DIFF
--- a/documentation_site/docs/integrations/githubValidate.md
+++ b/documentation_site/docs/integrations/githubValidate.md
@@ -86,8 +86,8 @@ External Validation can be configured per-component (described here) or at the p
    - `failure` — block the merge.
    - `neutral` — informational, doesn't block by itself.
    - `skipped` / `cancelled` — same as the GitHub semantics.
-9. **Optional Output JSON** (free-form `title` / `summary` / `text` for the check-run): can be left empty — ReARM provides sensible defaults.
-10. **Dynamic output (CEL)**: optional CEL expression to compute the output JSON at fire time.
+9. **Optional Output JSON** (free-form `title` / `summary` / `text` for the check-run): can be left empty — ReARM provides sensible defaults. See [Customising the check-run output](#customising-the-check-run-output) below for samples.
+10. **Dynamic output (CEL)**: optional CEL expression to compute the output JSON at fire time. Same section covers the available CEL bindings.
 11. Click **Save**.
 
 Repeat for each conclusion you want to drive — typically one trigger that posts `success` on approval and one that posts `failure` on rejection — and wire each into the appropriate input trigger / approval state.
@@ -144,6 +144,91 @@ For reference, both rearm-actions and the CLI are released:
 When a PR closes or merges, ReARM's `syncbranches` job archives the corresponding source branch (if it has been deleted upstream) and flips any open `pullRequestData` entries on that branch from `OPEN` to `CLOSED`. Re-runs of CI on a closed PR also explicitly set `--pr-state CLOSED` if the workflow detects a closed event.
 
 No additional configuration is needed — just make sure your CI pipeline runs on `pull_request` close events if you want closure events to be recorded in real time (otherwise `syncbranches` catches up on its own schedule).
+
+## Customising the check-run output
+
+The check-run that ReARM posts to GitHub has an `output` block with three fields — `title`, `summary`, and `text` (markdown). The trigger form exposes two ways to control it: **Optional Output JSON** (`clientPayload`) and **Dynamic output** (`celClientPayload`).
+
+### Precedence
+
+```
+celClientPayload  (CEL expression evaluated against the release)
+    │ result string overwrites clientPayload for this dispatch
+    ▼
+clientPayload     (static JSON: {"title": ..., "summary": ..., "text": ...})
+    │ if non-empty AND parses as JSON, replaces the entire default output
+    ▼
+default output    (computed server-side at fire time)
+```
+
+Either field, when set, **replaces the entire default output** — there is no field-level merge. If you set `clientPayload` to `{"text": "my note"}` you lose the default title and summary too. To customise just one field, copy the full default JSON into the form (use the **Use template** button next to each field) and edit from there.
+
+### Default output
+
+When both `clientPayload` and `celClientPayload` are empty, ReARM posts an `output` block roughly shaped like this — the `text` body is a markdown summary of the release's pre-aggregated metrics, so the developer reading the blocked PR sees what's wrong without leaving GitHub:
+
+```json
+{
+  "title": "ReARM verdict: failure",
+  "summary": "Release version: 1.2.3.",
+  "text": "### Vulnerabilities (47)\n\n| Severity | Count |\n|---|---|\n| Critical | 3 |\n| High | 9 |\n| Medium | 27 |\n| Low | 6 |\n| Unassigned | 2 |\n\n### Policy Violations (5)\n\n| Type | Total | Unaudited |\n|---|---|---|\n| Security | 4 | 2 |\n| License | 1 | 0 |\n| Operational | 0 | 0 |\n\n### Components\n- Scanned: 142\n- Vulnerable: 18\n- Findings: 50 audited / 7 unaudited / 12 suppressed\n\n_Last scanned: 2026-04-30T17:14:09Z_"
+}
+```
+
+The empty-state path (release not yet scanned) returns a single line so the absence of a table doesn't read as "all clear":
+
+```
+_No release metrics available — release has not been scanned yet._
+```
+
+### Sample `clientPayload` (static)
+
+A minimal static override. Useful when every fired check-run should carry the same custom message — e.g. linking to your own internal runbook:
+
+```json
+{
+  "title": "ReARM verdict: blocked",
+  "summary": "This release does not meet the org-wide policy gate.",
+  "text": "Open the [release page](https://your-rearm-instance.example.com/release/show/<release-uuid>) for full details, or see the [internal runbook](https://wiki.example.com/runbooks/rearm-blocked-pr).\n\n_To override per release, switch to the Dynamic output (CEL) field._"
+}
+```
+
+Notes:
+- The string has to be valid JSON; the form accepts a multi-line textarea but the value is parsed as a single JSON document.
+- `text` accepts GitHub-flavored markdown — tables, links, code fences, lists.
+
+### Sample `celClientPayload` (CEL expression)
+
+CEL expression evaluated server-side at fire time. The result must be a string that itself parses as JSON with `title` / `summary` / `text` keys. Useful when you want live release values in the output:
+
+```cel
+'{"title":"ReARM verdict: ' + release.lifecycle + '","summary":"Release ' + release.version + ' — ' + string(release.criticalVulns) + ' critical, ' + string(release.highVulns) + ' high","text":"Edit this CEL to customise per-release output. See bindings table below."}'
+```
+
+#### CEL bindings available on `release`
+
+| Binding | Type | Description |
+|---|---|---|
+| `release.version` | string | Release version |
+| `release.lifecycle` | string | `DRAFT` / `GENERAL_AVAILABILITY` / `END_OF_*` etc. |
+| `release.component` | string | Component UUID |
+| `release.branchType` | string | Branch type (`MAIN`, `FEATURE`, etc.) |
+| `release.firstScanned` | bool | True if the release has been scanned at least once |
+| `release.criticalVulns` | int | Count of CRITICAL-severity vulnerabilities |
+| `release.highVulns` | int | Count of HIGH-severity vulnerabilities |
+| `release.mediumVulns` | int | Count of MEDIUM-severity vulnerabilities |
+| `release.lowVulns` | int | Count of LOW-severity vulnerabilities |
+| `release.unassignedVulns` | int | Count of UNASSIGNED-severity vulnerabilities |
+| `release.securityViolations` | int | Count of policy violations of type SECURITY |
+| `release.licenseViolations` | int | Count of policy violations of type LICENSE |
+| `release.operationalViolations` | int | Count of policy violations of type OPERATIONAL |
+| `release.approvals[uuid]` | string | `APPROVED` / `DISAPPROVED` / `UNSET` per approval entry |
+
+CEL integers are 64-bit, so use `string(release.criticalVulns)` to interpolate counts into a JSON string.
+
+::: tip Use template buttons
+The trigger form has a **Use template** button next to each field that pre-fills a starting template you can edit. Clicking it overwrites whatever is currently in the field — clear the field first if you want to start fresh, or copy your work elsewhere before refilling.
+:::
 
 ## Troubleshooting
 

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -485,11 +485,41 @@
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
                                                         <n-select v-model:value="outputTrigger.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
                                                     </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Optional Output JSON (title / summary / text)" path="clientPayload">
-                                                        <n-input v-model:value="outputTrigger.clientPayload" placeholder='{"title":"...","summary":"...","text":"..."}' />
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="clientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Optional Output JSON (title / summary / text)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    Static JSON. When set, ReARM sends this as the GitHub check-run "output" verbatim — title, summary and text fields all replace ReARM's defaults (including the auto metrics summary). Leave empty to keep defaults. Use the Dynamic CEL field below if you need per-release values.
+                                                                </n-tooltip>
+                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerClientPayloadDefault">
+                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                                    Use template
+                                                                </n-button>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder='{"title":"...","summary":"...","text":"..."}' />
                                                     </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
-                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="celClientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Dynamic output (CEL string expression)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    CEL expression evaluated at fire time against the release. Result must be a JSON string with title / summary / text — it overwrites the Optional Output JSON above for this dispatch. Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
+                                                                </n-tooltip>
+                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerCelClientPayloadDefault">
+                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                                    Use template
+                                                                </n-button>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
                                                     </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
                                                         <n-input v-model:value="outputTrigger.checkName" :placeholder="'Defaults to rearm/' + (updatedComponent.name || '<component>')" />
@@ -1537,6 +1567,30 @@ function resetOutputTrigger () {
         checkName: null,
     }
     snapshotMode.value = 'NONE'
+}
+
+// Sample templates the user can pre-fill into the EXTERNAL_VALIDATION
+// output JSON / CEL fields and edit. The actual ReARM defaults are
+// computed server-side at fire time (see SaasIntegrationService) — we
+// can't preview them exactly here because they include the live
+// release version + a metrics summary block. These templates are
+// starting points that mirror the *shape* of the default and document
+// the available CEL bindings inline.
+const EXTERNAL_VALIDATION_CLIENT_PAYLOAD_TEMPLATE = JSON.stringify({
+    title: 'ReARM verdict',
+    summary: 'Edit this static JSON to fully override ReARM\u2019s default check-run output.',
+    text: 'Replace this body with markdown describing your custom output.\n\nNote: setting this field disables ReARM\u2019s automatic metrics summary. Use the Dynamic CEL field below if you need live per-release values.'
+}, null, 2)
+
+const EXTERNAL_VALIDATION_CEL_PAYLOAD_TEMPLATE =
+    "'{\"title\":\"ReARM verdict: ' + release.lifecycle + '\",\"summary\":\"Release ' + release.version + ' \u2014 ' + string(release.criticalVulns) + ' critical, ' + string(release.highVulns) + ' high\",\"text\":\"Edit this CEL to customise per-release output. Bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.\"}'"
+
+function populateOutputTriggerClientPayloadDefault () {
+    outputTrigger.value.clientPayload = EXTERNAL_VALIDATION_CLIENT_PAYLOAD_TEMPLATE
+}
+
+function populateOutputTriggerCelClientPayloadDefault () {
+    outputTrigger.value.celClientPayload = EXTERNAL_VALIDATION_CEL_PAYLOAD_TEMPLATE
 }
 
 const inputTrigger: Ref<InputTriggerEvent> = ref({

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -647,11 +647,41 @@
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
                                         <n-select v-model:value="globalOutputEvent.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
                                     </n-form-item>
-                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Optional Output JSON (title / summary / text)" path="clientPayload">
-                                        <n-input v-model:value="globalOutputEvent.clientPayload" placeholder='{"title":"...","summary":"...","text":"..."}' />
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" path="clientPayload">
+                                        <template #label>
+                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                Optional Output JSON (title / summary / text)
+                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                    <template #trigger>
+                                                        <n-icon size="16" class="clickable"><Info20Regular /></n-icon>
+                                                    </template>
+                                                    Static JSON. When set, ReARM sends this as the GitHub check-run "output" verbatim — title, summary and text fields all replace ReARM's defaults (including the auto metrics summary). Leave empty to keep defaults. Use the Dynamic CEL field below if you need per-release values.
+                                                </n-tooltip>
+                                                <n-button text type="primary" size="tiny" @click="populateGlobalOutputClientPayloadDefault">
+                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                    Use template
+                                                </n-button>
+                                            </span>
+                                        </template>
+                                        <n-input v-model:value="globalOutputEvent.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder='{"title":"...","summary":"...","text":"..."}' />
                                     </n-form-item>
-                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Dynamic output (CEL string expression)" path="celClientPayload">
-                                        <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
+                                    <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" path="celClientPayload">
+                                        <template #label>
+                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                Dynamic output (CEL string expression)
+                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                    <template #trigger>
+                                                        <n-icon size="16" class="clickable"><Info20Regular /></n-icon>
+                                                    </template>
+                                                    CEL expression evaluated at fire time against the release. Result must be a JSON string with title / summary / text — it overwrites the Optional Output JSON above for this dispatch. Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
+                                                </n-tooltip>
+                                                <n-button text type="primary" size="tiny" @click="populateGlobalOutputCelClientPayloadDefault">
+                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                    Use template
+                                                </n-button>
+                                            </span>
+                                        </template>
+                                        <n-input v-model:value="globalOutputEvent.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
                                     </n-form-item>
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
                                         <n-input v-model:value="globalOutputEvent.checkName" placeholder="Defaults to rearm/<componentName>; override e.g. rearm/policy" />
@@ -1203,7 +1233,7 @@ import { ComputedRef, h, ref, Ref, computed, onMounted, reactive } from 'vue'
 import type { SelectOption } from 'naive-ui'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import { Edit as EditIcon, Trash, LockOpen, CirclePlus, Eye, QuestionMark, Refresh, Search, FolderPlus, Package } from '@vicons/tabler'
+import { Edit as EditIcon, Trash, LockOpen, CirclePlus, Eye, QuestionMark, Refresh, Search, FolderPlus, Package, Clipboard } from '@vicons/tabler'
 import { Clean } from '@vicons/carbon'
 import { Info20Regular, Edit24Regular, DeleteDismiss24Regular, ArrowUpload24Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
@@ -5510,6 +5540,28 @@ function resetGlobalOutputEvent () {
         checkName: null
     }
     globalSnapshotMode.value = 'NONE'
+}
+
+// Sample templates the user can pre-fill into the EXTERNAL_VALIDATION
+// output JSON / CEL fields and edit. The actual ReARM defaults are
+// computed server-side at fire time (see SaasIntegrationService) — the
+// templates below mirror the *shape* of the default and document the
+// available CEL bindings inline so the user can iterate from there.
+const EXTERNAL_VALIDATION_CLIENT_PAYLOAD_TEMPLATE = JSON.stringify({
+    title: 'ReARM verdict',
+    summary: 'Edit this static JSON to fully override ReARM\u2019s default check-run output.',
+    text: 'Replace this body with markdown describing your custom output.\n\nNote: setting this field disables ReARM\u2019s automatic metrics summary. Use the Dynamic CEL field below if you need live per-release values.'
+}, null, 2)
+
+const EXTERNAL_VALIDATION_CEL_PAYLOAD_TEMPLATE =
+    "'{\"title\":\"ReARM verdict: ' + release.lifecycle + '\",\"summary\":\"Release ' + release.version + ' \u2014 ' + string(release.criticalVulns) + ' critical, ' + string(release.highVulns) + ' high\",\"text\":\"Edit this CEL to customise per-release output. Bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.\"}'"
+
+function populateGlobalOutputClientPayloadDefault () {
+    globalOutputEvent.value.clientPayload = EXTERNAL_VALIDATION_CLIENT_PAYLOAD_TEMPLATE
+}
+
+function populateGlobalOutputCelClientPayloadDefault () {
+    globalOutputEvent.value.celClientPayload = EXTERNAL_VALIDATION_CEL_PAYLOAD_TEMPLATE
 }
 
 const globalInputEvent: Ref<InputTriggerEvent> = ref({

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -4484,7 +4484,7 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                 'onUpdate:value': (v: string) => { approvalRowComments.value[row.uuid] = v },
                 type: 'textarea',
                 placeholder: 'Optional comment (sanitised, ≤4000 chars)',
-                autosize: { minRows: 1, maxRows: 4 },
+                autosize: { minRows: 2, maxRows: 4 },
                 maxlength: 4000,
                 showCount: true
             })


### PR DESCRIPTION
## Summary

UI-only ergonomics fix for the EXTERNAL_VALIDATION trigger editor. The two output-customisation fields (Optional Output JSON, Dynamic output CEL) get:

- **Info (?) tooltip** explaining that they **replace** the default check-run output rather than merge into it (mirrors the precedence rules in `SaasIntegrationService`).
- **"Use template" button** that pre-fills a starting payload the user can edit. Static template mirrors the shape of the server-rendered default; CEL template demonstrates per-release values via the available bindings.
- Both fields converted to autosizing textareas so multi-line JSON / CEL is easier to author than the single-line `n-input` we had.

Both editors carry the same treatment:
- `ui/src/components/ComponentView.vue` — per-component output triggers.
- `ui/src/components/OrgSettings.vue` — policy-wide global output events.

## Docs

`documentation_site/docs/integrations/githubValidate.md` gets a new "Customising the check-run output" section with:
- Precedence diagram (CEL → JSON → server default).
- Sample of the rendered default output (incl. the metrics summary block backend-side adds).
- Worked example for a static `clientPayload`.
- Worked example for a `celClientPayload`, plus the full bindings table.
- Empty-state output sample.

## Test plan
- [ ] Open a component → Output Events → add an EXTERNAL_VALIDATION event → click **Use template** next to "Optional Output JSON" → field populates with valid JSON
- [ ] Click **Use template** next to "Dynamic output (CEL)" → field populates with valid CEL, single-quoted, escaped JSON inside
- [ ] Hover the (i) icon next to either field → tooltip explains override semantics
- [ ] Save the trigger and dispatch — overwriting the static field disables the auto metrics summary as documented; clearing both fields restores it
- [ ] Repeat in **Organization Settings → Approval Policies → Policy-Wide Output Events**
- [ ] Visit the rendered docs page locally (`npm run docs:dev` in `documentation_site/`) and verify the new section renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)