### PR TITLE
feat(ui): clear-policy on component + GRC-aware wording on provenance card

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -377,7 +377,7 @@
                                                     <strong>Effective policy:</strong>
                                                     <span v-if="effectiveApprovalPolicy.source === 'PER_COMPONENT'">
                                                         <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
-                                                        (per-component, this row)
+                                                        (set directly on this component)
                                                     </span>
                                                     <span v-else-if="effectiveApprovalPolicy.source === 'ORG_RULE'">
                                                         <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -370,6 +370,8 @@
                                             <label>Approval Policy</label>
                                             <n-select
                                                 v-if="isWritable"
+                                                clearable
+                                                placeholder="Select an approval policy (or clear to remove)"
                                                 :options="approvalPolicies" v-model:value="updatedComponent.approvalPolicy" />
                                             <div v-else>{{ resolvedVisibilityLabel }}</div>
                                             <div v-if="effectiveApprovalPolicy" class="provenance" :class="provenanceClass" style="margin-top: 8px;">
@@ -377,22 +379,22 @@
                                                     <strong>Effective policy:</strong>
                                                     <span v-if="effectiveApprovalPolicy.source === 'PER_COMPONENT'">
                                                         <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
-                                                        (set directly on this component)
+                                                        (set directly on this {{ words.component }})
                                                     </span>
                                                     <span v-else-if="effectiveApprovalPolicy.source === 'ORG_RULE'">
                                                         <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
                                                         — inherited from org rule <code>{{ effectiveApprovalPolicy.ruleName }}</code>
                                                     </span>
-                                                    <span v-else>none — no per-component reference and no matching org rule</span>
+                                                    <span v-else>none — no per-{{ words.component }} reference and no matching org rule</span>
                                                 </div>
                                                 <div v-if="effectiveApprovalPolicy.perComponentPolicyArchived" class="provenance-warn">
-                                                    The per-component approval-policy reference points to an archived or
+                                                    The per-{{ words.component }} approval-policy reference points to an archived or
                                                     missing policy; resolution fell through to the org-wide rule list.
                                                 </div>
                                                 <div v-if="effectiveApprovalPolicy.alsoMatchedRuleNames && effectiveApprovalPolicy.alsoMatchedRuleNames.length" class="provenance-warn">
-                                                    Other org rules also match this component:
+                                                    Other org rules also match this {{ words.component }}:
                                                     <code v-for="(n, i) in effectiveApprovalPolicy.alsoMatchedRuleNames" :key="n">{{ i ? ', ' : '' }}{{ n }}</code>.
-                                                    First-match-wins; reorder in <em>Org Settings &rarr; Global Approval Policies</em> to change priority.
+                                                    First-match-wins; reorder in <em>Org Settings &rarr; Policies &rarr; Global Policy Assignment</em> to change priority.
                                                 </div>
                                             </div>
                                         </div>
@@ -1954,7 +1956,16 @@ const fetchVcsRepos = async function () : Promise<any[]> {
 }
 
 async function save () {
-    updatedComponent.value = commonFunctions.deepCopy(await store.dispatch('updateComponent', updatedComponent.value))
+    // approvalPolicy is sent as null both for "leave unchanged" (server
+    // convention) and "clear" (UI operator hit the clearable X). We
+    // disambiguate by setting an explicit clearApprovalPolicy flag when
+    // the prior saved value was non-null and the in-memory value has
+    // gone to null — the server then knows to actually clear it.
+    const payload: any = { ...updatedComponent.value }
+    if (componentData.value?.approvalPolicy && !updatedComponent.value.approvalPolicy) {
+        payload.clearApprovalPolicy = true
+    }
+    updatedComponent.value = commonFunctions.deepCopy(await store.dispatch('updateComponent', payload))
     // Update originalComponent to match current state so hasComponentChanges() returns false
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
     // Refresh the effective-policy snapshot so the provenance card

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -978,6 +978,7 @@ const storeObject : any = {
                 versionType: component.versionType,
                 branchSuffixMode: component.branchSuffixMode || 'INHERIT',
                 approvalPolicy: component.approvalPolicy,
+                clearApprovalPolicy: component.clearApprovalPolicy || false,
                 outputTriggers: stripTriggerFields(component.outputTriggers),
                 releaseInputTriggers: stripTriggerFields(component.releaseInputTriggers),
                 globalInputEventRefs: component.globalInputEventRefs?.map(({ uuid, overrideOutputEventsLocally, outputEventsOverride }: any) => ({ uuid, overrideOutputEventsLocally, outputEventsOverride })),


### PR DESCRIPTION
## Summary

Two related fixes on the ComponentView approval-policy card.

### 1. Allow removing an assigned policy

The n-select on the Approval Policy field gains \`clearable\`, so the operator can hit the X to set the value back to "no policy". The save path detects the saved-non-null → in-memory-null transition and sends the new \`clearApprovalPolicy: true\` flag on the updateComponent payload, which the server honours to actually remove the reference (the prior leave-unchanged-on-null convention would otherwise silently no-op).

Backend lives in [rearm-saas#58](https://github.com/relizaio/rearm-saas/pull/58) (\`clearApprovalPolicy\` on \`UpdateComponentInput\`).

### 2. Component vs Product wording

The PER_COMPONENT label was a hardcoded "(set directly on this component)" — wrong for product rows. Switched to \`(set directly on this {{ words.component }})\` which resolves to "component" or "product" via the existing per-org words selector. Same fix applied to the NONE-source line ("no per-{{ words.component }} reference"), the \`perComponentPolicyArchived\` warning, and the alsoMatched warning's "Other org rules also match this {{ words.component }}" line.

Cross-ref in that warning updated from "Global Approval Policies" to the new nested path "Policies → Global Policy Assignment" (matches the restructure in [rearm#45](https://github.com/relizaio/rearm/pull/45)).

## Test plan
- [x] UI CI green
- [ ] On a product: provenance card reads "this product" everywhere
- [ ] On a component: reads "this component"
- [ ] Clear-policy: X on the n-select → Save → effective policy line updates to NONE or to the matching ORG_RULE

🤖 Generated with [Claude Code](https://claude.com/claude-code)