### PR TITLE
feat(ui): AI Agents dashboard pages (PR 5/N)

### DIFF
--- a/ui/src/components/AiAgentSessionTable.vue
+++ b/ui/src/components/AiAgentSessionTable.vue
@@ -1,0 +1,57 @@
+<template>
+    <n-data-table
+        :columns="columns"
+        :data="rows"
+        :pagination="{ pageSize: 10 }"
+    />
+</template>
+
+<script setup lang="ts">
+import { h, computed } from 'vue'
+import { NDataTable, NTag, DataTableColumns } from 'naive-ui'
+
+const props = defineProps<{
+    rows: any[]
+    onOpen: (uuid: string) => void
+}>()
+
+const columns = computed<DataTableColumns<any>>(() => [
+    {
+        title: 'Session',
+        key: 'clientSessionId',
+        width: 200,
+        render: (row: any) =>
+            h(
+                'a',
+                {
+                    href: '#',
+                    onClick: (e: Event) => {
+                        e.preventDefault()
+                        props.onOpen(row.uuid)
+                    },
+                },
+                h('code', null, row.clientSessionId ?? row.uuid.slice(0, 8))
+            ),
+    },
+    { title: 'Title', key: 'title' },
+    { title: 'Branch', key: 'branch', render: (row: any) => (row.branch ? h('code', null, row.branch) : '—') },
+    {
+        title: 'Status',
+        key: 'status',
+        render: (row: any) =>
+            h(NTag, { size: 'small', type: row.status === 'OPEN' ? 'info' : 'default' }, { default: () => row.status }),
+    },
+    {
+        title: 'Started',
+        key: 'startedAt',
+        render: (row: any) => (row.startedAt ? new Date(row.startedAt).toLocaleString() : '—'),
+    },
+    {
+        title: 'Closed',
+        key: 'closedAt',
+        render: (row: any) => (row.closedAt ? new Date(row.closedAt).toLocaleString() : '—'),
+    },
+    { title: 'Artifacts', key: 'artifacts', width: 110, render: (row: any) => row.artifacts?.length ?? 0 },
+    { title: 'Commits', key: 'commits', width: 100, render: (row: any) => row.commits?.length ?? 0 },
+])
+</script>

--- a/ui/src/components/AiAgentSessionView.vue
+++ b/ui/src/components/AiAgentSessionView.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="aiAgentSessionView" v-if="session">
+        <div class="hero">
+            <n-tag :type="session.status === 'OPEN' ? 'info' : 'default'" size="small">
+                {{ session.status }}
+            </n-tag>
+            <code class="dim">{{ session.uuid }}</code>
+            <span class="dim">·</span>
+            <a v-if="agent" @click.prevent="openAgent" href="#">
+                <span :style="{ background: agent.color || '#888', color: 'white', padding: '0 4px', borderRadius: '4px', marginRight: '4px' }">
+                    {{ agent.iconKind || '◆' }}
+                </span>
+                {{ agent.name }}
+            </a>
+        </div>
+        <h3>{{ session.title || '(untitled)' }}</h3>
+        <div class="meta">
+            <div><span class="dim">Branch </span><code>{{ session.branch || '—' }}</code></div>
+            <div><span class="dim">Client session ID </span><code>{{ session.clientSessionId }}</code></div>
+            <div><span class="dim">Started </span>{{ formatDate(session.startedAt) }}</div>
+            <div v-if="session.closedAt"><span class="dim">Closed </span>{{ formatDate(session.closedAt) }}</div>
+            <div v-if="session.lastActivityAt"><span class="dim">Last activity </span>{{ formatDate(session.lastActivityAt) }}</div>
+        </div>
+
+        <n-tabs type="line" v-model:value="tab">
+            <n-tab-pane name="overview" tab="Overview">
+                <n-descriptions :column="2" bordered>
+                    <n-descriptions-item label="Commits"><strong>{{ session.commits?.length ?? 0 }}</strong></n-descriptions-item>
+                    <n-descriptions-item label="Artifacts"><strong>{{ session.artifacts?.length ?? 0 }}</strong></n-descriptions-item>
+                    <n-descriptions-item label="Policy verdicts"><strong>{{ session.policyEvents?.length ?? 0 }}</strong></n-descriptions-item>
+                    <n-descriptions-item label="API key"><code>{{ session.apiKey || '—' }}</code></n-descriptions-item>
+                </n-descriptions>
+            </n-tab-pane>
+            <n-tab-pane name="commits" :tab="`Commits · ${session.commits?.length ?? 0}`">
+                <div v-if="!session.commits?.length" class="empty">No commits attributed yet.</div>
+                <n-data-table v-else :columns="commitColumns" :data="session.commits.map((c: string) => ({ uuid: c }))" :pagination="{ pageSize: 25 }"/>
+            </n-tab-pane>
+            <n-tab-pane name="artifacts" :tab="`Artifacts · ${session.artifacts?.length ?? 0}`">
+                <div v-if="!session.artifacts?.length" class="empty">No artifacts attached.</div>
+                <n-data-table v-else :columns="artifactColumns" :data="session.artifacts.map((a: string) => ({ uuid: a }))" :pagination="{ pageSize: 25 }"/>
+            </n-tab-pane>
+            <n-tab-pane name="policies" :tab="`Policies · ${session.policyEvents?.length ?? 0}`">
+                <div v-if="!session.policyEvents?.length" class="empty">No policy evaluations on this session.</div>
+                <n-data-table v-else :columns="policyColumns" :data="session.policyEvents" :pagination="{ pageSize: 25 }"/>
+            </n-tab-pane>
+        </n-tabs>
+    </div>
+    <n-spin v-else size="small"/>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import { NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, DataTableColumns } from 'naive-ui'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+
+const sessionUuid = computed(() => route.params.uuid as string)
+const session = ref<any>(null)
+const agent = ref<any>(null)
+const tab = ref<string>('overview')
+
+onMounted(load)
+
+async function load () {
+    session.value = await store.dispatch('fetchSession', sessionUuid.value)
+    if (session.value?.agent) {
+        agent.value = await store.dispatch('fetchAgent', session.value.agent).catch(() => null)
+    }
+}
+
+function openAgent () {
+    if (agent.value) router.push({ name: 'AiAgentView', params: { uuid: agent.value.uuid } })
+}
+
+function formatDate (s: string | null | undefined) {
+    return s ? new Date(s).toLocaleString() : '—'
+}
+
+const commitColumns: DataTableColumns<any> = [
+    { title: 'SCE uuid', key: 'uuid', render: (row: any) => h('code', null, row.uuid) },
+]
+const artifactColumns: DataTableColumns<any> = [
+    { title: 'Artifact uuid', key: 'uuid', render: (row: any) => h('code', null, row.uuid) },
+]
+const policyColumns: DataTableColumns<any> = [
+    { title: 'Policy', key: 'policyName' },
+    { title: 'Kind', key: 'kind', width: 90 },
+    { title: 'Severity', key: 'severity', width: 100 },
+    {
+        title: 'State',
+        key: 'state',
+        width: 110,
+        render: (row: any) => {
+            const tone = row.state === 'PASSED' ? 'success'
+                : row.state === 'WARNING' ? 'warning'
+                : row.state === 'FAILED' ? 'error' : 'default'
+            return h(NTag, { size: 'small', type: tone }, { default: () => row.state })
+        },
+    },
+    { title: 'Message', key: 'message', render: (row: any) => row.message || '—' },
+    { title: 'Evaluated', key: 'evaluatedAt', render: (row: any) => row.evaluatedAt ? new Date(row.evaluatedAt).toLocaleString() : '—' },
+]
+</script>
+
+<style scoped>
+.aiAgentSessionView { padding: 16px; }
+.hero { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; font-size: 13px; }
+.dim { color: var(--n-text-color-3, #666); }
+.meta { display: flex; gap: 24px; margin: 6px 0 18px 0; font-size: 13px; flex-wrap: wrap; }
+.empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 12px 0; }
+</style>

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -1,0 +1,112 @@
+<template>
+    <div class="aiAgentView" v-if="agent">
+        <div class="hero">
+            <div class="hero__mark" :style="{ background: agent.color || '#888' }">
+                {{ agent.iconKind || '◆' }}
+            </div>
+            <div class="hero__title">
+                <h3>{{ agent.name }}</h3>
+                <div class="hero__sub">
+                    <n-tag size="small" :type="agent.agentType === 'ROOT' ? 'info' : 'default'">{{ agent.agentType }}</n-tag>
+                    <n-tag size="small" :type="agent.status === 'ACTIVE' ? 'success' : 'default'">{{ agent.status }}</n-tag>
+                    <span v-if="agent.model" class="dim">
+                        {{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version ? ' @ ' + agent.model.version : '' }}</code>
+                    </span>
+                    <span class="dim" v-if="agent.lastActivityAt">
+                        last activity {{ formatDate(agent.lastActivityAt) }}
+                    </span>
+                </div>
+            </div>
+            <div class="hero__stats">
+                <div><div class="stat__v">{{ agent.sessionCounts?.openSessions ?? 0 }}</div><div class="stat__l">open</div></div>
+                <div><div class="stat__v">{{ agent.sessionCounts?.closedSessions ?? 0 }}</div><div class="stat__l">closed</div></div>
+                <div><div class="stat__v">{{ agent.subAgents?.length ?? 0 }}</div><div class="stat__l">sub-agents</div></div>
+            </div>
+        </div>
+
+        <n-tabs type="line" v-model:value="tab">
+            <n-tab-pane name="open" :tab="`Open sessions · ${openSessions.length}`">
+                <SessionTable :rows="openSessions" :on-open="openSession"/>
+            </n-tab-pane>
+            <n-tab-pane name="closed" :tab="`Closed sessions · ${closedSessions.length}`">
+                <SessionTable :rows="closedSessions" :on-open="openSession"/>
+            </n-tab-pane>
+            <n-tab-pane name="subs" :tab="`Sub-agents · ${subAgentRows.length}`">
+                <n-data-table
+                    :columns="subAgentColumns"
+                    :data="subAgentRows"
+                    :pagination="{ pageSize: 10 }"
+                />
+            </n-tab-pane>
+            <n-tab-pane name="settings" tab="Settings">
+                <n-descriptions :column="2" bordered>
+                    <n-descriptions-item label="UUID"><code>{{ agent.uuid }}</code></n-descriptions-item>
+                    <n-descriptions-item label="Org"><code>{{ agent.org }}</code></n-descriptions-item>
+                    <n-descriptions-item label="API keys">{{ agent.apiKeys?.length ?? 0 }}</n-descriptions-item>
+                    <n-descriptions-item label="Created">{{ formatDate(agent.createdDate) }}</n-descriptions-item>
+                    <n-descriptions-item label="Notes" :span="2">{{ agent.notes || '—' }}</n-descriptions-item>
+                </n-descriptions>
+            </n-tab-pane>
+        </n-tabs>
+    </div>
+    <n-spin v-else size="small"/>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import { NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, DataTableColumns } from 'naive-ui'
+import SessionTable from './AiAgentSessionTable.vue'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+
+const agentUuid = computed(() => route.params.uuid as string)
+const agent = ref<any>(null)
+const subAgentRows = ref<any[]>([])
+const tab = ref<string>('open')
+
+const openSessions = computed(() => agent.value?.openSessions ?? [])
+const closedSessions = computed(() => agent.value?.closedSessions ?? [])
+
+onMounted(load)
+
+async function load () {
+    agent.value = await store.dispatch('fetchAgent', agentUuid.value)
+    if (agent.value?.subAgents?.length) {
+        const subs = await Promise.all(
+            agent.value.subAgents.map((uu: string) => store.dispatch('fetchAgent', uu).catch(() => null))
+        )
+        subAgentRows.value = subs.filter(Boolean)
+    }
+}
+
+function openSession (uuid: string) {
+    router.push({ name: 'AiAgentSessionView', params: { uuid } })
+}
+
+function formatDate (s: string | null | undefined) {
+    return s ? new Date(s).toLocaleString() : '—'
+}
+
+const subAgentColumns: DataTableColumns<any> = [
+    { title: 'Name', key: 'name', render: (row: any) => h('a', { onClick: () => router.push({ name: 'AiAgentView', params: { uuid: row.uuid } }) }, row.name) },
+    { title: 'Status', key: 'status' },
+    { title: 'Sessions', key: 'sess', render: (row: any) => (row.sessionCounts?.openSessions ?? 0) + ' open / ' + (row.sessionCounts?.closedSessions ?? 0) + ' closed' },
+    { title: 'Last activity', key: 'lastActivityAt', render: (row: any) => row.lastActivityAt ? new Date(row.lastActivityAt).toLocaleString() : '—' },
+]
+</script>
+
+<style scoped>
+.aiAgentView { padding: 16px; }
+.hero { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; }
+.hero__mark { width: 56px; height: 56px; border-radius: 12px; color: white; display: flex; align-items: center; justify-content: center; font-size: 28px; font-weight: 600; }
+.hero__title { flex: 1; }
+.hero__sub { display: flex; align-items: center; gap: 8px; font-size: 13px; margin-top: 4px; }
+.dim { color: var(--n-text-color-3, #666); }
+.hero__stats { display: flex; gap: 24px; }
+.stat__v { font-size: 24px; font-weight: 600; text-align: center; }
+.stat__l { font-size: 11px; color: var(--n-text-color-3, #666); text-transform: uppercase; letter-spacing: 0.04em; text-align: center; }
+</style>

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -1,0 +1,158 @@
+<template>
+    <div class="aiAgentsOfOrg">
+        <h4>AI Agents</h4>
+        <p class="sub">
+            Coding agents registered to this workspace. Each agent runs sessions that
+            produce artifacts, commits, pull requests and releases.
+        </p>
+
+        <n-spin v-if="loading" size="small"/>
+
+        <n-space vertical :size="20">
+            <!-- KPI row (cross-cutting dashboard metrics) -->
+            <div class="kpis" v-if="kpis">
+                <n-card class="kpi" size="small">
+                    <div class="kpi__l">Active sessions</div>
+                    <div class="kpi__v">{{ kpis.activeSessions }}</div>
+                    <div class="kpi__d">across {{ kpis.registeredAgents }} agents</div>
+                </n-card>
+                <n-card class="kpi" size="small">
+                    <div class="kpi__l">Closed (30d)</div>
+                    <div class="kpi__v">{{ kpis.closedSessions30d }}</div>
+                </n-card>
+                <n-card class="kpi" size="small">
+                    <div class="kpi__l">Artifacts produced</div>
+                    <div class="kpi__v">{{ kpis.artifactsProduced7d }}</div>
+                    <div class="kpi__d">last 7 days</div>
+                </n-card>
+                <n-card class="kpi" size="small">
+                    <div class="kpi__l">Registered agents</div>
+                    <div class="kpi__v">{{ kpis.registeredAgents }}</div>
+                </n-card>
+            </div>
+
+            <!-- Agent card grid -->
+            <div>
+                <h5>Registered agents</h5>
+                <div v-if="agents.length === 0" class="empty">
+                    No agents yet. Sessions auto-register an agent on first init.
+                </div>
+                <div class="agent-grid" v-else>
+                    <n-card
+                        v-for="a in rootAgents"
+                        :key="a.uuid"
+                        class="acard"
+                        size="small"
+                        hoverable
+                        @click="openAgent(a.uuid)"
+                    >
+                        <div class="acard__top">
+                            <div class="acard__mark" :style="{ background: a.color || '#888' }">
+                                {{ a.iconKind || '◆' }}
+                            </div>
+                            <div>
+                                <div class="acard__name">{{ a.name }}</div>
+                                <div class="acard__sub" v-if="a.model">
+                                    {{ a.model.publisher }} · <code>{{ a.model.name }}{{ a.model.version ? ' @ ' + a.model.version : '' }}</code>
+                                </div>
+                            </div>
+                            <n-tag size="small" :type="a.status === 'ACTIVE' ? 'success' : 'default'">
+                                {{ a.status }}
+                            </n-tag>
+                        </div>
+                        <div class="acard__row">
+                            <div><span class="acard__num">{{ a.sessionCounts?.openSessions ?? 0 }}</span><span class="acard__lab">open</span></div>
+                            <div><span class="acard__num">{{ a.sessionCounts?.closedSessions ?? 0 }}</span><span class="acard__lab">closed</span></div>
+                            <div><span class="acard__num">{{ a.subAgents?.length ?? 0 }}</span><span class="acard__lab">sub-agents</span></div>
+                        </div>
+                    </n-card>
+                </div>
+            </div>
+
+            <!-- Live sessions table -->
+            <div>
+                <h5>Live sessions</h5>
+                <n-data-table
+                    :columns="sessionColumns"
+                    :data="openSessions"
+                    :pagination="{ pageSize: 10 }"
+                    @update:row-click="(row: any) => openSession(row.uuid)"
+                />
+            </div>
+        </n-space>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import { NCard, NDataTable, NSpace, NSpin, NTag, DataTableColumns } from 'naive-ui'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+
+const orgUuid = computed(() => route.params.orguuid as string)
+const loading = ref<boolean>(false)
+const kpis = ref<any>(null)
+const agents = ref<any[]>([])
+const openSessions = ref<any[]>([])
+
+const rootAgents = computed(() => agents.value.filter(a => a.agentType === 'ROOT'))
+
+onMounted(async () => {
+    await refreshAll()
+})
+
+async function refreshAll () {
+    loading.value = true
+    try {
+        const [k, a, s] = await Promise.all([
+            store.dispatch('fetchAgentDashboardKpis', orgUuid.value),
+            store.dispatch('fetchAgentsOfOrg', orgUuid.value),
+            store.dispatch('fetchSessionsOfOrg', { orgUuid: orgUuid.value, statuses: ['OPEN'] }),
+        ])
+        kpis.value = k
+        agents.value = a ?? []
+        openSessions.value = s ?? []
+    } finally {
+        loading.value = false
+    }
+}
+
+function openAgent (uuid: string) {
+    router.push({ name: 'AiAgentView', params: { uuid } })
+}
+
+function openSession (uuid: string) {
+    router.push({ name: 'AiAgentSessionView', params: { uuid } })
+}
+
+const sessionColumns: DataTableColumns<any> = [
+    { title: 'Session', key: 'clientSessionId', width: 200, render: (row: any) => h('code', null, row.clientSessionId ?? row.uuid.slice(0, 8)) },
+    { title: 'Title', key: 'title' },
+    { title: 'Branch', key: 'branch', render: (row: any) => row.branch ? h('code', null, row.branch) : '—' },
+    { title: 'Started', key: 'startedAt', render: (row: any) => row.startedAt ? new Date(row.startedAt).toLocaleString() : '—' },
+    { title: 'Artifacts', key: 'artifacts', width: 110, render: (row: any) => row.artifacts?.length ?? 0 },
+    { title: 'Commits', key: 'commits', width: 100, render: (row: any) => row.commits?.length ?? 0 },
+]
+</script>
+
+<style scoped>
+.aiAgentsOfOrg { padding: 16px; }
+.sub { color: var(--n-text-color-3, #666); font-size: 13px; margin-bottom: 16px; }
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
+.kpi__l { text-transform: uppercase; font-size: 11px; letter-spacing: 0.06em; color: var(--n-text-color-3, #666); }
+.kpi__v { font-size: 32px; font-weight: 600; margin-top: 4px; }
+.kpi__d { font-size: 12px; color: var(--n-text-color-3, #666); margin-top: 2px; }
+.agent-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-top: 8px; }
+.acard__top { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.acard__mark { width: 36px; height: 36px; border-radius: 8px; color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 18px; }
+.acard__name { font-weight: 600; }
+.acard__sub { font-size: 12px; color: var(--n-text-color-3, #666); }
+.acard__row { display: flex; gap: 24px; }
+.acard__num { font-size: 22px; font-weight: 600; margin-right: 6px; }
+.acard__lab { font-size: 11px; color: var(--n-text-color-3, #666); text-transform: uppercase; letter-spacing: 0.04em; }
+.empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 12px 0; }
+</style>

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -44,7 +44,7 @@ import { ref, h, Component, ComputedRef, computed, Ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
 import { HomeOutlined as HomeIcon, CloudServerOutlined, BugOutlined } from '@vicons/antd'
-import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest } from '@vicons/tabler'
+import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest, Robot } from '@vicons/tabler'
 
 
 function renderIcon (icon: Component) {
@@ -128,6 +128,21 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
                 ),
             key: 'pullRequests',
             icon: renderIcon(GitPullRequest)
+        },
+        {
+            label: () =>
+                h(
+                    RouterLink,
+                    {
+                        to: {
+                            name: 'AiAgentsOfOrg',
+                            params: {orguuid: org}
+                        }
+                    },
+                    { default: () => 'AI Agents' }
+                ),
+            key: 'aiAgents',
+            icon: renderIcon(Robot)
         },
 
     ]
@@ -240,6 +255,9 @@ const routeToMenuKey: Record<string, string> = {
     'VcsRepository': 'vcsRepos',
     'PullRequestsOfOrg': 'pullRequests',
     'PullRequestView': 'pullRequests',
+    'AiAgentsOfOrg': 'aiAgents',
+    'AiAgentView': 'aiAgents',
+    'AiAgentSessionView': 'aiAgents',
     'InstancesOfOrg': 'instances',
     'Instance': 'instances',
     'SecretsOfOrg': 'secrets',

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -50,6 +50,21 @@ const routes : any[] = [
         component: () => import('@/components/VcsReposOfOrg.vue')
     },
     {
+        path: '/aiAgentsOfOrg/:orguuid',
+        name: 'AiAgentsOfOrg',
+        component: () => import('@/components/AiAgentsOfOrg.vue')
+    },
+    {
+        path: '/aiAgent/:uuid',
+        name: 'AiAgentView',
+        component: () => import('@/components/AiAgentView.vue')
+    },
+    {
+        path: '/aiAgentSession/:uuid',
+        name: 'AiAgentSessionView',
+        component: () => import('@/components/AiAgentSessionView.vue')
+    },
+    {
         path: '/secretsOfOrg/:orguuid',
         name: 'SecretsOfOrg',
         component: () => import('@/components/SecretsOfOrg.vue')

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1965,7 +1965,178 @@ const storeObject : any = {
             const updOrg = data.data.deleteApprovalRole
             context.commit('UPDATE_ORGANIZATION', updOrg)
             return updOrg
-        },  
+        },
+
+        // ---------- AI Agents (PR 5) ----------
+        async fetchAgentDashboardKpis (context: any, orgUuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query agentDashboardKpis($orgUuid: ID!) {
+                        agentDashboardKpis(orgUuid: $orgUuid) {
+                            activeSessions
+                            closedSessions30d
+                            artifactsProduced7d
+                            registeredAgents
+                        }
+                    }`,
+                variables: { orgUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.agentDashboardKpis
+        },
+        async fetchAgentsOfOrg (context: any, orgUuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query agentsOfOrg($orgUuid: ID!) {
+                        agentsOfOrg(orgUuid: $orgUuid) {
+                            uuid
+                            org
+                            name
+                            iconKind
+                            color
+                            notes
+                            apiKeys
+                            status
+                            agentType
+                            rootAgent
+                            subAgents
+                            createdDate
+                            sessionCounts {
+                                openSessions
+                                closedSessions
+                            }
+                            lastActivityAt
+                            model {
+                                uuid
+                                name
+                                version
+                                publisher
+                                description
+                            }
+                        }
+                    }`,
+                variables: { orgUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.agentsOfOrg
+        },
+        async fetchAgent (context: any, uuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query agent($uuid: ID!) {
+                        agent(uuid: $uuid) {
+                            uuid
+                            org
+                            name
+                            iconKind
+                            color
+                            notes
+                            apiKeys
+                            status
+                            agentType
+                            rootAgent
+                            subAgents
+                            createdDate
+                            sessionCounts {
+                                openSessions
+                                closedSessions
+                            }
+                            lastActivityAt
+                            openSessions {
+                                uuid
+                                clientSessionId
+                                title
+                                branch
+                                status
+                                startedAt
+                                lastActivityAt
+                                artifacts
+                                commits
+                            }
+                            closedSessions {
+                                uuid
+                                clientSessionId
+                                title
+                                branch
+                                status
+                                startedAt
+                                closedAt
+                                artifacts
+                                commits
+                            }
+                            model {
+                                uuid
+                                name
+                                version
+                                publisher
+                                description
+                            }
+                        }
+                    }`,
+                variables: { uuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.agent
+        },
+        async fetchSessionsOfOrg (context: any, payload: { orgUuid: string, statuses?: string[] }) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query sessionsOfOrg($orgUuid: ID!, $statuses: [SessionStatus]) {
+                        sessionsOfOrg(orgUuid: $orgUuid, statuses: $statuses) {
+                            uuid
+                            org
+                            agent
+                            clientSessionId
+                            apiKey
+                            title
+                            branch
+                            status
+                            startedAt
+                            closedAt
+                            lastActivityAt
+                            artifacts
+                            commits
+                        }
+                    }`,
+                variables: { orgUuid: payload.orgUuid, statuses: payload.statuses ?? null },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.sessionsOfOrg
+        },
+        async fetchSession (context: any, uuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query session($uuid: ID!) {
+                        session(uuid: $uuid) {
+                            uuid
+                            org
+                            agent
+                            clientSessionId
+                            apiKey
+                            title
+                            branch
+                            status
+                            startedAt
+                            closedAt
+                            lastActivityAt
+                            artifacts
+                            commits
+                            policyEvents {
+                                policyUuid
+                                policyName
+                                kind
+                                severity
+                                state
+                                message
+                                evaluatedAt
+                            }
+                        }
+                    }`,
+                variables: { uuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.session
+        },
     },
 }
 


### PR DESCRIPTION
## Summary

UI side of the AI-Agent stack — targets the long-lived `agentic`
branch in `rearm/`. Stacks on top of the backend PR series in
`rearm-core` (#73 / #74 / #75 / #76); won't render meaningful data
until those land on the matching sandbox.

## What it adds

Three pages + one shared table component:

| Component | Purpose |
|---|---|
| `AiAgentsOfOrg.vue` | Dashboard list view — KPI header row, agent card grid (filtered to ROOT agents), live-sessions table |
| `AiAgentView.vue` | Single-agent detail — Open / Closed sessions tabs, Sub-agents tab, Settings |
| `AiAgentSessionView.vue` | Session detail — overview, commits list, artifacts list, **policy verdicts** (SAAS-side data from PR 4) |
| `AiAgentSessionTable.vue` | Shared sessions table used by dashboard + agent detail |

Wiring:
- `router.ts` — three routes: `AiAgentsOfOrg`, `AiAgentView`, `AiAgentSessionView`
- `LeftNavBar.vue` — "AI Agents" nav entry (Robot icon from `@vicons/tabler`)
- `store.ts` — five new Apollo actions matching the backend's
  GraphQL surface from PR 1-4: `fetchAgentDashboardKpis`,
  `fetchAgentsOfOrg`, `fetchAgent`, `fetchSessionsOfOrg`,
  `fetchSession` (the last includes `policyEvents`).

## Scope discipline

v1 keeps styling minimal — `naive-ui` defaults, no custom
typography or animation. Matches the mockup's structure but not
its bespoke design system. Polish is a follow-up once the backend
lands and we have real data on psclaude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)