### PR TITLE
fix(ui): show INSTANCE-scope perms in FREEFORM key / user group editor

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -3873,6 +3873,30 @@ async function resolveScopedObjectName(scope: string, objectId: string): Promise
         return resolved
     }
 
+    if (scope === 'INSTANCE') {
+        // INSTANCE scope covers both clusters and per-namespace instances.
+        // Use the same display shape ScopedPermissions.vue's `instanceLabel`
+        // produces so the loaded perm matches what "Add instance"/"Add cluster"
+        // would have created.
+        const obj = orgInstancesAndClusters.value.find((x: any) => x.uuid === objectId)
+        if (!obj) {
+            scopedObjectNameCache.set(cacheKey, objectId)
+            return objectId
+        }
+        let resolved: string
+        if (obj.instanceType === constants.InstanceType.CLUSTER_INSTANCE) {
+            const parent = orgClusters.value.find((c: any) => Array.isArray(c.instances) && c.instances.includes(obj.uuid))
+            const parentName = parent ? parent.name : '(cluster)'
+            resolved = `${parentName} / ${obj.namespace || obj.uuid}`
+        } else if (obj.instanceType === constants.InstanceType.CLUSTER) {
+            resolved = obj.name || obj.uri || obj.uuid
+        } else {
+            resolved = obj.uri || obj.name || obj.uuid
+        }
+        scopedObjectNameCache.set(cacheKey, resolved)
+        return resolved
+    }
+
     const knownComponent = allComponents.value.find((c: any) => c.uuid === objectId)
     if (knownComponent) {
         scopedObjectNameCache.set(cacheKey, knownComponent.name)
@@ -3983,7 +4007,7 @@ async function editFreeFormKey(key: any) {
     for (const up of (selectedFreeFormKey.value.permissions?.permissions || [])) {
         if (up.scope === 'ORGANIZATION' && up.org === orgResolved.value) {
             orgPerm = { type: up.type, functions: up.functions || [], approvals: up.approvals || [] }
-        } else if ((up.scope === 'PERSPECTIVE' || up.scope === 'COMPONENT') && up.org === orgResolved.value) {
+        } else if ((up.scope === 'PERSPECTIVE' || up.scope === 'COMPONENT' || up.scope === 'INSTANCE') && up.org === orgResolved.value) {
             const objectName = await resolveScopedObjectName(up.scope, up.object)
             scopedPerms.push({
                 scope: up.scope,
@@ -4445,7 +4469,7 @@ async function editUserGroup(groupUuid: string) {
                         functions: p.functions || [],
                         approvals: p.approvals || []
                     }
-                } else if ((p.scope === 'PERSPECTIVE' || p.scope === 'COMPONENT') && p.org === orgResolved.value) {
+                } else if ((p.scope === 'PERSPECTIVE' || p.scope === 'COMPONENT' || p.scope === 'INSTANCE') && p.org === orgResolved.value) {
                     const objectName = await resolveScopedObjectName(p.scope, p.object)
                     scopedPerms.push({
                         scope: p.scope,


### PR DESCRIPTION
## Summary

`editFreeFormKey` and `editUserGroup` walked the stored permission list and only loaded `PERSPECTIVE` and `COMPONENT` scopes into ScopedPermissions state — every `INSTANCE`-scope grant (per-instance and per-cluster) was silently dropped. The Per-Instance Permissions section then rendered empty even when the underlying record had real INSTANCE entries, so a key with `READ_WRITE` + `[DEVOPS_READ, DEVOPS_WRITE]` on an instance looked like it had no instance access in the UI even though the backend was correctly honoring it. Worse, hitting "Save Permissions" rebuilds the wire-side permissions list from the filtered view — so a save would have wiped the missing entries.

Two-line fix in each load path: extend the scope filter to include `INSTANCE` alongside `PERSPECTIVE`/`COMPONENT`. `resolveScopedObjectName` now labels INSTANCE/CLUSTER objects using the same shape `ScopedPermissions.vue`'s `instanceLabel` produces, so the loaded card matches what "Add instance"/"Add cluster" would have created.

`editUser` keeps its legacy `instancePermissions` table for now — that path is users-only, predates ScopedPermissions for instances, and would need broader work to migrate (it doesn't track functions per instance, only the type).

## Test plan

- [x] Code review: load filters at `OrgSettings.vue:3986` (FREEFORM) and `OrgSettings.vue:4472` (UserGroup) now include `INSTANCE`. Save path at line 4025 already iterates `sp.scope` so the wire output rebuilds correctly. `resolveScopedObjectName` mirrors the `instanceLabel` logic in `ScopedPermissions.vue` so the card display matches new "Add instance" entries.
- [x] Built the UI image off this branch and switched psclaude to feature-set `2026-05-key-perms-ui-instance-scope` (paired with the `rearm-saas` PR `2026-05-product-write-no-cascade` build for backend coverage). UI pod rolled to `rearm-ui:2026-05-key-perms-ui-instance-scope.0`. Manual browser verification recommended — open a FREEFORM key with stored INSTANCE-scope permissions; the Per-Instance card should now appear with the right type/functions populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)