### PR TITLE
feat(ui): Global PR Validation tab + per-VCS provenance card

### DIFF
--- a/ui/src/components/OrgGlobalPrValidationRules.vue
+++ b/ui/src/components/OrgGlobalPrValidationRules.vue
@@ -1,0 +1,245 @@
+<template>
+    <div class="global-pr-validation-rules">
+        <div class="header">
+            <h4>Global PR Validation Trigger Rules</h4>
+            <n-tooltip trigger="hover">
+                <template #trigger>
+                    <n-icon size="16" style="cursor: help;"><QuestionMark/></n-icon>
+                </template>
+                When a VCS repository in this org has no per-repo PR-validation
+                trigger configured, the rule list below is walked in order and
+                the first rule whose URI regex matches contributes its trigger
+                as the effective EXTERNAL_VALIDATION trigger. Per-repo triggers
+                always win when present. List order is the priority order — use
+                the up/down arrows to reorder.
+            </n-tooltip>
+        </div>
+
+        <div class="actions">
+            <n-button v-if="isWritable" type="primary" @click="openAdd">
+                <template #icon><n-icon><CirclePlus/></n-icon></template>
+                Add rule
+            </n-button>
+        </div>
+
+        <n-data-table
+            :columns="columns"
+            :data="rules"
+            :pagination="false"
+            :bordered="false"/>
+
+        <n-modal
+            preset="dialog"
+            :show-icon="false"
+            style="width: 600px;"
+            v-model:show="editorOpen"
+            :title="editorTitle">
+            <n-form :model="draft" label-placement="top" class="mt-3">
+                <n-form-item label="Name" required>
+                    <n-input v-model:value="draft.name" placeholder="e.g. Default GitHub PR validation"/>
+                </n-form-item>
+                <n-form-item label="VCS URI regex" required>
+                    <n-input v-model:value="draft.uriPattern" placeholder="github.com/myorg/.*"/>
+                </n-form-item>
+                <n-form-item label="GitHub Validate Integration" required>
+                    <n-select
+                        v-model:value="draft.integration"
+                        placeholder="Select an integration"
+                        :options="validationIntegrationsForSelect"/>
+                </n-form-item>
+                <n-form-item label="GitHub Installation ID" required>
+                    <n-input v-model:value="draft.schedule" placeholder="GitHub App installation id"/>
+                </n-form-item>
+                <n-form-item label="Check name override">
+                    <n-input v-model:value="draft.checkName" placeholder="(optional) defaults to rearm/pr/<identity>"/>
+                </n-form-item>
+                <n-space>
+                    <n-button type="primary" :disabled="!canSave" @click="saveDraft">Save</n-button>
+                    <n-button @click="editorOpen = false">Cancel</n-button>
+                </n-space>
+            </n-form>
+        </n-modal>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, reactive, ref } from 'vue'
+import { useStore } from 'vuex'
+import {
+    NButton, NDataTable, NForm, NFormItem, NIcon, NInput, NModal, NSelect, NSpace, NTooltip, useNotification
+} from 'naive-ui'
+import { CirclePlus, QuestionMark, Edit as EditIcon, Trash, ArrowUp, ArrowDown } from '@vicons/tabler'
+import gql from 'graphql-tag'
+import graphqlClient from '@/utils/graphql'
+
+const props = defineProps<{ orgUuid: string, isWritable: boolean }>()
+
+const store = useStore()
+const notification = useNotification()
+
+const rules = ref<any[]>([])
+const ciIntegrations = ref<any[]>([])
+
+const editorOpen = ref(false)
+const editingIndex = ref<number | null>(null)
+const draft = reactive({
+    name: '',
+    uriPattern: '',
+    integration: '',
+    schedule: '',
+    checkName: ''
+})
+
+const editorTitle = computed(() => editingIndex.value === null ? 'Add rule' : 'Edit rule')
+
+const validationIntegrationsForSelect = computed(() => ciIntegrations.value
+    .filter((x: any) => x.type === 'GITHUB' && (x.capabilities || []).includes('PR_VALIDATE'))
+    .map((x: any) => ({ label: x.note || x.identifier || x.uuid, value: x.uuid })))
+
+const integrationLabel = (uuid: string) => {
+    if (!uuid) return '—'
+    const found = ciIntegrations.value.find((x: any) => x.uuid === uuid)
+    return found ? (found.note || found.identifier || uuid) : uuid + ' (missing)'
+}
+
+const canSave = computed(() => !!(draft.name && draft.uriPattern && draft.integration && draft.schedule))
+
+const resetDraft = () => {
+    draft.name = ''
+    draft.uriPattern = ''
+    draft.integration = ''
+    draft.schedule = ''
+    draft.checkName = ''
+}
+
+const openAdd = () => {
+    resetDraft()
+    editingIndex.value = null
+    editorOpen.value = true
+}
+
+const openEdit = (idx: number) => {
+    const r = rules.value[idx]
+    draft.name = r.name
+    draft.uriPattern = r.uriPattern
+    draft.integration = r.trigger?.integration || ''
+    draft.schedule = r.trigger?.schedule || ''
+    draft.checkName = r.trigger?.checkName || ''
+    editingIndex.value = idx
+    editorOpen.value = true
+}
+
+const saveDraft = async () => {
+    if (!canSave.value) return
+    const ruleObject = {
+        name: draft.name,
+        uriPattern: draft.uriPattern,
+        trigger: {
+            type: 'EXTERNAL_VALIDATION',
+            name: draft.name,
+            integration: draft.integration,
+            schedule: draft.schedule,
+            checkName: draft.checkName || null
+        }
+    }
+    const next = rules.value.slice()
+    if (editingIndex.value === null) next.push(ruleObject)
+    else next.splice(editingIndex.value, 1, ruleObject)
+    await persist(next, 'Rule saved.')
+    editorOpen.value = false
+}
+
+const remove = async (idx: number) => {
+    const next = rules.value.slice()
+    next.splice(idx, 1)
+    await persist(next, 'Rule deleted.')
+}
+
+const move = async (idx: number, delta: number) => {
+    const target = idx + delta
+    if (target < 0 || target >= rules.value.length) return
+    const next = rules.value.slice()
+    const [item] = next.splice(idx, 1)
+    next.splice(target, 0, item)
+    await persist(next, 'Rule reordered.')
+}
+
+const persist = async (next: any[], successMsg: string) => {
+    try {
+        rules.value = await store.dispatch('setGlobalPrValidationTriggerRules', {
+            orgUuid: props.orgUuid,
+            rules: next.map((r: any) => ({ name: r.name, uriPattern: r.uriPattern, trigger: r.trigger }))
+        })
+        notification.success({ title: 'Saved', content: successMsg, duration: 3500 })
+    } catch (e: any) {
+        notification.error({ title: 'Save failed', content: e?.message || 'Unknown error', duration: 6000 })
+    }
+}
+
+const columns = computed(() => [
+    { title: 'Order', key: 'order', width: 70, render: (_: any, idx: number) => `${idx + 1}` },
+    { title: 'Name', key: 'name' },
+    { title: 'URI regex', key: 'uriPattern' },
+    {
+        title: 'Integration',
+        key: 'integration',
+        render: (row: any) => integrationLabel(row.trigger?.integration)
+    },
+    {
+        title: 'Actions',
+        key: 'actions',
+        width: 200,
+        render: (row: any, idx: number) => h('div', { style: 'display: flex; gap: 6px;' },
+            props.isWritable ? [
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move up', onClick: () => move(idx, -1) },
+                    { default: () => h(ArrowUp) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move down', onClick: () => move(idx, 1) },
+                    { default: () => h(ArrowDown) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Edit', onClick: () => openEdit(idx) },
+                    { default: () => h(EditIcon) }),
+                h(NIcon, { size: 22, class: 'clickable', style: 'color: #d03050;', title: 'Delete',
+                    onClick: () => remove(idx) }, { default: () => h(Trash) })
+            ] : [])
+    }
+])
+
+async function fetchCiIntegrations() {
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query ciIntegrations($org: ID!) {
+                    ciIntegrations(org: $org) {
+                        uuid identifier org isEnabled type note capabilities
+                    }
+                }`,
+            variables: { org: props.orgUuid },
+            fetchPolicy: 'network-only'
+        })
+        ciIntegrations.value = resp.data?.ciIntegrations || []
+    } catch (err) { console.error(err) }
+}
+
+onMounted(async () => {
+    await fetchCiIntegrations()
+    rules.value = (await store.dispatch('fetchOrgValidationTriggerRules', props.orgUuid)) || []
+})
+</script>
+
+<style scoped lang="scss">
+.global-pr-validation-rules {
+    padding: 0.5rem 0;
+}
+.header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.actions {
+    margin-bottom: 0.75rem;
+}
+.mt-3 { margin-top: 0.75rem; }
+.clickable {
+    cursor: pointer;
+}
+</style>

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -904,6 +904,10 @@
                 </n-modal>
             </n-tab-pane>
 
+            <n-tab-pane name="globalPrValidation" tab="Global PR Validation" v-if="isOrgAdmin && myUser.installationType !== 'OSS'">
+                <OrgGlobalPrValidationRules :orgUuid="orgResolved" :isWritable="isWritable"/>
+            </n-tab-pane>
+
             <n-tab-pane name="terminology" tab="Terminology" v-if="isOrgAdmin">
                 <div class="terminologyBlock mt-4">
                     <h5>Custom Terminology</h5>
@@ -1344,6 +1348,7 @@ import CreateApprovalPolicy from './CreateApprovalPolicy.vue'
 import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
 import WebhooksOfOrg from './WebhooksOfOrg.vue'
+import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
 import { FetchPolicy } from '@apollo/client'
 import {ApprovalEntry, ApprovalRole, ApprovalRequirement} from '@/utils/commonTypes'
 

--- a/ui/src/components/VcsRepository.vue
+++ b/ui/src/components/VcsRepository.vue
@@ -17,6 +17,28 @@
             </div>
             <div class="meta">URI: {{ vcsRepo.uri }}</div>
 
+            <div v-if="effective" class="provenance" :class="provenanceClass">
+                <div class="provenance-line">
+                    <strong>Effective trigger:</strong>
+                    <span v-if="effective.source === 'PER_VCS'">configured directly on this repository</span>
+                    <span v-else-if="effective.source === 'ORG_RULE'">
+                        inherited from org rule
+                        <code>{{ effective.ruleName }}</code>
+                    </span>
+                    <span v-else>none — the aggregator will not dispatch a check-run for this repository</span>
+                </div>
+                <div v-if="effective.alsoMatchedRuleNames && effective.alsoMatchedRuleNames.length" class="provenance-warn">
+                    Other org rules also match this URI:
+                    <code v-for="(n, i) in effective.alsoMatchedRuleNames" :key="n">{{ i ? ', ' : '' }}{{ n }}</code>.
+                    The first match wins; reorder rules in
+                    <em>Org Settings &rarr; Global PR Validation</em> to change priority.
+                </div>
+                <div v-if="effective.staleRuleNames && effective.staleRuleNames.length" class="provenance-warn">
+                    Org rules with broken integrations were skipped:
+                    <code v-for="(n, i) in effective.staleRuleNames" :key="n">{{ i ? ', ' : '' }}{{ n }}</code>.
+                </div>
+            </div>
+
             <h3 class="mt-4">
                 Pull-request validation
                 <n-tooltip trigger="hover">
@@ -172,6 +194,7 @@ const saveTrigger = async () => {
             vcsUuid: vcsRepoUuid.value,
             triggers: [trigger]
         })
+        await fetchEffective()
         notification.success({ title: 'Saved', content: 'PR validation trigger updated.', duration: 3500 })
         editing.value = false
     } catch (e: any) {
@@ -185,6 +208,7 @@ const clearTrigger = async () => {
             vcsUuid: vcsRepoUuid.value,
             triggers: []
         })
+        await fetchEffective()
         notification.success({ title: 'Removed', content: 'PR validation trigger cleared.', duration: 3500 })
     } catch (e: any) {
         notification.error({ title: 'Remove failed', content: e?.message || 'Unknown error', duration: 5000 })
@@ -217,10 +241,29 @@ async function fetchCiIntegrations(orgUuid: string) {
     }
 }
 
+const effective = ref<any>(null)
+
+const provenanceClass = computed(() => {
+    if (!effective.value) return ''
+    if (effective.value.source === 'NONE') return 'provenance-none'
+    return 'provenance-ok'
+})
+
+async function fetchEffective() {
+    if (!vcsRepoUuid.value) return
+    try {
+        effective.value = await store.dispatch('fetchEffectivePrValidationTrigger', vcsRepoUuid.value)
+    } catch (err) {
+        console.error(err)
+        effective.value = null
+    }
+}
+
 async function loadAll() {
     if (!vcsRepoUuid.value) return
     const fresh = await store.dispatch('fetchVcsRepo', vcsRepoUuid.value)
     if (fresh?.org) await fetchCiIntegrations(fresh.org)
+    await fetchEffective()
 }
 
 const goToPullRequests = () => {
@@ -267,6 +310,29 @@ watch(vcsRepoUuid, loadAll)
     border-radius: 4px;
     p { margin: 0.25rem 0; }
 }
+.provenance {
+    border-radius: 4px;
+    padding: 0.6rem 0.9rem;
+    margin-bottom: 0.75rem;
+    border: 1px solid;
+    font-size: 0.95em;
+    code { background: rgba(0,0,0,0.05); padding: 0 4px; border-radius: 3px; }
+}
+.provenance-ok {
+    background: #f4f8fc;
+    border-color: #cfe0ee;
+    color: #2c3e50;
+}
+.provenance-none {
+    background: #fff7e6;
+    border-color: #ffcf80;
+    color: #6b4500;
+}
+.provenance-warn {
+    margin-top: 0.4rem;
+    color: #b25400;
+}
+.provenance-line { margin-bottom: 0; }
 .mt-3 { margin-top: 0.75rem; }
 .mt-4 { margin-top: 1rem; }
 </style>

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1164,6 +1164,84 @@ const storeObject : any = {
             context.commit('ADD_VCS_REPO', data.data.setVcsRepositoryOutputTriggers)
             return data.data.setVcsRepositoryOutputTriggers
         },
+        async fetchOrgValidationTriggerRules (context: any, orgUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query org($orgUuid: ID!) {
+                        organizations {
+                            uuid
+                            globalPrValidationTriggerRules {
+                                name
+                                uriPattern
+                                trigger {
+                                    uuid
+                                    name
+                                    type
+                                    integration
+                                    schedule
+                                    checkName
+                                }
+                            }
+                        }
+                    }`,
+                variables: { orgUuid },
+                fetchPolicy: 'no-cache'
+            })
+            const orgs = response.data.organizations || []
+            const found = orgs.find((o: any) => o.uuid === orgUuid)
+            return found?.globalPrValidationTriggerRules || []
+        },
+        async setGlobalPrValidationTriggerRules (context: any, payload: { orgUuid: string, rules: any[] }) {
+            const data = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setGlobalPrValidationTriggerRules($orgUuid: ID!, $rules: [GlobalPrValidationTriggerRuleInput!]!) {
+                        setGlobalPrValidationTriggerRules(orgUuid: $orgUuid, rules: $rules) {
+                            uuid
+                            globalPrValidationTriggerRules {
+                                name
+                                uriPattern
+                                trigger {
+                                    uuid
+                                    name
+                                    type
+                                    integration
+                                    schedule
+                                    checkName
+                                }
+                            }
+                        }
+                    }`,
+                variables: { orgUuid: payload.orgUuid, rules: payload.rules }
+            })
+            return data.data.setGlobalPrValidationTriggerRules.globalPrValidationTriggerRules || []
+        },
+        async fetchEffectivePrValidationTrigger (context: any, vcsUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query vcsRepository($vcs: ID!) {
+                        vcsRepository(vcs: $vcs) {
+                            uuid
+                            effectivePrValidationTrigger {
+                                source
+                                ruleName
+                                alsoMatchedRuleNames
+                                staleRuleNames
+                                trigger {
+                                    uuid
+                                    name
+                                    type
+                                    integration
+                                    schedule
+                                    checkName
+                                }
+                            }
+                        }
+                    }`,
+                variables: { vcs: vcsUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.vcsRepository?.effectivePrValidationTrigger || null
+        },
         async fetchPullRequestsOfOrg (context: any, payload: string | { org: string, states?: string[] }) {
             const org = typeof payload === 'string' ? payload : payload.org
             const states = typeof payload === 'string' ? undefined : payload.states


### PR DESCRIPTION
## Summary

Companion UI for relizaio/rearm-saas#55 — org-wide PR validation trigger rules.

- **OrgSettings** — new "Global PR Validation" tab (Pro-only via \`installationType !== 'OSS'\`). Self-contained child component \`OrgGlobalPrValidationRules.vue\` so OrgSettings doesn't grow further. Each rule: name, URI regex, GitHub Validate integration picker (filtered to GITHUB + PR_VALIDATE), installation id, optional check-name override. Up/down reorder buttons (list order = priority on the server).
- **VcsRepository** — provenance card above the per-repo trigger editor. Calls the new \`effectivePrValidationTrigger\` resolver and renders source (configured directly / inherited / none) plus multi-match and stale-integration warnings.
- **store.ts** — three new actions (\`fetchOrgValidationTriggerRules\`, \`setGlobalPrValidationTriggerRules\`, \`fetchEffectivePrValidationTrigger\`).

## Test plan
- [x] UI CI green on the feature branch
- [x] Verified end-to-end on agent-scully with the Pro backend on the same branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)