### PR TITLE
feat(ui): expose INVALIDATE_PR trigger option + render PENDING verdict

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1675,7 +1675,8 @@ const outputTriggerTypeOptions = [
     {label: 'Email Notification', value: 'EMAIL_NOTIFICATION'},
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'},
-    {label: 'Validate Pull Request', value: 'VALIDATE_PR'}
+    {label: 'Validate Pull Request', value: 'VALIDATE_PR'},
+    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'}
 ]
 
 const externalValidationConclusionOptions = [

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -5602,7 +5602,8 @@ const outputTriggerTypeOptions = [
     {label: 'Email Notification', value: 'EMAIL_NOTIFICATION'},
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'},
-    {label: 'Validate Pull Request', value: 'VALIDATE_PR'}
+    {label: 'Validate Pull Request', value: 'VALIDATE_PR'},
+    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'}
 ]
 
 const externalValidationConclusionOptions = [

--- a/ui/src/components/PullRequestView.vue
+++ b/ui/src/components/PullRequestView.vue
@@ -98,6 +98,7 @@ const stateTag = (s: string) => s === 'OPEN' ? 'success' : (s === 'MERGED' ? 'in
 const validationTag = (v: string) => {
     if (v === 'SUCCESS') return 'success'
     if (v === 'FAILURE' || v === 'CANCELLED') return 'error'
+    if (v === 'PENDING') return 'warning'
     return 'default'
 }
 


### PR DESCRIPTION
## Summary

- Add **Invalidate Pull Request** option to outputTrigger type dropdowns in OrgSettings + ComponentView, paired with the new `EventType.INVALIDATE_PR` backend value (failure-side companion to `VALIDATE_PR`).
- PR view: map the new `ValidationState.PENDING` to a "warning" tag so the in-flight verdict is visually distinct from terminal SUCCESS/FAILURE/NEUTRAL outcomes.

Backend PR: relizaio/rearm-saas#43

## Test plan

- [ ] OrgSettings → output triggers → dropdown shows "Invalidate Pull Request"
- [ ] ComponentView → output triggers → dropdown shows "Invalidate Pull Request"
- [ ] PR view: a `PENDING` `prValidationEvent` row renders with the warning (yellow) tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)