### PR TITLE
feat(ui-vex): tabbed Finding Analysis + new-tab review + severity gate

### DIFF
--- a/ui/src/components/FindingAnalysisPage.vue
+++ b/ui/src/components/FindingAnalysisPage.vue
@@ -1,0 +1,55 @@
+<template>
+    <div class="finding-analysis-page">
+        <n-tabs v-model:value="activeTab" type="line" animated @update:value="onTabChange">
+            <n-tab-pane name="findings" tab="Finding Analysis">
+                <vulnerability-analysis />
+            </n-tab-pane>
+            <n-tab-pane name="vex" tab="VEX Statement Proposals">
+                <vex-proposals-inbox />
+            </n-tab-pane>
+            <n-tab-pane name="attestations" tab="Mitigation Attestations">
+                <mitigation-attestations-inbox />
+            </n-tab-pane>
+        </n-tabs>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'FindingAnalysisPage'
+}
+</script>
+
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { NTabs, NTabPane } from 'naive-ui'
+import VulnerabilityAnalysis from './VulnerabilityAnalysis.vue'
+import VexProposalsInbox from './VexProposalsInbox.vue'
+import MitigationAttestationsInbox from './MitigationAttestationsInbox.vue'
+
+type TabKey = 'findings' | 'vex' | 'attestations'
+
+const route = useRoute()
+const router = useRouter()
+const activeTab = ref<TabKey>('findings')
+
+function parseTab(q: unknown): TabKey {
+    if (q === 'vex' || q === 'attestations' || q === 'findings') return q
+    return 'findings'
+}
+
+onMounted(() => {
+    activeTab.value = parseTab(route.query.tab)
+})
+
+function onTabChange(val: TabKey) {
+    router.replace({ query: { ...route.query, tab: val } })
+}
+</script>
+
+<style scoped>
+.finding-analysis-page {
+    padding: 0 16px;
+}
+</style>

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -44,7 +44,7 @@ import { ref, h, Component, ComputedRef, computed, Ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 import { HomeOutlined as HomeIcon, CloudServerOutlined, BugOutlined } from '@vicons/antd'
-import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest, Inbox, ShieldCheck } from '@vicons/tabler'
+import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest } from '@vicons/tabler'
 
 
 function renderIcon (icon: Component) {
@@ -202,36 +202,6 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
                     RouterLink,
                     {
                         to: {
-                            name: 'VexProposalsInbox',
-                            params: {orguuid: org}
-                        }
-                    },
-                    { default: () => 'VEX Proposals' }
-                ),
-            key: 'vexProposals',
-            icon: renderIcon(Inbox)
-        },
-        {
-            label: () =>
-                h(
-                    RouterLink,
-                    {
-                        to: {
-                            name: 'MitigationAttestationsInbox',
-                            params: {orguuid: org}
-                        }
-                    },
-                    { default: () => 'Mitigation Attestations' }
-                ),
-            key: 'mitigationAttestations',
-            icon: renderIcon(ShieldCheck)
-        },
-        {
-            label: () =>
-                h(
-                    RouterLink,
-                    {
-                        to: {
                             name: 'OrgSettings',
                             params: {orguuid: org}
                         }
@@ -275,10 +245,8 @@ const routeToMenuKey: Record<string, string> = {
     'SecretsOfOrg': 'secrets',
     'AnalyticsOfOrg': 'analytics',
     'VulnerabilityAnalysis': 'vulnerabilityAnalysis',
-    'VexProposalsInbox': 'vexProposals',
-    'VexProposalReview': 'vexProposals',
-    'MitigationAttestationsInbox': 'mitigationAttestations',
-    'MitigationAttestationReview': 'mitigationAttestations',
+    'VexProposalReview': 'vulnerabilityAnalysis',
+    'MitigationAttestationReview': 'vulnerabilityAnalysis',
     'OrgSettings': 'orgsettings'
 }
 

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1575,14 +1575,17 @@ const releaseVexColumns = [
         key: 'actions',
         width: 80,
         render (row: any) {
+            // Open in a new tab so reviewers can keep the release view open while triaging
+            // (matches the VexProposalsInbox behaviour).
+            const href = router.resolve({
+                name: 'VexProposalReview',
+                params: { orguuid: release.value.org, uuid: row.uuid }
+            }).href
             return h(NButton, {
                 size: 'small',
                 type: 'info',
-                title: 'Review proposal',
-                onClick: () => router.push({
-                    name: 'VexProposalReview',
-                    params: { orguuid: release.value.org, uuid: row.uuid }
-                })
+                title: 'Review proposal (opens in new tab)',
+                onClick: () => window.open(href, '_blank', 'noopener')
             }, { default: () => h(NIcon, null, { default: () => h(Eye) }) })
         }
     }

--- a/ui/src/components/VexProposalReview.vue
+++ b/ui/src/components/VexProposalReview.vue
@@ -82,9 +82,14 @@
 
             <n-divider />
             <n-h4 v-if="otherAnalyses.length || proposal.demotionReason">Existing analyses at other scopes for this finding</n-h4>
-            <n-alert v-if="proposal.demotionReason === 'BROADER_SCOPE_CONFLICT'" type="warning" style="margin-bottom: 12px;">
+            <n-alert v-if="hasDemotion('BROADER_SCOPE_CONFLICT')" type="warning" style="margin-bottom: 12px;">
                 Auto-accept was demoted to STAGE: an analysis at a broader scope already exists with a different
                 suppression class. Review the rows below before accepting.
+            </n-alert>
+            <n-alert v-if="hasDemotion('SEVERITY_MISSING')" type="warning" style="margin-bottom: 12px;">
+                Auto-accept was demoted to STAGE: the inbound statement has no severity and the system could not
+                derive one from existing finding analyses or the canonical vulnerability record.
+                <strong>Use Modify to set severity</strong> before accepting.
             </n-alert>
             <n-data-table
                 v-if="otherAnalyses.length"
@@ -112,11 +117,14 @@
                         :autosize="{ minRows: 2, maxRows: 4 }"
                         placeholder="Optional comment (reviewer note for accept, reason for reject)" />
                     <n-space>
-                        <n-button type="primary" :loading="busy" @click="onAccept">Accept</n-button>
+                        <n-button type="primary" :loading="busy" :disabled="!proposal.severity" @click="onAccept">Accept</n-button>
                         <n-button type="error" :loading="busy" :disabled="!actionComment.trim()" @click="onReject">
                             Reject
                         </n-button>
-                        <n-text v-if="!actionComment.trim()" depth="3" style="font-size: 12px; align-self: center;">
+                        <n-text v-if="!proposal.severity" depth="3" style="font-size: 12px; align-self: center;">
+                            (Severity is required — use Modify to set it)
+                        </n-text>
+                        <n-text v-else-if="!actionComment.trim()" depth="3" style="font-size: 12px; align-self: center;">
                             (Reject requires a comment)
                         </n-text>
                     </n-space>
@@ -261,6 +269,14 @@ const severityOptions = [
     { label: 'INFO', value: 'INFO' },
     { label: 'UNASSIGNED', value: 'UNASSIGNED' },
 ]
+
+function hasDemotion (reason: string): boolean {
+    // demotionReason is a ';'-separated list (e.g. "BROADER_SCOPE_CONFLICT;SEVERITY_MISSING")
+    // so both banners can render simultaneously.
+    const raw = proposal.value?.demotionReason
+    if (!raw) return false
+    return raw.split(';').map((s: string) => s.trim()).includes(reason)
+}
 
 const otherAnalyses = computed(() => {
     if (!proposal.value) return []

--- a/ui/src/components/VexProposalsInbox.vue
+++ b/ui/src/components/VexProposalsInbox.vue
@@ -92,11 +92,19 @@ const columns = computed(() => {
         key: 'actions',
         width: 80,
         render (row: any) {
+            // Open in a new tab so reviewers can keep the inbox open while triaging — they
+            // typically work through a queue of proposals and bouncing back to the inbox after
+            // each one breaks the cadence. window.open over <a target=_blank> because the
+            // click target is an NButton, not a plain anchor.
+            const href = router.resolve({
+                name: 'VexProposalReview',
+                params: { orguuid: orgUuid.value, uuid: row.uuid }
+            }).href
             return h(NButton, {
                 size: 'small',
                 type: 'info',
-                title: 'Review proposal',
-                onClick: () => router.push({ name: 'VexProposalReview', params: { orguuid: orgUuid.value, uuid: row.uuid } })
+                title: 'Review proposal (opens in new tab)',
+                onClick: () => window.open(href, '_blank', 'noopener')
             }, { default: () => h(NIcon, null, { default: () => h(Eye) }) })
         }
     })

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -77,7 +77,7 @@ const routes : any[] = [
     {
         path: '/vulnerabilityAnalysis/:orguuid',
         name: 'VulnerabilityAnalysis',
-        component: () => import('@/components/VulnerabilityAnalysis.vue')
+        component: () => import('@/components/FindingAnalysisPage.vue')
     },
     {
         path: '/orgSettings/:orguuid',
@@ -137,9 +137,14 @@ const routes : any[] = [
         component: () => import('@/components/DownloadTeaArtifactView.vue')
     },
     {
+        // Retired in 2026-05: VEX Proposals now lives as a tab inside the Finding Analysis page.
+        // Redirect preserves any bookmarks/links from the v1.2 dogfood period.
         path: '/vexProposalsOfOrg/:orguuid',
-        name: 'VexProposalsInbox',
-        component: () => import('@/components/VexProposalsInbox.vue')
+        redirect: (to: RouteLocationNormalized) => ({
+            name: 'VulnerabilityAnalysis',
+            params: { orguuid: to.params.orguuid },
+            query: { tab: 'vex' }
+        })
     },
     {
         path: '/vexProposal/:orguuid/:uuid',
@@ -147,9 +152,13 @@ const routes : any[] = [
         component: () => import('@/components/VexProposalReview.vue')
     },
     {
+        // Same as above — Mitigation Attestations is now a tab in Finding Analysis.
         path: '/mitigationAttestationsOfOrg/:orguuid',
-        name: 'MitigationAttestationsInbox',
-        component: () => import('@/components/MitigationAttestationsInbox.vue')
+        redirect: (to: RouteLocationNormalized) => ({
+            name: 'VulnerabilityAnalysis',
+            params: { orguuid: to.params.orguuid },
+            query: { tab: 'attestations' }
+        })
     },
     {
         path: '/mitigationAttestation/:orguuid/:uuid',


### PR DESCRIPTION
## Summary
UI follow-ups on the v1.2 VEX import dogfood feedback. Pairs with rearm-saas/pull/67 (backend).

- **3-tab restructure** — new \`FindingAnalysisPage\` hosts Finding Analysis | VEX Statement Proposals | Mitigation Attestations. Standalone left-nav entries dropped; legacy \`/vexProposalsOfOrg\` and \`/mitigationAttestationsOfOrg\` URLs redirect into the unified page with the correct tab pre-selected (\`?tab=vex|attestations\`).
- **Open VEX review in new tab** — \`VexProposalsInbox\` and the per-release VEX tab on \`ReleaseView\` use \`window.open\` so reviewers can stay on the queue while triaging individual proposals.
- **Severity gate** — \`VexProposalReview\` Accept button is disabled when \`proposal.severity\` is null (paired with the backend's accept-time validation in rearm-saas/pull/67). New \`SEVERITY_MISSING\` demotion banner mirrors \`BROADER_SCOPE_CONFLICT\`; \`demotionReason\` is parsed as \`;\`-separated so both can render simultaneously.

## Test plan
- [x] \`vite build\` green
- [ ] Manual: navigate to Finding Analysis, switch between 3 tabs, check ?tab= deep-links
- [ ] Manual: visit legacy /vexProposalsOfOrg URL, confirm redirect to /vulnerabilityAnalysis?tab=vex
- [ ] Manual: click Review on a VEX proposal in both the inbox and the per-release VEX tab, confirm new tab opens
- [ ] Manual: upload a CDX VEX without ratings, confirm SEVERITY_MISSING banner + disabled Accept until Modify sets severity
- [ ] Manual: re-test with a rated CDX VEX, confirm severity is populated automatically and Accept is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)