### PR TITLE
feat(ui): Global Approval Policies tab + per-component provenance card

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -372,6 +372,29 @@
                                                 v-if="isWritable"
                                                 :options="approvalPolicies" v-model:value="updatedComponent.approvalPolicy" />
                                             <div v-else>{{ resolvedVisibilityLabel }}</div>
+                                            <div v-if="effectiveApprovalPolicy" class="provenance" :class="provenanceClass" style="margin-top: 8px;">
+                                                <div class="provenance-line">
+                                                    <strong>Effective policy:</strong>
+                                                    <span v-if="effectiveApprovalPolicy.source === 'PER_COMPONENT'">
+                                                        <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        (per-component, this row)
+                                                    </span>
+                                                    <span v-else-if="effectiveApprovalPolicy.source === 'ORG_RULE'">
+                                                        <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        — inherited from org rule <code>{{ effectiveApprovalPolicy.ruleName }}</code>
+                                                    </span>
+                                                    <span v-else>none — no per-component reference and no matching org rule</span>
+                                                </div>
+                                                <div v-if="effectiveApprovalPolicy.perComponentPolicyArchived" class="provenance-warn">
+                                                    The per-component approval-policy reference points to an archived or
+                                                    missing policy; resolution fell through to the org-wide rule list.
+                                                </div>
+                                                <div v-if="effectiveApprovalPolicy.alsoMatchedRuleNames && effectiveApprovalPolicy.alsoMatchedRuleNames.length" class="provenance-warn">
+                                                    Other org rules also match this component:
+                                                    <code v-for="(n, i) in effectiveApprovalPolicy.alsoMatchedRuleNames" :key="n">{{ i ? ', ' : '' }}{{ n }}</code>.
+                                                    First-match-wins; reorder in <em>Org Settings &rarr; Global Approval Policies</em> to change priority.
+                                                </div>
+                                            </div>
                                         </div>
                                         <div class="coreSettingsActions" v-if="hasCoreSettingsChanges && isWritable" style="margin-top: 20px;">
                                             <n-space>
@@ -1207,6 +1230,32 @@ const resourceGroups: ComputedRef<any> = computed((): any => {
 
 const approvalPolicies : Ref<any[]> = ref([])
 
+// Snapshot of the resolved approval policy for this component:
+// per-component reference vs inherited from a Global Approval Policy
+// rule vs none. Used to render the provenance card in the Core
+// Settings tab. Refetched after a save so a freshly-saved per-component
+// reference is reflected immediately.
+const effectiveApprovalPolicy : Ref<any> = ref(null)
+const provenanceClass = computed(() => {
+    if (!effectiveApprovalPolicy.value) return ''
+    if (effectiveApprovalPolicy.value.source === 'NONE') return 'provenance-none'
+    if (effectiveApprovalPolicy.value.perComponentPolicyArchived) return 'provenance-warn-bg'
+    return 'provenance-ok'
+})
+
+async function fetchEffectiveApprovalPolicy () {
+    if (myUser.installationType === 'OSS' || !componentData.value?.uuid) {
+        effectiveApprovalPolicy.value = null
+        return
+    }
+    try {
+        effectiveApprovalPolicy.value = await store.dispatch('fetchEffectiveApprovalPolicy', componentData.value.uuid)
+    } catch (err) {
+        console.error(err)
+        effectiveApprovalPolicy.value = null
+    }
+}
+
 async function fetchApprovalPolicies () {
     if (myUser.installationType !== 'OSS') {
         const response = await graphqlClient.query({
@@ -1233,6 +1282,7 @@ async function fetchApprovalPolicies () {
 
 const openComponentSettings = async function() {
     await fetchApprovalPolicies()
+    await fetchEffectiveApprovalPolicy()
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
     showComponentSettingsModal.value = true
     
@@ -1907,6 +1957,10 @@ async function save () {
     updatedComponent.value = commonFunctions.deepCopy(await store.dispatch('updateComponent', updatedComponent.value))
     // Update originalComponent to match current state so hasComponentChanges() returns false
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
+    // Refresh the effective-policy snapshot so the provenance card
+    // reflects whatever the operator just saved (or cleared, in which
+    // case the resolver may now fall through to an org rule).
+    await fetchEffectiveApprovalPolicy()
     notify('success', 'Success', `${words.value.componentFirstUpper} updated successfully`)
 }
 
@@ -3117,5 +3171,33 @@ projSettingsCollapse {
 .componentIconsAndSettings {
     margin-bottom: 5px;
 }
+
+.provenance {
+    border-radius: 4px;
+    padding: 0.6rem 0.9rem;
+    border: 1px solid;
+    font-size: 0.9em;
+    code { background: rgba(0,0,0,0.05); padding: 0 4px; border-radius: 3px; }
+}
+.provenance-ok {
+    background: #f4f8fc;
+    border-color: #cfe0ee;
+    color: #2c3e50;
+}
+.provenance-none {
+    background: #fff7e6;
+    border-color: #ffcf80;
+    color: #6b4500;
+}
+.provenance-warn-bg {
+    background: #fff7e6;
+    border-color: #ffcf80;
+    color: #6b4500;
+}
+.provenance-warn {
+    margin-top: 0.4rem;
+    color: #b25400;
+}
+.provenance-line { margin-bottom: 0; }
 
 </style>

--- a/ui/src/components/OrgGlobalApprovalPolicyRules.vue
+++ b/ui/src/components/OrgGlobalApprovalPolicyRules.vue
@@ -1,0 +1,236 @@
+<template>
+    <div class="global-approval-policy-rules">
+        <div class="header">
+            <h4>Global Approval Policy Assignments</h4>
+            <n-tooltip trigger="hover">
+                <template #trigger>
+                    <n-icon size="16" style="cursor: help;"><QuestionMark/></n-icon>
+                </template>
+                When a component in this org has no per-component approval
+                policy reference (or it points to an archived/missing policy),
+                the rule list below is walked in order and the first rule whose
+                name regex AND component-type filter match contributes its
+                policy. Per-component references always win when present and
+                still valid. List order is the priority order — reorder with
+                the up/down arrows.
+            </n-tooltip>
+        </div>
+
+        <div class="actions">
+            <n-button v-if="isWritable" type="primary" @click="openAdd">
+                <template #icon><n-icon><CirclePlus/></n-icon></template>
+                Add rule
+            </n-button>
+        </div>
+
+        <n-data-table
+            :columns="columns"
+            :data="rules"
+            :pagination="false"
+            :bordered="false"/>
+
+        <n-modal
+            preset="dialog"
+            :show-icon="false"
+            style="width: 600px;"
+            v-model:show="editorOpen"
+            :title="editorTitle">
+            <n-form :model="draft" label-placement="top" class="mt-3">
+                <n-form-item label="Name" required>
+                    <n-input v-model:value="draft.name" placeholder="e.g. Default for frontend components"/>
+                </n-form-item>
+                <n-form-item label="Component name regex" required>
+                    <n-input v-model:value="draft.namePattern" placeholder="frontend-.*"/>
+                </n-form-item>
+                <n-form-item label="Applies to" required>
+                    <n-radio-group v-model:value="draft.componentType">
+                        <n-radio value="ANY">Components and products</n-radio>
+                        <n-radio value="COMPONENT">Components only</n-radio>
+                        <n-radio value="PRODUCT">Products only</n-radio>
+                    </n-radio-group>
+                </n-form-item>
+                <n-form-item label="Approval Policy" required>
+                    <n-select
+                        v-model:value="draft.approvalPolicy"
+                        placeholder="Select an approval policy"
+                        :options="approvalPolicyOptions"/>
+                </n-form-item>
+                <n-space>
+                    <n-button type="primary" :disabled="!canSave" @click="saveDraft">Save</n-button>
+                    <n-button @click="editorOpen = false">Cancel</n-button>
+                </n-space>
+            </n-form>
+        </n-modal>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, reactive, ref } from 'vue'
+import { useStore } from 'vuex'
+import {
+    NButton, NDataTable, NForm, NFormItem, NIcon, NInput, NModal, NRadio, NRadioGroup, NSelect, NSpace, NTooltip, useNotification
+} from 'naive-ui'
+import { CirclePlus, QuestionMark, Edit as EditIcon, Trash, ArrowUp, ArrowDown } from '@vicons/tabler'
+
+const props = defineProps<{ orgUuid: string, isWritable: boolean }>()
+
+const store = useStore()
+const notification = useNotification()
+
+const rules = ref<any[]>([])
+const approvalPolicies = ref<any[]>([])
+
+const editorOpen = ref(false)
+const editingIndex = ref<number | null>(null)
+const draft = reactive({
+    name: '',
+    namePattern: '',
+    componentType: 'ANY' as 'ANY' | 'COMPONENT' | 'PRODUCT',
+    approvalPolicy: ''
+})
+
+const editorTitle = computed(() => editingIndex.value === null ? 'Add rule' : 'Edit rule')
+
+const approvalPolicyOptions = computed(() => approvalPolicies.value
+    .filter((p: any) => p.status !== 'ARCHIVED')
+    .map((p: any) => ({ label: p.policyName || p.uuid, value: p.uuid })))
+
+const policyLabel = (uuid: string) => {
+    if (!uuid) return '—'
+    const found = approvalPolicies.value.find((p: any) => p.uuid === uuid)
+    if (!found) return uuid + ' (missing)'
+    if (found.status === 'ARCHIVED') return found.policyName + ' (archived)'
+    return found.policyName || uuid
+}
+
+const typeLabel = (t: string | null | undefined) => {
+    if (!t || t === 'ANY') return 'Any (Components and products)'
+    if (t === 'COMPONENT') return 'Components only'
+    if (t === 'PRODUCT') return 'Products only'
+    return t
+}
+
+const canSave = computed(() => !!(draft.name && draft.namePattern && draft.approvalPolicy))
+
+const resetDraft = () => {
+    draft.name = ''
+    draft.namePattern = ''
+    draft.componentType = 'ANY'
+    draft.approvalPolicy = ''
+}
+
+const openAdd = () => {
+    resetDraft()
+    editingIndex.value = null
+    editorOpen.value = true
+}
+
+const openEdit = (idx: number) => {
+    const r = rules.value[idx]
+    draft.name = r.name
+    draft.namePattern = r.namePattern
+    draft.componentType = r.componentType || 'ANY'
+    draft.approvalPolicy = r.approvalPolicy
+    editingIndex.value = idx
+    editorOpen.value = true
+}
+
+const saveDraft = async () => {
+    if (!canSave.value) return
+    const ruleObject = {
+        name: draft.name,
+        namePattern: draft.namePattern,
+        componentType: draft.componentType,
+        approvalPolicy: draft.approvalPolicy
+    }
+    const next = rules.value.slice()
+    if (editingIndex.value === null) next.push(ruleObject)
+    else next.splice(editingIndex.value, 1, ruleObject)
+    await persist(next, 'Rule saved.')
+    editorOpen.value = false
+}
+
+const remove = async (idx: number) => {
+    const next = rules.value.slice()
+    next.splice(idx, 1)
+    await persist(next, 'Rule deleted.')
+}
+
+const move = async (idx: number, delta: number) => {
+    const target = idx + delta
+    if (target < 0 || target >= rules.value.length) return
+    const next = rules.value.slice()
+    const [item] = next.splice(idx, 1)
+    next.splice(target, 0, item)
+    await persist(next, 'Rule reordered.')
+}
+
+const persist = async (next: any[], successMsg: string) => {
+    try {
+        rules.value = await store.dispatch('setGlobalApprovalPolicyRules', {
+            orgUuid: props.orgUuid,
+            rules: next.map((r: any) => ({
+                name: r.name,
+                namePattern: r.namePattern,
+                componentType: r.componentType || 'ANY',
+                approvalPolicy: r.approvalPolicy
+            }))
+        })
+        notification.success({ title: 'Saved', content: successMsg, duration: 3500 })
+    } catch (e: any) {
+        notification.error({ title: 'Save failed', content: e?.message || 'Unknown error', duration: 6000 })
+    }
+}
+
+const columns = computed(() => [
+    { title: 'Order', key: 'order', width: 70, render: (_: any, idx: number) => `${idx + 1}` },
+    { title: 'Name', key: 'name' },
+    { title: 'Component name regex', key: 'namePattern' },
+    { title: 'Applies to', key: 'componentType', render: (row: any) => typeLabel(row.componentType) },
+    {
+        title: 'Approval Policy',
+        key: 'approvalPolicy',
+        render: (row: any) => policyLabel(row.approvalPolicy)
+    },
+    {
+        title: 'Actions',
+        key: 'actions',
+        width: 200,
+        render: (row: any, idx: number) => h('div', { style: 'display: flex; gap: 6px;' },
+            props.isWritable ? [
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move up', onClick: () => move(idx, -1) },
+                    { default: () => h(ArrowUp) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move down', onClick: () => move(idx, 1) },
+                    { default: () => h(ArrowDown) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Edit', onClick: () => openEdit(idx) },
+                    { default: () => h(EditIcon) }),
+                h(NIcon, { size: 22, class: 'clickable', style: 'color: #d03050;', title: 'Delete',
+                    onClick: () => remove(idx) }, { default: () => h(Trash) })
+            ] : [])
+    }
+])
+
+onMounted(async () => {
+    approvalPolicies.value = (await store.dispatch('listApprovalPoliciesOfOrg', props.orgUuid)) || []
+    rules.value = (await store.dispatch('fetchOrgApprovalPolicyRules', props.orgUuid)) || []
+})
+</script>
+
+<style scoped lang="scss">
+.global-approval-policy-rules {
+    padding: 0.5rem 0;
+}
+.header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.actions {
+    margin-bottom: 0.75rem;
+}
+.mt-3 { margin-top: 0.75rem; }
+.clickable {
+    cursor: pointer;
+}
+</style>

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -908,6 +908,10 @@
                 <OrgGlobalPrValidationRules :orgUuid="orgResolved" :isWritable="isWritable"/>
             </n-tab-pane>
 
+            <n-tab-pane name="globalApprovalPolicyRules" tab="Global Approval Policies" v-if="isOrgAdmin && myUser.installationType !== 'OSS'">
+                <OrgGlobalApprovalPolicyRules :orgUuid="orgResolved" :isWritable="isWritable"/>
+            </n-tab-pane>
+
             <n-tab-pane name="terminology" tab="Terminology" v-if="isOrgAdmin">
                 <div class="terminologyBlock mt-4">
                     <h5>Custom Terminology</h5>
@@ -1349,6 +1353,7 @@ import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
 import WebhooksOfOrg from './WebhooksOfOrg.vue'
 import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
+import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
 import { FetchPolicy } from '@apollo/client'
 import {ApprovalEntry, ApprovalRole, ApprovalRequirement} from '@/utils/commonTypes'
 

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1242,6 +1242,92 @@ const storeObject : any = {
             })
             return response.data.vcsRepository?.effectivePrValidationTrigger || null
         },
+        async fetchOrgApprovalPolicyRules (context: any, orgUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query orgApprovalPolicyRules {
+                        organizations {
+                            uuid
+                            globalApprovalPolicyRules {
+                                name
+                                namePattern
+                                componentType
+                                approvalPolicy
+                                approvalPolicyDetails {
+                                    uuid
+                                    policyName
+                                    status
+                                }
+                            }
+                        }
+                    }`,
+                fetchPolicy: 'no-cache'
+            })
+            const orgs = response.data.organizations || []
+            const found = orgs.find((o: any) => o.uuid === orgUuid)
+            return found?.globalApprovalPolicyRules || []
+        },
+        async setGlobalApprovalPolicyRules (context: any, payload: { orgUuid: string, rules: any[] }) {
+            const data = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setGlobalApprovalPolicyRules($orgUuid: ID!, $rules: [GlobalApprovalPolicyRuleInput!]!) {
+                        setGlobalApprovalPolicyRules(orgUuid: $orgUuid, rules: $rules) {
+                            uuid
+                            globalApprovalPolicyRules {
+                                name
+                                namePattern
+                                componentType
+                                approvalPolicy
+                                approvalPolicyDetails {
+                                    uuid
+                                    policyName
+                                    status
+                                }
+                            }
+                        }
+                    }`,
+                variables: { orgUuid: payload.orgUuid, rules: payload.rules }
+            })
+            return data.data.setGlobalApprovalPolicyRules.globalApprovalPolicyRules || []
+        },
+        async fetchEffectiveApprovalPolicy (context: any, componentUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query component($componentUuid: ID!) {
+                        component(componentUuid: $componentUuid) {
+                            uuid
+                            effectiveApprovalPolicy {
+                                source
+                                approvalPolicy
+                                ruleName
+                                alsoMatchedRuleNames
+                                perComponentPolicyArchived
+                                approvalPolicyDetails {
+                                    uuid
+                                    policyName
+                                    status
+                                }
+                            }
+                        }
+                    }`,
+                variables: { componentUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.component?.effectiveApprovalPolicy || null
+        },
+        async listApprovalPoliciesOfOrg (context: any, orgUuid: NonNullable<string>) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query approvalPoliciesOfOrg($orgUuid: ID!) {
+                        approvalPoliciesOfOrg(orgUuid: $orgUuid) {
+                            uuid policyName status
+                        }
+                    }`,
+                variables: { orgUuid },
+                fetchPolicy: 'network-only'
+            })
+            return response.data.approvalPoliciesOfOrg || []
+        },
         async fetchPullRequestsOfOrg (context: any, payload: string | { org: string, states?: string[] }) {
             const org = typeof payload === 'string' ? payload : payload.org
             const states = typeof payload === 'string' ? undefined : payload.states


### PR DESCRIPTION
## Summary

Reopens #41 against a fresh branch off latest main (resolves conflicts from #40 cleanly).

Companion UI for relizaio/rearm-saas#57 — org-wide approval-policy assignment rules.

- **OrgSettings** — new "Global Approval Policies" tab (Pro-only via \`installationType !== 'OSS'\`). Self-contained child component \`OrgGlobalApprovalPolicyRules.vue\`. Each rule: name, component-name regex, applies-to radio (Components+Products / Components only / Products only — maps to \`ANY / COMPONENT / PRODUCT\`), approval policy picker (filtered to non-archived). Up/down reorder buttons.
- **ComponentView** — provenance card next to the existing per-component approval-policy selector. Calls the new \`Component.effectiveApprovalPolicy\` resolver and renders:
  - per-component reference (when present and still resolving)
  - inherited from org rule \`<name>\`
  - none — no per-component reference and no matching org rule (warning colour)
  - "Other org rules also match this component" listing the losing rules
  - "The per-component reference points to an archived or missing policy" warning when \`perComponentPolicyArchived\` fires
- **store.ts** — four new actions (\`fetchOrgApprovalPolicyRules\`, \`setGlobalApprovalPolicyRules\`, \`fetchEffectiveApprovalPolicy\`, \`listApprovalPoliciesOfOrg\`).

## Test plan
- [x] UI CI green on the feature branch
- [ ] Verified end-to-end on agent-scully with the Pro backend on the same branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)