### PR TITLE
feat(ui): expose VcsRepository detail + Pull Requests nav

### DIFF
--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -44,7 +44,7 @@ import { ref, h, Component, ComputedRef, computed, Ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 import { HomeOutlined as HomeIcon, CloudServerOutlined, BugOutlined } from '@vicons/antd'
-import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar } from '@vicons/tabler'
+import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest } from '@vicons/tabler'
 
 
 function renderIcon (icon: Component) {
@@ -113,6 +113,21 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
                 ),
             key: 'vcsRepos',
             icon: renderIcon(BrandGit)
+        },
+        {
+            label: () =>
+                h(
+                    RouterLink,
+                    {
+                        to: {
+                            name: 'PullRequestsOfOrg',
+                            params: {orguuid: org}
+                        }
+                    },
+                    { default: () => 'Pull Requests' }
+                ),
+            key: 'pullRequests',
+            icon: renderIcon(GitPullRequest)
         },
 
     ]
@@ -222,6 +237,9 @@ const routeToMenuKey: Record<string, string> = {
     'ComponentsOfOrg': 'components',
     'ProductsOfOrg': 'products',
     'VcsReposOfOrg': 'vcsRepos',
+    'VcsRepository': 'vcsRepos',
+    'PullRequestsOfOrg': 'pullRequests',
+    'PullRequestView': 'pullRequests',
     'InstancesOfOrg': 'instances',
     'Instance': 'instances',
     'SecretsOfOrg': 'secrets',

--- a/ui/src/components/VcsReposOfOrg.vue
+++ b/ui/src/components/VcsReposOfOrg.vue
@@ -71,7 +71,8 @@ import { NInput, NModal, NCard, NDataTable, useNotification, NotificationType, N
 import { ComputedRef, h, ref, Ref, computed, Component, reactive, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute } from 'vue-router'
-import { CirclePlus, Edit as EditIcon, ExternalLink, Eye, Check, X, Trash, Search } from '@vicons/tabler'
+import { CirclePlus, Edit as EditIcon, ExternalLink, Eye, Check, X, Trash, Search, Settings } from '@vicons/tabler'
+import { useRouter } from 'vue-router'
 import { Icon } from '@vicons/utils'
 import CreateVcsRepository from '@/components/CreateVcsRepository.vue'
 import commonFunctions from '@/utils/commonFunctions'
@@ -79,6 +80,7 @@ import { Info20Regular, Copy20Regular } from '@vicons/fluent'
 import Swal from 'sweetalert2'
 
 const route = useRoute()
+const router = useRouter()
 const store = useStore()
 
 const myorg: ComputedRef<string> = computed((): any => store.getters.myorg)
@@ -372,13 +374,22 @@ const vcsRepoFields: any[] = [
                         )
                     ]),
                     h(
-                        NIcon, 
+                        NIcon,
+                        {
+                            title: 'Open VCS settings (PR validation trigger)',
+                            class: 'icons clickable',
+                            size: 25,
+                            onClick: () => router.push({ name: 'VcsRepository', params: { uuid: row.uuid } })
+                        },
+                        () => h(Settings)),
+                    h(
+                        NIcon,
                         {
                             title: 'View Connected Components',
                             class: 'icons clickable',
                             size: 25,
                             onClick: () => showConnectedComponentsModal(row.uuid)
-                        }, 
+                        },
                         () => h(Eye)),
                     h(
                         NTooltip, {


### PR DESCRIPTION
## Summary

Follow-up to #26. The merged PR added the VcsRepository detail page (PR-validation trigger editor) and the `PullRequestsOfOrg` / `PullRequestView` surfaces, but nothing in the chrome linked to them.

- **Settings cog** in each row of `VcsReposOfOrg` actions column → routes to `/vcsRepository/<uuid>`.
- **"Pull Requests"** entry in the left nav under VCS → routes to `/pullRequestsOfOrg/<orguuid>`. Route-to-menu-key map covers `VcsRepository` and `PullRequestView` detail routes too so the nav highlight stays correct on drill-down.

## Test plan

- [x] `vite build` clean.
- [ ] Open `/vcsReposOfOrg/<org>` → click the cog on a row → confirm `/vcsRepository/<uuid>` loads with the trigger editor.
- [ ] Click "Pull Requests" in left nav → confirm `/pullRequestsOfOrg/<org>` loads; click into a PR detail and confirm the "Pull Requests" entry stays highlighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)