### PR TITLE
fix(ui): Updated By column for Free Form keys + Notes tab on edit modal

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -491,23 +491,40 @@
                         @update:show="(v) => { if (!v) showFreeFormKeyPermissionsModal = false }"
                         @after-enter="blurActiveElement"
                     >
-                        <template #header>Permissions for key {{ selectedFreeFormKey.keyOrder }}</template>
+                        <template #header>Edit key {{ selectedFreeFormKey.keyOrder }}</template>
                         <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
-                            <ScopedPermissions
-                                v-model="freeFormKeyScopedPermissions"
-                                :org-uuid="orgResolved"
-                                :approval-roles="myorg.approvalRoles || []"
-                                :perspectives="perspectives"
-                                :products="orgProducts"
-                                :components="orgComponents"
-                                :instances="orgInstances"
-                                :clusters="orgClusters"
-                                :show-sbom-probing="true"
-                            />
-                            <n-space style="margin-top: 20px;">
-                                <n-button type="success" @click="updateFreeFormKeyPermissions">Save Permissions</n-button>
-                                <n-button @click="showFreeFormKeyPermissionsModal = false">Cancel</n-button>
-                            </n-space>
+                            <n-tabs v-model:value="freeFormKeyEditTab" type="line" animated>
+                                <n-tab-pane name="permissions" tab="Permissions">
+                                    <ScopedPermissions
+                                        v-model="freeFormKeyScopedPermissions"
+                                        :org-uuid="orgResolved"
+                                        :approval-roles="myorg.approvalRoles || []"
+                                        :perspectives="perspectives"
+                                        :products="orgProducts"
+                                        :components="orgComponents"
+                                        :instances="orgInstances"
+                                        :clusters="orgClusters"
+                                        :show-sbom-probing="true"
+                                    />
+                                    <n-space style="margin-top: 20px;">
+                                        <n-button type="success" @click="updateFreeFormKeyPermissions">Save Permissions</n-button>
+                                        <n-button @click="showFreeFormKeyPermissionsModal = false">Cancel</n-button>
+                                    </n-space>
+                                </n-tab-pane>
+                                <n-tab-pane name="notes" tab="Notes">
+                                    <p style="color: #555; margin-top: 0;">
+                                        Free-text notes for this key. Visible only to org admins on the Free Form Keys tab.
+                                    </p>
+                                    <n-input v-model:value="freeFormKeyNotes"
+                                        type="textarea"
+                                        :autosize="{ minRows: 4, maxRows: 16 }"
+                                        placeholder="What this key is used for, who owns it, expiry, etc." />
+                                    <n-space style="margin-top: 20px;">
+                                        <n-button type="success" @click="updateFreeFormKeyNotes">Save Notes</n-button>
+                                        <n-button @click="showFreeFormKeyPermissionsModal = false">Cancel</n-button>
+                                    </n-space>
+                                </n-tab-pane>
+                            </n-tabs>
                         </div>
                     </n-modal>
                 </div>
@@ -1319,6 +1336,13 @@ async function loadTabSpecificData (tabName: string) {
         if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "freeFormKeys") {
+        // Same as programmaticAccess — formatValuesForApiKeys() resolves
+        // the Updated By column against users.value, so the user list
+        // must be loaded *before* the keys are formatted; otherwise
+        // formatValuesForApiKeys is skipped (loadProgrammaticAccessKeys
+        // only formats when both lists are non-empty) and the column
+        // ends up blank for FREEFORM rows.
+        await loadUsers()
         if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "approvalPolicies") {
@@ -1345,6 +1369,8 @@ const showOrgSettingsUserPermissionsModal = ref(false)
 
 const showFreeFormKeyPermissionsModal = ref(false)
 const selectedFreeFormKey = ref<any>({})
+const freeFormKeyEditTab = ref<'permissions' | 'notes'>('permissions')
+const freeFormKeyNotes = ref<string>('')
 const freeFormKeyScopedPermissions = ref<any>({
     orgPermission: { type: 'NONE', functions: [], approvals: [] },
     scopedPermissions: []
@@ -3973,6 +3999,8 @@ async function editFreeFormKey(key: any) {
         orgPermission: orgPerm,
         scopedPermissions: scopedPerms
     }
+    freeFormKeyNotes.value = key.notes || ''
+    freeFormKeyEditTab.value = 'permissions'
     showFreeFormKeyPermissionsModal.value = true
 }
 
@@ -4038,6 +4066,40 @@ async function updateFreeFormKeyPermissions() {
         notify('error', 'Error', 'Failed to save key permissions. Please retry or contact support.')
     }
 
+    showFreeFormKeyPermissionsModal.value = false
+    selectedFreeFormKey.value = {}
+}
+
+async function updateFreeFormKeyNotes() {
+    if (!selectedFreeFormKey.value || !selectedFreeFormKey.value.uuid) {
+        notify('error', 'Error', 'No key selected.')
+        return
+    }
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation setNotesOnApiKey($apiKeyUuid: ID!, $notes: String) {
+                    setNotesOnApiKey(apiKeyUuid: $apiKeyUuid, notes: $notes) {
+                        uuid notes
+                    }
+                }`,
+            variables: {
+                apiKeyUuid: selectedFreeFormKey.value.uuid,
+                notes: freeFormKeyNotes.value
+            }
+        })
+        if (!resp.data.setNotesOnApiKey || !resp.data.setNotesOnApiKey.uuid) {
+            notify('error', 'Error', 'Failed to save notes.')
+            return
+        }
+        notify('success', 'Saved', 'Saved key notes successfully!')
+        await loadProgrammaticAccessKeys(false)
+    } catch (error: any) {
+        console.error(error)
+        const errorMsg = commonFunctions.parseGraphQLError(error.message)
+        notify('error', 'Error', `Failed to save key notes: ${errorMsg}`)
+        return
+    }
     showFreeFormKeyPermissionsModal.value = false
     selectedFreeFormKey.value = {}
 }
@@ -4754,11 +4816,15 @@ async function loadProgrammaticAccessKeys(useCache: boolean) {
             },
             fetchPolicy: cachePolicy
         })
-    if (users.value.length && resp.data.apiKeys.length) {
-        programmaticAccessKeys.value = resp.data.apiKeys.map((key: any) => formatValuesForApiKeys(key))
-    } else if (resp.data.apiKeys.length) {
-        programmaticAccessKeys.value = resp.data.apiKeys
-    }
+    // Always run the formatter — formatValuesForApiKeys handles an
+    // empty users.value gracefully (updatedByName falls back to '').
+    // The previous skip-when-empty branch left raw rows in
+    // programmaticAccessKeys, which the FREEFORM table's computed
+    // could later re-format once users loaded but the Programmatic
+    // Access table never could because its computed doesn't re-run
+    // formatValuesForApiKeys.
+    programmaticAccessKeys.value = (resp.data.apiKeys || [])
+        .map((key: any) => formatValuesForApiKeys(key))
 }
 
 async function handleTabSwitch(tabName: string) {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -5390,9 +5390,14 @@ const computedProgrammaticAccessKeys: ComputedRef<any> = computed((): any => {
     })
 })
 const computedFreeFormKeys: ComputedRef<any> = computed((): any => {
-    return programmaticAccessKeys.value
-        .filter((k: any) => k.type === 'FREEFORM')
-        .map((k: any) => formatValuesForApiKeys(k))
+    // Don't re-run formatValuesForApiKeys — load-time format already
+    // localized createdDate / accessDate, and a second pass on the
+    // localized strings parses as Invalid Date. Users are loaded
+    // before the keys (see loadTabSpecificData('freeFormKeys')) so
+    // updatedByName is also already resolved at load time. The
+    // computed exists only so the table re-renders if the underlying
+    // ref mutates (post-edit reload).
+    return programmaticAccessKeys.value.filter((k: any) => k.type === 'FREEFORM')
 })
 const imageRegistry: ComputedRef<any> = computed((): any => {
     let content = '### OCI Container Images (Suitable for Docker and Helm):\n'


### PR DESCRIPTION
## Summary

Two changes on the Free Form Keys tab:

1. **Updated By column was empty for every Free Form row.** \`loadTabSpecificData('freeFormKeys')\` was missing the \`await loadUsers()\` call that the \`programmaticAccess\` tab does — \`loadProgrammaticAccessKeys\` gates the formatter on a non-empty \`users.value\`, so cold-opening the Free Form tab left rows raw. Added the same \`await loadUsers()\` and made the formatter unconditional (handles empty users gracefully). The Programmatic Access tab worked because users were always loaded before keys; Free Form had a different code path that didn't.
2. **New Notes tab on the Free Form key edit modal** alongside the existing Permissions content. Calls the new \`setNotesOnApiKey\` mutation so notes-only edits don't have to round-trip the full permissions list. Textarea is seeded from the row's current notes when the modal opens.

Backend PR: relizaio/rearm-saas#46

## Test plan

- [ ] Wait for backend #46 to merge + deploy
- [ ] Open the Free Form Keys tab cold — Updated By column populated for every row
- [ ] Click the edit pencil → modal opens with two tabs (Permissions | Notes)
- [ ] Notes tab shows current notes; saving via the new mutation persists the change and the row's Updated By updates
- [ ] Permissions tab still works exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)