### PR TITLE
fix(ui): rename rule-table policy-actions column to "Policy Actions"

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -2814,7 +2814,7 @@ const inputTriggerTableFields: DataTableColumns<any> = [
     },
     {
         key: 'outputTriggers',
-        title: 'Actions',
+        title: 'Policy Actions',
         render: (row: any) => {
             let outTriggers = ''
             if (row.outputEvents && row.outputEvents.length) {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -6325,7 +6325,7 @@ const globalInputEventTableFields: DataTableColumns<any> = [
     },
     {
         key: 'outputTriggers',
-        title: 'Actions',
+        title: 'Policy Actions',
         minWidth: 153,
         render: (row: any) => {
             let outNames = ''


### PR DESCRIPTION
## Summary

Follow-up to #43 — fixes the "Actions" / "Actions" header collision in the rule table. Screenshot showed two adjacent columns both titled "Actions" (the policy-action names + the per-row edit/delete icons), making it hard to tell which was which.

Rename the rule-side column to **Policy Actions**, leave the standard icon column as "Actions" (consistent with every other table in the app).

Two call sites — the org-settings policy editor and the per-component rule table.

## Test plan
- [x] UI compiles cleanly on CI
- [ ] Visual on agent-scully after roll: rule table now reads "Name | Condition | Policy Actions | Actions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)