### PR TITLE
fix(ui): release diff query 400 + lazy-load Part of Products

### DIFF
--- a/ui/src/components/ReleaseRevision.vue
+++ b/ui/src/components/ReleaseRevision.vue
@@ -134,10 +134,6 @@ const RELEASE_DIFF_QUERY = gql`
             branchDetails { uuid name }
             parentReleases {
                 release
-                artifact
-                type
-                namespace
-                state
             }
         }
     }

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -735,9 +735,18 @@
                         </h3>
                         <n-data-table :data="inboundDeliverables" :columns="deliverableTableFields" :row-key="artifactsRowKey" />
                     </div>
-                    <div class="container" v-if="updatedRelease.componentDetails.type === 'COMPONENT'">
-                        <h3>Part of Products</h3>
-                        <n-data-table :data="updatedRelease.inProducts" :columns="inProductsTableFields" :row-key="artifactsRowKey" />
+                </n-tab-pane>
+                <n-tab-pane v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'COMPONENT'" name="partOfProducts" tab="Part of Products">
+                    <div class="container" v-if="inProductsLoading">
+                        <n-spin size="large" />
+                        <p>Loading products that ship this release…</p>
+                    </div>
+                    <div class="container" v-else-if="inProductsLoaded">
+                        <n-data-table v-if="inProductsList.length" :data="inProductsList" :columns="inProductsTableFields" :row-key="artifactsRowKey" />
+                        <p v-else>This release isn't part of any product release.</p>
+                    </div>
+                    <div class="container" v-else>
+                        <p>Open this tab to load the list of product releases that include this release.</p>
                     </div>
                 </n-tab-pane>
                 <n-tab-pane v-if="isProductRelease" name="underlyingArtifacts" tab="Underlying Artifacts">
@@ -1474,6 +1483,14 @@ const isLoading: Ref<boolean> = ref(true)
 const isProductRelease: Ref<boolean> = ref(false)
 const productArtifactsLoaded: Ref<boolean> = ref(false)
 const productArtifactsLoading: Ref<boolean> = ref(false)
+
+// "Part of Products" is fetched lazily — the resolver scans every release
+// that lists this one as a parent, which is expensive for components that
+// ship across many product releases (the original symptom that prompted
+// pulling this out of the main FetchRelease payload).
+const inProductsLoaded: Ref<boolean> = ref(false)
+const inProductsLoading: Ref<boolean> = ref(false)
+const inProductsList: Ref<any[]> = ref([])
 
 async function detectIsProduct (): Promise<boolean> {
     // Check if release is already in store with component type info
@@ -5494,6 +5511,22 @@ async function fetchProductArtifacts () {
     }
 }
 
+async function fetchInProducts () {
+    if (inProductsLoaded.value || inProductsLoading.value) return
+    inProductsLoading.value = true
+    try {
+        const rlzFetchObj: any = { release: releaseUuid.value }
+        if (props.orgprop) rlzFetchObj.org = props.orgprop
+        inProductsList.value = await store.dispatch('fetchReleaseInProducts', rlzFetchObj)
+        inProductsLoaded.value = true
+    } catch (e: any) {
+        console.error('Failed to fetch inProducts:', e)
+        notify('error', 'Error', 'Failed to load products that ship this release.')
+    } finally {
+        inProductsLoading.value = false
+    }
+}
+
 async function handleTabSwitch(tabName: string) {
     if (tabName === "compare") {
         await fetchReleases()
@@ -5503,6 +5536,8 @@ async function handleTabSwitch(tabName: string) {
         await fetchProductArtifacts()
     } else if (tabName === "sbomComponents") {
         await loadSbomComponents()
+    } else if (tabName === "partOfProducts") {
+        await fetchInProducts()
     }
 }
 

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -784,6 +784,14 @@ const storeObject : any = {
             })
             return response.data.release
         },
+        async fetchReleaseInProducts (context: any, params: any) {
+            const response = await graphqlClient.query({
+                query: graphqlQueries.FetchReleaseInProductsGql,
+                variables: { releaseID: params.release, orgID: params.org },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.release?.inProducts || []
+        },
         async updateBranch (context: any, brProps: any) {
             let dependencies = []
             if (brProps.dependencies && brProps.dependencies.length) {

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -492,19 +492,6 @@ const singleReleaseDataNoParent = `
             }
         }
     }
-    inProducts {
-        uuid
-        version
-        component
-        componentDetails {
-            uuid
-            name
-        }
-        branchDetails {
-            name
-        }
-        lifecycle
-    }
     tags {
         key
         value
@@ -845,6 +832,30 @@ query FetchRelease($releaseID: ID!, $orgID: ID) {
     }
 }`
 
+// Slim selection used by ReleaseView's lazy "Part of Products" tab.
+// Stripped from the main SingleReleaseGql payload because the inProducts
+// resolver walks every release that lists this one as a parent, which
+// blows up page load for components that ship across many product releases.
+const FETCH_RELEASE_IN_PRODUCTS_GQL = gql`
+query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
+    release(releaseUuid: $releaseID, orgUuid: $orgID) {
+        uuid
+        inProducts {
+            uuid
+            version
+            component
+            componentDetails {
+                uuid
+                name
+            }
+            branchDetails {
+                name
+            }
+            lifecycle
+        }
+    }
+}`
+
 const singleReleaseProductNoParent = `
     createdDate
     org
@@ -888,19 +899,6 @@ const singleReleaseProductNoParent = `
                 }
             }
         }
-    }
-    inProducts {
-        uuid
-        version
-        component
-        componentDetails {
-            uuid
-            name
-        }
-        branchDetails {
-            name
-        }
-        lifecycle
     }
     tags {
         key
@@ -1255,6 +1253,7 @@ export default {
     SingleReleaseGqlLight: SINGLE_RELEASE_GQL_LIGHT,
     SingleReleaseProductGql: SINGLE_RELEASE_PRODUCT_GQL,
     SingleReleaseTypeDetectGql: SINGLE_RELEASE_TYPE_DETECT_GQL,
+    FetchReleaseInProductsGql: FETCH_RELEASE_IN_PRODUCTS_GQL,
     ComponentFullData: COMPONENT_FULL_DATA,
     ComponentMutate: COMPONENT_MUTATE,
     ReleaseGqlMutate: RELEASE_GQL_MUTATE,


### PR DESCRIPTION
## Summary
Two ReleaseView fixes bundled.

**1. `FetchReleaseForDiff` returns 400 (instance side-by-side diff)**

The query selected `artifact`, `type`, `namespace`, `state` under `parentReleases { … }`, but none of those fields exist on the GraphQL `ParentRelease` type (only `org`, `release`, `releaseDetails`). They live on `DeployedRelease` (Instance.releases). Result: schema validation 400; the release-side of the side-by-side diff fails to load.

Template only consumes `rl.release` directly; missing `rl.artifact` already defaults to "Not Set" via the existing guard, and namespace/state were never rendered on the release side anyway. So dropping the invalid fields is safe.

**2. Slow ReleaseView load when a release is part of many product releases**

The `inProducts` resolver walks every release that lists this one as a parent. For components shipped across many product releases, it dominates page-load time and was bundled into the main FetchRelease payload.

Moved it out:
- New slim query `FetchReleaseInProducts` + store action `fetchReleaseInProducts`
- New tab "Part of Products" (component-release only) replaces the inline section that used to sit at the bottom of the Components tab
- Loads on first tab activation; cached after that
- Empty result shows a plain message rather than a 0-row table

Side note: `ReleaseEl.vue` references `inProducts` under `showParents=true`, but no caller currently passes that prop, so the main-payload removal doesn't break any rendered path.

## Test plan
- [ ] Open a release on the Instance page → side-by-side diff loads without 400
- [ ] Open a COMPONENT release on the release page → main load is fast; "Part of Products" tab is present
- [ ] Click "Part of Products" → loads the list; shows table or empty message
- [ ] Re-click another tab and come back → no second fetch (cached)
- [ ] Open a PRODUCT release → no "Part of Products" tab (gate unchanged)