### PR TITLE
refactor(ui): rename approval-policy input/output events to rules/actions

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -413,9 +413,9 @@
                                             </n-space>
                                         </div>
                                     </n-tab-pane>
-                                    <n-tab-pane name="outputTriggers" tab="Output Events" v-if="myUser.installationType !== 'OSS'">
+                                    <n-tab-pane name="outputTriggers" tab="Actions" v-if="myUser.installationType !== 'OSS'">
                                         <n-data-table :data="updatedComponent.outputTriggers ? updatedComponent.outputTriggers : []" :columns="outputTriggerTableFields" :row-key="dataTableUuidRowKey" />
-                                        <Icon v-if="isWritable" class="clickable" size="25" title="Add Output Event" @click="resetOutputTrigger(); loadEnvTypes(); showCreateOutputTriggerModal = true">
+                                        <Icon v-if="isWritable" class="clickable" size="25" title="Add Action" @click="resetOutputTrigger(); loadEnvTypes(); showCreateOutputTriggerModal = true">
                                             <CirclePlus />
                                         </Icon>
                                         <div class="coreSettingsActions" v-if="hasTriggerChanges && isWritable" style="margin-top: 20px;">
@@ -441,7 +441,7 @@
                                             style="width: 90%"
                                         >
                                             <n-form :model="outputTrigger">
-                                                <h2>Add or Update Output Event</h2>
+                                                <h2>Add or Update Action</h2>
                                                 <n-space vertical size="large">
                                                     <n-form-item label="Name" path="name">
                                                         <n-input v-model:value="outputTrigger.name" required placeholder="Enter name" />
@@ -640,9 +640,9 @@
                                             </n-form>
                                         </n-modal>
                                     </n-tab-pane>
-                                    <n-tab-pane name="Input Events" v-if="myUser.installationType !== 'OSS'">
+                                    <n-tab-pane name="Input Events" tab="Rules" v-if="myUser.installationType !== 'OSS'">
                                         <n-data-table :data="updatedComponent.releaseInputTriggers ? updatedComponent.releaseInputTriggers : []" :columns="inputTriggerTableFields" :row-key="dataTableUuidRowKey" />
-                                        <Icon v-if="isWritable" class="clickable" size="25" title="Add Input Event" @click="resetInputTrigger(); showCreateInputTriggerModal = true">
+                                        <Icon v-if="isWritable" class="clickable" size="25" title="Add Rule" @click="resetInputTrigger(); showCreateInputTriggerModal = true">
                                             <CirclePlus />
                                         </Icon>
                                         <div class="coreSettingsActions" v-if="hasTriggerChanges && isWritable" style="margin-top: 20px;">
@@ -680,7 +680,7 @@
                                                             :error="celExpressionError"
                                                         />
                                                     </n-form-item>
-                                                    <n-form-item label="Output Events" path="inputTrigger.outputEvents">
+                                                    <n-form-item label="Actions" path="inputTrigger.outputEvents">
                                                         <n-select v-model:value="inputTrigger.outputEvents" 
                                                         :options="outputTriggersForInputForm" multiple />
                                                     </n-form-item>
@@ -691,12 +691,12 @@
                                             </n-form>
                                         </n-modal>
                                     </n-tab-pane>
-                                    <n-tab-pane name="globalTriggerEvents" tab="Policy-Wide Input Events" v-if="myUser.installationType !== 'OSS' && updatedComponent.approvalPolicy">
+                                    <n-tab-pane name="globalTriggerEvents" tab="Policy-Wide Rules" v-if="myUser.installationType !== 'OSS' && updatedComponent.approvalPolicy">
                                         <div v-if="policyGlobalInputEvents.length === 0" class="text-muted mt-2">
-                                            No policy-wide input events defined on the approval policy.
+                                            No policy-wide rules defined on the approval policy.
                                         </div>
                                         <div v-else>
-                                            <p class="text-muted">Select policy-wide input events from the approval policy to apply to this component. You can optionally override their output events.</p>
+                                            <p class="text-muted">Select policy-wide rules from the approval policy to apply to this component. You can optionally override their actions.</p>
                                             <div v-for="gie in policyGlobalInputEvents" :key="gie.uuid" class="mb-3" style="border: 1px solid #e0e0e0; border-radius: 6px; padding: 12px;">
                                                 <div style="display: flex; align-items: center; gap: 8px;">
                                                     <n-checkbox
@@ -706,7 +706,7 @@
                                                     />
                                                     <strong>{{ gie.name }}</strong>
                                                     <span class="text-muted" style="font-size: 0.85em;">
-                                                        ({{ gie.outputEvents?.length || 0 }} default output event{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
+                                                        ({{ gie.outputEvents?.length || 0 }} default action{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
                                                     </span>
                                                 </div>
                                                 <div v-if="isGlobalInputEventEnabled(gie.uuid)" style="margin-left: 28px; margin-top: 8px;">
@@ -716,7 +716,7 @@
                                                             @update:value="(val: boolean) => toggleOverrideOutputEvents(gie.uuid, val)"
                                                             :disabled="!isWritable"
                                                         />
-                                                        <span>Override output events locally</span>
+                                                        <span>Override actions locally</span>
                                                         <n-button v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally"
                                                             size="tiny" quaternary type="warning"
                                                             @click="resetGlobalInputEventOverride(gie.uuid)"
@@ -725,13 +725,13 @@
                                                         </n-button>
                                                     </div>
                                                     <div v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally" style="margin-top: 8px;">
-                                                        <span style="color: #f0a020; font-size: 0.85em; font-weight: bold;">⚠ Output events are overridden locally</span>
+                                                        <span style="color: #f0a020; font-size: 0.85em; font-weight: bold;">⚠ Actions are overridden locally</span>
                                                         <n-select
                                                             :value="getGlobalInputEventRef(gie.uuid)?.outputEventsOverride || []"
                                                             @update:value="(val: string[]) => updateOutputEventsOverride(gie.uuid, val)"
                                                             :options="allOutputEventsForOverride"
                                                             multiple
-                                                            placeholder="Select output events to use instead"
+                                                            placeholder="Select actions to use instead"
                                                             :disabled="!isWritable"
                                                             style="margin-top: 4px;"
                                                         />
@@ -2678,7 +2678,7 @@ async function deleteOutputTrigger (uuid: string) {
         inputTriggerIndex = updatedComponent.value.releaseInputTriggers.findIndex((rit: any) => rit.outputEvents.includes(uuid))
     }
     if (inputTriggerIndex > -1) {
-        notify('error', 'Error', `Unable to delete because this event is used in one or more input events!`)
+        notify('error', 'Error', `Unable to delete because this action is used by one or more rules!`)
     } else {
         const triggerIndex = updatedComponent.value.outputTriggers.findIndex((ot: any) => ot.uuid === uuid)
         if (triggerIndex > -1) {
@@ -2814,7 +2814,7 @@ const inputTriggerTableFields: DataTableColumns<any> = [
     },
     {
         key: 'outputTriggers',
-        title: 'Output Events',
+        title: 'Actions',
         render: (row: any) => {
             let outTriggers = ''
             if (row.outputEvents && row.outputEvents.length) {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -660,8 +660,8 @@
                             @approvalPolicyCreated="approvalPolicyCreated"/>
                     </n-modal>
 
-                    <h4>Policy-Wide Output Events:
-                        <Icon v-if="isWritable && selectedPolicyUuid" class="clickable addIcon" size="25" title="Add Policy-Wide Output Event" @click="resetGlobalOutputEvent(); loadEnvironmentTypesForOutputEvents(); showCreateGlobalOutputEventModal = true">
+                    <h4>Policy-Wide Actions:
+                        <Icon v-if="isWritable && selectedPolicyUuid" class="clickable addIcon" size="25" title="Add Policy-Wide Action" @click="resetGlobalOutputEvent(); loadEnvironmentTypesForOutputEvents(); showCreateGlobalOutputEventModal = true">
                             <CirclePlus/>
                         </Icon>
                     </h4>
@@ -674,7 +674,7 @@
                             style="width: 90%"
                         >
                             <n-form :model="globalOutputEvent">
-                                <h2>{{ globalOutputEvent.uuid ? 'Edit' : 'Add' }} Policy-Wide Output Event</h2>
+                                <h2>{{ globalOutputEvent.uuid ? 'Edit' : 'Add' }} Policy-Wide Action</h2>
                                 <n-space vertical size="large">
                                     <n-form-item label="Name" path="name">
                                         <n-input v-model:value="globalOutputEvent.name" required placeholder="Enter name" />
@@ -689,7 +689,7 @@
                                         <n-select v-model:value="globalOutputEvent.integration" placeholder="Select Integration" :options="ciIntegrationsForGlobalSelect" />
                                     </n-form-item>
                                     <n-alert v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER' && selectedGlobalCiIntegration && (selectedGlobalCiIntegration.type === 'GITHUB' || selectedGlobalCiIntegration.type === 'GITLAB')" type="info" :show-icon="false" style="font-size: 12px; margin-bottom: 8px;">
-                                        Policy-wide events use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this trigger is silently skipped for that component.
+                                        Policy-wide actions use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this action is silently skipped for that component.
                                     </n-alert>
                                     <n-form-item v-if="globalOutputEvent.type === 'INTEGRATION_TRIGGER' && selectedGlobalCiIntegration && selectedGlobalCiIntegration.type === 'GITHUB'" label="Installation ID" path="schedule">
                                         <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
@@ -719,7 +719,7 @@
                                         <n-select v-model:value="globalOutputEvent.integration" placeholder="Select GitHub Validate Integration" :options="validationIntegrationsForGlobalSelect" />
                                     </n-form-item>
                                     <n-alert v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" type="info" :show-icon="false" style="font-size: 12px; margin-bottom: 8px;">
-                                        Policy-wide events use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this trigger is silently skipped for that component.
+                                        Policy-wide actions use the <strong>component's VCS</strong> at fire time. If a participating component has no VCS configured, this action is silently skipped for that component.
                                     </n-alert>
                                     <n-form-item v-if="globalOutputEvent.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
                                         <n-input v-model:value="globalOutputEvent.schedule" required placeholder="Enter GitHub Installation ID" />
@@ -812,8 +812,8 @@
                         </n-modal>
                     </div>
 
-                    <h4>Policy-Wide Input Events:
-                        <Icon v-if="isWritable && selectedPolicyUuid" class="clickable addIcon" size="25" title="Add Policy-Wide Input Event" @click="resetGlobalInputEvent(); showCreateGlobalInputEventModal = true">
+                    <h4>Policy-Wide Rules:
+                        <Icon v-if="isWritable && selectedPolicyUuid" class="clickable addIcon" size="25" title="Add Policy-Wide Rule" @click="resetGlobalInputEvent(); showCreateGlobalInputEventModal = true">
                             <CirclePlus/>
                         </Icon>
                     </h4>
@@ -826,7 +826,7 @@
                             style="width: 90%"
                         >
                             <n-form :model="globalInputEvent">
-                                <h2>{{ globalInputEvent.uuid ? 'Edit' : 'Add' }} Policy-Wide Input Event</h2>
+                                <h2>{{ globalInputEvent.uuid ? 'Edit' : 'Add' }} Policy-Wide Rule</h2>
                                 <n-space vertical size="large">
                                     <n-form-item label="Name" path="name">
                                         <n-input v-model:value="globalInputEvent.name" required placeholder="Enter name" />
@@ -838,7 +838,7 @@
                                             :error="globalCelExpressionError"
                                         />
                                     </n-form-item>
-                                    <n-form-item label="Output Events" path="globalInputEvent.outputEvents">
+                                    <n-form-item label="Actions" path="globalInputEvent.outputEvents">
                                         <n-select v-model:value="globalInputEvent.outputEvents" 
                                         :options="globalOutputEventsForInputForm" multiple />
                                     </n-form-item>
@@ -877,9 +877,9 @@
                                 <div v-for="policy in defaultApprovalSetup.policies" :key="policy.policyName" style="margin-bottom: 12px;">
                                     <div>{{ policy.policyName }}</div>
                                     <div>Entries: {{ policy.approvalEntries.join(', ') }}</div>
-                                    <div>Output Events:</div>
+                                    <div>Actions:</div>
                                     <div v-for="event in defaultApprovalSetup.outputEvents" :key="`${policy.policyName}-${event.name}`">{{ event.name }} - {{ outputTriggerLifecycleOptions.find((opt: any) => opt.value === event.toReleaseLifecycle)?.label || event.toReleaseLifecycle }}</div>
-                                    <div>Input Events:</div>
+                                    <div>Rules:</div>
                                     <div v-for="event in getDefaultPolicyInputEvents(policy.approvalEntries)" :key="`${policy.policyName}-${event.name}`">{{ event.name }}</div>
                                 </div>
                             </div>
@@ -6075,7 +6075,7 @@ async function saveGlobalOutputEvents () {
                 approvalPoliciesFullData.value[policyIndex].globalOutputEvents = globalOutputEvents.value
             }
         }
-        notify('success', 'Success', 'Policy-wide output events saved.')
+        notify('success', 'Success', 'Policy-wide actions saved.')
     } catch (err: any) {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     }
@@ -6115,7 +6115,7 @@ async function saveGlobalInputEvents () {
                 approvalPoliciesFullData.value[policyIndex].globalInputEvents = globalInputEvents.value
             }
         }
-        notify('success', 'Success', 'Policy-wide input events saved.')
+        notify('success', 'Success', 'Policy-wide rules saved.')
     } catch (err: any) {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     }
@@ -6187,7 +6187,7 @@ async function deleteGlobalOutputEvent (uuid: string, name?: string) {
     // Check if any global input event references this output event
     const referencedBy = globalInputEvents.value.find((ie: any) => ie.outputEvents && ie.outputEvents.includes(uuid))
     if (referencedBy) {
-        notify('error', 'Error', 'Cannot delete: this output event is referenced by a policy-wide input event.')
+        notify('error', 'Error', 'Cannot delete: this action is referenced by a policy-wide rule.')
         return
     }
     const onSwalConfirm = async () => {
@@ -6195,14 +6195,14 @@ async function deleteGlobalOutputEvent (uuid: string, name?: string) {
         if (idx > -1) {
             globalOutputEvents.value.splice(idx, 1)
             saveGlobalOutputEvents()
-            notify('success', 'Deleted', 'Policy-wide output event deleted.')
+            notify('success', 'Deleted', 'Policy-wide action deleted.')
         }
     }
     const displayName = name || uuid
     const swalData: SwalData = {
-        questionText: `Are you sure you want to delete policy-wide output event ${displayName}?`,
+        questionText: `Are you sure you want to delete policy-wide action ${displayName}?`,
         successTitle: 'Deleted!',
-        successText: `Policy-wide output event ${displayName} has been deleted.`,
+        successText: `Policy-wide action ${displayName} has been deleted.`,
         dismissText: 'Delete has been cancelled.'
     }
     await commonFunctions.swalWrapper(onSwalConfirm, swalData, notify)
@@ -6247,14 +6247,14 @@ async function deleteGlobalInputEvent (uuid: string, name?: string) {
         if (idx > -1) {
             globalInputEvents.value.splice(idx, 1)
             saveGlobalInputEvents()
-            notify('success', 'Deleted', 'Policy-wide input event deleted.')
+            notify('success', 'Deleted', 'Policy-wide rule deleted.')
         }
     }
     const displayName = name || uuid
     const swalData: SwalData = {
-        questionText: `Are you sure you want to delete policy-wide input event ${displayName}?`,
+        questionText: `Are you sure you want to delete policy-wide rule ${displayName}?`,
         successTitle: 'Deleted!',
-        successText: `Policy-wide input event ${displayName} has been deleted.`,
+        successText: `Policy-wide rule ${displayName} has been deleted.`,
         dismissText: 'Delete has been cancelled.'
     }
     await commonFunctions.swalWrapper(onSwalConfirm, swalData, notify)
@@ -6289,13 +6289,13 @@ const globalOutputEventTableFields: DataTableColumns<any> = [
             let els: any[] = []
             if (isWritable.value) {
                 const editEl = h(NIcon, {
-                    title: 'Edit Output Event',
+                    title: 'Edit Action',
                     class: 'icons clickable',
                     size: 20,
                     onClick: () => editGlobalOutputEvent(row)
                 }, () => h(EditIcon))
                 const deleteEl = h(NIcon, {
-                    title: 'Delete Output Event',
+                    title: 'Delete Action',
                     class: 'icons clickable',
                     size: 20,
                     onClick: () => deleteGlobalOutputEvent(row.uuid, row.name)
@@ -6318,14 +6318,14 @@ const globalInputEventTableFields: DataTableColumns<any> = [
         title: 'Condition',
         render: (row: any) => {
             if (!row.celExpression) {
-                return h(NAlert, { type: 'warning', style: 'font-size: 12px;' }, { default: () => 'No CEL expression — trigger will not fire. Edit to add a condition.' })
+                return h(NAlert, { type: 'warning', style: 'font-size: 12px;' }, { default: () => 'No CEL expression — rule will not fire. Edit to add a condition.' })
             }
             return h('code', { style: 'font-size: 12px;' }, row.celExpression)
         }
     },
     {
         key: 'outputTriggers',
-        title: 'Output Events',
+        title: 'Actions',
         minWidth: 153,
         render: (row: any) => {
             let outNames = ''
@@ -6347,13 +6347,13 @@ const globalInputEventTableFields: DataTableColumns<any> = [
             let els: any[] = []
             if (isWritable.value) {
                 const editEl = h(NIcon, {
-                    title: 'Edit Input Event',
+                    title: 'Edit Rule',
                     class: 'icons clickable',
                     size: 20,
                     onClick: () => editGlobalInputEvent(row)
                 }, () => h(EditIcon))
                 const deleteEl = h(NIcon, {
-                    title: 'Delete Input Event',
+                    title: 'Delete Rule',
                     class: 'icons clickable',
                     size: 20,
                     onClick: () => deleteGlobalInputEvent(row.uuid, row.name)

--- a/ui/src/utils/triggerValidation.ts
+++ b/ui/src/utils/triggerValidation.ts
@@ -30,7 +30,7 @@ export function validateInputTrigger(trigger: any): TriggerValidationResult {
     }
 
     if (!trigger.outputEvents || trigger.outputEvents.length === 0) {
-        return { valid: false, error: 'At least one output event must be selected.' }
+        return { valid: false, error: 'At least one action must be selected.' }
     }
 
     return { valid: true }


### PR DESCRIPTION
## Summary

GRC-standard terminology pass on user-facing labels only — no code identifiers, GraphQL fields, or model classes touched.

  Input Event           → Rule
  Output Event          → Action
  Policy-Wide Input     → Policy-Wide Rule
  Policy-Wide Output    → Policy-Wide Action

The underlying \`globalInputEvents\` / \`globalOutputEvents\` / \`releaseInputTriggers\` / \`outputTriggers\` bindings on the backend stay exactly as they are. Operators see the new terminology; CI/CD callers, integration tests, and the GraphQL schema continue to use the existing field names.

## What changed

- **ComponentView**: tab labels, add/edit/delete tooltips, the policy-wide rule references section (override-locally text, "default action(s)" count, override warning), the input-trigger table's column header, and the delete-blocked error.
- **OrgSettings**: same set for the policy-wide editors — h4 headers, modal titles, form-item labels, the Populate-Defaults preview, the two info banners ("Policy-wide actions use the component's VCS..."), notification toasts, swal confirm/success copy, table action tooltips, and the "no CEL expression — rule will not fire" alert.
- **triggerValidation**: form-level error ("At least one action must be selected.").

Where \`n-tab-pane\` previously fell back to \`name\` for its display label, added an explicit \`tab\` attribute so the internal name stays stable (avoids breaking anything that keys off the tab name).

Code comments using "input event" / "output event" are left untouched — they describe model fields whose names did not change.

## Test plan
- [x] UI compiles cleanly on CI
- [ ] Visual smoke after auto-integrate roll: OrgSettings → Approval Policies, ComponentView → Settings tab — confirm new labels appear in: tab titles, modal headers, table columns, dialog text, info banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)