### PR TITLE
feat(ui): webhook management + Integration capabilities

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1055,17 +1055,25 @@ const genApiKey = function (type : string) {
 }
 
 const ciIntegrations: Ref<any[]> = ref([])
-// INTEGRATION_TRIGGER picker — exclude GITHUB_VALIDATE since those are
-// only valid targets for the EXTERNAL_VALIDATION event type.
+// INTEGRATION_TRIGGER picker — exclude GitHub integrations whose ONLY
+// capability is PR_VALIDATE, since those App credentials are reserved
+// for the EXTERNAL_VALIDATION event type (posting check-runs back to
+// GitHub) and shouldn't show up as workflow-dispatch targets.
 const ciIntegrationsForSelect: ComputedRef<any[]> = computed((): any => {
     return ciIntegrations.value
-        .filter((x: any) => x.type !== 'GITHUB_VALIDATE')
+        .filter((x: any) => {
+            if (x.type !== 'GITHUB') return true
+            const caps: string[] = x.capabilities || []
+            return caps.length === 0 || caps.includes('WORKFLOW_DISPATCH')
+        })
         .map((x: any) => {return {label: x.note, value: x.uuid}})
 })
-// EXTERNAL_VALIDATION picker — only GITHUB_VALIDATE integrations.
+// EXTERNAL_VALIDATION picker — GitHub integrations with the PR_VALIDATE
+// capability are the only valid targets for posting check-runs / PR
+// comments back to GitHub.
 const validationIntegrationsForSelect: ComputedRef<any[]> = computed((): any => {
     return ciIntegrations.value
-        .filter((x: any) => x.type === 'GITHUB_VALIDATE')
+        .filter((x: any) => x.type === 'GITHUB' && (x.capabilities || []).includes('PR_VALIDATE'))
         .map((x: any) => {return {label: x.note, value: x.uuid}})
 })
 const selectedCiIntegration: ComputedRef<any> = computed((): any => {
@@ -1385,6 +1393,7 @@ async function fetchCiIntegrations() {
                                     isEnabled
                                     type
                                     note
+                                    capabilities
                               }
                           }`,
             variables: {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -157,6 +157,10 @@
                         <h5>CI Integrations</h5>
                         <n-data-table :columns="ciIntegrationTableFields" :data="ciIntegrations" :row-key="dataTableRowKey"></n-data-table>
                         <n-button @click="showCIIntegrationModal=true">Add CI Integration</n-button>
+
+                        <div style="margin-top: 24px;">
+                            <WebhooksOfOrg :orguuid="orgResolved" />
+                        </div>
                     </template>
                 </div>
                 <n-modal
@@ -175,13 +179,22 @@
                             <n-form-item label="CI Type" path="createIntegrationObject.type">
                                 <n-radio-group v-model:value="createIntegrationObject.type" name="ciIntegrationType">
                                     <n-radio-button label="GitHub" value="GITHUB" />
-                                    <n-radio-button label="GitHub Validate" value="GITHUB_VALIDATE" />
                                     <n-radio-button label="GitLab" value="GITLAB" />
                                     <n-radio-button label="Jenkins" value="JENKINS" />
                                     <n-radio-button label="Azure DevOps" value="ADO" />
                                 </n-radio-group>
                             </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key"
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" label="Capabilities"
+                                description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK: receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch.">
+                                <n-checkbox-group v-model:value="createIntegrationObject.capabilities">
+                                    <n-space>
+                                        <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
+                                        <n-checkbox value="PR_VALIDATE" label="PR Validate" />
+                                        <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                    </n-space>
+                                </n-checkbox-group>
+                            </n-form-item>
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key"
                                 label-for="org_settings_create_github_integration_secret"
                                 description="Paste the .pem GitHub provides, upload the file directly, or paste a pre-converted DER base64 blob. Backend normalizes all three.">
                                 <n-space vertical style="width: 100%;">
@@ -204,7 +217,7 @@
                                     </n-text>
                                 </n-space>
                             </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB' || createIntegrationObject.type === 'GITHUB_VALIDATE'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
+                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
                                 label-for="org_settings_create_github_integration_appid"
                                 description="GitHub Application ID">
                                 <n-input type="number" id="org_settings_create_github_integration_appid"
@@ -1286,6 +1299,7 @@ import DownloadLogView from './DownloadLogView.vue'
 import CreateApprovalPolicy from './CreateApprovalPolicy.vue'
 import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
+import WebhooksOfOrg from './WebhooksOfOrg.vue'
 import { FetchPolicy } from '@apollo/client'
 import {ApprovalEntry, ApprovalRole, ApprovalRequirement} from '@/utils/commonTypes'
 
@@ -1928,7 +1942,8 @@ const createIntegrationObject: Ref<any> = ref({
     note: '',
     tenant: '',
     client: '',
-    schedule: ''
+    schedule: '',
+    capabilities: []
 })
 
 // Toggles between uploading the GitHub-provided .pem file directly
@@ -1956,7 +1971,8 @@ function resetCreateIntegrationObject() {
         note: '',
         tenant: '',
         client: '',
-        schedule: ''
+        schedule: '',
+        capabilities: []
     }
     uploadedSecretFileName.value = ''
 }
@@ -3036,6 +3052,14 @@ const ciIntegrationTableFields = [
     {
         key: 'type',
         title: 'Type'
+    },
+    {
+        key: 'capabilities',
+        title: 'Capabilities',
+        render: (row: any) => {
+            const caps = (row.capabilities || []) as string[]
+            return caps.length === 0 ? '—' : caps.join(', ')
+        }
     }
 ]
 
@@ -4674,6 +4698,7 @@ async function loadCiIntegrations(useCache: boolean) {
                                     isEnabled
                                     type
                                     note
+                                    capabilities
                               }
                           }`,
             variables: {
@@ -5726,17 +5751,29 @@ const outputTriggerLifecycleOptions = constants.LifecycleValueOptions
 
 const lifecycleOptions = constants.LifecycleOptions.map((lo: any) => {return {label: lo.label, value: lo.key}})
 
+// All non-validation integrations — the workflow-trigger picker shows
+// these. GitHub integrations whose ONLY capability is PR_VALIDATE
+// (i.e. App credentials reserved for posting check-runs back to GitHub)
+// are excluded so they don't show up as workflow-dispatch targets.
 const ciIntegrationsForGlobalSelect = computed((): any => {
     return ciIntegrations.value
-        .filter((ci: any) => ci.type !== 'GITHUB_VALIDATE')
+        .filter((ci: any) => {
+            if (ci.type !== 'GITHUB') return true
+            const caps: string[] = ci.capabilities || []
+            // Has WORKFLOW_DISPATCH explicitly, or no capabilities asserted
+            // (legacy / pre-capabilities rows fall back to "show it everywhere").
+            return caps.length === 0 || caps.includes('WORKFLOW_DISPATCH')
+        })
         .map((ci: any) => {
             return { label: ci.note + ' (' + ci.type + ')', value: ci.uuid }
         })
 })
 
+// Integrations that can post check-runs / PR comments back to GitHub —
+// must be GITHUB-typed with the PR_VALIDATE capability.
 const validationIntegrationsForGlobalSelect = computed((): any => {
     return ciIntegrations.value
-        .filter((ci: any) => ci.type === 'GITHUB_VALIDATE')
+        .filter((ci: any) => ci.type === 'GITHUB' && (ci.capabilities || []).includes('PR_VALIDATE'))
         .map((ci: any) => {
             return { label: ci.note, value: ci.uuid }
         })

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -254,6 +254,64 @@
                         </n-space>
                     </n-form>
                 </n-modal>
+
+                <!-- Edit CI Integration modal — GITHUB only for v1. Capabilities
+                     are always editable; if a Webhook is wired to the integration,
+                     slug + secret rotation surface inline so the operator doesn't
+                     have to bounce between two screens. -->
+                <n-modal
+                    v-if="myUser.installationType !== 'OSS'"
+                    v-model:show="showEditCiIntegrationModal"
+                    preset="dialog"
+                    :show-icon="false"
+                    style="width: 90%"
+                >
+                    <n-card style="width: 700px" size="huge"
+                        :title="'Edit CI Integration - ' + (editCiIntegrationObject.note || '')"
+                        :borderd="false" role="dialog" aria-modal="true">
+                        <n-form :model="editCiIntegrationObject">
+                            <n-space vertical size="large">
+                                <n-form-item label="Type">
+                                    <n-text>{{ editCiIntegrationObject.type }}</n-text>
+                                </n-form-item>
+                                <n-form-item label="Capabilities"
+                                    description="What this GitHub App is wired up to do. Reduce or expand without re-creating the integration.">
+                                    <n-checkbox-group v-model:value="editCiIntegrationObject.capabilities">
+                                        <n-space>
+                                            <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
+                                            <n-checkbox value="PR_VALIDATE" label="PR Validate" />
+                                            <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                        </n-space>
+                                    </n-checkbox-group>
+                                </n-form-item>
+
+                                <template v-if="editCiIntegrationObject.webhook">
+                                    <h6 style="margin-bottom: 0;">Webhook configuration</h6>
+                                    <n-form-item label="Webhook slug"
+                                        description="Lowercase a-z, 0-9, and hyphens. 4–63 chars, no leading/trailing hyphen. Changing this also changes the public URL — re-register on the GitHub App side at the same time.">
+                                        <n-input v-model:value="editCiIntegrationObject.webhook.slug" />
+                                    </n-form-item>
+                                    <n-form-item label="Rotate webhook secret"
+                                        description="Leave empty to keep the existing secret. If set, also paste the same value into the GitHub App's Webhook secret field — signature verification will fail until both sides match.">
+                                        <n-input v-model:value="editCiIntegrationObject.webhook.secret"
+                                            type="password" show-password-on="click" placeholder="(unchanged)" />
+                                    </n-form-item>
+                                </template>
+                                <template v-else>
+                                    <n-text depth="3" style="font-size: 13px;">
+                                        No webhook configured for this integration. Tick the WEBHOOK capability and use
+                                        the Webhooks section below to add one.
+                                    </n-text>
+                                </template>
+
+                                <n-space>
+                                    <n-button :loading="editCiIntegrationLoading" @click="saveEditCiIntegration" type="success">Save</n-button>
+                                    <n-button @click="showEditCiIntegrationModal=false" type="default">Cancel</n-button>
+                                </n-space>
+                            </n-space>
+                        </n-form>
+                    </n-card>
+                </n-modal>
             </n-tab-pane>
 
             <n-tab-pane name="users" tab="Users" v-if="isOrgAdmin">
@@ -1977,6 +2035,119 @@ function resetCreateIntegrationObject() {
     uploadedSecretFileName.value = ''
 }
 
+// ---- Edit GitHub CI Integration --------------------------------------------
+// Capabilities are user-editable; if a Webhook is wired to this integration,
+// the modal also exposes the webhook's slug + secret-rotate inline (one form,
+// one Save, two mutations). The existing secret is never read back — empty
+// secret input means "keep what's there".
+const editCiIntegrationObject: Ref<any> = ref({
+    uuid: '',
+    type: '',
+    note: '',
+    capabilities: [] as string[],
+    // Mirrored from the matching Webhook row when one exists; null otherwise.
+    webhook: null as null | {
+        uuid: string,
+        slug: string,
+        secret: string  // write-only; never populated on open
+    }
+})
+const showEditCiIntegrationModal: Ref<boolean> = ref(false)
+const editCiIntegrationLoading: Ref<boolean> = ref(false)
+
+async function openEditCiIntegrationModal(row: any) {
+    editCiIntegrationLoading.value = true
+    showEditCiIntegrationModal.value = true
+    editCiIntegrationObject.value = {
+        uuid: row.uuid,
+        type: row.type,
+        note: row.note,
+        capabilities: [...(row.capabilities || [])],
+        webhook: null
+    }
+    // Look up an existing webhook for this integration. There's no dedicated
+    // "by integration" query in the GraphQL surface — we list all webhooks
+    // for the org and filter client-side, which is fine at the org-config
+    // scale (handful of webhooks, not millions).
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query webhooks($orgUuid: ID!) {
+                    webhooks(orgUuid: $orgUuid) { uuid integration slug }
+                }`,
+            variables: { orgUuid: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        const wh = (resp.data?.webhooks || []).find((w: any) => w.integration === row.uuid)
+        if (wh) {
+            editCiIntegrationObject.value.webhook = {
+                uuid: wh.uuid,
+                slug: wh.slug,
+                secret: ''
+            }
+        }
+    } catch (e: any) {
+        console.error(e)
+    } finally {
+        editCiIntegrationLoading.value = false
+    }
+}
+
+async function saveEditCiIntegration() {
+    const obj = editCiIntegrationObject.value
+    try {
+        // 1. Update integration capabilities. Always called — server is
+        //    idempotent on equal lists, and skipping a noop here would mean
+        //    re-checking equality client-side, which isn't worth it.
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateIntegrationCapabilities($uuid: ID!, $capabilities: [IntegrationCapability!]!) {
+                    updateIntegrationCapabilities(uuid: $uuid, capabilities: $capabilities) {
+                        uuid capabilities
+                    }
+                }`,
+            variables: { uuid: obj.uuid, capabilities: obj.capabilities },
+            fetchPolicy: 'no-cache'
+        })
+
+        // 2. If a webhook exists and the user changed slug or set a new
+        //    secret, push that through too. updateWebhook accepts both in
+        //    the same call so it's one mutation per logical change.
+        if (obj.webhook) {
+            const input: any = { uuid: obj.webhook.uuid }
+            // Slug only surfaces as a change when it actually differs from
+            // what we loaded — guards against re-validating an unchanged
+            // slug on the server.
+            const original = ciIntegrations.value.find((c: any) => c.uuid === obj.uuid)
+            const originalSlug = obj.webhook.slug
+            if (obj.webhook.slug && obj.webhook.slug !== originalSlug) input.slug = obj.webhook.slug
+            // secret is write-only — non-empty means rotate.
+            if (obj.webhook.secret && obj.webhook.secret.trim().length > 0) input.secret = obj.webhook.secret.trim()
+            // Always send the (possibly-edited) slug to be safe; backend
+            // skips the rename branch if it's equal.
+            input.slug = obj.webhook.slug
+            // Only call when there's at least one mutable change.
+            if (input.slug || input.secret) {
+                await graphqlClient.mutate({
+                    mutation: gql`
+                        mutation updateWebhook($webhook: WebhookUpdateInput!) {
+                            updateWebhook(webhook: $webhook) { uuid slug }
+                        }`,
+                    variables: { webhook: input },
+                    fetchPolicy: 'no-cache'
+                })
+            }
+        }
+
+        showEditCiIntegrationModal.value = false
+        await loadCiIntegrations(false)
+    } catch (e: any) {
+        const msg = e?.message || String(e)
+        alert('Failed to save integration: ' + msg)
+        console.error(e)
+    }
+}
+
 
 const users: Ref<any[]> = ref([])
 async function loadUsers() {
@@ -3059,6 +3230,22 @@ const ciIntegrationTableFields = [
         render: (row: any) => {
             const caps = (row.capabilities || []) as string[]
             return caps.length === 0 ? '—' : caps.join(', ')
+        }
+    },
+    {
+        key: 'controls',
+        title: 'Actions',
+        render: (row: any) => {
+            // Edit only on GITHUB for now — that's the only type with
+            // capabilities to manage and the only one with a webhook
+            // counterpart that may need slug/secret rotation.
+            if (row.type !== 'GITHUB') return '—'
+            return h(NIcon, {
+                title: 'Edit integration',
+                class: 'clickable',
+                size: 22,
+                onClick: () => openEditCiIntegrationModal(row)
+            }, () => h(EditIcon))
         }
     }
 ]

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -285,24 +285,10 @@
                                     </n-checkbox-group>
                                 </n-form-item>
 
-                                <template v-if="editCiIntegrationObject.webhook">
-                                    <h6 style="margin-bottom: 0;">Webhook configuration</h6>
-                                    <n-form-item label="Webhook slug"
-                                        description="Lowercase a-z, 0-9, and hyphens. 4–63 chars, no leading/trailing hyphen. Changing this also changes the public URL — re-register on the GitHub App side at the same time.">
-                                        <n-input v-model:value="editCiIntegrationObject.webhook.slug" />
-                                    </n-form-item>
-                                    <n-form-item label="Rotate webhook secret"
-                                        description="Leave empty to keep the existing secret. If set, also paste the same value into the GitHub App's Webhook secret field — signature verification will fail until both sides match.">
-                                        <n-input v-model:value="editCiIntegrationObject.webhook.secret"
-                                            type="password" show-password-on="click" placeholder="(unchanged)" />
-                                    </n-form-item>
-                                </template>
-                                <template v-else>
-                                    <n-text depth="3" style="font-size: 13px;">
-                                        No webhook configured for this integration. Tick the WEBHOOK capability and use
-                                        the Webhooks section below to add one.
-                                    </n-text>
-                                </template>
+                                <n-text depth="3" style="font-size: 13px;">
+                                    To add or modify the inbound webhook (slug, secret) attached to this integration,
+                                    use the Webhooks (inbound) section below.
+                                </n-text>
 
                                 <n-space>
                                     <n-button :loading="editCiIntegrationLoading" @click="saveEditCiIntegration" type="success">Save</n-button>
@@ -2036,69 +2022,32 @@ function resetCreateIntegrationObject() {
 }
 
 // ---- Edit GitHub CI Integration --------------------------------------------
-// Capabilities are user-editable; if a Webhook is wired to this integration,
-// the modal also exposes the webhook's slug + secret-rotate inline (one form,
-// one Save, two mutations). The existing secret is never read back — empty
-// secret input means "keep what's there".
+// Only capabilities are editable from this modal. Webhook fields (slug,
+// secret) are deliberately scoped to the Webhook entity itself — see the
+// Webhooks (inbound) section's edit flow.
 const editCiIntegrationObject: Ref<any> = ref({
     uuid: '',
     type: '',
     note: '',
-    capabilities: [] as string[],
-    // Mirrored from the matching Webhook row when one exists; null otherwise.
-    webhook: null as null | {
-        uuid: string,
-        slug: string,
-        secret: string  // write-only; never populated on open
-    }
+    capabilities: [] as string[]
 })
 const showEditCiIntegrationModal: Ref<boolean> = ref(false)
 const editCiIntegrationLoading: Ref<boolean> = ref(false)
 
-async function openEditCiIntegrationModal(row: any) {
-    editCiIntegrationLoading.value = true
-    showEditCiIntegrationModal.value = true
+function openEditCiIntegrationModal(row: any) {
     editCiIntegrationObject.value = {
         uuid: row.uuid,
         type: row.type,
         note: row.note,
-        capabilities: [...(row.capabilities || [])],
-        webhook: null
+        capabilities: [...(row.capabilities || [])]
     }
-    // Look up an existing webhook for this integration. There's no dedicated
-    // "by integration" query in the GraphQL surface — we list all webhooks
-    // for the org and filter client-side, which is fine at the org-config
-    // scale (handful of webhooks, not millions).
-    try {
-        const resp = await graphqlClient.query({
-            query: gql`
-                query webhooks($orgUuid: ID!) {
-                    webhooks(orgUuid: $orgUuid) { uuid integration slug }
-                }`,
-            variables: { orgUuid: orgResolved.value },
-            fetchPolicy: 'no-cache'
-        })
-        const wh = (resp.data?.webhooks || []).find((w: any) => w.integration === row.uuid)
-        if (wh) {
-            editCiIntegrationObject.value.webhook = {
-                uuid: wh.uuid,
-                slug: wh.slug,
-                secret: ''
-            }
-        }
-    } catch (e: any) {
-        console.error(e)
-    } finally {
-        editCiIntegrationLoading.value = false
-    }
+    showEditCiIntegrationModal.value = true
 }
 
 async function saveEditCiIntegration() {
     const obj = editCiIntegrationObject.value
+    editCiIntegrationLoading.value = true
     try {
-        // 1. Update integration capabilities. Always called — server is
-        //    idempotent on equal lists, and skipping a noop here would mean
-        //    re-checking equality client-side, which isn't worth it.
         await graphqlClient.mutate({
             mutation: gql`
                 mutation updateIntegrationCapabilities($uuid: ID!, $capabilities: [IntegrationCapability!]!) {
@@ -2109,42 +2058,14 @@ async function saveEditCiIntegration() {
             variables: { uuid: obj.uuid, capabilities: obj.capabilities },
             fetchPolicy: 'no-cache'
         })
-
-        // 2. If a webhook exists and the user changed slug or set a new
-        //    secret, push that through too. updateWebhook accepts both in
-        //    the same call so it's one mutation per logical change.
-        if (obj.webhook) {
-            const input: any = { uuid: obj.webhook.uuid }
-            // Slug only surfaces as a change when it actually differs from
-            // what we loaded — guards against re-validating an unchanged
-            // slug on the server.
-            const original = ciIntegrations.value.find((c: any) => c.uuid === obj.uuid)
-            const originalSlug = obj.webhook.slug
-            if (obj.webhook.slug && obj.webhook.slug !== originalSlug) input.slug = obj.webhook.slug
-            // secret is write-only — non-empty means rotate.
-            if (obj.webhook.secret && obj.webhook.secret.trim().length > 0) input.secret = obj.webhook.secret.trim()
-            // Always send the (possibly-edited) slug to be safe; backend
-            // skips the rename branch if it's equal.
-            input.slug = obj.webhook.slug
-            // Only call when there's at least one mutable change.
-            if (input.slug || input.secret) {
-                await graphqlClient.mutate({
-                    mutation: gql`
-                        mutation updateWebhook($webhook: WebhookUpdateInput!) {
-                            updateWebhook(webhook: $webhook) { uuid slug }
-                        }`,
-                    variables: { webhook: input },
-                    fetchPolicy: 'no-cache'
-                })
-            }
-        }
-
         showEditCiIntegrationModal.value = false
         await loadCiIntegrations(false)
     } catch (e: any) {
         const msg = e?.message || String(e)
         alert('Failed to save integration: ' + msg)
         console.error(e)
+    } finally {
+        editCiIntegrationLoading.value = false
     }
 }
 

--- a/ui/src/components/PullRequestsOfOrg.vue
+++ b/ui/src/components/PullRequestsOfOrg.vue
@@ -2,44 +2,91 @@
     <div class="prsOfOrg">
         <h4>Pull Requests</h4>
 
-        <n-input
-            v-model:value="searchQuery"
-            round
-            clearable
-            placeholder="Filter by identity, title, or VCS"
-            :style="{ 'max-width': '400px', 'margin': '10px 0' }">
-            <template #suffix>
-                <n-icon size="18"><Search/></n-icon>
-            </template>
-        </n-input>
+        <div class="filters">
+            <n-input
+                v-model:value="searchQuery"
+                round
+                clearable
+                placeholder="Filter by identity, title, or VCS"
+                :style="{ 'max-width': '400px' }">
+                <template #suffix>
+                    <n-icon size="18"><Search/></n-icon>
+                </template>
+            </n-input>
+
+            <n-checkbox-group v-model:value="selectedStates" @update:value="onStatesChanged">
+                <n-space>
+                    <n-checkbox value="OPEN">OPEN</n-checkbox>
+                    <n-checkbox value="MERGED">MERGED</n-checkbox>
+                    <n-checkbox value="CLOSED">CLOSED</n-checkbox>
+                </n-space>
+            </n-checkbox-group>
+
+            <n-spin v-if="loading" size="small"/>
+        </div>
 
         <n-data-table
             :columns="columns"
             :data="filtered"
-            :pagination="{ pageSize: 25 }"/>
+            :pagination="{ pageSize: 25 }"
+            @update:filters="onFilterUpdate"/>
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, h, onMounted, ref } from 'vue'
+import { computed, h, onMounted, ref, watch } from 'vue'
 import { useStore } from 'vuex'
-import { useRoute, RouterLink } from 'vue-router'
-import { NDataTable, NIcon, NInput, NTag, DataTableColumns } from 'naive-ui'
+import { useRoute, useRouter, RouterLink } from 'vue-router'
+import { NDataTable, NIcon, NInput, NTag, NTooltip, NCheckbox, NCheckboxGroup, NSpace, NSpin, DataTableColumns, DataTableFilterState } from 'naive-ui'
 import { Search } from '@vicons/tabler'
+import { Info20Regular } from '@vicons/fluent'
 
 const store = useStore()
 const route = useRoute()
+const router = useRouter()
+
 const orgUuid = computed(() => route.params.orguuid as string)
 const searchQuery = ref('')
+const selectedStates = ref<string[]>(['OPEN'])
 const prs = ref<any[]>([])
+const loading = ref(false)
+const vcsFilter = ref<string[]>([])
 
 const stateTagType = (s: string) => s === 'OPEN' ? 'success' : (s === 'MERGED' ? 'info' : 'default')
 
-const fmt = (raw: string | null | undefined) => {
-    if (!raw) return '—'
+// Calendar-day display (en-CA → ISO yyyy-mm-dd) for the cell, plus a
+// second-granularity tooltip so operators can see exact times without
+// the column getting unreadably wide.
+const fmtDate = (raw: string | null | undefined) => {
+    if (!raw) return null
     const d = new Date(raw)
-    if (Number.isNaN(d.getTime())) return '—'
+    if (Number.isNaN(d.getTime())) return null
     return d.toLocaleDateString('en-CA')
+}
+
+const fmtFull = (raw: string | null | undefined) => {
+    if (!raw) return null
+    const d = new Date(raw)
+    if (Number.isNaN(d.getTime())) return null
+    const utc = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
+    const local = d.toLocaleString(undefined, {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+    })
+    return `${utc}\nlocal: ${local}`
+}
+
+const renderDateCell = (raw: string | null | undefined) => {
+    const day = fmtDate(raw)
+    if (!day) return '—'
+    const full = fmtFull(raw)
+    return h('span', { class: 'date-cell' }, [
+        day,
+        h(NTooltip, { trigger: 'hover', placement: 'top', style: 'white-space: pre-line' }, {
+            trigger: () => h(NIcon, { size: 14, class: 'date-info' }, { default: () => h(Info20Regular) }),
+            default: () => full
+        })
+    ])
 }
 
 const vcsName = (uuid: string) => {
@@ -48,7 +95,19 @@ const vcsName = (uuid: string) => {
     return repo?.name || uuid.slice(0, 8) + '…'
 }
 
-const columns: DataTableColumns<any> = [
+// Filter dropdown options come from every VCS repo registered in the
+// org — not just the ones that show up in the currently-loaded PR set.
+// Otherwise a cross-nav from a VCS page (which lands on OPEN-only by
+// default) could pre-apply a filter for a VCS that has no OPEN PRs and
+// the user wouldn't see the active filter listed in the dropdown.
+const vcsFilterOptions = computed(() => {
+    const repos = store.getters.vcsReposOfOrg(orgUuid.value) || []
+    return repos
+        .map((r: any) => ({ label: r.name, value: r.uuid }))
+        .sort((a: any, b: any) => a.label.localeCompare(b.label))
+})
+
+const columns = computed<DataTableColumns<any>>(() => [
     {
         title: 'Identity',
         key: 'identity',
@@ -72,7 +131,16 @@ const columns: DataTableColumns<any> = [
     {
         title: 'Target VCS',
         key: 'targetVcsRepository',
-        render: (row) => vcsName(row.targetVcsRepository)
+        filter: 'default',
+        filterMultiple: true,
+        filterOptionValues: vcsFilter.value,
+        filterOptions: vcsFilterOptions.value,
+        render: (row) => {
+            if (!row.targetVcsRepository) return '—'
+            return h(RouterLink as any,
+                { to: { name: 'VcsRepository', params: { uuid: row.targetVcsRepository } } },
+                { default: () => vcsName(row.targetVcsRepository) })
+        }
     },
     {
         title: 'Commits',
@@ -82,15 +150,15 @@ const columns: DataTableColumns<any> = [
     },
     {
         title: 'Created',
-        key: 'createdDate',
-        width: 110,
-        render: (row) => fmt(row.prCreatedDate || row.createdDate)
+        key: 'prCreatedDate',
+        width: 130,
+        render: (row) => renderDateCell(row.prCreatedDate || row.createdDate)
     },
     {
-        title: 'Closed',
-        key: 'closedDate',
-        width: 110,
-        render: (row) => fmt(row.closedDate)
+        title: 'Closed/Merged',
+        key: 'closedOrMergedDate',
+        width: 150,
+        render: (row) => renderDateCell(row.mergedDate || row.closedDate)
     },
     {
         title: 'Endpoint',
@@ -101,7 +169,7 @@ const columns: DataTableColumns<any> = [
                 row.endpoint.replace(/^https?:\/\//, ''))
         }
     }
-]
+])
 
 const filtered = computed(() => {
     const q = searchQuery.value.trim().toLowerCase()
@@ -113,14 +181,70 @@ const filtered = computed(() => {
     })
 })
 
-onMounted(async () => {
-    if (orgUuid.value) {
+const fetchPrs = async () => {
+    if (!orgUuid.value) return
+    loading.value = true
+    try {
+        // Pre-fetch VCS repos so vcsName() resolves for the rendered cells
+        // and the column filter dropdown has labels available.
         await store.dispatch('fetchVcsRepos', orgUuid.value)
-        prs.value = (await store.dispatch('fetchPullRequestsOfOrg', orgUuid.value)) || []
+        prs.value = (await store.dispatch('fetchPullRequestsOfOrg', {
+            org: orgUuid.value,
+            states: selectedStates.value
+        })) || []
+    } finally {
+        loading.value = false
     }
+}
+
+const onStatesChanged = () => {
+    // Persist active filters to the URL so a refresh (or someone sharing
+    // the link) lands on the same view. State always serializes; vcs is
+    // optional and only present when the user came from a VCS jump.
+    const query: any = { ...route.query, states: selectedStates.value.join(',') || undefined }
+    router.replace({ name: route.name as any, params: route.params, query })
+    fetchPrs()
+}
+
+// Naive-UI fires this with the current values of every filtered column;
+// we only care about Target VCS here.
+const onFilterUpdate = (filters: DataTableFilterState) => {
+    const v = filters['targetVcsRepository']
+    vcsFilter.value = Array.isArray(v) ? (v as string[]) : (v ? [v as string] : [])
+}
+
+onMounted(async () => {
+    // Hydrate filters from the URL: ?states=OPEN,MERGED&vcs=<uuid>
+    const stateParam = route.query.states
+    if (typeof stateParam === 'string' && stateParam.length > 0) {
+        selectedStates.value = stateParam.split(',').filter(Boolean)
+    }
+    const vcsParam = route.query.vcs
+    if (typeof vcsParam === 'string' && vcsParam.length > 0) {
+        vcsFilter.value = [vcsParam]
+    }
+    await fetchPrs()
 })
+
+watch(orgUuid, fetchPrs)
 </script>
 
 <style scoped lang="scss">
 .prsOfOrg { padding: 1rem; }
+.filters {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin: 10px 0;
+    flex-wrap: wrap;
+}
+.date-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.date-info {
+    color: #888;
+    cursor: help;
+}
 </style>

--- a/ui/src/components/PullRequestsOfOrg.vue
+++ b/ui/src/components/PullRequestsOfOrg.vue
@@ -81,16 +81,20 @@ const fmtDate = (raw: string | null | undefined) => {
     return d.toLocaleDateString('en-CA')
 }
 
+const pad = (n: number) => n.toString().padStart(2, '0')
+
+// yyyy-mm-dd HH:MM:SS, formatted by hand so the local row matches the
+// UTC row's shape — Intl.DateTimeFormat would render mm/dd/yyyy or a
+// locale-specific separator depending on the user's browser settings.
 const fmtFull = (raw: string | null | undefined) => {
     if (!raw) return null
     const d = new Date(raw)
     if (Number.isNaN(d.getTime())) return null
-    const utc = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')
-    const local = d.toLocaleString(undefined, {
-        year: 'numeric', month: '2-digit', day: '2-digit',
-        hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
-    })
-    return `${utc}\nlocal: ${local}`
+    const utc = `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} `
+        + `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`
+    const local = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} `
+        + `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())} local`
+    return `${utc}\n${local}`
 }
 
 const renderDateCell = (raw: string | null | undefined) => {

--- a/ui/src/components/PullRequestsOfOrg.vue
+++ b/ui/src/components/PullRequestsOfOrg.vue
@@ -54,6 +54,23 @@ const vcsFilter = ref<string[]>([])
 
 const stateTagType = (s: string) => s === 'OPEN' ? 'success' : (s === 'MERGED' ? 'info' : 'default')
 
+// Maps the ValidationState enum onto the Naive tag palette. null and
+// PENDING are both "not yet decided" — render as warning so they pop
+// against terminal verdicts. SKIPPED / CANCELLED are terminal but not
+// pass/fail; rendered neutral.
+type ValidationDisplay = { label: string, type: 'success' | 'error' | 'warning' | 'info' | 'default' }
+const validationDisplay = (v: string | null | undefined): ValidationDisplay => {
+    switch (v) {
+        case 'SUCCESS': return { label: 'Success', type: 'success' }
+        case 'FAILURE': return { label: 'Failure', type: 'error' }
+        case 'PENDING': return { label: 'Pending', type: 'warning' }
+        case 'NEUTRAL': return { label: 'Neutral', type: 'default' }
+        case 'SKIPPED': return { label: 'Skipped', type: 'default' }
+        case 'CANCELLED': return { label: 'Cancelled', type: 'default' }
+        default: return { label: 'Pending', type: 'warning' }
+    }
+}
+
 // Calendar-day display (en-CA → ISO yyyy-mm-dd) for the cell, plus a
 // second-granularity tooltip so operators can see exact times without
 // the column getting unreadably wide.
@@ -127,6 +144,15 @@ const columns = computed<DataTableColumns<any>>(() => [
         width: 100,
         render: (row) => h(NTag, { type: stateTagType(row.state), size: 'small', bordered: false },
             { default: () => row.state || '—' })
+    },
+    {
+        title: 'Validation',
+        key: 'currentValidationState',
+        width: 110,
+        render: (row) => {
+            const d = validationDisplay(row.currentValidationState)
+            return h(NTag, { type: d.type, size: 'small', bordered: false }, { default: () => d.label })
+        }
     },
     {
         title: 'Target VCS',

--- a/ui/src/components/VcsReposOfOrg.vue
+++ b/ui/src/components/VcsReposOfOrg.vue
@@ -71,7 +71,7 @@ import { NInput, NModal, NCard, NDataTable, useNotification, NotificationType, N
 import { ComputedRef, h, ref, Ref, computed, Component, reactive, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute } from 'vue-router'
-import { CirclePlus, Edit as EditIcon, ExternalLink, Eye, Check, X, Trash, Search, Settings } from '@vicons/tabler'
+import { CirclePlus, Edit as EditIcon, ExternalLink, Eye, Check, X, Trash, Search, Settings, GitPullRequest } from '@vicons/tabler'
 import { useRouter } from 'vue-router'
 import { Icon } from '@vicons/utils'
 import CreateVcsRepository from '@/components/CreateVcsRepository.vue'
@@ -382,6 +382,19 @@ const vcsRepoFields: any[] = [
                             onClick: () => router.push({ name: 'VcsRepository', params: { uuid: row.uuid } })
                         },
                         () => h(Settings)),
+                    h(
+                        NIcon,
+                        {
+                            title: 'View Pull Requests for this VCS Repository',
+                            class: 'icons clickable',
+                            size: 25,
+                            onClick: () => router.push({
+                                name: 'PullRequestsOfOrg',
+                                params: { orguuid: orguuid.value },
+                                query: { vcs: row.uuid }
+                            })
+                        },
+                        () => h(GitPullRequest)),
                     h(
                         NIcon,
                         {

--- a/ui/src/components/VcsRepository.vue
+++ b/ui/src/components/VcsRepository.vue
@@ -1,7 +1,20 @@
 <template>
     <div class="vcsRepoView">
         <div v-if="vcsRepo">
-            <h1>VCS Repository — {{ vcsRepo.name }}</h1>
+            <div class="title-row">
+                <h1>VCS Repository — {{ vcsRepo.name }}</h1>
+                <n-tooltip trigger="hover">
+                    <template #trigger>
+                        <n-icon
+                            size="28"
+                            class="pr-link"
+                            @click="goToPullRequests">
+                            <GitPullRequest/>
+                        </n-icon>
+                    </template>
+                    View Pull Requests for this VCS Repository
+                </n-tooltip>
+            </div>
             <div class="meta">URI: {{ vcsRepo.uri }}</div>
 
             <h3 class="mt-4">
@@ -61,14 +74,15 @@
 <script setup lang="ts">
 import { computed, reactive, ref, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { NButton, NForm, NFormItem, NIcon, NInput, NSelect, NSpace, NTooltip, useNotification } from 'naive-ui'
-import { QuestionMark } from '@vicons/tabler'
+import { QuestionMark, GitPullRequest } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 
 const store = useStore()
 const route = useRoute()
+const router = useRouter()
 const notification = useNotification()
 
 const vcsRepoUuid = computed(() => route.params.uuid as string)
@@ -209,6 +223,15 @@ async function loadAll() {
     if (fresh?.org) await fetchCiIntegrations(fresh.org)
 }
 
+const goToPullRequests = () => {
+    if (!vcsRepo.value?.org) return
+    router.push({
+        name: 'PullRequestsOfOrg',
+        params: { orguuid: vcsRepo.value.org },
+        query: { vcs: vcsRepoUuid.value }
+    })
+}
+
 onMounted(loadAll)
 watch(vcsRepoUuid, loadAll)
 </script>
@@ -216,6 +239,17 @@ watch(vcsRepoUuid, loadAll)
 <style scoped lang="scss">
 .vcsRepoView {
     padding: 1rem;
+}
+.title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    h1 { margin: 0; }
+}
+.pr-link {
+    cursor: pointer;
+    color: #4a89dc;
+    &:hover { color: #2c6bc4; }
 }
 .meta {
     color: #555;

--- a/ui/src/components/VcsRepository.vue
+++ b/ui/src/components/VcsRepository.vue
@@ -92,11 +92,12 @@ const currentTrigger = computed(() => {
     return triggers && triggers.length > 0 ? triggers[0] : null
 })
 
-// Mirror ComponentView: only GITHUB_VALIDATE integrations are valid
-// targets for an EXTERNAL_VALIDATION trigger.
+// Mirror ComponentView: GITHUB integrations with the PR_VALIDATE
+// capability are the only valid targets for an EXTERNAL_VALIDATION
+// trigger.
 const validationIntegrationsForSelect = computed(() => {
     return ciIntegrations.value
-        .filter((x: any) => x.type === 'GITHUB_VALIDATE')
+        .filter((x: any) => x.type === 'GITHUB' && (x.capabilities || []).includes('PR_VALIDATE'))
         .map((x: any) => ({ label: x.note || x.identifier || x.uuid, value: x.uuid }))
 })
 
@@ -188,6 +189,7 @@ async function fetchCiIntegrations(orgUuid: string) {
                         isEnabled
                         type
                         note
+                        capabilities
                     }
                 }`,
             variables: { org: orgUuid },

--- a/ui/src/components/WebhooksOfOrg.vue
+++ b/ui/src/components/WebhooksOfOrg.vue
@@ -1,0 +1,386 @@
+<template>
+    <div>
+        <h5>Webhooks (inbound)</h5>
+        <p style="color: #666; font-size: 13px; margin-top: 0;">
+            Receive GitHub <code>pull_request</code> events directly so PR state in ReARM stays in sync with GitHub
+            without waiting for the next CI run. Each webhook is bound to a GitHub integration that has the
+            <strong>Webhook</strong> capability.
+        </p>
+        <n-data-table :data="webhooks" :columns="webhookFields" :single-line="false" />
+        <n-button v-if="hasWebhookCapableIntegration" @click="onCreateOpen" style="margin-top: 8px;">Add Webhook</n-button>
+        <n-text v-else depth="3" style="display: block; margin-top: 8px;">
+            No GitHub integrations with the WEBHOOK capability — add one above first.
+        </n-text>
+
+        <!-- Create modal -->
+        <n-modal v-model:show="showCreateModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 700px" size="huge" title="Create Webhook" :borderd="false" role="dialog" aria-modal="true">
+                <n-form :model="webhookToCreate" :rules="createRules" ref="createFormRef">
+                    <n-form-item label="Integration" path="integration"
+                        description="Pick a GitHub integration with the Webhook capability.">
+                        <n-select v-model:value="webhookToCreate.integration"
+                            :options="webhookCapableIntegrationOptions" placeholder="Select integration" />
+                    </n-form-item>
+                    <n-form-item label="Slug" path="slug"
+                        description="Lowercase a-z, 0-9, and hyphens. 4–63 chars, no leading/trailing hyphen. Becomes part of the public webhook URL.">
+                        <n-input v-model:value="webhookToCreate.slug" placeholder="e.g. github-app-pr-events" />
+                    </n-form-item>
+                    <n-form-item label="Secret" path="secret"
+                        description="Random HMAC-SHA256 key. Paste the SAME value into the GitHub App's Webhook secret field. Stored encrypted.">
+                        <n-space vertical style="width: 100%;">
+                            <n-input v-model:value="webhookToCreate.secret" type="password"
+                                show-password-on="click" placeholder="Paste or generate a 32-byte hex string" />
+                            <n-button size="small" @click="generateSecret">Generate random secret</n-button>
+                        </n-space>
+                    </n-form-item>
+                    <n-form-item label="Installation ID" path="installation"
+                        description="GitHub App installation ID this webhook is scoped to. Optional but recommended.">
+                        <n-input v-model:value="webhookToCreate.installation" placeholder="Numeric installation id" />
+                    </n-form-item>
+                    <n-form-item label="Note" path="note">
+                        <n-input v-model:value="webhookToCreate.note" placeholder="Free-form note for ops" />
+                    </n-form-item>
+
+                    <!-- Live preview of the URL the user pastes into GitHub -->
+                    <n-form-item label="Webhook URL preview" v-if="webhookToCreate.slug">
+                        <n-input :value="previewUrl(webhookToCreate.slug)" readonly />
+                    </n-form-item>
+
+                    <n-space>
+                        <n-button @click="createWebhook" type="success">Create</n-button>
+                        <n-button @click="resetCreate" type="error">Reset</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- Edit modal -->
+        <n-modal v-model:show="showEditModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 700px" size="huge" :title="'Edit Webhook - ' + (webhookToEdit.slug || '')" :borderd="false" role="dialog" aria-modal="true">
+                <n-form :model="webhookToEdit">
+                    <n-form-item label="Webhook URL">
+                        <n-input :value="previewUrl(webhookToEdit.slug)" readonly />
+                    </n-form-item>
+                    <n-form-item label="Status">
+                        <n-radio-group v-model:value="webhookToEdit.status">
+                            <n-radio-button label="Active" value="ACTIVE" />
+                            <n-radio-button label="Disabled" value="DISABLED" />
+                        </n-radio-group>
+                    </n-form-item>
+                    <n-form-item label="Installation ID">
+                        <n-input v-model:value="webhookToEdit.installation" placeholder="Numeric installation id" />
+                    </n-form-item>
+                    <n-form-item label="Note">
+                        <n-input v-model:value="webhookToEdit.note" />
+                    </n-form-item>
+                    <n-form-item label="Rotate secret"
+                        description="Leave empty to keep the existing secret. If set, also update the secret on the GitHub App side or signature verification will fail.">
+                        <n-input v-model:value="webhookToEdit.secret" type="password" show-password-on="click" placeholder="(unchanged)" />
+                    </n-form-item>
+                    <n-space>
+                        <n-button @click="updateWebhook" type="success">Save</n-button>
+                        <n-button @click="showEditModal = false" type="default">Cancel</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import gql from 'graphql-tag'
+import graphqlClient from '../utils/graphql'
+import Swal from 'sweetalert2'
+import { NButton, NCard, NDataTable, NForm, NFormItem, NIcon, NInput, NModal, NRadioButton, NRadioGroup, NSelect, NSpace, NText, NotificationType, useNotification } from 'naive-ui'
+import { computed, ComputedRef, h, onMounted, Ref, ref, watch } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
+import { Edit as EditIcon, Trash, Copy } from '@vicons/tabler'
+
+const route = useRoute()
+const store = useStore()
+const notification = useNotification()
+const notify = (type: NotificationType, title: string, content: string) => {
+    notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
+}
+
+const props = defineProps<{
+    orguuid?: string
+}>()
+
+const myorg: ComputedRef<any> = computed(() => store.getters.myorg)
+const orgResolved = ref('')
+
+const webhooks: Ref<any[]> = ref([])
+const ciIntegrations: Ref<any[]> = ref([])
+
+// Public base URL for the webhook reception path. Origin is the same
+// as the UI itself — agent-scully or whatever the user is logged into.
+function previewUrl(slug: string): string {
+    if (!slug) return ''
+    return `${window.location.origin}/api/programmatic/v1/webhook/${orgResolved.value}/${slug}`
+}
+
+const webhookCapableIntegrationOptions = computed(() => {
+    return ciIntegrations.value
+        .filter((ci: any) => ci.type === 'GITHUB' && (ci.capabilities || []).includes('WEBHOOK'))
+        .map((ci: any) => ({ label: `${ci.note || ci.identifier} (${ci.uuid.substring(0, 8)})`, value: ci.uuid }))
+})
+const hasWebhookCapableIntegration = computed(() => webhookCapableIntegrationOptions.value.length > 0)
+
+const SLUG_REGEX = /^[a-z0-9]([a-z0-9-]{2,61}[a-z0-9])?$/
+const createRules = {
+    integration: {
+        required: true, message: 'Pick an integration', trigger: ['blur', 'change']
+    },
+    slug: {
+        required: true, trigger: ['blur', 'input'],
+        validator: (_rule: any, value: string) => {
+            if (!value) return new Error('Slug required')
+            if (!SLUG_REGEX.test(value)) return new Error('Lowercase a-z, 0-9, hyphen; 4–63 chars; no leading/trailing hyphen')
+            return true
+        }
+    },
+    secret: {
+        required: true, trigger: ['blur'],
+        validator: (_rule: any, value: string) => {
+            if (!value || value.trim().length < 16) return new Error('Use at least 16 chars (32-byte hex recommended)')
+            return true
+        }
+    }
+}
+
+const emptyWebhook = {
+    integration: null as string | null,
+    slug: '',
+    secret: '',
+    installation: '',
+    note: ''
+}
+const webhookToCreate: Ref<any> = ref({ ...emptyWebhook })
+const webhookToEdit: Ref<any> = ref({ uuid: '', slug: '', status: 'ACTIVE', installation: '', note: '', secret: '' })
+const showCreateModal = ref(false)
+const showEditModal = ref(false)
+const createFormRef = ref<any>(null)
+
+function generateSecret() {
+    // 32 random bytes → 64-char hex. crypto.getRandomValues is universally
+    // available in browsers; no need for the Node-style require.
+    const bytes = new Uint8Array(32)
+    window.crypto.getRandomValues(bytes)
+    webhookToCreate.value.secret = Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+function resetCreate() {
+    webhookToCreate.value = { ...emptyWebhook }
+}
+
+function onCreateOpen() {
+    resetCreate()
+    showCreateModal.value = true
+}
+
+const webhookFields: any[] = [
+    { key: 'slug', title: 'Slug' },
+    {
+        key: 'status', title: 'Status',
+        render: (row: any) => row.status || 'ACTIVE'
+    },
+    {
+        key: 'lastDeliveryStatus', title: 'Last Delivery',
+        render: (row: any) => {
+            if (!row.lastDeliveryAt) return '—'
+            const t = new Date(row.lastDeliveryAt).toLocaleString()
+            return `${row.lastDeliveryStatus || ''} @ ${t}`
+        }
+    },
+    {
+        key: 'consecutiveFailureCount', title: 'Failures',
+        render: (row: any) => {
+            const n = row.consecutiveFailureCount || 0
+            return n === 0 ? '0' : h('span', { style: { color: '#c00', fontWeight: 'bold' } }, String(n))
+        }
+    },
+    { key: 'note', title: 'Note' },
+    {
+        key: 'controls', title: 'Actions',
+        render: (row: any) => h('div', { style: { display: 'flex', gap: '6px' } }, [
+            h(NIcon, { title: 'Copy webhook URL', class: 'clickable', size: 22, onClick: () => copyUrl(row) }, () => h(Copy)),
+            h(NIcon, { title: 'Edit webhook', class: 'clickable', size: 22, onClick: () => onEditOpen(row) }, () => h(EditIcon)),
+            h(NIcon, { title: 'Delete webhook', class: 'clickable', size: 22, onClick: () => onDelete(row) }, () => h(Trash)),
+        ])
+    }
+]
+
+async function copyUrl(row: any) {
+    try {
+        await navigator.clipboard.writeText(previewUrl(row.slug))
+        notify('success', 'Copied', 'Webhook URL copied to clipboard')
+    } catch (e: any) {
+        notify('error', 'Copy failed', e?.message || 'Could not copy to clipboard')
+    }
+}
+
+function onEditOpen(row: any) {
+    webhookToEdit.value = {
+        uuid: row.uuid,
+        slug: row.slug,
+        status: row.status || 'ACTIVE',
+        installation: row.installation || '',
+        note: row.note || '',
+        secret: ''
+    }
+    showEditModal.value = true
+}
+
+async function loadWebhooks() {
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query webhooks($orgUuid: ID!) {
+                    webhooks(orgUuid: $orgUuid) {
+                        uuid org integration slug note status
+                        lastDeliveryAt lastDeliveryStatus consecutiveFailureCount
+                    }
+                }`,
+            variables: { orgUuid: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        webhooks.value = resp.data?.webhooks || []
+    } catch (e: any) {
+        console.error(e)
+        notify('error', 'Load failed', `Could not load webhooks: ${e?.message || e}`)
+    }
+}
+
+async function loadCiIntegrations() {
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query ciIntegrations($org: ID!) {
+                    ciIntegrations(org: $org) {
+                        uuid identifier type note capabilities
+                    }
+                }`,
+            variables: { org: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        ciIntegrations.value = resp.data?.ciIntegrations || []
+    } catch (e: any) {
+        console.error(e)
+    }
+}
+
+async function createWebhook() {
+    try {
+        if (createFormRef.value) {
+            await createFormRef.value.validate()
+        }
+        const input = {
+            org: orgResolved.value,
+            integration: webhookToCreate.value.integration,
+            slug: webhookToCreate.value.slug,
+            secret: webhookToCreate.value.secret,
+            installation: webhookToCreate.value.installation || null,
+            note: webhookToCreate.value.note || null
+        }
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation createWebhook($webhook: WebhookInput!) {
+                    createWebhook(webhook: $webhook) { uuid slug status }
+                }`,
+            variables: { webhook: input },
+            fetchPolicy: 'no-cache'
+        })
+        notify('success', 'Webhook created', `Now register the URL on the GitHub App side: ${previewUrl(input.slug)}`)
+        showCreateModal.value = false
+        resetCreate()
+        await loadWebhooks()
+    } catch (e: any) {
+        // form validate() errors are arrays of errors per field
+        const msg = Array.isArray(e) ? e.map((er: any) => er?.[0]?.message || er.message).join('; ') : (e?.message || String(e))
+        notify('error', 'Create failed', msg)
+    }
+}
+
+async function updateWebhook() {
+    try {
+        const input: any = {
+            uuid: webhookToEdit.value.uuid,
+            note: webhookToEdit.value.note || null,
+            status: webhookToEdit.value.status,
+            installation: webhookToEdit.value.installation || ''
+        }
+        if (webhookToEdit.value.secret && webhookToEdit.value.secret.trim().length > 0) {
+            input.secret = webhookToEdit.value.secret.trim()
+        }
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateWebhook($webhook: WebhookUpdateInput!) {
+                    updateWebhook(webhook: $webhook) { uuid slug status }
+                }`,
+            variables: { webhook: input },
+            fetchPolicy: 'no-cache'
+        })
+        notify('success', 'Saved', 'Webhook updated')
+        showEditModal.value = false
+        await loadWebhooks()
+    } catch (e: any) {
+        notify('error', 'Update failed', e?.message || String(e))
+    }
+}
+
+async function onDelete(row: any) {
+    const result = await Swal.fire({
+        title: `Delete webhook ${row.slug}?`,
+        text: 'GitHub will start failing deliveries to the URL — remember to remove the webhook on the GitHub App side too.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Yes, delete',
+        cancelButtonText: 'Cancel'
+    })
+    if (!result.value) return
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`mutation deleteWebhook($uuid: ID!) { deleteWebhook(uuid: $uuid) }`,
+            variables: { uuid: row.uuid },
+            fetchPolicy: 'no-cache'
+        })
+        notify('success', 'Deleted', `Webhook ${row.slug} removed`)
+        await loadWebhooks()
+    } catch (e: any) {
+        notify('error', 'Delete failed', e?.message || String(e))
+    }
+}
+
+onMounted(() => {
+    if (props.orguuid) {
+        orgResolved.value = props.orguuid
+    } else if (route.params.orguuid) {
+        orgResolved.value = route.params.orguuid.toString()
+    } else if (myorg.value?.uuid) {
+        orgResolved.value = myorg.value.uuid
+    }
+    if (orgResolved.value) {
+        loadWebhooks()
+        loadCiIntegrations()
+    }
+})
+
+watch(() => props.orguuid, (val) => {
+    if (val && val !== orgResolved.value) {
+        orgResolved.value = val
+        loadWebhooks()
+        loadCiIntegrations()
+    }
+})
+</script>
+
+<style scoped lang="scss">
+code {
+    background: #f0f0f0;
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+}
+</style>

--- a/ui/src/components/WebhooksOfOrg.vue
+++ b/ui/src/components/WebhooksOfOrg.vue
@@ -58,6 +58,10 @@
         <n-modal v-model:show="showEditModal" preset="dialog" :show-icon="false">
             <n-card style="width: 700px" size="huge" :title="'Edit Webhook - ' + (webhookToEdit.slug || '')" :borderd="false" role="dialog" aria-modal="true">
                 <n-form :model="webhookToEdit">
+                    <n-form-item label="Slug"
+                        description="Lowercase a-z, 0-9, and hyphens. 4–63 chars, no leading/trailing hyphen. Renaming changes the public URL — re-register on the GitHub App side at the same time.">
+                        <n-input v-model:value="webhookToEdit.slug" />
+                    </n-form-item>
                     <n-form-item label="Webhook URL">
                         <n-input :value="previewUrl(webhookToEdit.slug)" readonly />
                     </n-form-item>
@@ -305,11 +309,18 @@ async function createWebhook() {
 
 async function updateWebhook() {
     try {
+        // Slug validation client-side — matches the server regex so we don't
+        // round-trip a doomed mutation. Server still enforces uniqueness.
+        if (webhookToEdit.value.slug && !SLUG_REGEX.test(webhookToEdit.value.slug)) {
+            notify('error', 'Invalid slug', 'Lowercase a-z, 0-9, hyphen; 4–63 chars; no leading/trailing hyphen')
+            return
+        }
         const input: any = {
             uuid: webhookToEdit.value.uuid,
             note: webhookToEdit.value.note || null,
             status: webhookToEdit.value.status,
-            installation: webhookToEdit.value.installation || ''
+            installation: webhookToEdit.value.installation || '',
+            slug: webhookToEdit.value.slug
         }
         if (webhookToEdit.value.secret && webhookToEdit.value.secret.trim().length > 0) {
             input.secret = webhookToEdit.value.secret.trim()

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1164,11 +1164,13 @@ const storeObject : any = {
             context.commit('ADD_VCS_REPO', data.data.setVcsRepositoryOutputTriggers)
             return data.data.setVcsRepositoryOutputTriggers
         },
-        async fetchPullRequestsOfOrg (context: any, org: NonNullable<string>) {
+        async fetchPullRequestsOfOrg (context: any, payload: string | { org: string, states?: string[] }) {
+            const org = typeof payload === 'string' ? payload : payload.org
+            const states = typeof payload === 'string' ? undefined : payload.states
             const response = await graphqlClient.query({
                 query: gql`
-                    query pullRequestsOfOrg($orgUuid: ID!) {
-                        pullRequestsOfOrg(orgUuid: $orgUuid) {
+                    query pullRequestsOfOrg($orgUuid: ID!, $states: [String!]) {
+                        pullRequestsOfOrg(orgUuid: $orgUuid, states: $states) {
                             uuid
                             org
                             targetVcsRepository
@@ -1186,7 +1188,7 @@ const storeObject : any = {
                             createdDate
                         }
                     }`,
-                variables: { orgUuid: org },
+                variables: { orgUuid: org, states },
                 fetchPolicy: 'no-cache'
             })
             return response.data.pullRequestsOfOrg

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1186,6 +1186,7 @@ const storeObject : any = {
                             closedDate
                             mergedDate
                             createdDate
+                            currentValidationState
                         }
                     }`,
                 variables: { orgUuid: org, states },


### PR DESCRIPTION
## Summary

Adds the org-settings UI for the inbound GitHub webhook subsystem (backend in [relizaio/rearm-saas#54](https://github.com/relizaio/rearm-saas/pull/54)) and replaces the `GITHUB_VALIDATE` integration type with a capabilities multi-checkbox on `GITHUB`.

## What's new in OrgSettings → Integrations tab

- **CI Type radio** drops the legacy `GITHUB_VALIDATE` button. GitHub integrations now expose a capabilities multi-checkbox: `WORKFLOW_DISPATCH` / `PR_VALIDATE` / `WEBHOOK`. One App can be wired up for several roles instead of needing duplicate rows of different types.
- **Capabilities column** on the CI Integrations data table.
- **Webhooks (inbound) subsection** (new component `WebhooksOfOrg.vue`) with:
  - Data table: slug, status, last delivery + outcome, consecutive failure count, note, actions (copy-URL / edit / delete).
  - Create modal: integration dropdown filtered to `type=GITHUB && capabilities includes WEBHOOK`; slug input regex-validated (`^[a-z0-9]([a-z0-9-]{2,61}[a-z0-9])?$`); secret with "generate random" button (32-byte hex); installation id; note. Live URL preview shows exactly what to paste into the GitHub App.
  - Edit modal: status toggle (ACTIVE/DISABLED), rotate secret, edit installation + note.
  - Delete with confirmation.

## Picker filters refactored

Three places previously keyed on `type === 'GITHUB_VALIDATE'`:

| File | Filter |
|---|---|
| `OrgSettings.vue` global validation select | `type === 'GITHUB' && capabilities.includes('PR_VALIDATE')` |
| `ComponentView.vue` output-event picker | same |
| `VcsRepository.vue` EXTERNAL_VALIDATION picker | same |

The non-validation (workflow-dispatch) pickers conversely exclude GitHub integrations that don't have `WORKFLOW_DISPATCH` in their capabilities — except they fall back to "show all" when capabilities is empty, so legacy rows that haven't been backfilled don't silently disappear from the dropdown.

`ciIntegrations` queries in all three components updated to fetch the new `capabilities` field.

## Test plan

- [x] `npm run build` clean (`OrgSettings-DZpbZPXZ.js` 203 kB, no errors).
- [x] End-to-end against agent-scully: webhook row creates via mutation, GH App delivers events to the resulting URL, telemetry (`lastDeliveryStatus`, `consecutiveFailureCount`) surfaces in the table.
- [ ] Manual UI walkthrough on agent-scully (create / edit / delete; copy URL works; secret rotation works; status toggle disables intake).
- [ ] Existing CI Integration creation still works for GitLab, Jenkins, ADO, plain GITHUB (capabilities optional).

## What's not yet here

- **No migration UX** for legacy `GITHUB_VALIDATE` rows — those need to be migrated to `GITHUB + capabilities=['PR_VALIDATE']` directly in the DB on dev/claude instances. Once migrated they'll appear correctly in the new picker.
- **No webhook deliveries detail view** in v1 — table shows last-delivery summary; expanding to a full deliveries table per webhook is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)