### PR TITLE
fix(rebom): default metadata.component.type to application when missing

### DIFF
--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -263,8 +263,18 @@ export function augmentBomWithComponentContext(bom: any, componentDetails: Rebom
   const newPurl = establishPurl(origPurl, componentDetails);
   logger.debug(`established purl: ${newPurl}`);
 
+  // metadata.component.type is required by CycloneDX. Some scanners
+  // emit a BOM with no metadata.component at all (or with one missing
+  // the type field) — without this fallback those BOMs fail downstream
+  // schema validation, e.g. Dependency-Track rejects with
+  // `$.metadata.component.type: does not have a value in the
+  // enumeration [...]`. Existing type wins; "application" is the
+  // safest default for a release-level BOM (the BOM identifies a
+  // component the org ships, not a library it consumes).
+  const existingType = (bom.metadata && bom.metadata.component && bom.metadata.component.type) || undefined;
   newMetadata.component = {
     ...newMetadata.component,
+    type: existingType || 'application',
     purl: newPurl,
     ['bom-ref']: newPurl,
     name: componentDetails.name,

--- a/rebom-backend/test/unit/bomProcessingService.test.ts
+++ b/rebom-backend/test/unit/bomProcessingService.test.ts
@@ -382,27 +382,73 @@ describe('BOM Processing Service - Unit Tests', () => {
             const originalVersion = bom.version;
             const originalComponentCount = bom.components.length;
             const originalDependencyCount = bom.dependencies?.length || 0;
-            
+
             const rebomOptions: any = { name: 'test', group: 'com.test', version: '1.0.0' };
             const timestamp = new Date().toISOString();
-            
+
             const overriddenBom = BomProcessingService.overrideRootComponent(bom, rebomOptions, timestamp);
-            
+
             // Validate core BOM fields unchanged
             expect(overriddenBom.bomFormat).toBe(originalBomFormat);
             expect(overriddenBom.specVersion).toBe(originalSpecVersion);
             expect(overriddenBom.serialNumber).toBe(originalSerialNumber);
             expect(overriddenBom.version).toBe(originalVersion);
-            
+
             // Validate components array unchanged
             expect(overriddenBom.components).toEqual(bom.components);
             expect(overriddenBom.components.length).toBe(originalComponentCount);
-            
+
             // Validate dependencies unchanged if present
             if (bom.dependencies) {
                 expect(overriddenBom.dependencies).toEqual(bom.dependencies);
                 expect(overriddenBom.dependencies.length).toBe(originalDependencyCount);
             }
+        });
+
+        // Real-world regression: scanners that emit no metadata.component
+        // (or one missing the `type` field) used to slip through
+        // augmentation untouched and then fail downstream Dependency-Track
+        // schema validation with `$.metadata.component.type: does not have
+        // a value in the enumeration [...]`. The augmenter now stamps
+        // `type: 'application'` as a default so the augmented BOM is
+        // self-sufficient.
+        it('should default metadata.component.type to "application" when input BOM has no metadata.component', () => {
+            const bom: any = {
+                bomFormat: 'CycloneDX',
+                specVersion: '1.5',
+                serialNumber: 'urn:uuid:00000000-0000-0000-0000-000000000001',
+                version: 1,
+                metadata: { timestamp: '2026-01-01T00:00:00Z' },
+                components: []
+            };
+            const rebomOptions: any = { name: 'no-meta-app', group: 'com.example', version: '1.2.3' };
+            const augmented = BomProcessingService.augmentBomWithComponentContext(bom, rebomOptions);
+            expect(augmented.metadata.component).toBeDefined();
+            expect(augmented.metadata.component.type).toBe('application');
+            expect(augmented.metadata.component.name).toBe('no-meta-app');
+            expect(augmented.metadata.component.version).toBe('1.2.3');
+            expect(augmented.metadata.component.group).toBe('com.example');
+        });
+
+        it('should preserve an existing metadata.component.type rather than overriding it', () => {
+            const bom: any = {
+                bomFormat: 'CycloneDX',
+                specVersion: '1.5',
+                serialNumber: 'urn:uuid:00000000-0000-0000-0000-000000000002',
+                version: 1,
+                metadata: {
+                    timestamp: '2026-01-01T00:00:00Z',
+                    component: { type: 'library', name: 'pre-existing', version: '0.1.0' }
+                },
+                components: []
+            };
+            const rebomOptions: any = { name: 'override', group: 'com.example', version: '1.2.3' };
+            const augmented = BomProcessingService.augmentBomWithComponentContext(bom, rebomOptions);
+            // Existing type wins — augmenter only fills the default when missing.
+            expect(augmented.metadata.component.type).toBe('library');
+            // Other fields still get overridden by rebomOptions per the
+            // documented augmenter contract.
+            expect(augmented.metadata.component.name).toBe('override');
         });
     });
 


### PR DESCRIPTION
## Summary

Some scanners emit a CycloneDX BOM with no `metadata.component` (or one missing the `type` field). The rebom augmenter spread existing fields onto a synthetic root component but never stamped a default `type`, so those BOMs slipped through unchanged and then failed downstream Dependency-Track schema validation:

```
$.metadata.component.type: does not have a value in the enumeration
["application","framework","library","container","operating-system",
 "device","firmware","file"]
```

This was the same DTrack rejection class we debugged before — only this time the augmenter, not the SBOM, was the place to fix it.

### Fix

In `augmentBomWithComponentContext`, default `metadata.component.type` to `"application"` when not present. Existing type wins (we don't override `library` / `framework` / etc. that scanners do set explicitly). `"application"` is the safest default for a release-level BOM since the BOM identifies a component the org ships, not a library it consumes. Name / version / group already come from `RebomOptions`, which is wired from the ReARM release at attach time, so the augmented BOM is self-sufficient even when the raw input was bare.

### Tests

- **New**: missing-`metadata.component` input → augmenter stamps `type: "application"` plus the rebom-supplied name / version / group.
- **New**: existing `metadata.component.type: "library"` → augmenter preserves `library`, doesn't downgrade.
- Existing 26 augmenter / processing tests untouched, all green.

## Test plan

- [x] `npx vitest run test/unit/bomProcessingService.test.ts` — 28 / 28 pass.
- [ ] After deploy: re-upload one of the affected raw SBOMs and confirm the DTrack ingest no longer 400s on `$.metadata.component.type`.

Generated with Claude Code