### PR TITLE
feat(rebom): downgrade CycloneDX 1.7 → 1.6 on ingest

### DIFF
--- a/rebom-backend/src/services/bom/bomAddService.ts
+++ b/rebom-backend/src/services/bom/bomAddService.ts
@@ -12,6 +12,7 @@ import {
   extractRepositoryNameFromBom
 } from '../oci';
 import { computeBomDigest, augmentBomForStorage, getInitialEnrichmentStatus, enrichBomAsync } from './bomProcessingService';
+import { downgradeCycloneDxSpecIfNeeded } from '../cyclonedx/cdxSpecDowngrade';
 import validateBom from '../../validateBom';
 import { v4 as uuidv4 } from 'uuid';
 import { runQuery } from '../../utils';
@@ -98,7 +99,16 @@ async function findBomByRawDigest(serialNumber: string, rawDigest: string, org: 
 async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
   // Step 1: Process and validate BOM
   const rawBom = bomInput.bomInput.bom;
-  const processedBom = await processBomObj(rawBom);
+  // CycloneDX 1.7 is published upstream but no library in our stack
+  // (cyclonedx-go used by rearm-cli for BEAR enrichment, cyclonedx-core-java
+  // used by rearm-saas for SBOM-component parsing, cyclonedx-javascript-library
+  // used here for validation) supports it yet. Deep-clone the raw BOM and
+  // downgrade the clone's specVersion to 1.6 in place so all downstream sees
+  // a recognised spec. The original bytes are still stored verbatim under the
+  // `<uuid>-raw` OCI key below — once libraries catch up, that raw copy can
+  // be re-augmented at the new spec.
+  const inputForProcessing = downgradeCycloneDxSpecIfNeeded(structuredClone(rawBom));
+  const processedBom = await processBomObj(inputForProcessing);
 
   await validateBom(processedBom); // throws BomValidationError on failure
 

--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -670,6 +670,17 @@ export async function enrichBomAsync(bomUuid: string, bom: any, org: string, exi
     return;
   }
 
+  // Defensive shim: an artifact uploaded *before* the addCycloneDxBom shim
+  // deployed has its canonical OCI copy stored at an unsupported spec
+  // (e.g. 1.7), and the enrichment scheduler re-queries FAILED rows every
+  // cycle — without this line the BEAR call would fail "invalid
+  // specification version" forever and the FAILED→retry→FAILED loop never
+  // clears. Applying the shim here means one successful cycle rewrites the
+  // canonical OCI copy at the supported spec, so the next scheduler run
+  // sees a 1.6 BOM and the loop self-heals. No-op when the BOM is already
+  // at a supported spec (covers new uploads that were shimmed on ingest).
+  downgradeCycloneDxSpecIfNeeded(bom);
+
   // Perform enrichment
   const result = await enrichCycloneDxBom(bom, credentials.bearUri, credentials.bearApiKey, credentials.skipPatterns, bomUuid);
   

--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -16,6 +16,7 @@ import * as BomRepository from '../../bomRepository';
 import * as SpdxRepository from '../../spdxRepository';
 import { getBearCredentials, getBearIntegration } from '../integrationService';
 import { SpdxService } from '../spdx';
+import { downgradeCycloneDxSpecIfNeeded } from '../cyclonedx/cdxSpecDowngrade';
 const canonicalize = require('canonicalize');
 import { createHash } from 'crypto';
 import * as fs from 'fs';
@@ -905,11 +906,18 @@ async function reprocessCycloneDxBom(bomRecord: BomRecord): Promise<any | null> 
     const storedRepositoryName = extractRepositoryNameFromBom(bomRecord);
     const expectedDigest = bomRecord.meta?.originalFileDigest;
     const rawBom = await fetchRawBomWithFallback(bomRecord.uuid, storedRepositoryName, fetchFromOci, expectedDigest);
-    
+
+    // Apply the same 1.7→1.6 downgrade shim that addCycloneDxBom uses on
+    // ingest. Forced re-enrichment is the recovery path for artifacts that
+    // were uploaded *before* the shim deployed and got stuck in the
+    // FAILED-enrichment loop because their canonical copy is still 1.7.
+    // Mutating in place is safe — `rawBom` was just fetched fresh from OCI.
+    downgradeCycloneDxSpecIfNeeded(rawBom);
+
     // Re-augment the BOM with component context
     const rebomOptions = bomRecord.meta;
     const augmentedBom = augmentBomForStorage(rawBom, rebomOptions, new Date());
-    
+
     logger.debug({ bomUuid: bomRecord.uuid }, 'CycloneDX BOM reprocessed (augmented)');
     return augmentedBom;
     

--- a/rebom-backend/src/services/cyclonedx/cdxSpecDowngrade.ts
+++ b/rebom-backend/src/services/cyclonedx/cdxSpecDowngrade.ts
@@ -1,0 +1,52 @@
+import { logger } from '../../logger';
+
+/**
+ * Internal target spec version. CycloneDX 1.6 is the highest version every
+ * library in our stack (cyclonedx-go, cyclonedx-core-java,
+ * cyclonedx-javascript-library) currently understands; 1.7 is published
+ * upstream but no language binding has shipped support yet.
+ *
+ * Until upstream catches up we transparently downgrade incoming 1.7 BOMs to
+ * 1.6 *for the augmented (canonical) copy* — the original raw bytes are
+ * still pushed to OCI under the `<uuid>-raw` key in `addCycloneDxBom`, so
+ * the source-of-truth document is preserved verbatim and we can re-process
+ * once the libraries catch up.
+ */
+const TARGET_SPEC_VERSION = '1.6';
+
+/**
+ * Map from "incoming spec version we can't yet handle" → "spec version we
+ * pretend it is". Add new entries as future spec versions ship before our
+ * libraries catch up.
+ */
+const SUPPORTED_DOWNGRADES: Record<string, string> = {
+    '1.7': TARGET_SPEC_VERSION,
+};
+
+/**
+ * Mutates and returns the BOM with `specVersion` downgraded to a supported
+ * value when needed. Pass a clone if the caller wants to preserve the
+ * original (`addCycloneDxBom` does this — `rawBom` is pushed to OCI as the
+ * raw artifact while a deep-cloned, downgraded copy goes through validation
+ * + augmentation).
+ *
+ * Transform is deliberately minimal — only `specVersion` and the `$schema`
+ * URL are rewritten. We don't strip 1.7-only fields; cyclonedx-go's lenient
+ * decoder ignores unknown JSON fields and the 1.6 strict validator should
+ * tolerate additive ones. If a future BOM trips the strict validator on a
+ * 1.7-only field, the validator error will tell us exactly what to strip;
+ * revisit then.
+ */
+export function downgradeCycloneDxSpecIfNeeded<T extends { specVersion?: string; $schema?: string }>(bom: T): T {
+    if (!bom?.specVersion) return bom;
+    const target = SUPPORTED_DOWNGRADES[bom.specVersion];
+    if (!target) return bom;
+    const original = bom.specVersion;
+    bom.specVersion = target;
+    if (typeof bom.$schema === 'string' && bom.$schema.includes(original)) {
+        bom.$schema = bom.$schema.replace(original, target);
+    }
+    logger.info({ originalSpecVersion: original, targetSpecVersion: target },
+        'Downgraded CycloneDX BOM specVersion before processing — raw bytes preserved in OCI');
+    return bom;
+}

--- a/rebom-backend/src/services/cyclonedx/index.ts
+++ b/rebom-backend/src/services/cyclonedx/index.ts
@@ -1,2 +1,3 @@
 export * from './cycloneDxParser';
 export * from './cycloneDxService';
+export * from './cdxSpecDowngrade';

--- a/rebom-backend/test/unit/cdxSpecDowngrade.test.ts
+++ b/rebom-backend/test/unit/cdxSpecDowngrade.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { downgradeCycloneDxSpecIfNeeded } from '../../src/services/cyclonedx/cdxSpecDowngrade';
+
+/**
+ * Unit tests for the CycloneDX 1.7 → 1.6 downgrade shim. Lives at the
+ * BOM-receive boundary in `addCycloneDxBom` so all downstream (validation,
+ * augmentation, BEAR enrichment) sees a spec our libraries actually
+ * support. Pull this shim once cyclonedx-go / cyclonedx-core-java /
+ * cyclonedx-javascript-library all ship 1.7 support.
+ */
+describe('cdxSpecDowngrade', () => {
+    describe('downgradeCycloneDxSpecIfNeeded', () => {
+        it('rewrites specVersion 1.7 → 1.6', () => {
+            const bom: any = {
+                bomFormat: 'CycloneDX',
+                specVersion: '1.7',
+                serialNumber: 'urn:uuid:00000000-0000-0000-0000-000000000000',
+                version: 1,
+                components: [],
+            };
+            const result = downgradeCycloneDxSpecIfNeeded(bom);
+            expect(result.specVersion).toBe('1.6');
+        });
+
+        it('rewrites $schema URL when it embeds the original spec version', () => {
+            const bom: any = {
+                $schema: 'http://cyclonedx.org/schema/bom-1.7.schema.json',
+                bomFormat: 'CycloneDX',
+                specVersion: '1.7',
+            };
+            const result = downgradeCycloneDxSpecIfNeeded(bom);
+            expect(result.specVersion).toBe('1.6');
+            expect(result.$schema).toBe('http://cyclonedx.org/schema/bom-1.6.schema.json');
+        });
+
+        it('leaves supported spec versions untouched', () => {
+            const bom: any = {
+                bomFormat: 'CycloneDX',
+                specVersion: '1.6',
+                $schema: 'http://cyclonedx.org/schema/bom-1.6.schema.json',
+            };
+            const result = downgradeCycloneDxSpecIfNeeded(bom);
+            expect(result.specVersion).toBe('1.6');
+            expect(result.$schema).toBe('http://cyclonedx.org/schema/bom-1.6.schema.json');
+        });
+
+        it('leaves a BOM with no specVersion alone', () => {
+            const bom: any = { bomFormat: 'CycloneDX' };
+            const result = downgradeCycloneDxSpecIfNeeded(bom);
+            expect(result.specVersion).toBeUndefined();
+        });
+
+        it('preserves non-spec fields (additive 1.7 fields are not stripped)', () => {
+            // 1.7 may add new top-level fields; we don't enumerate them, we just
+            // pass them through. cyclonedx-go's lenient JSON decoder ignores
+            // unknown fields, and the 1.6 strict validator should tolerate
+            // additive ones. If a future BOM trips the validator we'll
+            // discover the offending field via the validator error and revisit.
+            const bom: any = {
+                bomFormat: 'CycloneDX',
+                specVersion: '1.7',
+                someNew17Field: { foo: 'bar' },
+                components: [{ name: 'x', purl: 'pkg:npm/x@1.0.0' }],
+            };
+            const result = downgradeCycloneDxSpecIfNeeded(bom);
+            expect(result.specVersion).toBe('1.6');
+            expect(result.someNew17Field).toEqual({ foo: 'bar' });
+            expect(result.components).toHaveLength(1);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
CycloneDX 1.7 is published upstream but no language binding in our stack ships 1.7 support yet:

- \`cyclonedx-go\` @ v0.10.0 (rearm-cli's BEAR enrichment) → max 1.6
- \`cyclonedx-core-java\` 12.x (rearm-saas SBOM-component parsing) → max 1.6
- \`@cyclonedx/cyclonedx-library\` 10.x (rebom validation) → max 1.6

Result: BOMs from cdxgen / Trivy with \`specVersion: 1.7\` blow up with **invalid specification version** during BEAR enrichment and **Unsupported schema version** in rebom's strict validator.

This PR adds a small ingest-time shim in rebom: clone the incoming BOM, rewrite \`specVersion\` to \`1.6\` (and \`$schema\` URL when present), and pass that through the regular validation / augmentation / OCI-push / BEAR-enrichment pipeline. **No new DB column** — the original 1.7 bytes are already preserved verbatim in OCI under the existing \`<uuid>-raw\` key by \`addCycloneDxBom\`, so when our libraries catch up to 1.7 we can re-augment from the raw copy.

## Pattern
Mirrors the SPDX-conversion entry point conceptually (\`SpdxService.convertSpdxToCycloneDx\`) — preprocess at the rebom boundary so everything downstream sees a recognised format. Stays in JS rather than shelling out to a new \`rearm bomutils\` subcommand because the transform is a single field rewrite, and putting it in the CLI would itself need to decode 1.7 (which cyclonedx-go can't).

## Scope choices
- **Only \`addCycloneDxBom\` is hooked.** The merge path (\`bomMergeService\`) shells out to \`rearm bomutils merge-boms\` which uses cyclonedx-go and would also fail on 1.7 inputs — but merge is not the path users are hitting right now per the failing-enrichment logs. Can be addressed separately.
- **Don't strip 1.7-only top-level fields.** cyclonedx-go's decoder is lenient with unknown fields; the 1.6 strict validator should tolerate additive ones. If a future BOM trips the validator, its error message will identify the field — revisit then.
- **Tracking**: ranger entry \`SUPPORTED_DOWNGRADES['1.7'] = '1.6'\` lives at the top of \`cdxSpecDowngrade.ts\`. When upstream catches up, drop the entry and re-augment raw OCI artifacts at the new spec.

## Tests
5 new unit tests covering specVersion rewrite, \`$schema\` URL rewrite, no-op on already-supported spec, no-op when specVersion is missing, and preservation of additive fields. \`npm test -- --run test/unit/cdxSpecDowngrade.test.ts\` passes locally.

Pairs with the integration-test scenario in [relizaio/rearm-integration-tests#3](https://github.com/relizaio/rearm-integration-tests/pull/3) (\`@cyclonedx-1-7\` scenario) — once this PR ships, that scenario should be passable end-to-end (drop the \`@skip\` tag).

## Test plan
- [ ] Upload a CDX 1.7 BOM via \`rearm addartifact\` against a release; rebom logs \`Downgraded CycloneDX BOM specVersion before processing\` and the BOM lands without errors
- [ ] BEAR enrichment fires asynchronously and succeeds (no more \`invalid specification version\`)
- [ ] Raw 1.7 BOM is preserved verbatim at the \`<uuid>-raw\` OCI key
- [ ] CDX 1.6 / 1.5 / 1.4 BOMs continue to flow through unchanged
- [ ] \`@cyclonedx-1-7\` integration scenario passes once \`@skip\` is removed (requires this PR + the harness PR deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)