### PR TITLE
fix(ui): show internal UUID in Edit FREEFORM key header

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -491,7 +491,7 @@
                         @update:show="(v) => { if (!v) showFreeFormKeyPermissionsModal = false }"
                         @after-enter="blurActiveElement"
                     >
-                        <template #header>Edit key {{ selectedFreeFormKey.keyOrder }}</template>
+                        <template #header>Edit key {{ selectedFreeFormKey.uuid }}</template>
                         <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
                             <n-tabs v-model:value="freeFormKeyEditTab" type="line" animated>
                                 <n-tab-pane name="permissions" tab="Permissions">


### PR DESCRIPTION
## Summary

The Edit-key modal title rendered `selectedFreeFormKey.keyOrder` — the random per-key salt used in the key's authorization header (`FREEFORM__<orgUuid>__ord__<keyOrder>`) — not the database UUID. So "Edit key cd038257-…" shown in the modal didn't match the key record's `uuid` column, making it useless for cross-referencing logs or DB records when debugging a permission issue. Switched to `selectedFreeFormKey.uuid`.

One-line change.

## Test plan

- [x] Built on this branch and switched psclaude UI to `rearm-ui:2026-05-key-edit-internal-uuid.0` (paired with the rearm-saas firstScanned-gate backend branch — backend image visible in `kubectl get pods -n rearm`). Open any FREEFORM key for editing — the modal title should now match the key's `uuid` (database column) rather than the unrelated `keyOrder` salt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)