### PR TITLE
fix(ui): FetchReleaseInProducts 400 — drop latestReleaseVersion from branchDetails

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -5127,7 +5127,11 @@ const partOfProductsComponentRows: ComputedRef<any[]> = computed((): any[] => {
                 name: bd.name,
                 status: bd.status,
                 versionSchema: bd.versionSchema,
-                latestReleaseVersion: bd.latestReleaseVersion,
+                // Branch type (vs BranchWithReleases) doesn't expose
+                // latestReleaseVersion; the Part of Products tab doesn't enable
+                // the "latest" column anyway. Leave undefined — table's
+                // isLatest derivation safely defaults to false.
+                latestReleaseVersion: undefined,
                 releases: []
             }
             comp.branches.set(bd.uuid, branch)

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -862,7 +862,6 @@ query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
                 name
                 status
                 versionSchema
-                latestReleaseVersion
             }
             metrics {
                 critical


### PR DESCRIPTION
## Summary
`ParentRelease.branchDetails` resolves to the `Branch` type, which doesn't have a `latestReleaseVersion` field — that field only lives on `BranchWithReleases`. Asking for it inside `branchDetails { … }` makes the server reject `FetchReleaseInProducts` with a 400 and the Part of Products tab fails to load anything.

Drop the field from the GraphQL fragment and stub `latestReleaseVersion: undefined` in `partOfProductsComponentRows` so the transform shape is unchanged. The tab doesn't pass `showIsLatestColumn` to `ComponentBranchesTable`, so the table's `isLatest` derivation defaulting to false is a no-op for this view.

## Test plan
- [ ] Open Part of Products on a COMPONENT release that ships in at least one product — tab loads, table renders one row per (product, feature set) with releases nested.
- [ ] Network panel: `FetchReleaseInProducts` now returns 200.
- [ ] Empty case (release not part of any product) still surfaces "This release isn't part of any product release."