### PR TITLE
feat(ui): group NONE product changelog per product release

### DIFF
--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -144,8 +144,38 @@
                         />
                     </div>
                 </div>
+
+                <!-- NONE aggregation, PRODUCT: grouped per product release -->
+                <div v-else-if="aggregationType === 'NONE' && changelog.__typename === 'NoneProductChangelog'">
+                    <div v-for="group in displayProductReleases" :key="group.releaseUuid" class="product-release-group">
+                        <ProductReleaseHeader
+                            :uuid="group.releaseUuid"
+                            :version="group.version"
+                            :lifecycle="group.lifecycle"
+                        />
+                        <template v-for="branch in group.branches" :key="branch.branchUuid">
+                            <div v-for="release in branch.releases" :key="release.releaseUuid">
+                                <ReleaseHeader
+                                    :uuid="release.releaseUuid"
+                                    :version="release.version"
+                                    :lifecycle="release.lifecycle"
+                                    :org-uuid="changelog.orgUuid"
+                                    :component-uuid="branch.componentUuid || changelog.componentUuid"
+                                    :component-name="branch.componentName"
+                                    :branch-uuid="branch.branchUuid"
+                                    :branch-name="branch.branchName"
+                                    :branch-change-type="branch.changeType"
+                                />
+                                <CodeChangesDisplay
+                                    :changes="formatCodeChanges(release)"
+                                    :selected-severity="selectedSeverity"
+                                />
+                            </div>
+                        </template>
+                    </div>
+                </div>
             </n-tab-pane>
-            
+
             <n-tab-pane name="sbom" tab="📦 SBOM Changes">
                 <div v-if="!hasData" style="padding: 40px; text-align: center; color: #999;">
                     <p style="font-size: 16px; margin-bottom: 10px;">No SBOM changes available{{ isDateBased ? ' for the selected date range' : '' }}</p>
@@ -168,7 +198,33 @@
                         <SbomChangesDisplay :sbom-changes="entry.release.sbomChanges" />
                     </div>
                 </div>
-                
+
+                <!-- NONE mode, PRODUCT: grouped per product release -->
+                <div v-else-if="aggregationType === 'NONE' && changelog.__typename === 'NoneProductChangelog'">
+                    <div v-for="group in displayProductReleases" :key="group.releaseUuid" class="product-release-group">
+                        <ProductReleaseHeader
+                            :uuid="group.releaseUuid"
+                            :version="group.version"
+                            :lifecycle="group.lifecycle"
+                        />
+                        <template v-for="branch in group.branches" :key="branch.branchUuid">
+                            <div v-for="release in branch.releases" :key="release.releaseUuid">
+                                <ReleaseHeader
+                                    :uuid="release.releaseUuid"
+                                    :version="release.version"
+                                    :lifecycle="release.lifecycle"
+                                    :org-uuid="changelog.orgUuid"
+                                    :component-uuid="branch.componentUuid || changelog.componentUuid"
+                                    :component-name="branch.componentName"
+                                    :branch-uuid="branch.branchUuid"
+                                    :branch-name="branch.branchName"
+                                />
+                                <SbomChangesDisplay :sbom-changes="release.sbomChanges" />
+                            </div>
+                        </template>
+                    </div>
+                </div>
+
                 <!-- AGGREGATED mode: Show top-level aggregated changes -->
                 <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog'">
                     <p style="margin-bottom: 10px; font-style: italic;">{{ aggregatedDescription }}</p>
@@ -197,7 +253,33 @@
                         <FindingChangesDisplay :finding-changes="entry.release.findingChanges" />
                     </div>
                 </div>
-                
+
+                <!-- NONE mode, PRODUCT: grouped per product release -->
+                <div v-else-if="aggregationType === 'NONE' && changelog.__typename === 'NoneProductChangelog'">
+                    <div v-for="group in displayProductReleases" :key="group.releaseUuid" class="product-release-group">
+                        <ProductReleaseHeader
+                            :uuid="group.releaseUuid"
+                            :version="group.version"
+                            :lifecycle="group.lifecycle"
+                        />
+                        <template v-for="branch in group.branches" :key="branch.branchUuid">
+                            <div v-for="release in branch.releases" :key="release.releaseUuid">
+                                <ReleaseHeader
+                                    :uuid="release.releaseUuid"
+                                    :version="release.version"
+                                    :lifecycle="release.lifecycle"
+                                    :org-uuid="changelog.orgUuid"
+                                    :component-uuid="branch.componentUuid || changelog.componentUuid"
+                                    :component-name="branch.componentName"
+                                    :branch-uuid="branch.branchUuid"
+                                    :branch-name="branch.branchName"
+                                />
+                                <FindingChangesDisplay :finding-changes="release.findingChanges" />
+                            </div>
+                        </template>
+                    </div>
+                </div>
+
                 <!-- AGGREGATED mode: Show top-level aggregated changes -->
                 <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog'">
                     <p style="margin-bottom: 10px; font-style: italic;">{{ aggregatedDescription }}</p>
@@ -217,20 +299,21 @@ export default {
 import { Ref, ref, watch, computed } from 'vue'
 import { NTabs, NTabPane, NButton, useNotification } from 'naive-ui'
 import { useStore } from 'vuex'
-import { 
+import {
     FindingChangesDisplay,
     FindingChangesDisplayWithAttribution,
-    SbomChangesDisplay, 
-    CodeChangesDisplay, 
+    SbomChangesDisplay,
+    CodeChangesDisplay,
     ReleaseHeader,
+    ProductReleaseHeader,
     ChangelogControls,
     SeverityFilter
 } from './changelog'
-import { 
-    fetchComponentChangelogByDate, 
-    fetchComponentChangelog 
+import {
+    fetchComponentChangelogByDate,
+    fetchComponentChangelog
 } from '../utils/changelogQueries'
-import type { ComponentChangelog, NoneReleaseChanges, CodeCommit } from '../types/changelog-sealed'
+import type { ComponentChangelog, NoneReleaseChanges, CodeCommit, ProductReleaseChanges } from '../types/changelog-sealed'
 import { exportChangelogToPdf } from '../utils/changelogPdfExport'
 import type { ChangelogTab } from '../utils/changelogPdfExport'
 
@@ -290,11 +373,39 @@ const componentType = props.componenttypeprop
 
 const isProduct = computed(() => componentType === 'PRODUCT')
 const isDateBased = computed(() => props.iscomponentchangelog)
-const hasData = computed(() => changelog.value && changelog.value.branches && changelog.value.branches.length > 0)
+const hasData = computed(() => {
+    const cl = changelog.value
+    if (!cl) return false
+    if (cl.__typename === 'NoneProductChangelog') {
+        return !!(cl.productReleases && cl.productReleases.length > 0)
+    }
+    return !!(cl.branches && cl.branches.length > 0)
+})
 
 const displayBranches = computed((): any[] => {
     if (!hasData.value || !changelog.value) return []
+    if (changelog.value.__typename === 'NoneProductChangelog') return []
     return changelog.value.branches
+})
+
+// Product NONE changelog: groups sorted newest product release first, and each
+// group's child releases sorted newest first. Shallow copies avoid mutating source.
+const displayProductReleases = computed<ProductReleaseChanges[]>(() => {
+    if (!changelog.value || changelog.value.__typename !== 'NoneProductChangelog') return []
+    const byCreatedDesc = (a: { createdDate?: string }, b: { createdDate?: string }) => {
+        const aDate = a.createdDate ? new Date(a.createdDate).getTime() : 0
+        const bDate = b.createdDate ? new Date(b.createdDate).getTime() : 0
+        return bDate - aDate
+    }
+    return [...changelog.value.productReleases]
+        .sort(byCreatedDesc)
+        .map(group => ({
+            ...group,
+            branches: (group.branches || []).map(branch => ({
+                ...branch,
+                releases: [...(branch.releases || [])].sort(byCreatedDesc)
+            }))
+        }))
 })
 
 const showBranchHeadings = computed(() => {
@@ -444,4 +555,7 @@ function handleExportPdf() {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+.product-release-group {
+    margin-bottom: 20px;
+}
 </style>

--- a/ui/src/components/changelog/ProductReleaseHeader.vue
+++ b/ui/src/components/changelog/ProductReleaseHeader.vue
@@ -1,0 +1,47 @@
+<template>
+    <h2 class="product-release-header">
+        <router-link :to="releaseLink">{{ version }}</router-link>
+        <n-tag v-if="lifecycle === 'REJECTED'" type="error" size="small" class="lifecycle-tag">REJECTED</n-tag>
+        <n-tag v-else-if="lifecycle === 'PENDING'" type="warning" size="small" class="lifecycle-tag">PENDING</n-tag>
+    </h2>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { NTag } from 'naive-ui'
+
+interface Props {
+    uuid: string
+    version: string
+    lifecycle?: string
+}
+
+const props = defineProps<Props>()
+
+const releaseLink = computed(() => ({
+    name: 'ReleaseView',
+    params: { uuid: props.uuid }
+}))
+</script>
+
+<style scoped lang="scss">
+.product-release-header {
+    margin-top: 24px;
+    margin-bottom: 10px;
+    padding-bottom: 6px;
+    border-bottom: 2px solid #e0e0e6;
+
+    .lifecycle-tag {
+        margin-left: 8px;
+    }
+
+    a {
+        color: #18a058;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+</style>

--- a/ui/src/components/changelog/index.ts
+++ b/ui/src/components/changelog/index.ts
@@ -3,6 +3,7 @@ export { default as FindingChangesDisplayWithAttribution } from './FindingChange
 export { default as SbomChangesDisplay } from './SbomChangesDisplay.vue'
 export { default as CodeChangesDisplay } from './CodeChangesDisplay.vue'
 export { default as ReleaseHeader } from './ReleaseHeader.vue'
+export { default as ProductReleaseHeader } from './ProductReleaseHeader.vue'
 export { default as ComponentHeader } from './ComponentHeader.vue'
 export { default as ChangelogControls } from './ChangelogControls.vue'
 export { default as SeverityFilter } from './SeverityFilter.vue'

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -149,6 +149,31 @@ export interface NoneChangelog {
 }
 
 /**
+ * Child component changes introduced by a single product release (NONE mode).
+ */
+export interface ProductReleaseChanges {
+    releaseUuid: string
+    version: string
+    lifecycle: string
+    createdDate: string
+    branches: NoneBranchChanges[]
+}
+
+/**
+ * NONE mode changelog scoped to a PRODUCT — child component changes grouped
+ * per product release rather than as a flat branch list.
+ */
+export interface NoneProductChangelog {
+    __typename: 'NoneProductChangelog'
+    componentUuid: string
+    componentName: string
+    orgUuid: string
+    firstRelease: ReleaseInfo
+    lastRelease: ReleaseInfo
+    productReleases: ProductReleaseChanges[]
+}
+
+/**
  * AGGREGATED mode changelog (component-level summary)
  */
 export interface AggregatedChangelog {
@@ -166,7 +191,7 @@ export interface AggregatedChangelog {
 /**
  * Union type for component changelog
  */
-export type ComponentChangelog = NoneChangelog | AggregatedChangelog
+export type ComponentChangelog = NoneChangelog | AggregatedChangelog | NoneProductChangelog
 
 /**
  * NONE mode organization changelog (per-component, per-release breakdown)
@@ -209,6 +234,13 @@ export function isNoneChangelog(changelog: ComponentChangelog): changelog is Non
  */
 export function isAggregatedChangelog(changelog: ComponentChangelog): changelog is AggregatedChangelog {
     return changelog.__typename === 'AggregatedChangelog'
+}
+
+/**
+ * Type guard to check if changelog is a NONE mode product changelog
+ */
+export function isNoneProductChangelog(changelog: ComponentChangelog): changelog is NoneProductChangelog {
+    return changelog.__typename === 'NoneProductChangelog'
 }
 
 /**

--- a/ui/src/utils/changelogPdfExport.ts
+++ b/ui/src/utils/changelogPdfExport.ts
@@ -21,6 +21,8 @@ interface PdfCell {
     text: string
     color?: string
     bold?: boolean
+    colSpan?: number
+    fillColor?: string
 }
 
 interface PdfRow {
@@ -82,13 +84,64 @@ function flattenNoneReleases(changelog: any): FlatNoneEntry[] {
     return entries
 }
 
+// Newest-first comparator by createdDate.
+function byCreatedDateDesc(a: { createdDate?: string }, b: { createdDate?: string }): number {
+    const aDate = a.createdDate ? new Date(a.createdDate).getTime() : 0
+    const bDate = b.createdDate ? new Date(b.createdDate).getTime() : 0
+    return bDate - aDate
+}
+
+// A full-width section-header row (used to label each product release group).
+function sectionHeaderRow(label: string, columnCount: number): PdfRow {
+    const cells: PdfCell[] = [{ text: label, bold: true, colSpan: columnCount, fillColor: '#eef3ff' }]
+    for (let i = 1; i < columnCount; i++) {
+        cells.push({ text: '', fillColor: '#eef3ff' })
+    }
+    return { cells }
+}
+
+// Builds grouped rows for a NoneProductChangelog: a section-header row per product
+// release (newest first) followed by that release's child-component rows. Product
+// releases that produced no rows for the current tab are skipped.
+function buildProductGroupedRows(
+    changelog: any,
+    columnCount: number,
+    emitRelease: (branchLabel: string, release: any) => PdfRow[]
+): PdfRow[] {
+    const rows: PdfRow[] = []
+    const groups = [...(changelog.productReleases || [])].sort(byCreatedDateDesc)
+    for (const group of groups) {
+        const childEntries: { branchLabel: string; release: any }[] = []
+        for (const branch of (group.branches || [])) {
+            const branchLabel = branch.componentName
+                ? `${branch.componentName} / ${branch.branchName || ''}`
+                : (branch.branchName || '')
+            for (const release of (branch.releases || [])) {
+                childEntries.push({ branchLabel, release })
+            }
+        }
+        childEntries.sort((a, b) => byCreatedDateDesc(a.release, b.release))
+        const groupRows: PdfRow[] = []
+        for (const e of childEntries) {
+            groupRows.push(...emitRelease(e.branchLabel, e.release))
+        }
+        if (groupRows.length > 0) {
+            rows.push(sectionHeaderRow(`Product Release: ${group.version || ''}`, columnCount))
+            rows.push(...groupRows)
+        }
+    }
+    return rows
+}
+
 function buildCodeTable(changelog: any, aggregationType: string): { headers: string[]; rows: PdfRow[]; widths: string[] } {
     const headers = ['Branch', 'Release', 'Change Type', 'Commit Message', 'Author']
     const widths = ['auto', 'auto', 'auto', '*', 'auto']
     const rows: PdfRow[] = []
 
     const branches = changelog.branches || []
-    if (!branches.length && !(changelog.components || []).length) return { headers, rows, widths }
+    if (!branches.length && !(changelog.components || []).length && !(changelog.productReleases || []).length) {
+        return { headers, rows, widths }
+    }
 
     if (aggregationType === 'NONE' && changelog.__typename === 'NoneChangelog') {
         for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
@@ -102,6 +155,16 @@ function buildCodeTable(changelog: any, aggregationType: string): { headers: str
                 ]})
             }
         }
+    } else if (aggregationType === 'NONE' && changelog.__typename === 'NoneProductChangelog') {
+        rows.push(...buildProductGroupedRows(changelog, headers.length, (branchLabel, release) =>
+            (release.commits || []).map((commit: any) => ({ cells: [
+                { text: branchLabel },
+                { text: release.version || '' },
+                { text: commit.changeType || '' },
+                { text: commit.message || '' },
+                { text: commit.author || '' }
+            ]}))
+        ))
     } else if (aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog') {
         for (const branch of branches) {
             const branchLabel = branch.componentName ? `${branch.componentName} / ${branch.branchName || ''}` : (branch.branchName || '')
@@ -134,13 +197,13 @@ function buildSbomTable(changelog: any, aggregationType: string): { headers: str
 function buildSbomNoneTable(changelog: any): { headers: string[]; rows: PdfRow[]; widths: string[] } {
     const headers = ['Branch', 'Release', 'Status', 'PURL', 'Name', 'Version']
     const widths = ['auto', 'auto', 'auto', '*', 'auto', 'auto']
-    const rows: PdfRow[] = []
 
-    for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
+    const emitSbom = (branchLabel: string, release: any): PdfRow[] => {
+        const out: PdfRow[] = []
         const sbom = release.sbomChanges
-        if (!sbom) continue
+        if (!sbom) return out
         for (const art of (sbom.addedArtifacts || [])) {
-            rows.push({ cells: [
+            out.push({ cells: [
                 { text: branchLabel },
                 { text: release.version || '' },
                 { text: 'Added', color: '#18a058' },
@@ -150,7 +213,7 @@ function buildSbomNoneTable(changelog: any): { headers: string[]; rows: PdfRow[]
             ]})
         }
         for (const art of (sbom.removedArtifacts || [])) {
-            rows.push({ cells: [
+            out.push({ cells: [
                 { text: branchLabel },
                 { text: release.version || '' },
                 { text: 'Removed', color: '#d03050' },
@@ -159,8 +222,17 @@ function buildSbomNoneTable(changelog: any): { headers: string[]; rows: PdfRow[]
                 { text: art.version || '' }
             ]})
         }
+        return out
     }
 
+    if (changelog.__typename === 'NoneProductChangelog') {
+        return { headers, rows: buildProductGroupedRows(changelog, headers.length, emitSbom), widths }
+    }
+
+    const rows: PdfRow[] = []
+    for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
+        rows.push(...emitSbom(branchLabel, release))
+    }
     return { headers, rows, widths }
 }
 
@@ -209,14 +281,23 @@ function buildFindingTable(changelog: any, aggregationType: string): { headers: 
 function buildFindingNoneTable(changelog: any): { headers: string[]; rows: PdfRow[]; widths: string[] } {
     const headers = ['Branch', 'Release', 'Status', 'Type', 'Issue ID', 'PURL / Location', 'Severity']
     const widths = ['auto', 'auto', 'auto', 'auto', 'auto', '*', 'auto']
-    const rows: PdfRow[] = []
 
-    for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
+    const emitFinding = (branchLabel: string, release: any): PdfRow[] => {
         const fc = release.findingChanges
-        if (!fc) continue
-        addNoneFindingRows(rows, branchLabel, release.version, fc)
+        if (!fc) return []
+        const out: PdfRow[] = []
+        addNoneFindingRows(out, branchLabel, release.version, fc)
+        return out
     }
 
+    if (changelog.__typename === 'NoneProductChangelog') {
+        return { headers, rows: buildProductGroupedRows(changelog, headers.length, emitFinding), widths }
+    }
+
+    const rows: PdfRow[] = []
+    for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
+        rows.push(...emitFinding(branchLabel, release))
+    }
     return { headers, rows, widths }
 }
 
@@ -423,6 +504,8 @@ export function exportChangelogToPdf(options: ChangelogPdfOptions): { success: b
             const cellDef: any = { text: cell.text }
             if (cell.color) cellDef.color = cell.color
             if (cell.bold) cellDef.bold = true
+            if (cell.colSpan) cellDef.colSpan = cell.colSpan
+            if (cell.fillColor) cellDef.fillColor = cell.fillColor
             return cellDef
         })
         tableBody.push(pdfRow)

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -217,6 +217,17 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
 
 // ========== Shared Component Changelog Fragments ==========
 
+const NONE_BRANCH_CHANGES_FRAGMENT = `
+    branchUuid
+    branchName
+    componentUuid
+    componentName
+    changeType
+    releases {
+        ${NONE_RELEASE_CHANGES_FRAGMENT}
+    }
+`
+
 const NONE_CHANGELOG_FIELDS = `
     componentUuid
     componentName
@@ -228,13 +239,27 @@ const NONE_CHANGELOG_FIELDS = `
         ${RELEASE_INFO_FRAGMENT}
     }
     branches {
-        branchUuid
-        branchName
-        componentUuid
-        componentName
-        changeType
-        releases {
-            ${NONE_RELEASE_CHANGES_FRAGMENT}
+        ${NONE_BRANCH_CHANGES_FRAGMENT}
+    }
+`
+
+const NONE_PRODUCT_CHANGELOG_FIELDS = `
+    componentUuid
+    componentName
+    orgUuid
+    firstRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    lastRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    productReleases {
+        releaseUuid
+        version
+        lifecycle
+        createdDate
+        branches {
+            ${NONE_BRANCH_CHANGES_FRAGMENT}
         }
     }
 `
@@ -303,6 +328,9 @@ export async function fetchComponentChangelog(params: {
                     ... on NoneChangelog {
                         ${NONE_CHANGELOG_FIELDS}
                     }
+                    ... on NoneProductChangelog {
+                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
+                    }
                     ... on AggregatedChangelog {
                         ${AGGREGATED_CHANGELOG_FIELDS}
                     }
@@ -357,6 +385,9 @@ export async function fetchComponentChangelogByDate(params: {
                     __typename
                     ... on NoneChangelog {
                         ${NONE_CHANGELOG_FIELDS}
+                    }
+                    ... on NoneProductChangelog {
+                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
                     }
                     ... on AggregatedChangelog {
                         ${AGGREGATED_CHANGELOG_FIELDS}


### PR DESCRIPTION
## Context

The non-aggregated (NONE) **product** changelog rendered a flat chronological list of every child component release. A legacy version grouped changes per product release (a header per product release, with the child component releases that landed in it nested underneath). This restores that grouping across all three tabs — Component, SBOM, and Finding changes.

## Changes

- **Types** (`changelog-sealed.ts`): new `NoneProductChangelog` / `ProductReleaseChanges` interfaces, added to the `ComponentChangelog` union, plus an `isNoneProductChangelog` type guard.
- **Queries** (`changelogQueries.ts`): extracted a reusable `NONE_BRANCH_CHANGES_FRAGMENT`; added a `... on NoneProductChangelog` inline fragment to **both** the release-comparison and date-based queries.
- **`ChangelogView.vue`**: `hasData` / `displayBranches` are now typename-aware; new `displayProductReleases` computed; each of the three tabs gets a grouped rendering branch for `NoneProductChangelog` — a `ProductReleaseHeader` per product release, with the existing `ReleaseHeader` + per-tab display component for each child release nested underneath.
- **New `ProductReleaseHeader.vue`** component for the per-product-release group header.
- **`changelogPdfExport.ts`**: emits a full-width product-release section header per group in the NONE export for all three tabs; empty groups are skipped.

## Scope / notes

- AGGREGATED mode and plain-component NONE changelogs are unchanged. The change is backward compatible — it still handles `NoneChangelog`, so it is safe to deploy before the backend.
- **Paired with the backend change in `relizaio/rearm-saas`** (`relizaio/rearm-saas#84`), which adds the `NoneProductChangelog` type. Deploy this UI change first.
- `npm run build` passes. `npm run lint` is currently broken on `main` independently of this change — the repo's `.eslintrc.js` (legacy config) is incompatible with the lockfile-pinned ESLint 10 (flat-config only); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)