### PR TITLE
feat(ui): expose PR_COMMENT output trigger + integration / payload fields

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -540,6 +540,43 @@
                                                     <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
                                                         <n-input v-model:value="outputTrigger.checkName" :placeholder="'Defaults to rearm/' + (updatedComponent.name || '<component>')" />
                                                     </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Choose Validation Integration" path="integration">
+                                                        <n-select
+                                                            v-model:value="outputTrigger.integration"
+                                                            placeholder="Select GitHub Validate Integration"
+                                                            :options="validationIntegrationsForSelect" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Installation ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="clientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Optional Comment Suffix (markdown)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    Static markdown appended to ReARM's auto-generated PR comment body (header / metrics / PR conditions are kept). Use this for organisation-wide footers — links to runbooks, escalation contacts, etc. Leave empty to use the default body unchanged.
+                                                                </n-tooltip>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder="### See also&#10;- [Runbook](https://...)" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="celClientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Dynamic Comment Suffix (CEL string expression)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    CEL expression evaluated at fire time. Result must be a markdown string. Appended to the auto-generated body — additive, not a replacement (contrast with External Validation, which substitutes). Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
+                                                                </n-tooltip>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"_Triggered for release " + release.version + "._"' />
+                                                    </n-form-item>
                                                     <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Users to notify" path="users">
                                                         <n-select v-model:value="outputTrigger.users" tag multiple required :options="users" />
                                                     </n-form-item>
@@ -1676,7 +1713,8 @@ const outputTriggerTypeOptions = [
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'},
     {label: 'Validate Pull Request', value: 'VALIDATE_PR'},
-    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'}
+    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'},
+    {label: 'Pull Request Comment', value: 'PR_COMMENT'}
 ]
 
 const externalValidationConclusionOptions = [

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -692,6 +692,18 @@
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
                                         <n-input v-model:value="globalOutputEvent.checkName" placeholder="Defaults to rearm/<componentName>; override e.g. rearm/policy" />
                                     </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'PR_COMMENT'" label="Choose Validation Integration" path="integration">
+                                        <n-select v-model:value="globalOutputEvent.integration" placeholder="Select GitHub Validate Integration" :options="validationIntegrationsForGlobalSelect" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'PR_COMMENT'" label="Installation ID" path="schedule">
+                                        <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'PR_COMMENT'" label="Optional Comment Suffix (markdown)" path="clientPayload">
+                                        <n-input v-model:value="globalOutputEvent.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder="### See also&#10;- [Runbook](https://...)" />
+                                    </n-form-item>
+                                    <n-form-item v-if="globalOutputEvent.type === 'PR_COMMENT'" label="Dynamic Comment Suffix (CEL string expression)" path="celClientPayload">
+                                        <n-input v-model:value="globalOutputEvent.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"_Triggered for release " + release.version + "._"' />
+                                    </n-form-item>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER'" label="Dynamic client payload (CEL string expression)" path="celClientPayload">
                                         <n-input v-model:value="globalOutputEvent.celClientPayload" style="font-family: monospace;" placeholder='"refs/tags/" + release.version' />
                                     </n-form-item>
@@ -5603,7 +5615,8 @@ const outputTriggerTypeOptions = [
     {label: 'VDR Snapshot Artifact', value: 'VDR_SNAPSHOT_ARTIFACT'},
     {label: 'Add Approved Environment', value: 'ADD_APPROVED_ENVIRONMENT'},
     {label: 'Validate Pull Request', value: 'VALIDATE_PR'},
-    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'}
+    {label: 'Invalidate Pull Request', value: 'INVALIDATE_PR'},
+    {label: 'Pull Request Comment', value: 'PR_COMMENT'}
 ]
 
 const externalValidationConclusionOptions = [


### PR DESCRIPTION
## Summary

Adds **PR_COMMENT** to the outputTrigger type dropdowns in OrgSettings (global) and ComponentView (component-local), pairing with the backend trigger type added in relizaio/rearm-saas#45.

When PR_COMMENT is selected, the form surfaces:
- **Validation Integration** picker (GitHub Validate apps only) — same picker EXTERNAL_VALIDATION uses; reuses the App token.
- **Installation ID** input.
- **Optional Comment Suffix (markdown)** — additive, NOT a replacement for the auto-generated body. Tooltip spells the difference vs EXTERNAL_VALIDATION's substitution semantic.
- **Dynamic Comment Suffix (CEL string expression)** — same evaluator and bindings.

Backend PR: relizaio/rearm-saas#45

## Test plan

- [ ] Wait for backend #45 to merge + deploy
- [ ] OrgSettings → Global Output Events → dropdown shows "Pull Request Comment"
- [ ] ComponentView → Output Triggers → dropdown shows "Pull Request Comment"
- [ ] Selecting PR_COMMENT shows integration / installation / suffix / CEL fields with the right tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)