### PR TITLE
feat(ui): output-trigger vcs as optional override with component fallback

### DIFF
--- a/documentation_site/docs/integrations/githubValidate.md
+++ b/documentation_site/docs/integrations/githubValidate.md
@@ -171,7 +171,7 @@ When both `clientPayload` and `celClientPayload` are empty, ReARM posts an `outp
 {
   "title": "ReARM verdict: failure",
   "summary": "Release version: 1.2.3.",
-  "text": "### Vulnerabilities (47)\n\n| Severity | Count |\n|---|---|\n| Critical | 3 |\n| High | 9 |\n| Medium | 27 |\n| Low | 6 |\n| Unassigned | 2 |\n\n### Policy Violations (5)\n\n| Type | Total | Unaudited |\n|---|---|---|\n| Security | 4 | 2 |\n| License | 1 | 0 |\n| Operational | 0 | 0 |\n\n### Components\n- Scanned: 142\n- Vulnerable: 18\n- Findings: 50 audited / 7 unaudited / 12 suppressed\n\n_Last scanned: 2026-04-30T17:14:09Z_"
+  "text": "### Vulnerabilities (47)\n\n| Severity | Count |\n|---|---|\n| Critical | 3 |\n| High | 9 |\n| Medium | 27 |\n| Low | 6 |\n| Unassigned | 2 |\n\n### Policy Violations (5)\n\n| Type | Count |\n|---|---|\n| Security | 4 |\n| License | 1 |\n| Operational | 0 |\n\n_Last scanned: 2026-04-30T17:14:09Z_"
 }
 ```
 

--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -129,6 +129,20 @@
                 <n-input v-if="isWritable" id="vcsBranch" v-model:value="modifiedBranch.vcsBranch" />
                 <n-input v-else type="text" id="vcsBranch" name="vcsBranch" :value="modifiedBranch.vcsBranch" readonly/>
             </div>
+            <div class="pullRequestsBlock mt-3" v-if="branchPullRequests && branchPullRequests.length">
+                <p>
+                    <strong>Pull Requests </strong>
+                    <n-tooltip trigger="hover">
+                        <template #trigger>
+                            <n-icon size="16" style="cursor: help;">
+                                <QuestionMark />
+                            </n-icon>
+                        </template>
+                        PR metadata captured from CI when a release is minted on this branch via <code>--pr-*</code> flags. Updated each time a release fires for the same PR number.
+                    </n-tooltip>
+                </p>
+                <n-data-table :data="branchPullRequests" :columns="pullRequestColumns" :row-key="(row: any) => row.number" />
+            </div>
             <n-button
                 v-if="isWritable && modifiedBranch && !modifiedBranch.vcs && !isLinkVcsRepo && branchData.componentDetails === 'COMPONENT'"
                 @click="isLinkVcsRepo = true">
@@ -1165,6 +1179,71 @@ const isPatternNew = function (row: any): boolean {
     if (!branchData.value.dependencyPatterns) return true
     return !branchData.value.dependencyPatterns.some((p: any) => p.uuid === row.uuid)
 }
+
+const branchPullRequests: ComputedRef<any[]> = computed((): any[] => {
+    return modifiedBranch.value?.pullRequests || []
+})
+
+const formatPrDate = (raw: string | null | undefined): string => {
+    if (!raw) return '—'
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) return '—'
+    return d.toLocaleDateString('en-CA') + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+const resolveBranchName = (branchUuid: string | null | undefined): string => {
+    if (!branchUuid) return '—'
+    const bd = store.getters.branchById(branchUuid)
+    return bd?.name || branchUuid
+}
+
+const pullRequestColumns: DataTableColumns<any> = [
+    {
+        title: '#',
+        key: 'number',
+        width: 60,
+        render: (row: any) => h('span', { style: 'font-family: monospace;' }, '#' + row.number)
+    },
+    {
+        title: 'Title',
+        key: 'title',
+        render: (row: any) => row.title || '—'
+    },
+    {
+        title: 'State',
+        key: 'state',
+        width: 90,
+        render: (row: any) => {
+            const tagType = row.state === 'OPEN' ? 'success' : (row.state === 'CLOSED' ? 'default' : 'info')
+            return h(NTag, { type: tagType, size: 'small', bordered: false }, { default: () => row.state || '—' })
+        }
+    },
+    {
+        title: 'Target Branch',
+        key: 'targetBranch',
+        render: (row: any) => resolveBranchName(row.targetBranch)
+    },
+    {
+        title: 'Endpoint',
+        key: 'endpoint',
+        render: (row: any) => {
+            if (!row.endpoint) return '—'
+            return h('a', { href: row.endpoint, target: '_blank', rel: 'noopener' }, row.endpoint.replace(/^https?:\/\//, ''))
+        }
+    },
+    {
+        title: 'Created',
+        key: 'createdDate',
+        width: 150,
+        render: (row: any) => formatPrDate(row.createdDate)
+    },
+    {
+        title: 'Closed',
+        key: 'closedDate',
+        width: 150,
+        render: (row: any) => formatPrDate(row.closedDate)
+    }
+]
 
 const patternTableFields: DataTableColumns<any> = [
     {

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -449,11 +449,19 @@
                                                     <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITLAB'" label="GitLab Schedule Id" path="schedule">
                                                         <n-input type="number" v-model:value="outputTrigger.schedule" required placeholder="Enter numeric GitLab Schedule Id" />
                                                     </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && (selectedCiIntegration.type === 'GITHUB' || selectedCiIntegration.type === 'GITLAB')" label="CI Repository" path="vcs">
-                                                        <span v-if="!selectNewIntegrationRepo && outputTrigger.vcs">{{ getVcsRepoObjById(outputTrigger.vcs).uri }} </span>
-                                                        <span v-if="!selectNewIntegrationRepo && !outputTrigger.vcs">Not Set</span>
-                                                        <n-select v-if="selectNewIntegrationRepo" :options="vcsRepos" required v-model:value="outputTrigger.vcs" />
-                                                        <n-icon v-if="!selectNewIntegrationRepo" class="clickable" @click="async () => {selectNewIntegrationRepo = true;}" title="Select New Integration Repository" size="20"><Edit /></n-icon>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && (selectedCiIntegration.type === 'GITHUB' || selectedCiIntegration.type === 'GITLAB')" label="CI Repository (override)" path="vcs">
+                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
+                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
+                                                                Override active. Component VCS will not be used for this trigger.
+                                                            </span>
+                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
+                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
+                                                            </span>
+                                                            <span v-else style="font-size: 12px; color: #c95900;">
+                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
+                                                            </span>
+                                                        </div>
                                                     </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'JENKINS'" label="Jenkins Job Name" path="schedule">
                                                         <n-input v-model:value="outputTrigger.schedule" required placeholder="Jenkins Job Name" />
@@ -476,11 +484,19 @@
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
                                                         <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
                                                     </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="VCS Repository" path="vcs">
-                                                        <span v-if="!selectNewIntegrationRepo && outputTrigger.vcs">{{ getVcsRepoObjById(outputTrigger.vcs).uri }} </span>
-                                                        <span v-if="!selectNewIntegrationRepo && !outputTrigger.vcs">Not Set</span>
-                                                        <n-select v-if="selectNewIntegrationRepo" :options="vcsRepos" required v-model:value="outputTrigger.vcs" />
-                                                        <n-icon v-if="!selectNewIntegrationRepo" class="clickable" @click="async () => {selectNewIntegrationRepo = true;}" title="Select VCS Repository" size="20"><Edit /></n-icon>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="VCS Repository (override)" path="vcs">
+                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
+                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
+                                                                Override active. Component VCS will not be used for this trigger.
+                                                            </span>
+                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
+                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
+                                                            </span>
+                                                            <span v-else style="font-size: 12px; color: #c95900;">
+                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
+                                                            </span>
+                                                        </div>
                                                     </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
                                                         <n-select v-model:value="outputTrigger.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
@@ -2505,7 +2521,21 @@ async function addOutputTrigger () {
         notify('error', 'Validation Error', validation.error!)
         return
     }
-    
+
+    // VCS-required check for SCM-bound output triggers. Backend dispatcher
+    // silently skips when neither the trigger override nor the component
+    // carries a vcs — that's the right runtime behaviour for global events,
+    // but here on the component editor it would mean a configured trigger
+    // never fires with no signal to the user. Block save instead.
+    const isSCMTrigger = outputTriggerToPush.type === 'EXTERNAL_VALIDATION' ||
+        (outputTriggerToPush.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration.value &&
+            (selectedCiIntegration.value.type === 'GITHUB' || selectedCiIntegration.value.type === 'GITLAB'))
+    if (isSCMTrigger && !outputTriggerToPush.vcs && !updatedComponent.value.vcs) {
+        notify('error', 'VCS required',
+            'This trigger needs a VCS Repository: either pick one as override on the trigger, or set a VCS on the component itself.')
+        return
+    }
+
     if (outputTriggerToPush.uuid) {
         // Check if trigger with this UUID already exists
         const existingIndex = updatedComponent.value.outputTriggers.findIndex((ot: any) => ot.uuid === outputTriggerToPush.uuid)

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -614,6 +614,9 @@
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER'" label="Choose CI Integration" path="integration">
                                         <n-select v-model:value="globalOutputEvent.integration" placeholder="Select Integration" :options="ciIntegrationsForGlobalSelect" />
                                     </n-form-item>
+                                    <n-alert v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER' && selectedGlobalCiIntegration && (selectedGlobalCiIntegration.type === 'GITHUB' || selectedGlobalCiIntegration.type === 'GITLAB')" type="info" :show-icon="false" style="font-size: 12px; margin-bottom: 8px;">
+                                        Policy-wide events use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this trigger is silently skipped for that component.
+                                    </n-alert>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER' && selectedGlobalCiIntegration && selectedGlobalCiIntegration.type === 'GITHUB'" label="Installation ID" path="schedule">
                                         <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
                                     </n-form-item>
@@ -641,6 +644,9 @@
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Choose Validation Integration" path="integration">
                                         <n-select v-model:value="globalOutputEvent.integration" placeholder="Select GitHub Validate Integration" :options="validationIntegrationsForGlobalSelect" />
                                     </n-form-item>
+                                    <n-alert v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" type="info" :show-icon="false" style="font-size: 12px; margin-bottom: 8px;">
+                                        Policy-wide events use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this trigger is silently skipped for that component.
+                                    </n-alert>
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
                                         <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
                                     </n-form-item>

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -829,6 +829,16 @@ const BRANCH_GQL_DATA = `
         type
         createdType
     }
+    pullRequests {
+        number
+        state
+        title
+        endpoint
+        targetBranch
+        createdDate
+        closedDate
+        mergedDate
+    }
 `
 
 const SINGLE_RELEASE_GQL = gql`


### PR DESCRIPTION
## Summary
Companion to the backend fallback. UI changes split between the per-component editor and the policy-wide editor.

### Component editor (\`ComponentView.vue\`)
- VCS / CI Repository fields for INTEGRATION_TRIGGER (GitHub/GitLab) and EXTERNAL_VALIDATION are now **clearable** selects with placeholder \`Leave empty to use the component's VCS\`.
- A small hint underneath the field shows the resolved fallback at glance:
  - Override active → "Component VCS will not be used for this trigger."
  - Override empty + component has VCS → "Will use component's VCS at fire time: \<uri>"
  - Override empty + component has no VCS → ⚠ warning that save will be blocked.
- **Pre-save validation** in \`addOutputTrigger\` blocks the save with a notify error when both the override and the component VCS are empty for SCM-bound trigger types. (Backend would silently skip at fire time — without the UI block, the user would have no signal that their configured trigger never fires.)

### Policy-wide editor (\`OrgSettings.vue\`)
- No new field — global events intentionally don't pin a VCS. An \`n-alert\` info banner under the INTEGRATION_TRIGGER (GitHub/GitLab) and EXTERNAL_VALIDATION sections makes the runtime semantics explicit:
  > Policy-wide events use the **component's VCS** at fire time. If a participating component has no VCS configured, this trigger is silently skipped for that component.

## Pairs with
- Backend: [relizaio/rearm-saas](https://github.com/relizaio/rearm-saas/pulls)

## Test plan
- [ ] Component → Output Events → add INTEGRATION_TRIGGER (GitHub) → leave VCS empty → hint shows "Will use component's VCS: \<uri>" when component has one
- [ ] Same but the component has no VCS → warning text appears, Save blocked with notify error
- [ ] Same flow for EXTERNAL_VALIDATION
- [ ] Existing triggers with VCS set: open editor → override hint shown, save still works
- [ ] Org Settings → Approval Policies → Policy-Wide Output Events → INTEGRATION_TRIGGER (GitHub/GitLab) shows the info banner
- [ ] Same with EXTERNAL_VALIDATION

🤖 Generated with [Claude Code](https://claude.com/claude-code)