### PR TITLE
docs: trim default-output sample to match backend trim

### DIFF
--- a/documentation_site/docs/integrations/githubValidate.md
+++ b/documentation_site/docs/integrations/githubValidate.md
@@ -171,7 +171,7 @@ When both `clientPayload` and `celClientPayload` are empty, ReARM posts an `outp
 {
   "title": "ReARM verdict: failure",
   "summary": "Release version: 1.2.3.",
-  "text": "### Vulnerabilities (47)\n\n| Severity | Count |\n|---|---|\n| Critical | 3 |\n| High | 9 |\n| Medium | 27 |\n| Low | 6 |\n| Unassigned | 2 |\n\n### Policy Violations (5)\n\n| Type | Total | Unaudited |\n|---|---|---|\n| Security | 4 | 2 |\n| License | 1 | 0 |\n| Operational | 0 | 0 |\n\n### Components\n- Scanned: 142\n- Vulnerable: 18\n- Findings: 50 audited / 7 unaudited / 12 suppressed\n\n_Last scanned: 2026-04-30T17:14:09Z_"
+  "text": "### Vulnerabilities (47)\n\n| Severity | Count |\n|---|---|\n| Critical | 3 |\n| High | 9 |\n| Medium | 27 |\n| Low | 6 |\n| Unassigned | 2 |\n\n### Policy Violations (5)\n\n| Type | Count |\n|---|---|\n| Security | 4 |\n| License | 1 |\n| Operational | 0 |\n\n_Last scanned: 2026-04-30T17:14:09Z_"
 }
 ```
 


### PR DESCRIPTION
## Summary
Companion to the backend trim — drops the **Components** section and the **Unaudited** column from the rendered default-output JSON sample in \`integrations/githubValidate.md\`, so the documentation matches what the backend actually emits now.

## Pairs with
- Backend: [relizaio/rearm-saas](https://github.com/relizaio/rearm-saas/pulls)

## Test plan
- [ ] \`npm run docs:build\` clean
- [ ] Rendered \`/integrations/githubValidate\` page shows the trimmed sample under "Default output"

🤖 Generated with [Claude Code](https://claude.com/claude-code)