### PR TITLE
fix(ui): PR view query — SourceCodeEntry.vcsUuid not .vcs

### DIFF
--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1229,7 +1229,7 @@ const storeObject : any = {
                                 commitMessage
                                 commitAuthor
                                 commitEmail
-                                vcs
+                                vcsUuid
                                 vcsBranch
                                 dateActual
                             }


### PR DESCRIPTION
Follow-up to the merged PR view polish (#30). Discovered while wiring an end-to-end probe for the new resolver fields against psclaude.

The `pullRequest` query in `store.ts` selected `commitDetails { vcs }`, but the GraphQL `SourceCodeEntry` type exposes the field as `vcsUuid` (not `vcs`). Server-side schema validation rejects with HTTP 400 (`Validation error type FieldUndefined@[…/vcs]`). On dev the Reliza WAF replaces the JSON GraphQL error body with its generic-error HTML page on 400, which is why the response looked WAF-shaped and nothing showed up in backend application logs.

One-character schema fix. Caught end-to-end by the new `@pull_requests` scenario on rearm-integration-tests (10/10 pass on psclaude with the fix).

## Test plan

- [x] `vite build` clean.
- [x] `npm run test:pull_requests` against psclaude: 10/10 including the new resolver-fields probe.
- [ ] After deploy on dev: open PR detail page, confirm head SHA renders + page loads without 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)