### PR TITLE
perf(backend): normalize SBOM component aggregation storage

### DIFF
--- a/backend/src/main/java/io/reliza/model/ArtifactCanonicalMap.java
+++ b/backend/src/main/java/io/reliza/model/ArtifactCanonicalMap.java
@@ -1,0 +1,68 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Per-org pointer from a BOM-bearing {@code artifacts} row to its canonical
+ * (content-identical) counterpart. Populated <em>lazily</em> during SBOM
+ * reconcile — non-BOM artifacts never appear here.
+ *
+ * <p>An artifact that is the first occurrence of its content within the org
+ * maps to itself ({@code canonical_artifact_uuid = artifact_uuid}); all
+ * subsequent uploads with the same digest map to that first row. The
+ * mapping is the single authoritative source for "which artifact UUID does
+ * the SBOM aggregation use" — there's no implicit "missing row means
+ * canonical" rule.
+ *
+ * <p>No foreign keys on the table by design. If the referenced canonical
+ * artifact is later deleted, the SBOM service surfaces a "no data found"
+ * outcome and log.warn's the dangling reference instead of cascading.
+ * Keeps the map orthogonal to the artifacts table lifecycle.
+ */
+@Entity
+@Table(schema = ModelProperties.DB_SCHEMA, name = "artifact_canonical_map")
+public class ArtifactCanonicalMap implements Serializable {
+	private static final long serialVersionUID = 234741L;
+
+	@Id
+	private UUID uuid = UUID.randomUUID();
+
+	@Column(nullable = false)
+	private UUID org;
+
+	@Column(nullable = false)
+	private UUID artifactUuid;
+
+	@Column(nullable = false)
+	private UUID canonicalArtifactUuid;
+
+	@Column(nullable = false)
+	private ZonedDateTime createdDate = ZonedDateTime.now();
+
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
+
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
+
+	public UUID getArtifactUuid() { return artifactUuid; }
+	public void setArtifactUuid(UUID artifactUuid) { this.artifactUuid = artifactUuid; }
+
+	public UUID getCanonicalArtifactUuid() { return canonicalArtifactUuid; }
+	public void setCanonicalArtifactUuid(UUID canonicalArtifactUuid) {
+		this.canonicalArtifactUuid = canonicalArtifactUuid;
+	}
+
+	public ZonedDateTime getCreatedDate() { return createdDate; }
+	public void setCreatedDate(ZonedDateTime createdDate) { this.createdDate = createdDate; }
+}

--- a/backend/src/main/java/io/reliza/model/PurlQualifier.java
+++ b/backend/src/main/java/io/reliza/model/PurlQualifier.java
@@ -1,0 +1,53 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Per-(org, full_purl) interning row referenced by
+ * release_sbom_component_artifacts and release_sbom_edges. Lets the same
+ * qualifier-bearing PURL be stored once per org instead of repeated inside
+ * JSONB across every release / artifact / edge.
+ *
+ * <p>NULL references in the child tables mean "exact PURL equals canonical
+ * PURL" on the related sbom_components row — we avoid intern rows for the
+ * ~80% of components that carry no qualifiers.
+ */
+@Entity
+@Table(schema = ModelProperties.DB_SCHEMA, name = "purl_qualifiers")
+public class PurlQualifier implements Serializable {
+	private static final long serialVersionUID = 234738L;
+
+	@Id
+	private UUID uuid = UUID.randomUUID();
+
+	@Column(nullable = false)
+	private UUID org;
+
+	@Column(name = "full_purl", nullable = false)
+	private String fullPurl;
+
+	@Column(nullable = false)
+	private ZonedDateTime createdDate = ZonedDateTime.now();
+
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
+
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
+
+	public String getFullPurl() { return fullPurl; }
+	public void setFullPurl(String fullPurl) { this.fullPurl = fullPurl; }
+
+	public ZonedDateTime getCreatedDate() { return createdDate; }
+	public void setCreatedDate(ZonedDateTime createdDate) { this.createdDate = createdDate; }
+}

--- a/backend/src/main/java/io/reliza/model/ReleaseSbomComponent.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseSbomComponent.java
@@ -13,11 +13,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
-
-import org.hibernate.annotations.Type;
-
-import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 
 @Entity
 @Table(schema = ModelProperties.DB_SCHEMA, name = "release_sbom_components")
@@ -49,118 +46,64 @@ public class ReleaseSbomComponent implements Serializable, RelizaEntity {
 	@Column(nullable = false)
 	private UUID sbomComponentUuid;
 
-	@Type(JsonBinaryType.class)
-	@Column(columnDefinition = ModelProperties.JSONB, nullable = false)
+	/**
+	 * Per-artifact participations populated at read time from
+	 * release_sbom_component_artifacts. Shape preserved for the GraphQL
+	 * surface: list of {@code {artifact, exactPurls: [...]}} maps.
+	 * Not persisted — the source of truth lives in the child table.
+	 */
+	@Transient
 	private List<Map<String, Object>> artifactParticipations;
 
 	/**
-	 * In-edges for this component within the release: one entry per
-	 * (sourceSbomComponentUuid, relationshipType) — i.e. "what depends on
-	 * this component." Reverse of the more common BOM dependsOn direction;
-	 * picked because the impact / vulnerability propagation query is the
-	 * dominant lookup. See SbomComponentDataFetcher for forward-edge
-	 * reconstruction.
+	 * In-edges (parents) populated at read time from release_sbom_edges.
+	 * Shape preserved for the GraphQL surface: list of {@code
+	 * {sourceSbomComponentUuid, sourceCanonicalPurl, relationshipType,
+	 * declaringArtifacts: [...]}} maps. Not persisted.
 	 */
-	@Type(JsonBinaryType.class)
-	@Column(columnDefinition = ModelProperties.JSONB, nullable = false)
+	@Transient
 	private List<Map<String, Object>> parents;
 
-	@Type(JsonBinaryType.class)
-	@Column(columnDefinition = ModelProperties.JSONB)
-	private Map<String, Object> recordData;
+	@Override
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
 
 	@Override
-	public UUID getUuid() {
-		return uuid;
-	}
-
-	public void setUuid(UUID uuid) {
-		this.uuid = uuid;
-	}
+	public int getRevision() { return revision; }
+	public void setRevision(int revision) { this.revision = revision; }
 
 	@Override
-	public int getRevision() {
-		return revision;
-	}
-
-	public void setRevision(int revision) {
-		this.revision = revision;
-	}
+	public ZonedDateTime getCreatedDate() { return createdDate; }
+	public void setCreatedDate(ZonedDateTime createdDate) { this.createdDate = createdDate; }
 
 	@Override
-	public ZonedDateTime getCreatedDate() {
-		return createdDate;
-	}
+	public ZonedDateTime getLastUpdatedDate() { return lastUpdatedDate; }
+	public void setLastUpdatedDate(ZonedDateTime lastUpdatedDate) { this.lastUpdatedDate = lastUpdatedDate; }
 
-	public void setCreatedDate(ZonedDateTime createdDate) {
-		this.createdDate = createdDate;
-	}
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
 
-	@Override
-	public ZonedDateTime getLastUpdatedDate() {
-		return lastUpdatedDate;
-	}
+	public UUID getReleaseUuid() { return releaseUuid; }
+	public void setReleaseUuid(UUID releaseUuid) { this.releaseUuid = releaseUuid; }
 
-	public void setLastUpdatedDate(ZonedDateTime lastUpdatedDate) {
-		this.lastUpdatedDate = lastUpdatedDate;
-	}
+	public UUID getSbomComponentUuid() { return sbomComponentUuid; }
+	public void setSbomComponentUuid(UUID sbomComponentUuid) { this.sbomComponentUuid = sbomComponentUuid; }
 
-	public UUID getOrg() {
-		return org;
-	}
-
-	public void setOrg(UUID org) {
-		this.org = org;
-	}
-
-	public UUID getReleaseUuid() {
-		return releaseUuid;
-	}
-
-	public void setReleaseUuid(UUID releaseUuid) {
-		this.releaseUuid = releaseUuid;
-	}
-
-	public UUID getSbomComponentUuid() {
-		return sbomComponentUuid;
-	}
-
-	public void setSbomComponentUuid(UUID sbomComponentUuid) {
-		this.sbomComponentUuid = sbomComponentUuid;
-	}
-
-	public List<Map<String, Object>> getArtifactParticipations() {
-		return artifactParticipations;
-	}
-
+	public List<Map<String, Object>> getArtifactParticipations() { return artifactParticipations; }
 	public void setArtifactParticipations(List<Map<String, Object>> artifactParticipations) {
 		this.artifactParticipations = artifactParticipations;
 	}
 
-	public List<Map<String, Object>> getParents() {
-		return parents;
-	}
-
-	public void setParents(List<Map<String, Object>> parents) {
-		this.parents = parents;
-	}
+	public List<Map<String, Object>> getParents() { return parents; }
+	public void setParents(List<Map<String, Object>> parents) { this.parents = parents; }
 
 	@Override
-	public Map<String, Object> getRecordData() {
-		return recordData;
-	}
+	public Map<String, Object> getRecordData() { return null; }
 
 	@Override
-	public void setRecordData(Map<String, Object> recordData) {
-		this.recordData = recordData;
-	}
+	public void setRecordData(Map<String, Object> recordData) { /* no-op: release_sbom_components no longer carries a JSONB record_data column */ }
 
 	@Override
-	public int getSchemaVersion() {
-		return schemaVersion;
-	}
-
-	public void setSchemaVersion(int schemaVersion) {
-		this.schemaVersion = schemaVersion;
-	}
+	public int getSchemaVersion() { return schemaVersion; }
+	public void setSchemaVersion(int schemaVersion) { this.schemaVersion = schemaVersion; }
 }

--- a/backend/src/main/java/io/reliza/model/ReleaseSbomComponentArtifact.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseSbomComponentArtifact.java
@@ -1,0 +1,67 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * One row per (release, canonical component, declaring artifact, exact PURL).
+ * Replaces the prior {@code release_sbom_components.artifact_participations}
+ * JSONB array. Keyed by canonical {@code sbom_component_uuid} (not by the
+ * {@code release_sbom_components.uuid} anchor row) so that PRODUCT-release
+ * read-time merging collapses to a single
+ * {@code WHERE release_uuid IN (...) GROUP BY sbom_component_uuid} query.
+ *
+ * <p>Internal child row — no audit timestamps, no {@code RelizaEntity}
+ * interface participation. Lifetime is fully managed by the parent
+ * release_sbom_components row's reconcile cycle.
+ */
+@Entity
+@Table(schema = ModelProperties.DB_SCHEMA, name = "release_sbom_component_artifacts")
+public class ReleaseSbomComponentArtifact implements Serializable {
+	private static final long serialVersionUID = 234739L;
+
+	@Id
+	private UUID uuid = UUID.randomUUID();
+
+	@Column(nullable = false)
+	private UUID org;
+
+	@Column(nullable = false)
+	private UUID releaseUuid;
+
+	@Column(nullable = false)
+	private UUID sbomComponentUuid;
+
+	@Column(nullable = false)
+	private UUID artifactUuid;
+
+	/** NULL means exact PURL equals canonical PURL on the referenced sbom_components row. */
+	@Column
+	private UUID exactPurlUuid;
+
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
+
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
+
+	public UUID getReleaseUuid() { return releaseUuid; }
+	public void setReleaseUuid(UUID releaseUuid) { this.releaseUuid = releaseUuid; }
+
+	public UUID getSbomComponentUuid() { return sbomComponentUuid; }
+	public void setSbomComponentUuid(UUID sbomComponentUuid) { this.sbomComponentUuid = sbomComponentUuid; }
+
+	public UUID getArtifactUuid() { return artifactUuid; }
+	public void setArtifactUuid(UUID artifactUuid) { this.artifactUuid = artifactUuid; }
+
+	public UUID getExactPurlUuid() { return exactPurlUuid; }
+	public void setExactPurlUuid(UUID exactPurlUuid) { this.exactPurlUuid = exactPurlUuid; }
+}

--- a/backend/src/main/java/io/reliza/model/ReleaseSbomComponentArtifact.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseSbomComponentArtifact.java
@@ -40,6 +40,14 @@ public class ReleaseSbomComponentArtifact implements Serializable {
 	@Column(nullable = false)
 	private UUID sbomComponentUuid;
 
+	/**
+	 * Always a CANONICAL artifact UUID, resolved through
+	 * {@code artifact_canonical_map} at reconcile time. Two uploads of the
+	 * same BOM (content-identical, same REARM-scope digest, same org) both
+	 * land here as the single canonical UUID. No code path in
+	 * {@link io.reliza.service.SbomComponentService} writes a
+	 * non-canonical UUID into this column.
+	 */
 	@Column(nullable = false)
 	private UUID artifactUuid;
 

--- a/backend/src/main/java/io/reliza/model/ReleaseSbomEdge.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseSbomEdge.java
@@ -1,0 +1,97 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * One row per in-edge between canonical components inside a single release.
+ * Replaces the prior {@code release_sbom_components.parents} JSONB array.
+ *
+ * <p>Both ends are canonical {@code sbom_components} UUIDs (not
+ * {@code release_sbom_components.uuid}). That keeps product-release merging
+ * a UNION over many {@code release_uuid}s without any per-release UUID
+ * remapping — the in-memory dedup key is naturally (source canonical,
+ * target canonical, relationship, declaring artifact, exact purls).
+ *
+ * <p>Internal child row — no audit timestamps. Lifetime managed by the
+ * parent release_sbom_components reconcile cycle.
+ */
+@Entity
+@Table(schema = ModelProperties.DB_SCHEMA, name = "release_sbom_edges")
+public class ReleaseSbomEdge implements Serializable {
+	private static final long serialVersionUID = 234740L;
+
+	@Id
+	private UUID uuid = UUID.randomUUID();
+
+	@Column(nullable = false)
+	private UUID org;
+
+	@Column(nullable = false)
+	private UUID releaseUuid;
+
+	@Column(nullable = false)
+	private UUID targetSbomComponentUuid;
+
+	@Column(nullable = false)
+	private UUID sourceSbomComponentUuid;
+
+	@Column(nullable = false)
+	private String relationshipType;
+
+	@Column(nullable = false)
+	private UUID declaringArtifactUuid;
+
+	/** NULL means source exact PURL equals source canonical PURL. */
+	@Column
+	private UUID sourceExactPurlUuid;
+
+	/** NULL means target exact PURL equals target canonical PURL. */
+	@Column
+	private UUID targetExactPurlUuid;
+
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
+
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
+
+	public UUID getReleaseUuid() { return releaseUuid; }
+	public void setReleaseUuid(UUID releaseUuid) { this.releaseUuid = releaseUuid; }
+
+	public UUID getTargetSbomComponentUuid() { return targetSbomComponentUuid; }
+	public void setTargetSbomComponentUuid(UUID targetSbomComponentUuid) {
+		this.targetSbomComponentUuid = targetSbomComponentUuid;
+	}
+
+	public UUID getSourceSbomComponentUuid() { return sourceSbomComponentUuid; }
+	public void setSourceSbomComponentUuid(UUID sourceSbomComponentUuid) {
+		this.sourceSbomComponentUuid = sourceSbomComponentUuid;
+	}
+
+	public String getRelationshipType() { return relationshipType; }
+	public void setRelationshipType(String relationshipType) { this.relationshipType = relationshipType; }
+
+	public UUID getDeclaringArtifactUuid() { return declaringArtifactUuid; }
+	public void setDeclaringArtifactUuid(UUID declaringArtifactUuid) {
+		this.declaringArtifactUuid = declaringArtifactUuid;
+	}
+
+	public UUID getSourceExactPurlUuid() { return sourceExactPurlUuid; }
+	public void setSourceExactPurlUuid(UUID sourceExactPurlUuid) {
+		this.sourceExactPurlUuid = sourceExactPurlUuid;
+	}
+
+	public UUID getTargetExactPurlUuid() { return targetExactPurlUuid; }
+	public void setTargetExactPurlUuid(UUID targetExactPurlUuid) {
+		this.targetExactPurlUuid = targetExactPurlUuid;
+	}
+}

--- a/backend/src/main/java/io/reliza/model/ReleaseSbomEdge.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseSbomEdge.java
@@ -47,6 +47,17 @@ public class ReleaseSbomEdge implements Serializable {
 	@Column(nullable = false)
 	private String relationshipType;
 
+	/**
+	 * Always a CANONICAL artifact UUID, resolved through
+	 * {@code artifact_canonical_map} at reconcile time. Two uploads of the
+	 * same BOM (content-identical, same REARM-scope digest, same org) both
+	 * land here as the single canonical UUID, so cross-release "which
+	 * uploads declared this edge" is a join on
+	 * {@code artifact_canonical_map.canonical_artifact_uuid} — never a
+	 * digest comparison. No code path in
+	 * {@link io.reliza.service.SbomComponentService} writes a
+	 * non-canonical UUID into this column.
+	 */
 	@Column(nullable = false)
 	private UUID declaringArtifactUuid;
 

--- a/backend/src/main/java/io/reliza/model/SbomComponent.java
+++ b/backend/src/main/java/io/reliza/model/SbomComponent.java
@@ -5,7 +5,6 @@ package io.reliza.model;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.Map;
 import java.util.UUID;
 
 import jakarta.persistence.Column;
@@ -13,10 +12,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
-
-import org.hibernate.annotations.Type;
-
-import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 
 @Entity
 @Table(schema = ModelProperties.DB_SCHEMA, name = "sbom_components")
@@ -45,78 +40,72 @@ public class SbomComponent implements Serializable, RelizaEntity {
 	@Column(nullable = false)
 	private String canonicalPurl;
 
-	@Type(JsonBinaryType.class)
-	@Column(columnDefinition = ModelProperties.JSONB)
-	private Map<String, Object> recordData;
+	/** CycloneDX component type (library, application, framework, …). */
+	@Column(name = "purl_type")
+	private String purlType;
+
+	/** Package group / namespace (e.g. Maven groupId, npm scope). */
+	@Column(name = "pkg_group")
+	private String pkgGroup;
+
+	@Column
+	private String name;
+
+	@Column
+	private String version;
+
+	/**
+	 * True when at least one uploaded BOM declared this component as its
+	 * metadata.component (the "subject" of the BOM). Flips on once observed
+	 * as root and stays on for the lifetime of the row.
+	 */
+	@Column(name = "is_root", nullable = false)
+	private boolean isRoot = false;
 
 	@Override
-	public UUID getUuid() {
-		return uuid;
-	}
-
-	public void setUuid(UUID uuid) {
-		this.uuid = uuid;
-	}
+	public UUID getUuid() { return uuid; }
+	public void setUuid(UUID uuid) { this.uuid = uuid; }
 
 	@Override
-	public int getRevision() {
-		return revision;
-	}
-
-	public void setRevision(int revision) {
-		this.revision = revision;
-	}
+	public int getRevision() { return revision; }
+	public void setRevision(int revision) { this.revision = revision; }
 
 	@Override
-	public ZonedDateTime getCreatedDate() {
-		return createdDate;
-	}
-
-	public void setCreatedDate(ZonedDateTime createdDate) {
-		this.createdDate = createdDate;
-	}
+	public ZonedDateTime getCreatedDate() { return createdDate; }
+	public void setCreatedDate(ZonedDateTime createdDate) { this.createdDate = createdDate; }
 
 	@Override
-	public ZonedDateTime getLastUpdatedDate() {
-		return lastUpdatedDate;
-	}
+	public ZonedDateTime getLastUpdatedDate() { return lastUpdatedDate; }
+	public void setLastUpdatedDate(ZonedDateTime lastUpdatedDate) { this.lastUpdatedDate = lastUpdatedDate; }
 
-	public void setLastUpdatedDate(ZonedDateTime lastUpdatedDate) {
-		this.lastUpdatedDate = lastUpdatedDate;
-	}
+	public UUID getOrg() { return org; }
+	public void setOrg(UUID org) { this.org = org; }
 
-	public UUID getOrg() {
-		return org;
-	}
+	public String getCanonicalPurl() { return canonicalPurl; }
+	public void setCanonicalPurl(String canonicalPurl) { this.canonicalPurl = canonicalPurl; }
 
-	public void setOrg(UUID org) {
-		this.org = org;
-	}
+	public String getPurlType() { return purlType; }
+	public void setPurlType(String purlType) { this.purlType = purlType; }
 
-	public String getCanonicalPurl() {
-		return canonicalPurl;
-	}
+	public String getPkgGroup() { return pkgGroup; }
+	public void setPkgGroup(String pkgGroup) { this.pkgGroup = pkgGroup; }
 
-	public void setCanonicalPurl(String canonicalPurl) {
-		this.canonicalPurl = canonicalPurl;
-	}
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
 
-	@Override
-	public Map<String, Object> getRecordData() {
-		return recordData;
-	}
+	public String getVersion() { return version; }
+	public void setVersion(String version) { this.version = version; }
+
+	public boolean isRoot() { return isRoot; }
+	public void setRoot(boolean root) { this.isRoot = root; }
 
 	@Override
-	public void setRecordData(Map<String, Object> recordData) {
-		this.recordData = recordData;
-	}
+	public java.util.Map<String, Object> getRecordData() { return null; }
 
 	@Override
-	public int getSchemaVersion() {
-		return schemaVersion;
-	}
+	public void setRecordData(java.util.Map<String, Object> recordData) { /* no-op: sbom_components no longer carries a JSONB record_data column */ }
 
-	public void setSchemaVersion(int schemaVersion) {
-		this.schemaVersion = schemaVersion;
-	}
+	@Override
+	public int getSchemaVersion() { return schemaVersion; }
+	public void setSchemaVersion(int schemaVersion) { this.schemaVersion = schemaVersion; }
 }

--- a/backend/src/main/java/io/reliza/repositories/ArtifactCanonicalMapRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ArtifactCanonicalMapRepository.java
@@ -1,0 +1,27 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.repositories;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+
+import io.reliza.model.ArtifactCanonicalMap;
+
+public interface ArtifactCanonicalMapRepository extends CrudRepository<ArtifactCanonicalMap, UUID> {
+
+	Optional<ArtifactCanonicalMap> findByArtifactUuid(UUID artifactUuid);
+
+	List<ArtifactCanonicalMap> findByOrgAndArtifactUuidIn(UUID org, Collection<UUID> artifactUuids);
+
+	/**
+	 * Reverse lookup: every artifact uuid in the org that points to the given
+	 * canonical. Useful for surfacing "which uploads share this content"
+	 * cross-release analytics.
+	 */
+	List<ArtifactCanonicalMap> findByOrgAndCanonicalArtifactUuid(UUID org, UUID canonicalArtifactUuid);
+}

--- a/backend/src/main/java/io/reliza/repositories/PurlQualifierRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/PurlQualifierRepository.java
@@ -1,0 +1,27 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.repositories;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import io.reliza.model.PurlQualifier;
+
+public interface PurlQualifierRepository extends CrudRepository<PurlQualifier, UUID> {
+
+	Optional<PurlQualifier> findByOrgAndFullPurl(UUID org, String fullPurl);
+
+	@Query(
+		value = "SELECT * FROM rearm.purl_qualifiers WHERE org = CAST(:orgUuidAsString AS uuid) AND full_purl IN (:fullPurls)",
+		nativeQuery = true)
+	List<PurlQualifier> findByOrgAndFullPurlIn(
+			@Param("orgUuidAsString") String orgUuidAsString,
+			@Param("fullPurls") Collection<String> fullPurls);
+}

--- a/backend/src/main/java/io/reliza/repositories/ReleaseRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ReleaseRepository.java
@@ -410,4 +410,19 @@ public interface ReleaseRepository extends CrudRepository<Release, UUID> {
 			+ "WHERE uuid = :uuid", nativeQuery = true)
 	void recordSbomReconcileFailure(@Param("uuid") UUID uuid, @Param("skipSeconds") int skipSeconds);
 
+	/**
+	 * Stamp {@code sbom_schema_version} after a successful reconcile so the
+	 * catch-up scheduler can later identify releases still on an older
+	 * aggregation layout via the partial index added in V37. Updated
+	 * separately from the flow_control clear so future migrations of this
+	 * area can simply bump the constant in code — rows below it surface as
+	 * eligible-for-reconcile without any Flyway re-enqueue UPDATE.
+	 */
+	@Transactional
+	@Modifying
+	@Query(value = "UPDATE rearm.releases "
+			+ "SET sbom_schema_version = :version "
+			+ "WHERE uuid = :uuid AND sbom_schema_version < :version", nativeQuery = true)
+	void recordSbomReconciledAtVersion(@Param("uuid") UUID uuid, @Param("version") int version);
+
 }

--- a/backend/src/main/java/io/reliza/repositories/ReleaseSbomComponentArtifactRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ReleaseSbomComponentArtifactRepository.java
@@ -1,0 +1,28 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.repositories;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.reliza.model.ReleaseSbomComponentArtifact;
+
+public interface ReleaseSbomComponentArtifactRepository
+		extends CrudRepository<ReleaseSbomComponentArtifact, UUID> {
+
+	List<ReleaseSbomComponentArtifact> findByOrgAndReleaseUuid(UUID org, UUID releaseUuid);
+
+	List<ReleaseSbomComponentArtifact> findByOrgAndReleaseUuidIn(UUID org, Collection<UUID> releaseUuids);
+
+	@Modifying
+	@Transactional
+	@Query("DELETE FROM ReleaseSbomComponentArtifact r WHERE r.org = :org AND r.releaseUuid = :releaseUuid")
+	int deleteAllByOrgAndReleaseUuid(UUID org, UUID releaseUuid);
+}

--- a/backend/src/main/java/io/reliza/repositories/ReleaseSbomEdgeRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ReleaseSbomEdgeRepository.java
@@ -1,0 +1,27 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.repositories;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.reliza.model.ReleaseSbomEdge;
+
+public interface ReleaseSbomEdgeRepository extends CrudRepository<ReleaseSbomEdge, UUID> {
+
+	List<ReleaseSbomEdge> findByOrgAndReleaseUuid(UUID org, UUID releaseUuid);
+
+	List<ReleaseSbomEdge> findByOrgAndReleaseUuidIn(UUID org, Collection<UUID> releaseUuids);
+
+	@Modifying
+	@Transactional
+	@Query("DELETE FROM ReleaseSbomEdge e WHERE e.org = :org AND e.releaseUuid = :releaseUuid")
+	int deleteAllByOrgAndReleaseUuid(UUID org, UUID releaseUuid);
+}

--- a/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
@@ -26,22 +26,15 @@ public interface SbomComponentRepository extends CrudRepository<SbomComponent, U
 			@Param("canonicalPurls") Collection<String> canonicalPurls);
 
 	/**
-	 * Search canonical sbom_components scoped to an org. With per-org pinning
-	 * the org filter is a direct column match — no join through
-	 * release_sbom_components. Version filter is optional; pass null to match
-	 * any version.
+	 * Search canonical sbom_components scoped to an org. Hits the
+	 * (org, name) composite b-tree index — no JSONB scan. Version filter is
+	 * optional; pass null to match any version.
 	 */
-	@Query(
-		value = """
-			SELECT *
-			FROM rearm.sbom_components
-			WHERE org = CAST(:orgUuidAsString AS uuid)
-			AND record_data->>'name' = :name
-			AND (CAST(:version AS text) IS NULL OR record_data->>'version' = :version)
-		""",
-		nativeQuery = true)
+	@Query("SELECT sc FROM SbomComponent sc "
+			+ "WHERE sc.org = :org AND sc.name = :name "
+			+ "AND (:version IS NULL OR sc.version = :version)")
 	List<SbomComponent> searchByOrgAndNameAndOptionalVersion(
-			@Param("orgUuidAsString") String orgUuidAsString,
+			@Param("org") UUID org,
 			@Param("name") String name,
 			@Param("version") String version);
 }

--- a/backend/src/main/java/io/reliza/service/SbomComponentService.java
+++ b/backend/src/main/java/io/reliza/service/SbomComponentService.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -24,53 +25,89 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import io.reliza.model.Artifact;
+import io.reliza.model.ArtifactCanonicalMap;
 import io.reliza.model.ArtifactData;
+import io.reliza.model.ArtifactData.DigestRecord;
+import io.reliza.model.ArtifactData.DigestScope;
 import io.reliza.model.ComponentData.ComponentType;
 import io.reliza.model.DeliverableData;
 import io.reliza.model.FlowControl;
+import io.reliza.model.PurlQualifier;
 import io.reliza.model.Release;
 import io.reliza.model.ReleaseData;
 import io.reliza.model.ReleaseSbomComponent;
+import io.reliza.model.ReleaseSbomComponentArtifact;
+import io.reliza.model.ReleaseSbomEdge;
 import io.reliza.model.SbomComponent;
 import io.reliza.model.tea.Rebom.ParsedBom;
 import io.reliza.model.tea.Rebom.ParsedBomComponent;
 import io.reliza.model.tea.Rebom.ParsedBomDependency;
+import io.reliza.repositories.ArtifactCanonicalMapRepository;
+import io.reliza.repositories.PurlQualifierRepository;
 import io.reliza.repositories.ReleaseRepository;
+import io.reliza.repositories.ReleaseSbomComponentArtifactRepository;
 import io.reliza.repositories.ReleaseSbomComponentRepository;
+import io.reliza.repositories.ReleaseSbomEdgeRepository;
 import io.reliza.repositories.SbomComponentRepository;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Maintains the SBOM component tables ({@code sbom_components} and
- * {@code release_sbom_components}). Rebom parses components and dependency
- * edges out of each uploaded BOM; reconciliation aggregates both per release
- * and keeps the two tables in sync by rebuilding the release's component /
+ * Maintains the SBOM component aggregation tables. Rebom parses components
+ * and dependency edges out of each uploaded BOM; reconciliation aggregates
+ * both per release and rebuilds the release's component / participation /
  * edge rows from scratch on every reconcile call.
  *
- * <p>Each {@code release_sbom_components} row is strictly local to its own
- * release — only the BOMs the release itself carries (release-attached
- * artifacts, deliverables, source-code-entry artifacts) flow into its rows.
- * For PRODUCT releases the dep-aggregated inventory is synthesised at read
- * time in {@link #listReleaseSbomComponents(UUID)} by unioning the rows of
- * the product itself with every transitive dependency's rows. This avoids
- * write-time fan-out (a dep's BOM update doesn't have to re-reconcile every
- * product that bundles it) and means a product's inventory is always
- * up-to-date with the latest dep state without a product-side reconcile.
+ * <p>Schema (post V37 — normalized):
+ * <ul>
+ *   <li>{@code sbom_components} — canonical per-(org, canonical_purl) row
+ *       with frequently-read metadata (type / group / name / version /
+ *       is_root) in typed columns.</li>
+ *   <li>{@code release_sbom_components} — per-(release, canonical) anchor
+ *       row; no JSONB content of its own.</li>
+ *   <li>{@code release_sbom_component_artifacts} — one row per (release,
+ *       canonical component, declaring artifact, exact PURL). Replaces the
+ *       prior {@code artifactParticipations} JSONB array. Declaring
+ *       artifact UUIDs are resolved through {@code artifact_canonical_map}
+ *       to canonical form, so two releases that uploaded the same BOM
+ *       collapse onto one canonical artifact UUID in the rows.</li>
+ *   <li>{@code release_sbom_edges} — one row per (release, source canonical,
+ *       target canonical, relationship, declaring artifact, exact source /
+ *       target PURLs). Replaces the prior {@code parents} JSONB array.</li>
+ *   <li>{@code purl_qualifiers} — per-org intern for full PURLs with
+ *       qualifiers / subpaths. Null FK in child rows means exact == canonical.</li>
+ *   <li>{@code artifact_canonical_map} — lazy per-org pointer from each BOM
+ *       artifact UUID to its content-canonical counterpart. Populated only
+ *       when the SBOM reconcile path needs it. No FK to the artifacts
+ *       table: dangling references surface as "no data found" + log.warn.</li>
+ * </ul>
  *
- * <p>Reconciliation is idempotent and cheap to re-run. It used to fire
- * synchronously from every artifact-mutation event, which raced on the
- * global {@code sbom_components} unique constraint and on per-release
- * delete/insert. We now <em>queue</em> reconciles by stamping
- * {@code releases.sbom_reconcile_requested_at} and let the every-minute
- * dependency-track scheduler drain the queue serially under its existing
- * advisory lock — multiple triggers within a minute coalesce into one
- * reconcile, and there is at most one reconcile in flight at a time across
- * replicas. The {@link #reconcileReleaseSbomComponents(UUID)} entry point
- * remains public for the operator force-reconcile GraphQL mutation.
+ * <p>The public {@link ReleaseSbomComponent} type still exposes
+ * {@code artifactParticipations} / {@code parents} as map-shaped lists, but
+ * those are populated as <em>transient</em> fields at read time from the
+ * normalized child tables — the GraphQL surface is unchanged from the prior
+ * JSONB-backed implementation.
+ *
+ * <p>Reconciliation is queued via {@code releases.flow_control} and drained
+ * by the every-minute scheduler; on success the reconciler stamps
+ * {@code releases.sbom_schema_version} with {@link #CURRENT_SBOM_SCHEMA_VERSION}
+ * — the "did this release's aggregation use the current schema?" cookie that
+ * future migrations can bump in code (no Flyway re-enqueue UPDATE needed)
+ * to force fresh reconciles of stale rows.
  */
 @Slf4j
 @Service
 public class SbomComponentService {
+
+	/**
+	 * Bumped whenever the on-disk SBOM aggregation layout changes. The
+	 * reconciler stamps this onto {@code releases.sbom_schema_version} on
+	 * success. Future migrations can either re-enqueue everything via
+	 * flow_control (V25 / V27 / V28 / V37 pattern) or simply bump this
+	 * constant — the catch-up scheduler can then enqueue any release
+	 * whose stored version is below the current value.
+	 */
+	public static final int CURRENT_SBOM_SCHEMA_VERSION = 1;
 
 	@Autowired
 	private RebomService rebomService;
@@ -80,6 +117,9 @@ public class SbomComponentService {
 
 	@Autowired
 	private ArtifactService artifactService;
+
+	@Autowired
+	private SharedArtifactService sharedArtifactService;
 
 	@Autowired
 	private GetSourceCodeEntryService getSourceCodeEntryService;
@@ -96,47 +136,44 @@ public class SbomComponentService {
 	@Autowired
 	private ReleaseRepository releaseRepository;
 
-	/**
-	 * Self-injection so {@link #processPendingReconciles(int)} can call the
-	 * {@code @Transactional} reconcile method through Spring's proxy. Direct
-	 * {@code this.*} calls bypass AOP, leaving the {@code @Modifying} delete
-	 * queries running outside any transaction.
-	 */
 	@Autowired
 	@Lazy
 	private SbomComponentService self;
 
-	/** Failure-backoff caps; exponential up to one hour. */
 	private static final int BASE_BACKOFF_SECONDS = 30;
 	private static final int MAX_BACKOFF_SECONDS = 3600;
 
 	private final SbomComponentRepository sbomComponentRepository;
 	private final ReleaseSbomComponentRepository releaseSbomComponentRepository;
+	private final ReleaseSbomComponentArtifactRepository releaseSbomComponentArtifactRepository;
+	private final ReleaseSbomEdgeRepository releaseSbomEdgeRepository;
+	private final PurlQualifierRepository purlQualifierRepository;
+	private final ArtifactCanonicalMapRepository artifactCanonicalMapRepository;
 
 	SbomComponentService(
 			SbomComponentRepository sbomComponentRepository,
-			ReleaseSbomComponentRepository releaseSbomComponentRepository) {
+			ReleaseSbomComponentRepository releaseSbomComponentRepository,
+			ReleaseSbomComponentArtifactRepository releaseSbomComponentArtifactRepository,
+			ReleaseSbomEdgeRepository releaseSbomEdgeRepository,
+			PurlQualifierRepository purlQualifierRepository,
+			ArtifactCanonicalMapRepository artifactCanonicalMapRepository) {
 		this.sbomComponentRepository = sbomComponentRepository;
 		this.releaseSbomComponentRepository = releaseSbomComponentRepository;
+		this.releaseSbomComponentArtifactRepository = releaseSbomComponentArtifactRepository;
+		this.releaseSbomEdgeRepository = releaseSbomEdgeRepository;
+		this.purlQualifierRepository = purlQualifierRepository;
+		this.artifactCanonicalMapRepository = artifactCanonicalMapRepository;
 	}
 
-	/**
-	 * Mark a release as needing SBOM-component reconciliation. Idempotent —
-	 * the timestamp is only set if currently NULL (preserves FIFO ordering
-	 * across the burst of triggers an artifact mutation can produce).
-	 */
+	// ===================================================================
+	// Queue API
+	// ===================================================================
+
 	public void requestReconcile(UUID releaseUuid) {
 		if (releaseUuid == null) return;
 		releaseRepository.markSbomReconcileRequested(releaseUuid);
 	}
 
-	/**
-	 * Drain up to {@code batchLimit} pending reconciles. Called from the
-	 * every-minute dependency-track scheduler under its advisory lock, so
-	 * concurrency across replicas is already serialized; failures bump a
-	 * backoff counter rather than re-throwing so one poison-pill release
-	 * doesn't block the rest of the queue.
-	 */
 	public void processPendingReconciles(int batchLimit) {
 		List<Release> pending = releaseRepository.findReleasesPendingSbomReconcile(batchLimit);
 		if (pending.isEmpty()) return;
@@ -163,22 +200,10 @@ public class SbomComponentService {
 		return fc.sbomReconcileFailureCount();
 	}
 
-	/**
-	 * Rebuild the sbom_components / release_sbom_components mappings for a
-	 * single release. For every BOM artifact participating in the release
-	 * we fetch the parsed components + dependencies from rebom, upsert the
-	 * canonical component rows (synthesising an isRoot flag where rebom
-	 * flagged it), and then upsert one join row per (release, component)
-	 * containing all artifact participations and every <em>incoming</em>
-	 * edge whose source canonical purl also appears in the release's
-	 * component set. Stale join rows are dropped.
-	 *
-	 * <p>Edges are stored as in-edges (parents) rather than out-edges
-	 * because the impact-analysis "what depends on this component" query
-	 * is the dominant lookup; storing parents makes that a primary-key
-	 * read instead of a GIN-on-jsonb scan. Forward "what does this depend
-	 * on" is reconstructed in memory from a single per-release fetch.
-	 */
+	// ===================================================================
+	// Reconcile — writes the normalized rows.
+	// ===================================================================
+
 	@Transactional
 	public void reconcileReleaseSbomComponents(UUID releaseUuid) {
 		Optional<ReleaseData> ord = sharedReleaseService.getReleaseData(releaseUuid);
@@ -193,9 +218,9 @@ public class SbomComponentService {
 					"reconcileReleaseSbomComponents: release " + releaseUuid + " has no org");
 		}
 
+		// Aggregate keyed by TARGET canonical purl.
 		Map<String, ComponentAggregation> componentAggs = new LinkedHashMap<>();
-		// Aggregation is keyed by TARGET canonical: each entry is a target
-		// component carrying the list of source components that point at it.
+		// Edges keyed by target canonical → (source canonical, relationship) → declarations.
 		Map<String, Map<ParentKey, ParentAggregation>> parentAggs = new LinkedHashMap<>();
 
 		for (UUID artifactUuid : collectBomArtifactUuids(rd)) {
@@ -203,6 +228,8 @@ public class SbomComponentService {
 			if (oad.isEmpty()) continue;
 			ArtifactData ad = oad.get();
 			if (ad.getInternalBom() == null || ad.getInternalBom().id() == null) continue;
+
+			UUID canonicalArtifactUuid = resolveCanonicalArtifact(ad, orgUuid);
 
 			ParsedBom parsed;
 			try {
@@ -220,7 +247,7 @@ public class SbomComponentService {
 					ComponentAggregation agg = componentAggs.computeIfAbsent(
 							pc.canonicalPurl(), k -> new ComponentAggregation(pc));
 					agg.mergeSample(pc);
-					agg.addParticipation(artifactUuid, pc.fullPurl());
+					agg.addParticipation(canonicalArtifactUuid, pc.fullPurl());
 				}
 			}
 
@@ -234,65 +261,135 @@ public class SbomComponentService {
 					ParentAggregation parentAgg = parentAggs
 							.computeIfAbsent(pd.targetCanonicalPurl(), k -> new LinkedHashMap<>())
 							.computeIfAbsent(key, k -> new ParentAggregation());
-					parentAgg.addDeclaration(artifactUuid, pd.sourceFullPurl(), pd.targetFullPurl());
+					parentAgg.addDeclaration(canonicalArtifactUuid, pd.sourceFullPurl(), pd.targetFullPurl());
 				}
 			}
 		}
 
+		// Empty aggregation → just drop everything for this release.
 		if (componentAggs.isEmpty()) {
-			// No components → just clear any existing rows for this release.
+			releaseSbomEdgeRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
+			releaseSbomComponentArtifactRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
 			releaseSbomComponentRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
+			markReleaseReconciled(releaseUuid);
 			return;
 		}
 
-		// Upsert the canonical component rows; returns canonical→uuid map the
-		// edge upsert step uses to resolve source component UUIDs.
+		// Canonical sbom_components rows. Returns canonical_purl → uuid.
 		Map<String, UUID> canonicalToUuid = upsertSbomComponents(componentAggs.values(), orgUuid);
 
+		// Compute keep-set and decide which anchors stay.
 		Set<UUID> keepComponentUuids = new HashSet<>();
+		for (String canonical : componentAggs.keySet()) {
+			UUID uuid = canonicalToUuid.get(canonical);
+			if (uuid != null) keepComponentUuids.add(uuid);
+		}
+
+		// Drop anchors no longer present — cascades to existing child rows.
+		releaseSbomComponentRepository
+				.deleteByOrgAndReleaseUuidAndSbomComponentUuidNotIn(orgUuid, releaseUuid, keepComponentUuids);
+
+		// Wipe child rows for the remaining anchors — we're rebuilding them.
+		releaseSbomEdgeRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
+		releaseSbomComponentArtifactRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
+
+		// Upsert anchors — insert if missing, leave existing alone so their
+		// stable uuid (UI navigates by this) is preserved across reconciles.
+		Map<UUID, ReleaseSbomComponent> anchorByComponentUuid = new HashMap<>();
+		for (ReleaseSbomComponent existing :
+				releaseSbomComponentRepository.findByOrgAndReleaseUuid(orgUuid, releaseUuid)) {
+			anchorByComponentUuid.put(existing.getSbomComponentUuid(), existing);
+		}
+		for (UUID componentUuid : keepComponentUuids) {
+			ReleaseSbomComponent anchor = anchorByComponentUuid.get(componentUuid);
+			if (anchor != null) {
+				anchor.setLastUpdatedDate(ZonedDateTime.now());
+				releaseSbomComponentRepository.save(anchor);
+			} else {
+				ReleaseSbomComponent fresh = new ReleaseSbomComponent();
+				fresh.setOrg(orgUuid);
+				fresh.setReleaseUuid(releaseUuid);
+				fresh.setSbomComponentUuid(componentUuid);
+				try {
+					releaseSbomComponentRepository.save(fresh);
+				} catch (DataIntegrityViolationException dive) {
+					// Race with another writer — accept the prior winner.
+				}
+			}
+		}
+
+		// Resolve / intern every exact PURL referenced by the new child rows
+		// (skipping those equal to the canonical — those stay as NULL FK).
+		Set<String> exactPurlsToIntern = collectExactPurlsToIntern(componentAggs, parentAggs);
+		Map<String, UUID> purlToUuid = upsertPurlQualifiers(exactPurlsToIntern, orgUuid);
+
+		// Insert release_sbom_component_artifacts.
+		List<ReleaseSbomComponentArtifact> artRows = new ArrayList<>();
 		for (Map.Entry<String, ComponentAggregation> e : componentAggs.entrySet()) {
 			UUID componentUuid = canonicalToUuid.get(e.getKey());
 			if (componentUuid == null) continue;
-			keepComponentUuids.add(componentUuid);
-			List<Map<String, Object>> parentsJson = renderParents(
-					parentAggs.get(e.getKey()), canonicalToUuid);
-			upsertReleaseSbomComponent(orgUuid, releaseUuid, componentUuid, e.getValue(), parentsJson);
+			ComponentAggregation agg = e.getValue();
+			String canonicalPurl = e.getKey();
+			for (Map.Entry<UUID, Set<String>> part : agg.participations.entrySet()) {
+				UUID artifactCanonicalUuid = part.getKey();
+				for (String fullPurl : part.getValue()) {
+					UUID exactPurlUuid = canonicalPurl.equals(fullPurl)
+							? null
+							: purlToUuid.get(fullPurl);
+					ReleaseSbomComponentArtifact row = new ReleaseSbomComponentArtifact();
+					row.setOrg(orgUuid);
+					row.setReleaseUuid(releaseUuid);
+					row.setSbomComponentUuid(componentUuid);
+					row.setArtifactUuid(artifactCanonicalUuid);
+					row.setExactPurlUuid(exactPurlUuid);
+					artRows.add(row);
+				}
+			}
 		}
+		if (!artRows.isEmpty()) releaseSbomComponentArtifactRepository.saveAll(artRows);
 
-		// Drop any join rows for components that no longer participate.
-		if (keepComponentUuids.isEmpty()) {
-			releaseSbomComponentRepository.deleteAllByOrgAndReleaseUuid(orgUuid, releaseUuid);
-		} else {
-			releaseSbomComponentRepository
-					.deleteByOrgAndReleaseUuidAndSbomComponentUuidNotIn(orgUuid, releaseUuid, keepComponentUuids);
+		// Insert release_sbom_edges.
+		List<ReleaseSbomEdge> edgeRows = new ArrayList<>();
+		for (Map.Entry<String, Map<ParentKey, ParentAggregation>> e : parentAggs.entrySet()) {
+			UUID targetUuid = canonicalToUuid.get(e.getKey());
+			if (targetUuid == null) continue;
+			String targetCanonicalPurl = e.getKey();
+			for (Map.Entry<ParentKey, ParentAggregation> edgeEntry : e.getValue().entrySet()) {
+				UUID sourceUuid = canonicalToUuid.get(edgeEntry.getKey().sourceCanonical);
+				if (sourceUuid == null) continue;
+				String sourceCanonicalPurl = edgeEntry.getKey().sourceCanonical;
+				String relationship = edgeEntry.getKey().relationshipType;
+				for (DeclaringArtifactRecord d : edgeEntry.getValue().declarations.values()) {
+					UUID sourceExactPurlUuid = sourceCanonicalPurl.equals(d.sourceFullPurl)
+							? null
+							: purlToUuid.get(d.sourceFullPurl);
+					UUID targetExactPurlUuid = targetCanonicalPurl.equals(d.targetFullPurl)
+							? null
+							: purlToUuid.get(d.targetFullPurl);
+					ReleaseSbomEdge edge = new ReleaseSbomEdge();
+					edge.setOrg(orgUuid);
+					edge.setReleaseUuid(releaseUuid);
+					edge.setTargetSbomComponentUuid(targetUuid);
+					edge.setSourceSbomComponentUuid(sourceUuid);
+					edge.setRelationshipType(relationship);
+					edge.setDeclaringArtifactUuid(d.artifactUuid);
+					edge.setSourceExactPurlUuid(sourceExactPurlUuid);
+					edge.setTargetExactPurlUuid(targetExactPurlUuid);
+					edgeRows.add(edge);
+				}
+			}
 		}
+		if (!edgeRows.isEmpty()) releaseSbomEdgeRepository.saveAll(edgeRows);
+
+		markReleaseReconciled(releaseUuid);
+	}
+
+	private void markReleaseReconciled(UUID releaseUuid) {
+		releaseRepository.recordSbomReconciledAtVersion(releaseUuid, CURRENT_SBOM_SCHEMA_VERSION);
 	}
 
 	/**
-	 * Per-release SBOM component inventory.
-	 *
-	 * <p>For COMPONENT releases this is a direct read of
-	 * {@code release_sbom_components}. For PRODUCT releases it is a
-	 * read-time union of (a) the product's own rows (e.g. an aggregated
-	 * BOM uploaded directly to the product) and (b) every transitive
-	 * dependency's rows. The same canonical {@code sbom_components} row
-	 * may appear in many deps; we merge those into one synthetic
-	 * {@link ReleaseSbomComponent} stamped with the product's
-	 * {@code releaseUuid} so the GraphQL surface is releaseUuid-consistent
-	 * and dependency / dependedOnBy edge resolution sees the unioned
-	 * parent set. The synthetic row is a transient JPA instance — never
-	 * saved — so the persisted table stays strictly per-release-local.
-	 */
-	/**
-	 * Operator force-reconcile for a release. For COMPONENT releases this is
-	 * just {@link #reconcileReleaseSbomComponents(UUID)}. For PRODUCT releases
-	 * we first cascade-reconcile every transitive dependency so the read-time
-	 * aggregation on the product picks up the freshest dep state — the queue
-	 * scheduler would catch up within a minute, but force-reconcile is the
-	 * "do it now" entry point and should leave the product fully up-to-date
-	 * the moment it returns. Each cascade reconcile runs in its own
-	 * transaction (delegated through the Spring proxy) so a single dep
-	 * failure doesn't poison the rest.
+	 * Operator force-reconcile — same as before, just bypasses the queue.
 	 */
 	public void forceReconcileWithDeps(UUID releaseUuid) {
 		Optional<ReleaseData> ord = sharedReleaseService.getReleaseData(releaseUuid);
@@ -317,6 +414,63 @@ public class SbomComponentService {
 		self.reconcileReleaseSbomComponents(releaseUuid);
 	}
 
+	// ===================================================================
+	// Canonical artifact resolution (lazy, BOM artifacts only, org-scoped,
+	// no FK constraints). Called from inside reconcile only.
+	// ===================================================================
+
+	/**
+	 * Returns the canonical artifact UUID this artifact maps to within its
+	 * org. Creates the mapping row on first request — subsequent reconciles
+	 * for any release that touches this artifact will hit the cached row.
+	 *
+	 * <p>Self-canonical (mapping = artifact_uuid → artifact_uuid) is the
+	 * default when no other artifact in the org carries the same REARM-scope
+	 * digest. The artifacts table is never modified.
+	 */
+	private UUID resolveCanonicalArtifact(ArtifactData ad, UUID orgUuid) {
+		UUID artifactUuid = ad.getUuid();
+
+		Optional<ArtifactCanonicalMap> existing =
+				artifactCanonicalMapRepository.findByArtifactUuid(artifactUuid);
+		if (existing.isPresent()) {
+			return existing.get().getCanonicalArtifactUuid();
+		}
+
+		String rearmDigest = extractRearmDigest(ad);
+		UUID canonical = artifactUuid;
+		if (rearmDigest != null) {
+			Optional<Artifact> match = sharedArtifactService.findArtifactByStoredDigest(orgUuid, rearmDigest);
+			canonical = match.map(Artifact::getUuid).orElse(artifactUuid);
+		}
+
+		ArtifactCanonicalMap row = new ArtifactCanonicalMap();
+		row.setOrg(orgUuid);
+		row.setArtifactUuid(artifactUuid);
+		row.setCanonicalArtifactUuid(canonical);
+		try {
+			artifactCanonicalMapRepository.save(row);
+		} catch (DataIntegrityViolationException dive) {
+			return artifactCanonicalMapRepository.findByArtifactUuid(artifactUuid)
+					.map(ArtifactCanonicalMap::getCanonicalArtifactUuid)
+					.orElse(artifactUuid);
+		}
+		return canonical;
+	}
+
+	private static String extractRearmDigest(ArtifactData ad) {
+		Set<DigestRecord> drs = ad.getDigestRecords();
+		if (drs == null || drs.isEmpty()) return null;
+		for (DigestRecord dr : drs) {
+			if (dr.scope() == DigestScope.REARM && dr.digest() != null) return dr.digest();
+		}
+		return null;
+	}
+
+	// ===================================================================
+	// Read API — assemble Map-shaped views from the normalized child tables.
+	// ===================================================================
+
 	public List<ReleaseSbomComponent> listReleaseSbomComponents(UUID releaseUuid) {
 		Optional<ReleaseData> ord = sharedReleaseService.getReleaseData(releaseUuid);
 		if (ord.isEmpty()) return List.of();
@@ -327,19 +481,15 @@ public class SbomComponentService {
 				.map(cd -> cd.getType() == ComponentType.PRODUCT)
 				.orElse(false);
 		if (!isProduct) {
-			return releaseSbomComponentRepository.findByOrgAndReleaseUuid(orgUuid, releaseUuid);
+			return loadAssembledRowsForReleases(orgUuid, List.of(releaseUuid));
 		}
 
 		Set<UUID> sourceReleaseUuids = new LinkedHashSet<>();
 		sourceReleaseUuids.add(releaseUuid);
-		// unwindReleaseDependencies enforces same-org/external-org guard, so
-		// every dep we see here belongs to the product's org and the org-scoped
-		// repo lookup below is safe.
 		for (ReleaseData dep : sharedReleaseService.unwindReleaseDependencies(rd)) {
 			sourceReleaseUuids.add(dep.getUuid());
 		}
-		List<ReleaseSbomComponent> rawRows = releaseSbomComponentRepository
-				.findByOrgAndReleaseUuidIn(orgUuid, sourceReleaseUuids);
+		List<ReleaseSbomComponent> rawRows = loadAssembledRowsForReleases(orgUuid, sourceReleaseUuids);
 		if (rawRows.isEmpty()) return List.of();
 
 		Map<UUID, List<ReleaseSbomComponent>> byComponent = new LinkedHashMap<>();
@@ -354,15 +504,155 @@ public class SbomComponentService {
 	}
 
 	/**
-	 * Build one synthetic per-product row for a single canonical component
-	 * by unioning the {@code artifactParticipations} and {@code parents}
-	 * jsonb across all source rows. Participations are deduped by artifact
-	 * UUID with their {@code exactPurls} unioned; parents are deduped by
-	 * (sourceSbomComponentUuid, relationshipType) with their
-	 * {@code declaringArtifacts} unioned by (artifact, sourceExactPurl,
-	 * targetExactPurl). Created/updated dates take the earliest/latest seen
-	 * so the consumer sees a sensible aggregate timestamp.
+	 * Load anchor rows + child rows for the given release UUIDs and
+	 * populate each anchor's transient {@code artifactParticipations} and
+	 * {@code parents} so the GraphQL surface keeps its prior shape.
 	 */
+	private List<ReleaseSbomComponent> loadAssembledRowsForReleases(UUID orgUuid, Collection<UUID> releaseUuids) {
+		List<ReleaseSbomComponent> anchors =
+				releaseSbomComponentRepository.findByOrgAndReleaseUuidIn(orgUuid, releaseUuids);
+		if (anchors.isEmpty()) return List.of();
+
+		List<ReleaseSbomComponentArtifact> artifactRows =
+				releaseSbomComponentArtifactRepository.findByOrgAndReleaseUuidIn(orgUuid, releaseUuids);
+		List<ReleaseSbomEdge> edgeRows =
+				releaseSbomEdgeRepository.findByOrgAndReleaseUuidIn(orgUuid, releaseUuids);
+
+		// Resolve PURL intern rows and canonical components referenced by the children.
+		Set<UUID> purlIds = new HashSet<>();
+		for (ReleaseSbomComponentArtifact r : artifactRows) {
+			if (r.getExactPurlUuid() != null) purlIds.add(r.getExactPurlUuid());
+		}
+		for (ReleaseSbomEdge e : edgeRows) {
+			if (e.getSourceExactPurlUuid() != null) purlIds.add(e.getSourceExactPurlUuid());
+			if (e.getTargetExactPurlUuid() != null) purlIds.add(e.getTargetExactPurlUuid());
+		}
+		Map<UUID, String> purlByUuid = new HashMap<>(purlIds.size() * 2);
+		if (!purlIds.isEmpty()) {
+			purlQualifierRepository.findAllById(purlIds).forEach(q ->
+					purlByUuid.put(q.getUuid(), q.getFullPurl()));
+		}
+
+		Set<UUID> componentIds = new HashSet<>();
+		for (ReleaseSbomComponent a : anchors) componentIds.add(a.getSbomComponentUuid());
+		for (ReleaseSbomEdge e : edgeRows) {
+			componentIds.add(e.getSourceSbomComponentUuid());
+			componentIds.add(e.getTargetSbomComponentUuid());
+		}
+		Map<UUID, SbomComponent> sbomCompByUuid = new HashMap<>(componentIds.size() * 2);
+		if (!componentIds.isEmpty()) {
+			sbomComponentRepository.findAllById(componentIds).forEach(sc -> {
+				if (orgUuid.equals(sc.getOrg())) sbomCompByUuid.put(sc.getUuid(), sc);
+			});
+		}
+
+		// Group child rows by (release, target/component) so each anchor
+		// can grab its slice in O(1).
+		Map<RowKey, List<ReleaseSbomComponentArtifact>> artByAnchor = new HashMap<>();
+		for (ReleaseSbomComponentArtifact r : artifactRows) {
+			artByAnchor.computeIfAbsent(
+					new RowKey(r.getReleaseUuid(), r.getSbomComponentUuid()),
+					k -> new ArrayList<>()).add(r);
+		}
+		Map<RowKey, List<ReleaseSbomEdge>> edgesByAnchor = new HashMap<>();
+		for (ReleaseSbomEdge e : edgeRows) {
+			edgesByAnchor.computeIfAbsent(
+					new RowKey(e.getReleaseUuid(), e.getTargetSbomComponentUuid()),
+					k -> new ArrayList<>()).add(e);
+		}
+
+		for (ReleaseSbomComponent anchor : anchors) {
+			RowKey key = new RowKey(anchor.getReleaseUuid(), anchor.getSbomComponentUuid());
+			SbomComponent target = sbomCompByUuid.get(anchor.getSbomComponentUuid());
+			String targetCanonicalPurl = target != null ? target.getCanonicalPurl() : null;
+			anchor.setArtifactParticipations(renderParticipations(
+					artByAnchor.getOrDefault(key, List.of()),
+					purlByUuid,
+					targetCanonicalPurl));
+			anchor.setParents(renderParents(
+					edgesByAnchor.getOrDefault(key, List.of()),
+					purlByUuid,
+					sbomCompByUuid));
+		}
+		return anchors;
+	}
+
+	private static List<Map<String, Object>> renderParticipations(
+			List<ReleaseSbomComponentArtifact> rows,
+			Map<UUID, String> purlByUuid,
+			String targetCanonicalPurl) {
+		if (rows.isEmpty()) return List.of();
+		// Group by artifact_uuid → set of exact purls (canonical when FK is null).
+		Map<UUID, Set<String>> byArtifact = new LinkedHashMap<>();
+		for (ReleaseSbomComponentArtifact r : rows) {
+			String exact = r.getExactPurlUuid() == null
+					? targetCanonicalPurl
+					: purlByUuid.get(r.getExactPurlUuid());
+			if (exact == null) continue;
+			byArtifact.computeIfAbsent(r.getArtifactUuid(), k -> new TreeSet<>()).add(exact);
+		}
+		List<Map<String, Object>> out = new ArrayList<>(byArtifact.size());
+		byArtifact.entrySet().stream()
+				.sorted(Map.Entry.comparingByKey((a, b) -> a.toString().compareTo(b.toString())))
+				.forEach(e -> {
+					Map<String, Object> entry = new LinkedHashMap<>();
+					entry.put("artifact", e.getKey().toString());
+					entry.put("exactPurls", new ArrayList<>(e.getValue()));
+					out.add(entry);
+				});
+		return out;
+	}
+
+	private static List<Map<String, Object>> renderParents(
+			List<ReleaseSbomEdge> rows,
+			Map<UUID, String> purlByUuid,
+			Map<UUID, SbomComponent> sbomCompByUuid) {
+		if (rows.isEmpty()) return List.of();
+		// Group by (source_uuid, relationship); collect per-declaring-artifact records.
+		Map<EdgeGroupKey, EdgeGroup> grouped = new LinkedHashMap<>();
+		for (ReleaseSbomEdge e : rows) {
+			EdgeGroupKey key = new EdgeGroupKey(e.getSourceSbomComponentUuid(), e.getRelationshipType());
+			EdgeGroup g = grouped.computeIfAbsent(key, k -> new EdgeGroup());
+			SbomComponent source = sbomCompByUuid.get(e.getSourceSbomComponentUuid());
+			SbomComponent target = sbomCompByUuid.get(e.getTargetSbomComponentUuid());
+			String sourceCanonical = source == null ? null : source.getCanonicalPurl();
+			String targetCanonical = target == null ? null : target.getCanonicalPurl();
+			g.sourceCanonicalPurl = sourceCanonical;
+			String srcExact = e.getSourceExactPurlUuid() == null
+					? sourceCanonical
+					: purlByUuid.get(e.getSourceExactPurlUuid());
+			String tgtExact = e.getTargetExactPurlUuid() == null
+					? targetCanonical
+					: purlByUuid.get(e.getTargetExactPurlUuid());
+			g.addDeclaration(e.getDeclaringArtifactUuid(), srcExact, tgtExact);
+		}
+		List<Map<String, Object>> out = new ArrayList<>(grouped.size());
+		for (Map.Entry<EdgeGroupKey, EdgeGroup> e : grouped.entrySet()) {
+			Map<String, Object> entry = new LinkedHashMap<>();
+			entry.put("sourceSbomComponentUuid", e.getKey().sourceUuid.toString());
+			entry.put("sourceCanonicalPurl", e.getValue().sourceCanonicalPurl);
+			entry.put("relationshipType", e.getKey().relationshipType);
+			entry.put("declaringArtifacts", e.getValue().sortedDeclarations());
+			out.add(entry);
+		}
+		out.sort((a, b) -> {
+			String sa = (String) a.get("sourceCanonicalPurl");
+			String sb = (String) b.get("sourceCanonicalPurl");
+			if (sa == null) sa = "";
+			if (sb == null) sb = "";
+			int byCanonical = sa.compareTo(sb);
+			if (byCanonical != 0) return byCanonical;
+			return ((String) a.get("relationshipType"))
+					.compareTo((String) b.get("relationshipType"));
+		});
+		return out;
+	}
+
+	// ===================================================================
+	// Product-release in-memory merge — identical to prior implementation
+	// since it operates on the already-assembled Map-shaped views.
+	// ===================================================================
+
 	@SuppressWarnings("unchecked")
 	private ReleaseSbomComponent mergeProductRow(UUID orgUuid, UUID productReleaseUuid, UUID sbomComponentUuid,
 			List<ReleaseSbomComponent> sourceRows) {
@@ -413,7 +703,7 @@ public class SbomComponentService {
 				for (Map<String, Object> parent : parents) {
 					if (parent == null) continue;
 					String parentKey = parent.get("sourceSbomComponentUuid")
-							+ "\u0000" + parent.get("relationshipType");
+							+ " " + parent.get("relationshipType");
 					Map<String, Object> existing = parentsByKey.get(parentKey);
 					if (existing == null) {
 						Map<String, Object> copy = new LinkedHashMap<>(parent);
@@ -447,14 +737,6 @@ public class SbomComponentService {
 		}
 
 		ReleaseSbomComponent merged = new ReleaseSbomComponent();
-		// Deterministic synthetic uuid derived from (productReleaseUuid,
-		// sbomComponentUuid). Without this, ReleaseSbomComponent's @Id default
-		// initializer hands out a fresh randomUUID on every merge call —
-		// breaking UI navigation that round-trips row.uuid through the URL,
-		// and churning Apollo's normalized cache (which keys on uuid) on every
-		// query against a product release. v5/name-based UUIDs occupy a
-		// different version-bit space than the v4 randomUUIDs used for real
-		// persisted rows, so synthetic ids cannot collide with persisted ones.
 		merged.setUuid(syntheticProductRowUuid(productReleaseUuid, sbomComponentUuid));
 		merged.setOrg(orgUuid);
 		merged.setReleaseUuid(productReleaseUuid);
@@ -473,23 +755,18 @@ public class SbomComponentService {
 
 	private static String declarationKey(Map<String, Object> declaration) {
 		return String.valueOf(declaration.get("artifact"))
-				+ "\u0000" + String.valueOf(declaration.get("sourceExactPurl"))
-				+ "\u0000" + String.valueOf(declaration.get("targetExactPurl"));
+				+ " " + String.valueOf(declaration.get("sourceExactPurl"))
+				+ " " + String.valueOf(declaration.get("targetExactPurl"));
 	}
+
+	// ===================================================================
+	// Misc public API used by other services / GraphQL.
+	// ===================================================================
 
 	public Optional<SbomComponent> getSbomComponent(UUID uuid) {
 		return sbomComponentRepository.findById(uuid);
 	}
 
-	/**
-	 * Bulk-fetch sbom_components by UUID, filtered to {@code orgUuid}, into a
-	 * uuid→component map. Used by the per-release graph resolver to avoid an
-	 * N+1 against the components table when resolving {@code component} /
-	 * {@code targetCanonicalPurl} on many edges. The org filter is defensive
-	 * — UUIDs are globally unique so a cross-org id wouldn't be in {@code ids}
-	 * for a properly-scoped release read, but we honour the contract that
-	 * every read in this service is org-bounded.
-	 */
 	public Map<UUID, SbomComponent> findSbomComponentsByIds(Collection<UUID> ids, UUID orgUuid) {
 		if (ids == null || ids.isEmpty() || orgUuid == null) return Map.of();
 		Map<UUID, SbomComponent> out = new LinkedHashMap<>();
@@ -507,27 +784,14 @@ public class SbomComponentService {
 
 	public record ComponentPurlToSbom(String purl, List<UUID> sbomComponents) {}
 
-	/**
-	 * Native (non-DependencyTrack) batch search analogue of
-	 * {@code IntegrationService.searchDependencyTrackComponentBatch}. Each
-	 * input query is matched against {@code sbom_components} narrowed to the
-	 * org via {@code release_sbom_components}, then results are grouped by
-	 * canonical purl. The grouped shape mirrors {@code ComponentPurlToDtrack}
-	 * so the UI can feed the resulting component UUIDs into
-	 * {@code releasesBySbomComponents}. Each canonical purl maps to exactly
-	 * one {@code sbom_components.uuid} today, so the {@code sbomComponents}
-	 * list is typically length 1 — kept as a list for shape parity and
-	 * future-proofing.
-	 */
 	public List<ComponentPurlToSbom> searchSbomComponentsBatch(
 			List<SbomComponentSearchQuery> queries, UUID orgUuid) {
 		if (queries == null || queries.isEmpty() || orgUuid == null) return List.of();
-		String orgUuidStr = orgUuid.toString();
 		Map<String, Set<UUID>> byCanonical = new LinkedHashMap<>();
 		for (SbomComponentSearchQuery q : queries) {
 			if (q == null || q.name() == null || q.name().isBlank()) continue;
 			List<SbomComponent> matches = sbomComponentRepository
-					.searchByOrgAndNameAndOptionalVersion(orgUuidStr, q.name(), q.version());
+					.searchByOrgAndNameAndOptionalVersion(orgUuid, q.name(), q.version());
 			for (SbomComponent sc : matches) {
 				byCanonical.computeIfAbsent(sc.getCanonicalPurl(), k -> new LinkedHashSet<>())
 						.add(sc.getUuid());
@@ -540,12 +804,6 @@ public class SbomComponentService {
 		return out;
 	}
 
-	/**
-	 * Resolve a (possibly qualifier- or subpath-bearing) purl to its canonical
-	 * sbom_components row within {@code orgUuid}. Returns null if the purl
-	 * can't be parsed or no sbom_components row matches the canonical form
-	 * for that org.
-	 */
 	public UUID searchSbomComponentByPurl(String purl, UUID orgUuid) {
 		if (orgUuid == null) return null;
 		String canonical = io.reliza.common.Utils.canonicalizePurl(purl);
@@ -555,29 +813,11 @@ public class SbomComponentService {
 				.orElse(null);
 	}
 
-	/**
-	 * Whether the given release has any rows in release_sbom_components.
-	 * VEX import precondition guard — a release with no SBOM has no inventory to match against.
-	 */
 	public boolean releaseHasSbomComponents(UUID releaseUuid, UUID orgUuid) {
 		if (orgUuid == null || releaseUuid == null) return false;
 		return releaseSbomComponentRepository.existsByOrgAndReleaseUuid(orgUuid, releaseUuid);
 	}
 
-	/**
-	 * Distinct release UUIDs (within {@code orgUuid}) whose inventory
-	 * references any of the given canonical sbom_components. Returns both
-	 * (a) component releases that directly carry the component in
-	 * {@code release_sbom_components} and (b) every transitive product
-	 * release that bundles those component releases — products no longer
-	 * materialise their own rows under the read-time aggregation model, so
-	 * the upward walk is what makes impact analysis ("which releases are
-	 * affected by component X?") actually surface affected products.
-	 *
-	 * <p>The org scope is a direct {@code release_sbom_components.org}
-	 * column match — sbom_components is now per-org so no cross-org leakage
-	 * is possible by construction.
-	 */
 	public Set<UUID> findReleaseUuidsBySbomComponents(Collection<UUID> sbomComponentUuids, UUID orgUuid) {
 		if (sbomComponentUuids == null || sbomComponentUuids.isEmpty() || orgUuid == null) return Set.of();
 		List<UUID> directReleaseUuids = releaseSbomComponentRepository
@@ -595,20 +835,10 @@ public class SbomComponentService {
 		return all;
 	}
 
-	/**
-	 * Pull all BOM-bearing artifact UUIDs that participate in a single
-	 * release: inbound + outbound deliverables, source-code entry artifacts
-	 * scoped to the release's component, and release-attached artifacts.
-	 *
-	 * <p>For PRODUCT releases we deliberately do <em>not</em> recurse into
-	 * dependencies here — dep aggregation now happens at read time in
-	 * {@link #listReleaseSbomComponents(UUID)}. This keeps each
-	 * {@code release_sbom_components} row strictly local to its own release
-	 * (a product reconcile only writes rows for BOMs the product itself
-	 * carries, e.g. an aggregate uploaded directly), and the read path
-	 * unions across deps so a product's inventory always reflects the
-	 * latest dep state without re-reconciling the product.
-	 */
+	// ===================================================================
+	// BOM artifact collection (unchanged from prior implementation).
+	// ===================================================================
+
 	private Set<UUID> collectBomArtifactUuids(ReleaseData rd) {
 		Set<UUID> artifactUuids = new LinkedHashSet<>();
 
@@ -620,7 +850,6 @@ public class SbomComponentService {
 			if (dd.getArtifacts() != null) artifactUuids.addAll(dd.getArtifacts());
 		}
 
-		// Artifacts on the source-code entry matching the release component.
 		if (rd.getSourceCodeEntry() != null) {
 			getSourceCodeEntryService.getSourceCodeEntryData(rd.getSourceCodeEntry())
 					.ifPresent(sce -> {
@@ -631,28 +860,22 @@ public class SbomComponentService {
 						}
 					});
 		}
-		// Artifacts directly attached to the release.
 		if (rd.getArtifacts() != null) artifactUuids.addAll(rd.getArtifacts());
 		return artifactUuids;
 	}
 
-	/**
-	 * Ensure a row exists for every canonical purl in the aggregation set
-	 * within {@code orgUuid} and return a canonical→uuid map. With per-org
-	 * pinning the same canonical purl can exist as separate rows in
-	 * different orgs, so all lookups + inserts are scoped to the caller's
-	 * org. Concurrent inserts of the same (org, canonical) pair are now
-	 * serialised by the dtrack advisory lock the queue scheduler runs
-	 * under, but the race-tolerant catch is kept for the operator
-	 * force-reconcile path.
-	 */
+	// ===================================================================
+	// Canonical sbom_components upsert (promoted columns, no JSONB).
+	// ===================================================================
+
 	private Map<String, UUID> upsertSbomComponents(Collection<ComponentAggregation> aggs, UUID orgUuid) {
 		List<String> canonicals = new ArrayList<>();
 		for (ComponentAggregation agg : aggs) canonicals.add(agg.sample.canonicalPurl());
 
 		Map<String, UUID> canonicalToUuid = new HashMap<>();
 		Map<String, SbomComponent> existingByCanonical = new HashMap<>();
-		for (SbomComponent sc : sbomComponentRepository.findByOrgAndCanonicalPurlIn(orgUuid.toString(), canonicals)) {
+		for (SbomComponent sc :
+				sbomComponentRepository.findByOrgAndCanonicalPurlIn(orgUuid.toString(), canonicals)) {
 			existingByCanonical.put(sc.getCanonicalPurl(), sc);
 			canonicalToUuid.put(sc.getCanonicalPurl(), sc.getUuid());
 		}
@@ -661,18 +884,12 @@ public class SbomComponentService {
 			String canonical = agg.sample.canonicalPurl();
 			SbomComponent existing = existingByCanonical.get(canonical);
 			if (existing != null) {
-				// Flip isRoot on only if we now have evidence the component is a root.
-				if (agg.isRoot && !isMarkedRoot(existing)) {
-					Map<String, Object> rec = existing.getRecordData() != null
-							? new HashMap<>(existing.getRecordData())
-							: new HashMap<>();
-					rec.put("isRoot", true);
-					existing.setRecordData(rec);
+				if (agg.isRoot && !existing.isRoot()) {
+					existing.setRoot(true);
 					existing.setLastUpdatedDate(ZonedDateTime.now());
 					try {
 						sbomComponentRepository.save(existing);
 					} catch (DataIntegrityViolationException ignored) {
-						// best-effort; the read-side still resolves the row.
 					}
 				}
 				continue;
@@ -682,7 +899,6 @@ public class SbomComponentService {
 				sc = sbomComponentRepository.save(sc);
 				canonicalToUuid.put(canonical, sc.getUuid());
 			} catch (DataIntegrityViolationException dive) {
-				// Lost the race with another writer — re-read within the same org.
 				sbomComponentRepository.findByOrgAndCanonicalPurl(orgUuid, canonical)
 						.ifPresent(rec -> canonicalToUuid.put(canonical, rec.getUuid()));
 			}
@@ -690,103 +906,76 @@ public class SbomComponentService {
 		return canonicalToUuid;
 	}
 
-	private boolean isMarkedRoot(SbomComponent sc) {
-		Map<String, Object> rd = sc.getRecordData();
-		return rd != null && Boolean.TRUE.equals(rd.get("isRoot"));
-	}
-
 	private SbomComponent buildSbomComponent(ComponentAggregation agg, UUID orgUuid) {
 		SbomComponent sc = new SbomComponent();
 		sc.setOrg(orgUuid);
 		sc.setCanonicalPurl(agg.sample.canonicalPurl());
-		Map<String, Object> record = new HashMap<>();
-		if (agg.sample.type() != null) record.put("type", agg.sample.type());
-		if (agg.sample.group() != null) record.put("group", agg.sample.group());
-		if (agg.sample.name() != null) record.put("name", agg.sample.name());
-		if (agg.sample.version() != null) record.put("version", agg.sample.version());
-		if (agg.isRoot) record.put("isRoot", true);
-		sc.setRecordData(record);
+		sc.setPurlType(agg.sample.type());
+		sc.setPkgGroup(agg.sample.group());
+		sc.setName(agg.sample.name());
+		sc.setVersion(agg.sample.version());
+		sc.setRoot(agg.isRoot);
 		return sc;
 	}
 
-	/**
-	 * Render the parents jsonb for one target component: one entry per
-	 * (source canonical, relationshipType), each carrying its per-artifact
-	 * declarations. Source entries that don't resolve to a canonical uuid
-	 * (shouldn't happen since rebom only returns resolved edges, but
-	 * defensive) are dropped.
-	 */
-	private List<Map<String, Object>> renderParents(
-			Map<ParentKey, ParentAggregation> edges,
-			Map<String, UUID> canonicalToUuid) {
-		if (edges == null || edges.isEmpty()) return new ArrayList<>();
-		List<Map<String, Object>> out = new ArrayList<>();
-		for (Map.Entry<ParentKey, ParentAggregation> e : edges.entrySet()) {
-			UUID sourceUuid = canonicalToUuid.get(e.getKey().sourceCanonical);
-			if (sourceUuid == null) continue;
-			Map<String, Object> entry = new LinkedHashMap<>();
-			entry.put("sourceSbomComponentUuid", sourceUuid.toString());
-			entry.put("sourceCanonicalPurl", e.getKey().sourceCanonical);
-			entry.put("relationshipType", e.getKey().relationshipType);
-			entry.put("declaringArtifacts", e.getValue().sortedDeclarations());
-			out.add(entry);
+	// ===================================================================
+	// PURL qualifier interning.
+	// ===================================================================
+
+	private Set<String> collectExactPurlsToIntern(
+			Map<String, ComponentAggregation> componentAggs,
+			Map<String, Map<ParentKey, ParentAggregation>> parentAggs) {
+		Set<String> need = new HashSet<>();
+		for (Map.Entry<String, ComponentAggregation> e : componentAggs.entrySet()) {
+			String canonical = e.getKey();
+			for (Set<String> exacts : e.getValue().participations.values()) {
+				for (String exact : exacts) {
+					if (exact != null && !exact.equals(canonical)) need.add(exact);
+				}
+			}
 		}
-		// Stable output: sort by source canonical purl then relationship type.
-		out.sort((a, b) -> {
-			int bySource = ((String) a.get("sourceCanonicalPurl"))
-					.compareTo((String) b.get("sourceCanonicalPurl"));
-			if (bySource != 0) return bySource;
-			return ((String) a.get("relationshipType"))
-					.compareTo((String) b.get("relationshipType"));
-		});
+		for (Map.Entry<String, Map<ParentKey, ParentAggregation>> e : parentAggs.entrySet()) {
+			String targetCanonical = e.getKey();
+			for (Map.Entry<ParentKey, ParentAggregation> edge : e.getValue().entrySet()) {
+				String sourceCanonical = edge.getKey().sourceCanonical;
+				for (DeclaringArtifactRecord d : edge.getValue().declarations.values()) {
+					if (d.sourceFullPurl != null && !d.sourceFullPurl.equals(sourceCanonical)) {
+						need.add(d.sourceFullPurl);
+					}
+					if (d.targetFullPurl != null && !d.targetFullPurl.equals(targetCanonical)) {
+						need.add(d.targetFullPurl);
+					}
+				}
+			}
+		}
+		return need;
+	}
+
+	private Map<String, UUID> upsertPurlQualifiers(Set<String> fullPurls, UUID orgUuid) {
+		if (fullPurls.isEmpty()) return Map.of();
+		Map<String, UUID> out = new HashMap<>(fullPurls.size() * 2);
+		for (PurlQualifier q : purlQualifierRepository.findByOrgAndFullPurlIn(orgUuid.toString(), fullPurls)) {
+			out.put(q.getFullPurl(), q.getUuid());
+		}
+		for (String full : fullPurls) {
+			if (out.containsKey(full)) continue;
+			PurlQualifier q = new PurlQualifier();
+			q.setOrg(orgUuid);
+			q.setFullPurl(full);
+			try {
+				PurlQualifier saved = purlQualifierRepository.save(q);
+				out.put(full, saved.getUuid());
+			} catch (DataIntegrityViolationException dive) {
+				purlQualifierRepository.findByOrgAndFullPurl(orgUuid, full)
+						.ifPresent(prior -> out.put(full, prior.getUuid()));
+			}
+		}
 		return out;
 	}
 
-	private void upsertReleaseSbomComponent(
-			UUID orgUuid,
-			UUID releaseUuid,
-			UUID sbomComponentUuid,
-			ComponentAggregation agg,
-			List<Map<String, Object>> parentsJson) {
-		List<Map<String, Object>> participations = new ArrayList<>();
-		for (Map.Entry<UUID, Set<String>> part : agg.sortedParticipations().entrySet()) {
-			Map<String, Object> entry = new LinkedHashMap<>();
-			entry.put("artifact", part.getKey().toString());
-			entry.put("exactPurls", new ArrayList<>(part.getValue()));
-			participations.add(entry);
-		}
-
-		Optional<ReleaseSbomComponent> existing = releaseSbomComponentRepository
-				.findByOrgAndReleaseUuidAndSbomComponentUuid(orgUuid, releaseUuid, sbomComponentUuid);
-		if (existing.isPresent()) {
-			ReleaseSbomComponent row = existing.get();
-			row.setArtifactParticipations(participations);
-			row.setParents(parentsJson);
-			row.setLastUpdatedDate(ZonedDateTime.now());
-			releaseSbomComponentRepository.save(row);
-		} else {
-			ReleaseSbomComponent row = new ReleaseSbomComponent();
-			row.setOrg(orgUuid);
-			row.setReleaseUuid(releaseUuid);
-			row.setSbomComponentUuid(sbomComponentUuid);
-			row.setArtifactParticipations(participations);
-			row.setParents(parentsJson);
-			try {
-				releaseSbomComponentRepository.save(row);
-			} catch (DataIntegrityViolationException dive) {
-				// Defensive — the queue should serialize per-release work, so
-				// this branch is only reachable on a genuine concurrent write.
-				releaseSbomComponentRepository
-						.findByOrgAndReleaseUuidAndSbomComponentUuid(orgUuid, releaseUuid, sbomComponentUuid)
-						.ifPresent(r -> {
-							r.setArtifactParticipations(participations);
-							r.setParents(parentsJson);
-							r.setLastUpdatedDate(ZonedDateTime.now());
-							releaseSbomComponentRepository.save(r);
-						});
-			}
-		}
-	}
+	// ===================================================================
+	// Helpers + aggregation buckets.
+	// ===================================================================
 
 	private static String relationshipType(ParsedBomDependency pd) {
 		String raw = pd.relationshipType();
@@ -794,16 +983,10 @@ public class SbomComponentService {
 		return raw.toUpperCase();
 	}
 
-	/**
-	 * Per-canonical aggregation bucket: one representative ParsedBomComponent
-	 * (first one seen; used for the record_data on sbom_components), whether
-	 * we've seen any artifact declare this component as a root, plus the map
-	 * of participating artifacts → full purls observed for that artifact.
-	 */
 	private static final class ComponentAggregation {
-		private final ParsedBomComponent sample;
-		private boolean isRoot;
-		private final Map<UUID, Set<String>> participations = new LinkedHashMap<>();
+		final ParsedBomComponent sample;
+		boolean isRoot;
+		final Map<UUID, Set<String>> participations = new LinkedHashMap<>();
 
 		ComponentAggregation(ParsedBomComponent sample) {
 			this.sample = sample;
@@ -817,42 +1000,53 @@ public class SbomComponentService {
 		void addParticipation(UUID artifactUuid, String fullPurl) {
 			participations.computeIfAbsent(artifactUuid, k -> new TreeSet<>()).add(fullPurl);
 		}
+	}
 
-		Map<UUID, Set<String>> sortedParticipations() {
-			Map<UUID, Set<String>> sorted = new LinkedHashMap<>();
-			participations.entrySet().stream()
-					.sorted(Map.Entry.comparingByKey((a, b) -> a.toString().compareTo(b.toString())))
-					.forEach(e -> sorted.put(e.getKey(), e.getValue()));
-			return sorted;
+	private record ParentKey(String sourceCanonical, String relationshipType) {}
+
+	private static final class ParentAggregation {
+		final Map<String, DeclaringArtifactRecord> declarations = new LinkedHashMap<>();
+
+		void addDeclaration(UUID artifactUuid, String sourceFullPurl, String targetFullPurl) {
+			String key = artifactUuid + " "
+					+ (sourceFullPurl == null ? "" : sourceFullPurl) + " "
+					+ (targetFullPurl == null ? "" : targetFullPurl);
+			declarations.putIfAbsent(key, new DeclaringArtifactRecord(artifactUuid, sourceFullPurl, targetFullPurl));
 		}
 	}
 
-	/** Grouping key for parent aggregation within one target canonical. */
-	private record ParentKey(String sourceCanonical, String relationshipType) {}
+	private record DeclaringArtifactRecord(UUID artifactUuid, String sourceFullPurl, String targetFullPurl) {}
 
-	/**
-	 * Per (source, target, relationshipType) bucket: one entry per artifact
-	 * that declared the edge, capturing the exact purls it used on both ends.
-	 */
-	private static final class ParentAggregation {
-		/** Keyed by (artifact, source full purl, target full purl). */
-		private final Map<String, Map<String, Object>> declarations = new LinkedHashMap<>();
+	private record RowKey(UUID releaseUuid, UUID sbomComponentUuid) {}
 
-		void addDeclaration(UUID artifactUuid, String sourceFullPurl, String targetFullPurl) {
-			String key = artifactUuid + "\u0000" + sourceFullPurl + "\u0000" + targetFullPurl;
+	private record EdgeGroupKey(UUID sourceUuid, String relationshipType) {}
+
+	private static final class EdgeGroup {
+		String sourceCanonicalPurl;
+		final Map<String, Map<String, Object>> declarations = new LinkedHashMap<>();
+
+		void addDeclaration(UUID artifactUuid, String sourceExact, String targetExact) {
+			String key = artifactUuid + " "
+					+ (sourceExact == null ? "" : sourceExact) + " "
+					+ (targetExact == null ? "" : targetExact);
 			if (declarations.containsKey(key)) return;
 			Map<String, Object> entry = new LinkedHashMap<>();
 			entry.put("artifact", artifactUuid.toString());
-			entry.put("sourceExactPurl", sourceFullPurl);
-			entry.put("targetExactPurl", targetFullPurl);
+			entry.put("sourceExactPurl", sourceExact);
+			entry.put("targetExactPurl", targetExact);
 			declarations.put(key, entry);
 		}
 
 		List<Map<String, Object>> sortedDeclarations() {
-			return declarations.entrySet().stream()
-					.sorted(Map.Entry.comparingByKey())
-					.map(Map.Entry::getValue)
-					.toList();
+			List<Map<String, Object>> out = new ArrayList<>(declarations.values());
+			Collections.sort(out, (a, b) -> {
+				int byArtifact = String.valueOf(a.get("artifact")).compareTo(String.valueOf(b.get("artifact")));
+				if (byArtifact != 0) return byArtifact;
+				int bySrc = String.valueOf(a.get("sourceExactPurl")).compareTo(String.valueOf(b.get("sourceExactPurl")));
+				if (bySrc != 0) return bySrc;
+				return String.valueOf(a.get("targetExactPurl")).compareTo(String.valueOf(b.get("targetExactPurl")));
+			});
+			return out;
 		}
 	}
 }

--- a/backend/src/main/java/io/reliza/ws/SbomComponentDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/SbomComponentDataFetcher.java
@@ -481,16 +481,11 @@ public class SbomComponentDataFetcher {
 		Map<String, Object> dto = new LinkedHashMap<>();
 		dto.put("uuid", sc.getUuid());
 		dto.put("canonicalPurl", sc.getCanonicalPurl());
-		Map<String, Object> rd = sc.getRecordData();
-		if (rd != null) {
-			dto.put("type", rd.get("type"));
-			dto.put("group", rd.get("group"));
-			dto.put("name", rd.get("name"));
-			dto.put("version", rd.get("version"));
-			dto.put("isRoot", Boolean.TRUE.equals(rd.get("isRoot")));
-		} else {
-			dto.put("isRoot", false);
-		}
+		dto.put("type", sc.getPurlType());
+		dto.put("group", sc.getPkgGroup());
+		dto.put("name", sc.getName());
+		dto.put("version", sc.getVersion());
+		dto.put("isRoot", sc.isRoot());
 		return dto;
 	}
 

--- a/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
+++ b/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
@@ -136,6 +136,15 @@ CREATE TABLE rearm.sbom_components (
         UNIQUE (org, canonical_purl)
 );
 
+-- lz4 compression hint on canonical_purl. PG 14+ honours per-column
+-- compression preference; only kicks in when a value crosses the
+-- inline-storage threshold (~2 KB) and gets TOASTed. Most canonical
+-- PURLs are well under that limit and stay inline, so no compression
+-- actually runs today — but this future-proofs the column against
+-- unusually long canonicals (e.g. monorepo-style subpath URLs) without
+-- a follow-up migration. Cheap and harmless.
+ALTER TABLE rearm.sbom_components ALTER COLUMN canonical_purl SET COMPRESSION lz4;
+
 CREATE INDEX sbom_components_org_idx
     ON rearm.sbom_components (org);
 
@@ -191,6 +200,11 @@ CREATE TABLE rearm.purl_qualifiers (
     CONSTRAINT purl_qualifiers_org_full_purl_unique UNIQUE (org, full_purl)
 );
 
+-- lz4 compression hint on full_purl. Same caveat as on canonical_purl:
+-- typical PURLs stay inline and don't compress. Future-proofs the column
+-- against pathological cases without a follow-up migration.
+ALTER TABLE rearm.purl_qualifiers ALTER COLUMN full_purl SET COMPRESSION lz4;
+
 CREATE INDEX purl_qualifiers_org_idx
     ON rearm.purl_qualifiers (org);
 
@@ -230,12 +244,17 @@ CREATE TABLE rearm.release_sbom_component_artifacts (
     release_uuid uuid NOT NULL,
     sbom_component_uuid uuid NOT NULL,
     artifact_uuid uuid NOT NULL,
-    exact_purl_uuid uuid,
-    -- NULLS NOT DISTINCT (PG15+) makes the (rel, comp, artifact, NULL) shape
-    -- unique too, so the upsert path doesn't insert duplicates when
-    -- exact_purl_uuid is NULL (i.e. exact == canonical).
-    CONSTRAINT release_sbom_component_artifacts_unique
-        UNIQUE NULLS NOT DISTINCT (release_uuid, sbom_component_uuid, artifact_uuid, exact_purl_uuid)
+    exact_purl_uuid uuid
+    -- No UNIQUE constraint on the natural key by design.
+    --
+    -- Application-level dedup is sufficient: reconcile deletes all child
+    -- rows for a release before re-inserting, the aggregation TreeSet/Map
+    -- keying dedups logical tuples before bulk insert, and the per-release
+    -- advisory lock serializes concurrent reconciles across replicas. A
+    -- DB-side UNIQUE NULLS NOT DISTINCT (rel, comp, artifact, exact_purl)
+    -- here would add a heavy multi-column index (4 UUIDs + tid ≈ 70 B per
+    -- row) without preventing any class of bug the in-memory path doesn't
+    -- already catch.
 );
 
 CREATE INDEX release_sbom_component_artifacts_release_component_idx
@@ -258,16 +277,16 @@ CREATE TABLE rearm.release_sbom_edges (
     relationship_type text NOT NULL,
     declaring_artifact_uuid uuid NOT NULL,
     source_exact_purl_uuid uuid,
-    target_exact_purl_uuid uuid,
-    CONSTRAINT release_sbom_edges_unique
-        UNIQUE NULLS NOT DISTINCT (
-            release_uuid,
-            target_sbom_component_uuid,
-            source_sbom_component_uuid,
-            relationship_type,
-            declaring_artifact_uuid,
-            source_exact_purl_uuid,
-            target_exact_purl_uuid)
+    target_exact_purl_uuid uuid
+    -- No UNIQUE constraint on the natural key. Same reasoning as
+    -- release_sbom_component_artifacts above: application-level dedup is
+    -- sufficient and the would-be 7-column UNIQUE (release + target +
+    -- source + relationship + artifact + 2× exact PURL) costs ~145 B per
+    -- row on its index — the single biggest line item in the per-row
+    -- footprint when this was profiled in production. ParentAggregation
+    -- already keys declarations by (artifact, source-full-PURL,
+    -- target-full-PURL) before flushing to the bulk insert, so the
+    -- aggregation result is duplicate-free by construction.
 );
 
 -- Two read patterns dominate: "in-edges for one target" (impact / reverse)

--- a/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
+++ b/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
@@ -84,9 +84,20 @@
 --                                 each successful reconcile.
 
 -- ---------------------------------------------------------------------------
--- 1. Tear down the old shape. CASCADE on sbom_components drops both the
---    release_sbom_components rows and the FKs by virtue of the existing
---    ON DELETE CASCADE chain.
+-- Foreign-key policy for this migration.
+--
+-- Per the no-FK convention in rearm-core/ai-agents/coding_principles.md,
+-- none of the new tables below declare FOREIGN KEY constraints. App-layer
+-- code (SbomComponentService) writes child rows transactionally and clears
+-- them on the same transactional boundary; orphan-cleanup races are
+-- absorbed in the read path (log.warn + skip). The drop here uses CASCADE
+-- only to dispose of the V25/V28-era FKs that referenced the old shape —
+-- the new tables that follow do not introduce any new ones.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. Tear down the old shape. CASCADE handles the V25/V28-era FK chain
+--    pointing at the dropped tables.
 -- ---------------------------------------------------------------------------
 DROP TABLE IF EXISTS rearm.release_sbom_components CASCADE;
 DROP TABLE IF EXISTS rearm.sbom_components CASCADE;
@@ -196,11 +207,7 @@ CREATE TABLE rearm.release_sbom_components (
     release_uuid uuid NOT NULL,
     sbom_component_uuid uuid NOT NULL,
     CONSTRAINT release_sbom_components_release_component_unique
-        UNIQUE (release_uuid, sbom_component_uuid),
-    CONSTRAINT release_sbom_components_release_fk FOREIGN KEY (release_uuid)
-        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_components_component_fk FOREIGN KEY (sbom_component_uuid)
-        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE
+        UNIQUE (release_uuid, sbom_component_uuid)
 );
 
 CREATE INDEX release_sbom_components_release_idx
@@ -224,12 +231,6 @@ CREATE TABLE rearm.release_sbom_component_artifacts (
     sbom_component_uuid uuid NOT NULL,
     artifact_uuid uuid NOT NULL,
     exact_purl_uuid uuid,
-    CONSTRAINT release_sbom_component_artifacts_release_fk FOREIGN KEY (release_uuid)
-        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_component_artifacts_component_fk FOREIGN KEY (sbom_component_uuid)
-        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_component_artifacts_purl_fk FOREIGN KEY (exact_purl_uuid)
-        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
     -- NULLS NOT DISTINCT (PG15+) makes the (rel, comp, artifact, NULL) shape
     -- unique too, so the upsert path doesn't insert duplicates when
     -- exact_purl_uuid is NULL (i.e. exact == canonical).
@@ -258,16 +259,6 @@ CREATE TABLE rearm.release_sbom_edges (
     declaring_artifact_uuid uuid NOT NULL,
     source_exact_purl_uuid uuid,
     target_exact_purl_uuid uuid,
-    CONSTRAINT release_sbom_edges_release_fk FOREIGN KEY (release_uuid)
-        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_edges_target_fk FOREIGN KEY (target_sbom_component_uuid)
-        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_edges_source_fk FOREIGN KEY (source_sbom_component_uuid)
-        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
-    CONSTRAINT release_sbom_edges_source_purl_fk FOREIGN KEY (source_exact_purl_uuid)
-        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
-    CONSTRAINT release_sbom_edges_target_purl_fk FOREIGN KEY (target_exact_purl_uuid)
-        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
     CONSTRAINT release_sbom_edges_unique
         UNIQUE NULLS NOT DISTINCT (
             release_uuid,

--- a/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
+++ b/backend/src/main/resources/db/migration/V37__sbom_components_normalized_shape.sql
@@ -1,0 +1,305 @@
+-- Drop & recreate the SBOM-component aggregation tables with a normalized
+-- shape. The old layout stored everything per row as JSONB arrays
+-- (artifactParticipations, parents), with full PURLs and UUID-as-string
+-- repeated across every artifact and every in-edge. Profiling showed the
+-- per-release storage was dominated by (a) string-form UUIDs inside JSONB
+-- (~41 B each vs 16 B native), (b) duplicated exact PURLs across the
+-- artifact_participations and parents arrays, and (c) the GIN index on
+-- artifact_participations needed to make any non-trivial filter remotely
+-- cheap. At AI-scale release velocity these stack into tens of GB very
+-- quickly.
+--
+-- New layout — same public GraphQL surface, normalized underneath:
+--
+--   sbom_components               Canonical per-(org, canonical_purl)
+--                                 component identity. Frequently-read
+--                                 metadata (type / group / name /
+--                                 version / is_root) promoted out of the
+--                                 prior record_data JSONB into typed
+--                                 columns so the search query is a
+--                                 plain b-tree probe instead of a
+--                                 JSONB ->> expression. record_data
+--                                 column dropped entirely.
+--
+--   purl_qualifiers               Interning table for exact PURLs (the
+--                                 qualifier-/subpath-bearing form). Same
+--                                 exact PURL appears repeatedly across
+--                                 artifacts, edges and releases — store
+--                                 the string once per (org, full_purl)
+--                                 and reference by uuid from the leaf
+--                                 tables. NULL exact_purl_uuid in those
+--                                 tables means the exact PURL equals
+--                                 the canonical PURL on the referenced
+--                                 sbom_components row (saves intern
+--                                 rows for the ~80% of components that
+--                                 carry no qualifiers).
+--
+--   release_sbom_components       Existence anchor only — keys
+--                                 (release, canonical component) and
+--                                 carries timestamps + the uuid the UI
+--                                 navigates by. No JSONB columns left.
+--
+--   release_sbom_component_artifacts
+--                                 Replaces the artifact_participations
+--                                 JSONB array. One row per
+--                                 (release, canonical component,
+--                                 declaring artifact, exact PURL). Keyed
+--                                 by canonical component (not by
+--                                 release_sbom_components.uuid) so
+--                                 product-release read-time merging is
+--                                 a simple UNION over the product's own
+--                                 release_uuid + every dep's release_uuid
+--                                 grouped by sbom_component_uuid.
+--
+--   release_sbom_edges            Replaces the parents JSONB array. One
+--                                 row per (release, source canonical,
+--                                 target canonical, relationship,
+--                                 declaring artifact, source exact PURL,
+--                                 target exact PURL). Edges between
+--                                 canonical components — same semantics
+--                                 as the prior in-edge model, with the
+--                                 read-time inversion to forward edges
+--                                 still happening in the API layer.
+--
+-- Tables are dropped and recreated rather than backfilled — every release
+-- in the queue rebuilds from its BOM artifacts on the next reconcile tick.
+-- This matches the V28 cutover pattern and is safe because the only data
+-- in these tables is derived from artifact BOMs that we still hold.
+--
+-- The reconcile queue itself (releases.flow_control->sbomReconcileRequestedAt)
+-- is re-seeded for every non-archived release at the tail of this migration,
+-- as in V25 / V27 / V28.
+--
+-- Additionally introduce a generation cookie on releases:
+--
+--   releases.sbom_schema_version  Bumped by the reconciler on success.
+--                                 Future migrations of this area can
+--                                 increment a Java-side constant and the
+--                                 catch-up scheduler will rediscover rows
+--                                 whose stored version is below current —
+--                                 no Flyway re-enqueue UPDATE needed,
+--                                 and stuck / partial reconciles are
+--                                 self-healing. Default 0 here; service
+--                                 stamps the new current value (1) on
+--                                 each successful reconcile.
+
+-- ---------------------------------------------------------------------------
+-- 1. Tear down the old shape. CASCADE on sbom_components drops both the
+--    release_sbom_components rows and the FKs by virtue of the existing
+--    ON DELETE CASCADE chain.
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS rearm.release_sbom_components CASCADE;
+DROP TABLE IF EXISTS rearm.sbom_components CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 2. Schema-version cookie on releases. Stays at 0 on every existing
+--    release; bumped to CURRENT_SBOM_SCHEMA_VERSION by SbomComponentService
+--    on successful reconcile.
+-- ---------------------------------------------------------------------------
+ALTER TABLE rearm.releases
+    ADD COLUMN IF NOT EXISTS sbom_schema_version integer NOT NULL DEFAULT 0;
+
+-- Partial index lets the catch-up scheduler find rows below the current
+-- version without scanning the full releases table.
+CREATE INDEX IF NOT EXISTS releases_sbom_schema_version_idx
+    ON rearm.releases (sbom_schema_version)
+    WHERE sbom_schema_version < 1;
+
+-- ---------------------------------------------------------------------------
+-- 3. Recreate canonical sbom_components with promoted columns.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.sbom_components (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    revision integer NOT NULL default 0,
+    schema_version integer NOT NULL default 0,
+    created_date timestamptz NOT NULL default now(),
+    last_updated_date timestamptz NOT NULL default now(),
+    org uuid NOT NULL,
+    canonical_purl text NOT NULL,
+    purl_type text,
+    pkg_group text,
+    name text,
+    version text,
+    is_root boolean NOT NULL default false,
+    CONSTRAINT sbom_components_org_canonical_purl_unique
+        UNIQUE (org, canonical_purl)
+);
+
+CREATE INDEX sbom_components_org_idx
+    ON rearm.sbom_components (org);
+
+-- Replaces the old expression index on record_data->>'name'. Most reads
+-- carry org + name (or org + name + version), so a single composite
+-- covers both the listing and the optional-version search.
+CREATE INDEX sbom_components_org_name_idx
+    ON rearm.sbom_components (org, name);
+
+-- ---------------------------------------------------------------------------
+-- 3b. artifact_canonical_map — per-org dedup pointers from any BOM artifact
+--     to its canonical (content-identical) counterpart. Mapping is populated
+--     LAZILY during SBOM reconcile, only for BOM-bearing artifacts that
+--     participate in a release's aggregation. Non-BOM artifacts are never
+--     mapped (and won't appear here).
+--
+--     The existing org-scoped digest lookup
+--     (VariableQueries.FIND_ARTIFACTS_BY_STORED_DIGEST) decides the
+--     canonical: first artifact seen with a given (org, digest) wins; all
+--     subsequent artifacts with the same digest map to it. An artifact
+--     that is the first occurrence maps to itself (canonical_artifact_uuid
+--     = artifact_uuid) so the table is the single authoritative source —
+--     no "missing row means canonical" implicit rule.
+--
+--     DELIBERATELY NO FOREIGN KEYS. If the referenced artifact is later
+--     deleted, the SBOM service surfaces a "no data found" result and
+--     log.warn's the dangling row instead of cascading. Keeps this map
+--     orthogonal to the artifacts table lifecycle.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.artifact_canonical_map (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    org uuid NOT NULL,
+    artifact_uuid uuid NOT NULL,
+    canonical_artifact_uuid uuid NOT NULL,
+    created_date timestamptz NOT NULL default now(),
+    CONSTRAINT artifact_canonical_map_artifact_unique UNIQUE (artifact_uuid)
+);
+
+CREATE INDEX artifact_canonical_map_org_idx
+    ON rearm.artifact_canonical_map (org);
+CREATE INDEX artifact_canonical_map_canonical_idx
+    ON rearm.artifact_canonical_map (canonical_artifact_uuid);
+
+-- ---------------------------------------------------------------------------
+-- 4. PURL interning table. Stores each full (qualifier-bearing) PURL once
+--    per org. Leaf tables reference by uuid; NULL means exact == canonical.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.purl_qualifiers (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    org uuid NOT NULL,
+    full_purl text NOT NULL,
+    created_date timestamptz NOT NULL default now(),
+    CONSTRAINT purl_qualifiers_org_full_purl_unique UNIQUE (org, full_purl)
+);
+
+CREATE INDEX purl_qualifiers_org_idx
+    ON rearm.purl_qualifiers (org);
+
+-- ---------------------------------------------------------------------------
+-- 5. release_sbom_components — the existence anchor. No JSONB.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.release_sbom_components (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    revision integer NOT NULL default 0,
+    schema_version integer NOT NULL default 0,
+    created_date timestamptz NOT NULL default now(),
+    last_updated_date timestamptz NOT NULL default now(),
+    org uuid NOT NULL,
+    release_uuid uuid NOT NULL,
+    sbom_component_uuid uuid NOT NULL,
+    CONSTRAINT release_sbom_components_release_component_unique
+        UNIQUE (release_uuid, sbom_component_uuid),
+    CONSTRAINT release_sbom_components_release_fk FOREIGN KEY (release_uuid)
+        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_components_component_fk FOREIGN KEY (sbom_component_uuid)
+        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE
+);
+
+CREATE INDEX release_sbom_components_release_idx
+    ON rearm.release_sbom_components (release_uuid);
+CREATE INDEX release_sbom_components_component_idx
+    ON rearm.release_sbom_components (sbom_component_uuid);
+CREATE INDEX release_sbom_components_org_idx
+    ON rearm.release_sbom_components (org);
+
+-- ---------------------------------------------------------------------------
+-- 6. release_sbom_component_artifacts — normalized participations.
+--    Keyed by canonical sbom_component_uuid + release_uuid (not by
+--    release_sbom_components.uuid) so that PRODUCT-release read-time
+--    aggregation across many dep releases collapses to a single
+--    SELECT ... WHERE release_uuid IN (...) GROUP BY sbom_component_uuid.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.release_sbom_component_artifacts (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    org uuid NOT NULL,
+    release_uuid uuid NOT NULL,
+    sbom_component_uuid uuid NOT NULL,
+    artifact_uuid uuid NOT NULL,
+    exact_purl_uuid uuid,
+    CONSTRAINT release_sbom_component_artifacts_release_fk FOREIGN KEY (release_uuid)
+        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_component_artifacts_component_fk FOREIGN KEY (sbom_component_uuid)
+        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_component_artifacts_purl_fk FOREIGN KEY (exact_purl_uuid)
+        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
+    -- NULLS NOT DISTINCT (PG15+) makes the (rel, comp, artifact, NULL) shape
+    -- unique too, so the upsert path doesn't insert duplicates when
+    -- exact_purl_uuid is NULL (i.e. exact == canonical).
+    CONSTRAINT release_sbom_component_artifacts_unique
+        UNIQUE NULLS NOT DISTINCT (release_uuid, sbom_component_uuid, artifact_uuid, exact_purl_uuid)
+);
+
+CREATE INDEX release_sbom_component_artifacts_release_component_idx
+    ON rearm.release_sbom_component_artifacts (release_uuid, sbom_component_uuid);
+CREATE INDEX release_sbom_component_artifacts_artifact_idx
+    ON rearm.release_sbom_component_artifacts (artifact_uuid);
+
+-- ---------------------------------------------------------------------------
+-- 7. release_sbom_edges — normalized in-edges. Source / target reference
+--    canonical sbom_components (not release_sbom_components) for the same
+--    reason as #6: product-release merging is a UNION over release_uuids
+--    keyed by (source canonical, target canonical) without any UUID remapping.
+-- ---------------------------------------------------------------------------
+CREATE TABLE rearm.release_sbom_edges (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    org uuid NOT NULL,
+    release_uuid uuid NOT NULL,
+    target_sbom_component_uuid uuid NOT NULL,
+    source_sbom_component_uuid uuid NOT NULL,
+    relationship_type text NOT NULL,
+    declaring_artifact_uuid uuid NOT NULL,
+    source_exact_purl_uuid uuid,
+    target_exact_purl_uuid uuid,
+    CONSTRAINT release_sbom_edges_release_fk FOREIGN KEY (release_uuid)
+        REFERENCES rearm.releases(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_edges_target_fk FOREIGN KEY (target_sbom_component_uuid)
+        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_edges_source_fk FOREIGN KEY (source_sbom_component_uuid)
+        REFERENCES rearm.sbom_components(uuid) ON DELETE CASCADE,
+    CONSTRAINT release_sbom_edges_source_purl_fk FOREIGN KEY (source_exact_purl_uuid)
+        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
+    CONSTRAINT release_sbom_edges_target_purl_fk FOREIGN KEY (target_exact_purl_uuid)
+        REFERENCES rearm.purl_qualifiers(uuid) ON DELETE RESTRICT,
+    CONSTRAINT release_sbom_edges_unique
+        UNIQUE NULLS NOT DISTINCT (
+            release_uuid,
+            target_sbom_component_uuid,
+            source_sbom_component_uuid,
+            relationship_type,
+            declaring_artifact_uuid,
+            source_exact_purl_uuid,
+            target_exact_purl_uuid)
+);
+
+-- Two read patterns dominate: "in-edges for one target" (impact / reverse)
+-- and "out-edges for one source" (forward dependency reconstruction). Both
+-- get a composite that includes release_uuid as the lead so product-release
+-- merging across many release_uuids stays cheap.
+CREATE INDEX release_sbom_edges_release_target_idx
+    ON rearm.release_sbom_edges (release_uuid, target_sbom_component_uuid);
+CREATE INDEX release_sbom_edges_release_source_idx
+    ON rearm.release_sbom_edges (release_uuid, source_sbom_component_uuid);
+CREATE INDEX release_sbom_edges_org_idx
+    ON rearm.release_sbom_edges (org);
+
+-- ---------------------------------------------------------------------------
+-- 8. Re-enqueue every non-archived release so the reconcile scheduler /
+--    operator force-reconcile rebuilds the now-empty tables. Mirrors the
+--    V25 / V27 / V28 tail UPDATEs. Archived releases are deliberately
+--    excluded — their aggregation will never change.
+-- ---------------------------------------------------------------------------
+UPDATE rearm.releases
+SET flow_control = jsonb_set(
+        coalesce(flow_control, '{}'::jsonb),
+        '{sbomReconcileRequestedAt}',
+        to_jsonb(now()),
+        true)
+WHERE coalesce(record_data->>'status', 'ACTIVE') != 'ARCHIVED';


### PR DESCRIPTION
## Summary

CE mirror of the Pro-side change [relizaio/rearm-saas#79](https://github.com/relizaio/rearm-saas/pull/79). Drops and recreates `sbom_components` / `release_sbom_components` with a normalized shape, adds `purl_qualifiers` / `release_sbom_component_artifacts` / `release_sbom_edges` / `artifact_canonical_map`, and stamps `releases.sbom_schema_version` on successful reconcile.

The shared `service.*` / `model.*` / `repositories.*` surface stays identical to the Pro backend (per `rearm-core/ai-agents/sandbox.md` layering rules). See the Pro PR for the full design, the storage estimate, and the deploy/test record on the sandbox.

## Test plan

- [x] `mvn -DskipTests clean compile` green on this repo
- [x] Pro mirror was deployed + integration-tested on the SAAS sandbox (sbom_components + sbom_product cucumber tags pass)
- [ ] CE smoke (deferred — the same schema applies; the smoke can run whenever a CE sandbox is exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)