### PR TITLE
feat(ui): first-class PullRequest entity surfaces

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -129,20 +129,6 @@
                 <n-input v-if="isWritable" id="vcsBranch" v-model:value="modifiedBranch.vcsBranch" />
                 <n-input v-else type="text" id="vcsBranch" name="vcsBranch" :value="modifiedBranch.vcsBranch" readonly/>
             </div>
-            <div class="pullRequestsBlock mt-3" v-if="branchPullRequests && branchPullRequests.length">
-                <p>
-                    <strong>Pull Requests </strong>
-                    <n-tooltip trigger="hover">
-                        <template #trigger>
-                            <n-icon size="16" style="cursor: help;">
-                                <QuestionMark />
-                            </n-icon>
-                        </template>
-                        PR metadata captured from CI when a release is minted on this branch via <code>--pr-*</code> flags. Updated each time a release fires for the same PR number.
-                    </n-tooltip>
-                </p>
-                <n-data-table :data="branchPullRequests" :columns="pullRequestColumns" :row-key="(row: any) => row.number" />
-            </div>
             <n-button
                 v-if="isWritable && modifiedBranch && !modifiedBranch.vcs && !isLinkVcsRepo && branchData.componentDetails === 'COMPONENT'"
                 @click="isLinkVcsRepo = true">
@@ -1179,71 +1165,6 @@ const isPatternNew = function (row: any): boolean {
     if (!branchData.value.dependencyPatterns) return true
     return !branchData.value.dependencyPatterns.some((p: any) => p.uuid === row.uuid)
 }
-
-const branchPullRequests: ComputedRef<any[]> = computed((): any[] => {
-    return modifiedBranch.value?.pullRequests || []
-})
-
-const formatPrDate = (raw: string | null | undefined): string => {
-    if (!raw) return '—'
-    const d = new Date(raw)
-    if (Number.isNaN(d.getTime())) return '—'
-    return d.toLocaleDateString('en-CA') + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
-
-const resolveBranchName = (branchUuid: string | null | undefined): string => {
-    if (!branchUuid) return '—'
-    const bd = store.getters.branchById(branchUuid)
-    return bd?.name || branchUuid
-}
-
-const pullRequestColumns: DataTableColumns<any> = [
-    {
-        title: '#',
-        key: 'number',
-        width: 60,
-        render: (row: any) => h('span', { style: 'font-family: monospace;' }, '#' + row.number)
-    },
-    {
-        title: 'Title',
-        key: 'title',
-        render: (row: any) => row.title || '—'
-    },
-    {
-        title: 'State',
-        key: 'state',
-        width: 90,
-        render: (row: any) => {
-            const tagType = row.state === 'OPEN' ? 'success' : (row.state === 'CLOSED' ? 'default' : 'info')
-            return h(NTag, { type: tagType, size: 'small', bordered: false }, { default: () => row.state || '—' })
-        }
-    },
-    {
-        title: 'Target Branch',
-        key: 'targetBranch',
-        render: (row: any) => resolveBranchName(row.targetBranch)
-    },
-    {
-        title: 'Endpoint',
-        key: 'endpoint',
-        render: (row: any) => {
-            if (!row.endpoint) return '—'
-            return h('a', { href: row.endpoint, target: '_blank', rel: 'noopener' }, row.endpoint.replace(/^https?:\/\//, ''))
-        }
-    },
-    {
-        title: 'Created',
-        key: 'createdDate',
-        width: 150,
-        render: (row: any) => formatPrDate(row.createdDate)
-    },
-    {
-        title: 'Closed',
-        key: 'closedDate',
-        width: 150,
-        render: (row: any) => formatPrDate(row.closedDate)
-    }
-]
 
 const patternTableFields: DataTableColumns<any> = [
     {

--- a/ui/src/components/PullRequestView.vue
+++ b/ui/src/components/PullRequestView.vue
@@ -1,0 +1,170 @@
+<template>
+    <div class="prView">
+        <div v-if="pr">
+            <h1>
+                Pull Request {{ pr.identity }}
+                <n-tag :type="stateTag(pr.state)" size="small" bordered="false">{{ pr.state }}</n-tag>
+            </h1>
+            <p v-if="pr.title" class="title-line">{{ pr.title }}</p>
+
+            <div class="meta">
+                <p><strong>Target VCS:</strong> {{ vcsName(pr.targetVcsRepository) }}</p>
+                <p v-if="pr.sourceVcsRepository && pr.sourceVcsRepository !== pr.targetVcsRepository">
+                    <strong>Source VCS (cross-repo):</strong> {{ vcsName(pr.sourceVcsRepository) }}
+                </p>
+                <p v-if="pr.sourceBranchName"><strong>Source branch:</strong> {{ pr.sourceBranchName }}</p>
+                <p v-if="pr.targetBranchName"><strong>Target branch:</strong> {{ pr.targetBranchName }}</p>
+                <p v-if="pr.endpoint">
+                    <strong>SCM:</strong>
+                    <a :href="pr.endpoint" target="_blank" rel="noopener">{{ pr.endpoint }}</a>
+                </p>
+                <p><strong>Commits attributed:</strong> {{ (pr.commits || []).length }}</p>
+                <p v-if="(pr.commits || []).length">
+                    <strong>Head SCE:</strong>
+                    <code>{{ pr.commits[pr.commits.length - 1] }}</code>
+                </p>
+            </div>
+
+            <h3 class="mt-4">PR validation events
+                <n-tooltip trigger="hover">
+                    <template #trigger>
+                        <n-icon size="16" style="cursor: help;"><QuestionMark/></n-icon>
+                    </template>
+                    Outbound dispatches the aggregator made to the SCM. Latest entry whose
+                    sourceCodeEntry matches the head is the current verdict.
+                </n-tooltip>
+            </h3>
+            <n-data-table
+                v-if="(pr.prValidationEvents || []).length"
+                :columns="prEventCols"
+                :data="pr.prValidationEvents"/>
+            <p v-else class="empty">None recorded yet.</p>
+
+            <h3 class="mt-4">Release validation events
+                <n-tooltip trigger="hover">
+                    <template #trigger>
+                        <n-icon size="16" style="cursor: help;"><QuestionMark/></n-icon>
+                    </template>
+                    Inbound contributions from individual releases attributed to this PR. The
+                    aggregator folds the latest event per release into the next dispatch.
+                </n-tooltip>
+            </h3>
+            <n-data-table
+                v-if="(pr.releaseValidationEvents || []).length"
+                :columns="releaseEventCols"
+                :data="pr.releaseValidationEvents"/>
+            <p v-else class="empty">None recorded yet.</p>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
+import { NDataTable, NIcon, NTag, NTooltip, DataTableColumns } from 'naive-ui'
+import { QuestionMark } from '@vicons/tabler'
+
+const store = useStore()
+const route = useRoute()
+const prUuid = computed(() => route.params.uuid as string)
+const pr = ref<any>(null)
+
+const stateTag = (s: string) => s === 'OPEN' ? 'success' : (s === 'MERGED' ? 'info' : 'default')
+const validationTag = (v: string) => {
+    if (v === 'SUCCESS') return 'success'
+    if (v === 'FAILURE' || v === 'CANCELLED') return 'error'
+    return 'default'
+}
+
+const vcsName = (uuid: string) => {
+    if (!uuid) return '—'
+    const repo = store.getters.vcsRepoById(uuid)
+    return repo?.name || uuid
+}
+
+const fmtDateTime = (raw: string | null | undefined) => {
+    if (!raw) return '—'
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) return '—'
+    return d.toLocaleDateString('en-CA') + ' ' + d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+const prEventCols: DataTableColumns<any> = [
+    {
+        title: 'When',
+        key: 'date',
+        width: 160,
+        render: (row) => fmtDateTime(row.date)
+    },
+    {
+        title: 'Verdict',
+        key: 'validationState',
+        width: 110,
+        render: (row) => h(NTag, { type: validationTag(row.validationState), size: 'small', bordered: false },
+            { default: () => row.validationState })
+    },
+    {
+        title: 'Head SCE',
+        key: 'sourceCodeEntry',
+        render: (row) => h('code', {}, (row.sourceCodeEntry || '').slice(0, 8))
+    },
+    {
+        title: 'Releases',
+        key: 'attributedReleases',
+        render: (row) => (row.attributedReleases || []).length
+    },
+    {
+        title: 'Comment',
+        key: 'comment',
+        render: (row) => row.comment || '—'
+    }
+]
+
+const releaseEventCols: DataTableColumns<any> = [
+    {
+        title: 'When',
+        key: 'date',
+        width: 160,
+        render: (row) => fmtDateTime(row.date)
+    },
+    {
+        title: 'Release',
+        key: 'release',
+        render: (row) => h('code', {}, (row.release || '').slice(0, 8))
+    },
+    {
+        title: 'Outcome',
+        key: 'validationResult',
+        width: 110,
+        render: (row) => h(NTag, { type: validationTag(row.validationResult), size: 'small', bordered: false },
+            { default: () => row.validationResult })
+    }
+]
+
+async function load () {
+    if (prUuid.value) {
+        pr.value = await store.dispatch('fetchPullRequest', prUuid.value)
+        if (pr.value?.org) {
+            await store.dispatch('fetchVcsReposOfOrganization', pr.value.org)
+        }
+    }
+}
+
+onMounted(load)
+watch(prUuid, load)
+</script>
+
+<style scoped lang="scss">
+.prView { padding: 1rem; }
+.title-line { color: #555; margin-top: -0.5rem; }
+.meta {
+    background: #fafafa;
+    border: 1px solid #eee;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    p { margin: 0.25rem 0; }
+}
+.empty { color: #888; font-style: italic; }
+.mt-4 { margin-top: 1.25rem; }
+</style>

--- a/ui/src/components/PullRequestsOfOrg.vue
+++ b/ui/src/components/PullRequestsOfOrg.vue
@@ -1,0 +1,126 @@
+<template>
+    <div class="prsOfOrg">
+        <h4>Pull Requests</h4>
+
+        <n-input
+            v-model:value="searchQuery"
+            round
+            clearable
+            placeholder="Filter by identity, title, or VCS"
+            :style="{ 'max-width': '400px', 'margin': '10px 0' }">
+            <template #suffix>
+                <n-icon size="18"><Search/></n-icon>
+            </template>
+        </n-input>
+
+        <n-data-table
+            :columns="columns"
+            :data="filtered"
+            :pagination="{ pageSize: 25 }"/>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, RouterLink } from 'vue-router'
+import { NDataTable, NIcon, NInput, NTag, DataTableColumns } from 'naive-ui'
+import { Search } from '@vicons/tabler'
+
+const store = useStore()
+const route = useRoute()
+const orgUuid = computed(() => route.params.orguuid as string)
+const searchQuery = ref('')
+const prs = ref<any[]>([])
+
+const stateTagType = (s: string) => s === 'OPEN' ? 'success' : (s === 'MERGED' ? 'info' : 'default')
+
+const fmt = (raw: string | null | undefined) => {
+    if (!raw) return '—'
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) return '—'
+    return d.toLocaleDateString('en-CA')
+}
+
+const vcsName = (uuid: string) => {
+    if (!uuid) return '—'
+    const repo = store.getters.vcsRepoById(uuid)
+    return repo?.name || uuid.slice(0, 8) + '…'
+}
+
+const columns: DataTableColumns<any> = [
+    {
+        title: 'Identity',
+        key: 'identity',
+        width: 130,
+        render: (row) => h(RouterLink as any,
+            { to: { name: 'PullRequestView', params: { uuid: row.uuid } } },
+            { default: () => row.identity || row.uuid.slice(0, 8) })
+    },
+    {
+        title: 'Title',
+        key: 'title',
+        render: (row) => row.title || '—'
+    },
+    {
+        title: 'State',
+        key: 'state',
+        width: 100,
+        render: (row) => h(NTag, { type: stateTagType(row.state), size: 'small', bordered: false },
+            { default: () => row.state || '—' })
+    },
+    {
+        title: 'Target VCS',
+        key: 'targetVcsRepository',
+        render: (row) => vcsName(row.targetVcsRepository)
+    },
+    {
+        title: 'Commits',
+        key: 'commits',
+        width: 90,
+        render: (row) => (row.commits || []).length
+    },
+    {
+        title: 'Created',
+        key: 'createdDate',
+        width: 110,
+        render: (row) => fmt(row.prCreatedDate || row.createdDate)
+    },
+    {
+        title: 'Closed',
+        key: 'closedDate',
+        width: 110,
+        render: (row) => fmt(row.closedDate)
+    },
+    {
+        title: 'Endpoint',
+        key: 'endpoint',
+        render: (row) => {
+            if (!row.endpoint) return '—'
+            return h('a', { href: row.endpoint, target: '_blank', rel: 'noopener' },
+                row.endpoint.replace(/^https?:\/\//, ''))
+        }
+    }
+]
+
+const filtered = computed(() => {
+    const q = searchQuery.value.trim().toLowerCase()
+    if (!q) return prs.value
+    return prs.value.filter((pr) => {
+        return (pr.identity || '').toLowerCase().includes(q)
+            || (pr.title || '').toLowerCase().includes(q)
+            || vcsName(pr.targetVcsRepository).toLowerCase().includes(q)
+    })
+})
+
+onMounted(async () => {
+    if (orgUuid.value) {
+        await store.dispatch('fetchVcsReposOfOrganization', orgUuid.value)
+        prs.value = (await store.dispatch('fetchPullRequestsOfOrg', orgUuid.value)) || []
+    }
+})
+</script>
+
+<style scoped lang="scss">
+.prsOfOrg { padding: 1rem; }
+</style>

--- a/ui/src/components/VcsRepository.vue
+++ b/ui/src/components/VcsRepository.vue
@@ -1,41 +1,189 @@
 <template>
     <div class="vcsRepoView">
-        <h1 v-if="vcsRepo">Vcs Repository - {{ vcsRepo.name }}</h1>
-        <div v-if="vcsRepo">URI: {{ vcsRepo.uri }}</div>
+        <div v-if="vcsRepo">
+            <h1>VCS Repository — {{ vcsRepo.name }}</h1>
+            <div class="meta">URI: {{ vcsRepo.uri }}</div>
 
-        <h5>Branches using this repository:</h5>
+            <h3 class="mt-4">
+                Pull-request validation
+                <n-tooltip trigger="hover">
+                    <template #trigger>
+                        <n-icon size="16" style="cursor: help;">
+                            <QuestionMark />
+                        </n-icon>
+                    </template>
+                    Optional EXTERNAL_VALIDATION trigger that the PR aggregator uses to dispatch the
+                    aggregated check-run verdict to the SCM. At most one trigger per VCS repository.
+                </n-tooltip>
+            </h3>
+
+            <div v-if="!editing && !currentTrigger" class="empty">
+                <p>No PR validation trigger configured.</p>
+                <n-button @click="startEdit">Add validation trigger</n-button>
+            </div>
+
+            <div v-if="!editing && currentTrigger" class="trigger-summary">
+                <p><strong>Name:</strong> {{ currentTrigger.name || '—' }}</p>
+                <p><strong>Integration:</strong> {{ currentTrigger.integration || '—' }}</p>
+                <p><strong>Installation ID:</strong> {{ currentTrigger.schedule || '—' }}</p>
+                <p><strong>Check name override:</strong> {{ currentTrigger.checkName || '(default)' }}</p>
+                <n-space>
+                    <n-button @click="startEdit">Edit</n-button>
+                    <n-button type="error" @click="clearTrigger">Remove</n-button>
+                </n-space>
+            </div>
+
+            <n-form v-if="editing" :model="draft" label-placement="top" class="mt-3">
+                <n-form-item label="Name" required>
+                    <n-input v-model:value="draft.name" placeholder="e.g. PR validation"/>
+                </n-form-item>
+                <n-form-item label="Integration UUID (GITHUB_VALIDATE)" required>
+                    <n-input v-model:value="draft.integration" placeholder="UUID of the GitHub validation integration"/>
+                </n-form-item>
+                <n-form-item label="GitHub installation ID">
+                    <n-input v-model:value="draft.schedule" placeholder="(optional) GitHub App installation id"/>
+                </n-form-item>
+                <n-form-item label="Check name override">
+                    <n-input v-model:value="draft.checkName" placeholder="(optional) defaults to rearm/pr/<identity>"/>
+                </n-form-item>
+                <n-space>
+                    <n-button type="primary" :disabled="!draft.name || !draft.integration" @click="saveTrigger">Save</n-button>
+                    <n-button @click="cancelEdit">Cancel</n-button>
+                </n-space>
+            </n-form>
+        </div>
     </div>
 </template>
 
-<script>
+<script setup lang="ts">
+import { computed, reactive, ref, onMounted, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
+import { NButton, NForm, NFormItem, NIcon, NInput, NSpace, NTooltip, useNotification } from 'naive-ui'
+import { QuestionMark } from '@vicons/tabler'
 
-export default {
-    name: 'VcsRepository',
-    components: {
-    },
-    data () {
-        return {
-            vcsRepoUuid: this.$route.params.uuid
+const store = useStore()
+const route = useRoute()
+const notification = useNotification()
+
+const vcsRepoUuid = computed(() => route.params.uuid as string)
+const editing = ref(false)
+const draft = reactive({
+    uuid: '',
+    name: '',
+    type: 'EXTERNAL_VALIDATION',
+    integration: '',
+    schedule: '',
+    checkName: '',
+    eventType: '',
+    clientPayload: '',
+    celClientPayload: ''
+})
+
+const vcsRepo = computed(() => store.getters.vcsRepoById(vcsRepoUuid.value))
+const currentTrigger = computed(() => {
+    const triggers = vcsRepo.value?.outputTriggers
+    return triggers && triggers.length > 0 ? triggers[0] : null
+})
+
+const startEdit = () => {
+    if (currentTrigger.value) {
+        Object.assign(draft, {
+            uuid: currentTrigger.value.uuid || '',
+            name: currentTrigger.value.name || '',
+            type: 'EXTERNAL_VALIDATION',
+            integration: currentTrigger.value.integration || '',
+            schedule: currentTrigger.value.schedule || '',
+            checkName: currentTrigger.value.checkName || '',
+            eventType: currentTrigger.value.eventType || '',
+            clientPayload: currentTrigger.value.clientPayload || '',
+            celClientPayload: currentTrigger.value.celClientPayload || ''
+        })
+    } else {
+        Object.assign(draft, {
+            uuid: '',
+            name: '',
+            type: 'EXTERNAL_VALIDATION',
+            integration: '',
+            schedule: '',
+            checkName: '',
+            eventType: '',
+            clientPayload: '',
+            celClientPayload: ''
+        })
+    }
+    editing.value = true
+}
+
+const cancelEdit = () => { editing.value = false }
+
+const saveTrigger = async () => {
+    try {
+        const trigger = {
+            uuid: draft.uuid || undefined,
+            name: draft.name,
+            type: 'EXTERNAL_VALIDATION',
+            integration: draft.integration,
+            schedule: draft.schedule || null,
+            checkName: draft.checkName || null,
+            eventType: draft.eventType || null,
+            clientPayload: draft.clientPayload || null,
+            celClientPayload: draft.celClientPayload || null
         }
-    },
-    props: {
-
-    },
-    methods: {
-
-    },
-    created () {
-        this.$store.dispatch('fetchVcsRepo', this.vcsRepoUuid)
-    },
-    computed: {
-        vcsRepo () {
-            return this.$store.getters.vcsRepoById(this.vcsRepoUuid)
-        }
+        await store.dispatch('setVcsRepoOutputTriggers', {
+            vcsUuid: vcsRepoUuid.value,
+            triggers: [trigger]
+        })
+        notification.success({ title: 'Saved', content: 'PR validation trigger updated.', duration: 3500 })
+        editing.value = false
+    } catch (e: any) {
+        notification.error({ title: 'Save failed', content: e?.message || 'Unknown error', duration: 5000 })
     }
 }
 
+const clearTrigger = async () => {
+    try {
+        await store.dispatch('setVcsRepoOutputTriggers', {
+            vcsUuid: vcsRepoUuid.value,
+            triggers: []
+        })
+        notification.success({ title: 'Removed', content: 'PR validation trigger cleared.', duration: 3500 })
+    } catch (e: any) {
+        notification.error({ title: 'Remove failed', content: e?.message || 'Unknown error', duration: 5000 })
+    }
+}
+
+onMounted(() => {
+    if (vcsRepoUuid.value) {
+        store.dispatch('fetchVcsRepo', vcsRepoUuid.value)
+    }
+})
+
+watch(vcsRepoUuid, (uuid) => {
+    if (uuid) store.dispatch('fetchVcsRepo', uuid)
+})
 </script>
 
 <style scoped lang="scss">
-
+.vcsRepoView {
+    padding: 1rem;
+}
+.meta {
+    color: #555;
+    margin-bottom: 1rem;
+}
+.empty {
+    color: #777;
+    font-style: italic;
+    padding: 0.5rem 0;
+}
+.trigger-summary {
+    background: #fafafa;
+    border: 1px solid #eee;
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    p { margin: 0.25rem 0; }
+}
+.mt-3 { margin-top: 0.75rem; }
+.mt-4 { margin-top: 1rem; }
 </style>

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -19,9 +19,24 @@ const routes : any[] = [
         component: () => import('@/components/SystemSettings.vue')
     },
     {
-        path: '/componentsOfOrg/:orguuid/:compuuid?/:branchuuid?/:prnumber?',
+        path: '/componentsOfOrg/:orguuid/:compuuid?/:branchuuid?',
         name: 'ComponentsOfOrg',
         component: () => import('@/components/ComponentsOfOrg.vue')
+    },
+    {
+        path: '/pullRequestsOfOrg/:orguuid',
+        name: 'PullRequestsOfOrg',
+        component: () => import('@/components/PullRequestsOfOrg.vue')
+    },
+    {
+        path: '/pullRequest/show/:uuid',
+        name: 'PullRequestView',
+        component: () => import('@/components/PullRequestView.vue')
+    },
+    {
+        path: '/vcsRepository/:uuid',
+        name: 'VcsRepository',
+        component: () => import('@/components/VcsRepository.vue')
     },
     {
         path: '/productsOfOrg/:orguuid/:compuuid?/:branchuuid?',

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1110,6 +1110,18 @@ const storeObject : any = {
                             org
                             uri
                             type
+                            outputTriggers {
+                                uuid
+                                name
+                                type
+                                integration
+                                vcs
+                                schedule
+                                eventType
+                                clientPayload
+                                celClientPayload
+                                checkName
+                            }
                         }
                     }`,
                 variables: {
@@ -1119,6 +1131,104 @@ const storeObject : any = {
             })
             context.commit('ADD_VCS_REPO', response.data.vcsRepository)
             return response.data.vcsRepository
+        },
+        async setVcsRepoOutputTriggers (context: any, payload: { vcsUuid: string, triggers: any[] }) {
+            const data = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setVcsRepositoryOutputTriggers($vcsUuid: ID!, $triggers: [ReleaseOutputEventInput!]!) {
+                        setVcsRepositoryOutputTriggers(vcsUuid: $vcsUuid, triggers: $triggers) {
+                            uuid
+                            name
+                            org
+                            uri
+                            type
+                            outputTriggers {
+                                uuid
+                                name
+                                type
+                                integration
+                                vcs
+                                schedule
+                                eventType
+                                clientPayload
+                                celClientPayload
+                                checkName
+                            }
+                        }
+                    }`,
+                variables: {
+                    vcsUuid: payload.vcsUuid,
+                    triggers: payload.triggers
+                }
+            })
+            context.commit('ADD_VCS_REPO', data.data.setVcsRepositoryOutputTriggers)
+            return data.data.setVcsRepositoryOutputTriggers
+        },
+        async fetchPullRequestsOfOrg (context: any, org: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query pullRequestsOfOrg($orgUuid: ID!) {
+                        pullRequestsOfOrg(orgUuid: $orgUuid) {
+                            uuid
+                            org
+                            targetVcsRepository
+                            sourceVcsRepository
+                            identity
+                            state
+                            title
+                            sourceBranchName
+                            targetBranchName
+                            endpoint
+                            commits
+                            prCreatedDate
+                            closedDate
+                            mergedDate
+                            createdDate
+                        }
+                    }`,
+                variables: { orgUuid: org },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.pullRequestsOfOrg
+        },
+        async fetchPullRequest (context: any, prUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query pullRequest($prUuid: ID!) {
+                        pullRequest(prUuid: $prUuid) {
+                            uuid
+                            org
+                            targetVcsRepository
+                            sourceVcsRepository
+                            identity
+                            state
+                            title
+                            sourceBranchName
+                            targetBranchName
+                            endpoint
+                            commits
+                            prCreatedDate
+                            closedDate
+                            mergedDate
+                            createdDate
+                            prValidationEvents {
+                                date
+                                validationState
+                                comment
+                                sourceCodeEntry
+                                attributedReleases
+                            }
+                            releaseValidationEvents {
+                                release
+                                date
+                                validationResult
+                            }
+                        }
+                    }`,
+                variables: { prUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.pullRequest
         },
         async updateVcsRepo (context: any, vcsRepoProps: any) {
             const data = await graphqlClient.mutate({

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -470,12 +470,6 @@ const singleReleaseDataNoParent = `
         uuid
         name
         vcs
-        pullRequests {
-            endpoint
-            number
-            commits
-            title
-        }
     }
     componentDetails {
         uuid
@@ -636,12 +630,6 @@ const SINGLE_RELEASE_GQL_DATA_LIGHT = `
     branchDetails {
         uuid
         name
-        pullRequests {
-            endpoint
-            number
-            commits
-            title
-        }
     }
     componentDetails {
         uuid
@@ -828,16 +816,6 @@ const BRANCH_GQL_DATA = `
         uri
         type
         createdType
-    }
-    pullRequests {
-        number
-        state
-        title
-        endpoint
-        targetBranch
-        createdDate
-        closedDate
-        mergedDate
     }
 `
 


### PR DESCRIPTION
## Summary

UI counterpart to the backend PullRequest entity work (https://github.com/relizaio/rearm-saas/pull/39).

- Drops the `BranchView` `pullRequestData` panel and `Branch.pullRequests` GraphQL fields (source-of-truth moved to a dedicated `PullRequest` entity on the backend).
- `VcsRepository.vue` gains a PR-validation trigger editor — at most one `EXTERNAL_VALIDATION` trigger; the aggregator dispatches with this config when re-folding releases attributed to an open PR.
- New `PullRequestsOfOrg.vue` and `PullRequestView.vue` — list + detail surfaces for the entity, exposing both event streams (outbound dispatches + inbound release contributions).
- Wires the existing `/pullRequest/show/:uuid` link the backend emits on check-run `details_url`.
- Drops the now-unused `:prnumber?` param on the `ComponentsOfOrg` route.

## Test plan

- [x] `vite build` clean (4.6 MB index, no errors).
- [ ] No browser smoke test yet — sandbox UI deploy goes through the rearm CE rebom flow which hasn't been triggered.
- [ ] After deploy: open `/pullRequestsOfOrg/<org>` for a run org with PRs upserted via the integration test harness, click into one detail page, verify both event-stream tables render (empty initially).
- [ ] After deploy: open a VCS detail page, add an `EXTERNAL_VALIDATION` trigger, verify the form persists and re-fetches with the saved fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)