### PR TITLE
feat(ui): type filter on Most Recent Releases + Part of Products tab refresh

### DIFF
--- a/ui/src/components/MostRecentReleasesPage.vue
+++ b/ui/src/components/MostRecentReleasesPage.vue
@@ -26,6 +26,12 @@
                     style="width: 100px;"
                     placeholder="Custom"
                 />
+                <span>Type:</span>
+                <n-select
+                    v-model:value="componentTypeValue"
+                    :options="componentTypeOptions"
+                    style="width: 140px;"
+                />
             </n-space>
         </div>
         <div class="widget-container">
@@ -37,6 +43,7 @@
                 :limit="effectiveLimit"
                 :start-date="dateFrom"
                 :end-date="dateTo"
+                :component-type="componentTypeValue"
             />
         </div>
     </div>
@@ -93,11 +100,23 @@ function onLimitPresetChange(val: number | 'custom') {
     if (val !== 'custom') customLimit.value = val as number
 }
 
+const componentTypeOptions = [
+    { label: 'Any', value: null },
+    { label: 'Component', value: 'COMPONENT' },
+    { label: 'Product', value: 'PRODUCT' }
+]
+const componentTypeValue = ref<'COMPONENT' | 'PRODUCT' | null>(null)
+
 function syncUrl() {
     const q: Record<string, string> = { ...route.query as Record<string, string> }
     if (startDateValue.value) q.fromDate = new Date(startDateValue.value).toISOString().split('T')[0]
     if (endDateValue.value) q.toDate = new Date(endDateValue.value).toISOString().split('T')[0]
     q.limit = String(effectiveLimit.value)
+    if (componentTypeValue.value) {
+        q.type = componentTypeValue.value
+    } else {
+        delete q.type
+    }
     router.replace({ query: q })
 }
 
@@ -121,9 +140,13 @@ onMounted(() => {
             }
         }
     }
+    const urlType = route.query.type as string | undefined
+    if (urlType === 'COMPONENT' || urlType === 'PRODUCT') {
+        componentTypeValue.value = urlType
+    }
 })
 
-watch([startDateValue, endDateValue, effectiveLimit], syncUrl)
+watch([startDateValue, endDateValue, effectiveLimit, componentTypeValue], syncUrl)
 </script>
 
 <style scoped lang="scss">

--- a/ui/src/components/MostRecentReleasesWidget.vue
+++ b/ui/src/components/MostRecentReleasesWidget.vue
@@ -7,6 +7,13 @@
                 style="display: inline-block; width: 80px;"
                 :min="1"
             />
+            <n-select
+                v-if="props.showFullPageIcon"
+                v-model:value="localComponentType"
+                :options="componentTypeOptions"
+                style="display: inline-block; width: 130px;"
+                title="Filter by component type"
+            />
             <span v-if="props.showFullPageIcon">Most Recent Releases</span>
             <h3 v-else style="margin: 0;">Most Recent Releases</h3>
             <n-icon class="clickable" size="20" title="Refresh" @click="fetchReleases">
@@ -98,7 +105,7 @@ export default {
 
 <script lang="ts" setup>
 import { ref, Ref, computed, watch, onMounted } from 'vue'
-import { NIcon, NSpin, NSpace, NInputNumber, NTooltip, useNotification } from 'naive-ui'
+import { NIcon, NSpin, NSpace, NInputNumber, NSelect, NTooltip, useNotification } from 'naive-ui'
 import { ArrowExpand20Regular } from '@vicons/fluent'
 import { Refresh } from '@vicons/tabler'
 import graphqlClient from '@/utils/graphql'
@@ -115,8 +122,18 @@ const props = withDefaults(defineProps<{
     limit?: number
     startDate?: Date
     endDate?: Date
+    /**
+     * Optional ComponentType filter — `'COMPONENT'`, `'PRODUCT'`, or null
+     * (== Any). When the widget is hosted on the home page (no inline
+     * selector — `showFullPageIcon=true`, parent doesn't pass `componentType`),
+     * the internal `localComponentType` defaults to null so the home view
+     * matches the pre-filter behaviour. The full-page wrapper passes
+     * `componentType` in to keep the URL the source of truth.
+     */
+    componentType?: 'COMPONENT' | 'PRODUCT' | null
 }>(), {
-    showFullPageIcon: true
+    showFullPageIcon: true,
+    componentType: null
 })
 
 const notification = useNotification()
@@ -131,6 +148,22 @@ function getPendingStatus (rel: any): ReleaseScanStatus {
 // Internal limit for home-page widget mode; overridden by props.limit on full-page
 const localLimit = ref(5)
 const effectiveLimit = computed(() => props.limit ?? localLimit.value)
+
+// Type selector — visible alongside the limit input when the widget is in
+// home-page mode (showFullPageIcon=true). When the parent passes a
+// componentType prop (full-page wrapper sourcing from URL), we mirror it
+// into the local value so the selector shows the current state.
+const componentTypeOptions = [
+    { label: 'Any', value: null },
+    { label: 'Component', value: 'COMPONENT' },
+    { label: 'Product', value: 'PRODUCT' }
+]
+const localComponentType: Ref<'COMPONENT' | 'PRODUCT' | null> = ref(props.componentType ?? null)
+const effectiveComponentType = computed<'COMPONENT' | 'PRODUCT' | null>(() =>
+    props.componentType !== undefined && props.componentType !== null
+        ? props.componentType
+        : localComponentType.value
+)
 
 const showVulnModal = ref(false)
 const vulnModalRelease: Ref<any> = ref(null)
@@ -170,7 +203,8 @@ async function fetchReleases() {
                     perspectiveUuid: props.perspectiveUuid,
                     startDate: startDate.toISOString(),
                     endDate: endDate.toISOString(),
-                    limit: effectiveLimit.value
+                    limit: effectiveLimit.value,
+                    componentType: effectiveComponentType.value
                 },
                 fetchPolicy: 'no-cache'
             })
@@ -182,7 +216,8 @@ async function fetchReleases() {
                     org: props.orgUuid,
                     startDate: startDate.toISOString(),
                     endDate: endDate.toISOString(),
-                    limit: effectiveLimit.value
+                    limit: effectiveLimit.value,
+                    componentType: effectiveComponentType.value
                 },
                 fetchPolicy: 'no-cache'
             })
@@ -228,7 +263,12 @@ function formatDate(dateStr: string): string {
 watch(() => props.perspectiveUuid, () => fetchReleases())
 watch(() => [props.startDate, props.endDate], () => fetchReleases())
 watch(() => props.limit, () => fetchReleases())
+watch(() => props.componentType, (val) => {
+    if (val !== undefined) localComponentType.value = val
+    fetchReleases()
+})
 watch(localLimit, () => fetchReleases())
+watch(localComponentType, () => fetchReleases())
 
 onMounted(async () => {
     if (props.orgUuid) {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -736,19 +736,6 @@
                         <n-data-table :data="inboundDeliverables" :columns="deliverableTableFields" :row-key="artifactsRowKey" />
                     </div>
                 </n-tab-pane>
-                <n-tab-pane v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'COMPONENT'" name="partOfProducts" tab="Part of Products">
-                    <div class="container" v-if="inProductsLoading">
-                        <n-spin size="large" />
-                        <p>Loading products that ship this release…</p>
-                    </div>
-                    <div class="container" v-else-if="inProductsLoaded">
-                        <n-data-table v-if="inProductsList.length" :data="inProductsList" :columns="inProductsTableFields" :row-key="artifactsRowKey" />
-                        <p v-else>This release isn't part of any product release.</p>
-                    </div>
-                    <div class="container" v-else>
-                        <p>Open this tab to load the list of product releases that include this release.</p>
-                    </div>
-                </n-tab-pane>
                 <n-tab-pane v-if="isProductRelease" name="underlyingArtifacts" tab="Underlying Artifacts">
                     <div class="container" v-if="productArtifactsLoading">
                         <n-spin size="large" />
@@ -820,6 +807,24 @@
                                 Reset Approvals
                             </n-button>
                         </n-space>
+                    </div>
+                </n-tab-pane>
+                <n-tab-pane v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'COMPONENT'" name="partOfProducts" tab="Part of Products">
+                    <div class="container" v-if="inProductsLoading">
+                        <n-spin size="large" />
+                        <p>Loading products that ship this release…</p>
+                    </div>
+                    <div class="container" v-else-if="inProductsLoaded">
+                        <component-branches-table
+                            v-if="partOfProductsComponentRows.length"
+                            :data="partOfProductsComponentRows"
+                            :org-uuid="updatedRelease.org"
+                            :feature-set-label="featureSetLabel"
+                        />
+                        <p v-else>This release isn't part of any product release.</p>
+                    </div>
+                    <div class="container" v-else>
+                        <p>Open this tab to load the list of product releases that include this release.</p>
                     </div>
                 </n-tab-pane>
                 <n-tab-pane v-if="false" name="tickets" tab="Tickets">
@@ -1162,6 +1167,7 @@ export default {
 </script>
 <script lang="ts" setup>
 import ChangelogView from '@/components/ChangelogView.vue'
+import ComponentBranchesTable from '@/components/ComponentBranchesTable.vue'
 import CreateArtifact from '@/components/CreateArtifact.vue'
 import CreateDeliverable from '@/components/CreateDeliverable.vue'
 import CreateRelease from '@/components/CreateRelease.vue'
@@ -1207,6 +1213,10 @@ const notify = async function (type: NotificationType, title: string, content: s
 
 const myUser = store.getters.myuser
 const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
+
+// Label shown on the "Branch / <label>" column in ComponentBranchesTable
+// for product releases. Org terminology can override the default.
+const featureSetLabel = computed(() => myorg.value?.terminology?.featureSetLabel || 'Feature Set')
 
 const users: Ref<any[]> = ref([])
 const acollections: Ref<any[]> = ref([])
@@ -4950,46 +4960,58 @@ const deliverableTableFields: DataTableColumns<any> = [
     }
 ]
 
-const inProductsTableFields: ComputedRef<DataTableColumns<any>> = computed((): DataTableColumns<any> => [
-    {
-        key: 'productName',
-        title: 'Product',
-        render(row: any) {
-            return h(RouterLink, 
-                {to: {name: 'ProductsOfOrg',
-                    params: {orguuid: release.value.org, compuuid: row.componentDetails.uuid}},
-                style: "text-decoration: none;"},
-                () => row.componentDetails.name )
+// Group the flat inProducts release list into the 3-level
+// (component → branch → releases) shape that ComponentBranchesTable
+// renders — same display the "Releases for day" widget uses, so the two
+// surfaces stay consistent. Releases without resolved componentDetails
+// or branchDetails are dropped (no anchor for the table's hierarchy).
+const partOfProductsComponentRows: ComputedRef<any[]> = computed((): any[] => {
+    const list: any[] = inProductsList.value || []
+    if (!list.length) return []
+    const byComponent = new Map<string, any>()
+    for (const rel of list) {
+        const cd = rel?.componentDetails
+        const bd = rel?.branchDetails
+        if (!cd?.uuid || !bd?.uuid) continue
+        let comp = byComponent.get(cd.uuid)
+        if (!comp) {
+            comp = {
+                uuid: cd.uuid,
+                name: cd.name,
+                type: cd.type,
+                versionSchema: cd.versionSchema,
+                branches: new Map<string, any>()
+            }
+            byComponent.set(cd.uuid, comp)
         }
-    },
-    {
-        key: 'featureSetName',
-        title: words.value.branchFirstUpper || 'Feature Set',
-        render(row: any) {
-            return h(RouterLink, 
-                {to: {name: 'ProductsOfOrg',
-                    params: {orguuid: release.value.org, compuuid: row.componentDetails.uuid,
-                        branchuuid: row.branchDetails.uuid
-                    }},
-                style: "text-decoration: none;"},
-                () => row.branchDetails.name )
+        let branch = comp.branches.get(bd.uuid)
+        if (!branch) {
+            branch = {
+                uuid: bd.uuid,
+                name: bd.name,
+                status: bd.status,
+                versionSchema: bd.versionSchema,
+                latestReleaseVersion: bd.latestReleaseVersion,
+                releases: []
+            }
+            comp.branches.set(bd.uuid, branch)
         }
-    },
-    {
-        key: 'version',
-        title: 'Version',
-        render(row: any) {
-            return h(RouterLink, 
-                {to: {name: 'ReleaseView', params: {uuid: row.uuid}},
-                    style: "text-decoration: none;"},
-                () => row.version )
-        }
-    },
-    {
-        key: 'lifecycle',
-        title: 'Lifecycle'
+        branch.releases.push({
+            uuid: rel.uuid,
+            version: rel.version,
+            createdDate: rel.createdDate,
+            lifecycle: rel.lifecycle,
+            metrics: rel.metrics
+        })
     }
-])
+    return Array.from(byComponent.values()).map(c => ({
+        uuid: c.uuid,
+        name: c.name,
+        type: c.type,
+        versionSchema: c.versionSchema,
+        branches: Array.from(c.branches.values())
+    }))
+})
 
 const parentReleaseTableFields: ComputedRef<DataTableColumns<any>> = computed((): DataTableColumns<any> => [
     {

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -836,6 +836,11 @@ query FetchRelease($releaseID: ID!, $orgID: ID) {
 // Stripped from the main SingleReleaseGql payload because the inProducts
 // resolver walks every release that lists this one as a parent, which
 // blows up page load for components that ship across many product releases.
+//
+// Field set mirrors what ComponentBranchesTable consumes after the
+// (release → component → branch → releases) transform in
+// ReleaseView.partOfProductsComponentRows — we group the flat inProducts
+// list back into the 3-level shape the table renders.
 const FETCH_RELEASE_IN_PRODUCTS_GQL = gql`
 query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
     release(releaseUuid: $releaseID, orgUuid: $orgID) {
@@ -844,14 +849,31 @@ query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
             uuid
             version
             component
+            createdDate
+            lifecycle
             componentDetails {
                 uuid
                 name
+                type
+                versionSchema
             }
             branchDetails {
+                uuid
                 name
+                status
+                versionSchema
+                latestReleaseVersion
             }
-            lifecycle
+            metrics {
+                critical
+                high
+                medium
+                low
+                unassigned
+                policyViolationsLicenseTotal
+                policyViolationsSecurityTotal
+                policyViolationsOperationalTotal
+            }
         }
     }
 }`
@@ -1227,15 +1249,15 @@ query EnvironmentTypes($orgUuid: ID!) {
 }`
 
 const RELEASES_BY_DATE_RANGE_GQL = gql`
-query releasesByDateRange($org: ID!, $startDate: DateTime!, $endDate: DateTime!, $limit: Int) {
-    releasesByDateRange(org: $org, startDate: $startDate, endDate: $endDate, limit: $limit) {
+query releasesByDateRange($org: ID!, $startDate: DateTime!, $endDate: DateTime!, $limit: Int, $componentType: ComponentType) {
+    releasesByDateRange(org: $org, startDate: $startDate, endDate: $endDate, limit: $limit, componentType: $componentType) {
         ${MULTI_RELEASE_GQL_DATA}
     }
 }`
 
 const RELEASES_BY_DATE_RANGE_AND_PERSPECTIVE_GQL = gql`
-query releasesByDateRangeAndPerspective($perspectiveUuid: ID!, $startDate: DateTime!, $endDate: DateTime!, $limit: Int) {
-    releasesByDateRangeAndPerspective(perspectiveUuid: $perspectiveUuid, startDate: $startDate, endDate: $endDate, limit: $limit) {
+query releasesByDateRangeAndPerspective($perspectiveUuid: ID!, $startDate: DateTime!, $endDate: DateTime!, $limit: Int, $componentType: ComponentType) {
+    releasesByDateRangeAndPerspective(perspectiveUuid: $perspectiveUuid, startDate: $startDate, endDate: $endDate, limit: $limit, componentType: $componentType) {
         ${MULTI_RELEASE_GQL_DATA}
     }
 }`


### PR DESCRIPTION
## Summary
Three related changes bundled:

**1. Type filter on Most Recent Releases (widget + page)**

`MostRecentReleasesWidget` gains a Component / Product / Any selector next to the limit input (home-page mode). `MostRecentReleasesPage` sources it from `?type=` so deep links carry the filter, and pushes it back into the widget via a new `componentType` prop.

Pairs with backend PR #64 which added the `componentType` arg to `releasesByDateRange` / `…AndPerspective`.

**2. Reorder Part of Products tab to after Approvals**

The tab was sitting in the Components pane group right above the dependency tree section; moved to after Approvals where it sits next to the other release-status tabs.

**3. Switch Part of Products to ComponentBranchesTable (3-level display)**

Replaced the flat data-table with the same `component → branch → releases` hierarchical table that powers the "Releases for day" modal off the home page. Per-release vuln + violation circles, lifecycle, and create date are surfaced via the table's existing renderer.

`FetchReleaseInProducts` GraphQL fragment is extended (`componentDetails.type` / `versionSchema`, `branchDetails.uuid` / `status` / `versionSchema` / `latestReleaseVersion`, release `createdDate` + `metrics`) so the client-side regroup into the hierarchical shape lands without a second round trip.

## Test plan
- [ ] Open Most Recent Releases widget on home page → Type selector visible; flipping to Component / Product filters; "Any" returns everything
- [ ] Open full-page Most Recent Releases → Type selector + URL `?type=COMPONENT` deep link works; flipping survives a reload
- [ ] Open a COMPONENT release → tabs in order: Components / Underlying Artifacts / Approvals / Part of Products / ...
- [ ] Click Part of Products tab → loads via `FetchReleaseInProducts`; shows 3-level table grouped by product → feature set → release
- [ ] Each release row in Part of Products surfaces metrics circles + lifecycle
- [ ] Empty case: release not part of any product → "This release isn't part of any product release."
- [ ] PRODUCT release: no Part of Products tab (gate unchanged)