### PR TITLE
rebom-backend: verifySignature GraphQL mutation (draft)

### DIFF
--- a/rebom-backend/Dockerfile
+++ b/rebom-backend/Dockerfile
@@ -82,7 +82,9 @@ ENV \
     LANG=en_US.UTF-8
 RUN apk add --no-cache \
     icu-data-full \
-    icu-libs && \
+    icu-libs \
+    openssh-keygen \
+    gnupg && \
     mkdir /app && echo "version=$VERSION" > /app/version && echo "commit=$GIT_COMMIT" >> /app/version && echo "branch=$GIT_BRANCH" >> /app/version
 
 WORKDIR /app

--- a/rebom-backend/src/bomResolver.ts
+++ b/rebom-backend/src/bomResolver.ts
@@ -6,6 +6,7 @@ import { BomDto, BomMetaDto, BomInput, BomRecord, BomSearch, WeaknessDto, Vulner
 import * as IntegrationService from './services/integrationService';
 import { toGraphQLError } from './types/errors';
 import { bomToExcel, bomToCsv } from './services/bom/bomExportService';
+import { verifySignature as runVerifySignature, VerifyInput, VerifyResult } from './services/signatureVerifier';
 import { GraphQLError } from 'graphql';
 import { logger } from './logger';
 
@@ -105,7 +106,10 @@ const resolvers = {
 		}, 'updateBearSkipPatterns'),
 		deleteBearIntegration: withErrorHandling(async (_:any, input: { org: string }): Promise<boolean> => {
 			return IntegrationService.deleteBearIntegration(input.org);
-		}, 'deleteBearIntegration')
+		}, 'deleteBearIntegration'),
+		verifySignature: withErrorHandling(async (_:any, input: { input: VerifyInput }): Promise<VerifyResult> => {
+			return runVerifySignature(input.input);
+		}, 'verifySignature')
 	}
 }
 export default resolvers;

--- a/rebom-backend/src/schema.graphql.ts
+++ b/rebom-backend/src/schema.graphql.ts
@@ -34,6 +34,47 @@ const typeDefs = gql`
     setBearIntegration(org: ID!, uri: String!, apiKey: String!, skipPatterns: [String]): BearIntegration
     updateBearSkipPatterns(org: ID!, skipPatterns: [String]): BearIntegration
     deleteBearIntegration(org: ID!): Boolean!
+    """
+    Verify a detached signature against a payload using one of the
+    supported wire formats (SSH | GPG). The trust store is the
+    aggregated list of enrolled public keys for the org — passed
+    inline by rearm-backend so this resolver is stateless w.r.t.
+    the ReARM keystore. Never consults the public key embedded in
+    the signature blob; the trust store is authoritative.
+    """
+    verifySignature(input: VerifySignatureInput!): VerifySignatureResult!
+  }
+
+  input VerifySignatureInput {
+    format: VerifierSignatureFormat!
+    """Base64-encoded raw signature bytes (the gpgsig blob or the ssh-keygen -Y signature)."""
+    signatureB64: String!
+    """Base64-encoded signed payload bytes (commit object body, etc.)."""
+    payloadB64: String!
+    """Base64-encoded trust store — ssh allowed_signers file for SSH; concatenated ASCII-armoured pubkeys for GPG."""
+    trustStoreB64: String!
+    """SSH allowed_signers principal expected on the signature; optional."""
+    expectedIdentity: String
+  }
+
+  type VerifySignatureResult {
+    verdict: VerifierVerdict!
+    """Fingerprint of the enrolled key that matched, when verdict = VERIFIED."""
+    matchedFingerprint: String
+    """Free-form diagnostic for the UI / debugging."""
+    details: String
+  }
+
+  enum VerifierSignatureFormat {
+    SSH
+    GPG
+  }
+
+  enum VerifierVerdict {
+    VERIFIED
+    INVALID_SIGNATURE
+    UNKNOWN_KEY
+    ERRORED
   }
 
   type EnrichmentTriggerResult {

--- a/rebom-backend/src/services/signatureVerifier.ts
+++ b/rebom-backend/src/services/signatureVerifier.ts
@@ -83,6 +83,7 @@ async function verifySsh (input: VerifyInput): Promise<VerifyResult> {
     }
 
     let lastErr = 'no identity verified'
+    let sawInvalidSignature = false
     for (const identity of identitiesToTry) {
       const res = await runSshKeygenYVerify({
         sigPath,
@@ -94,9 +95,19 @@ async function verifySsh (input: VerifyInput): Promise<VerifyResult> {
       if (res.verdict === 'VERIFIED') {
         return res
       }
+      // Parse failures / subprocess errors are blob-level — they aren't going
+      // to change between principals, so don't mask them as UNKNOWN_KEY by
+      // continuing the loop. Surface them immediately.
+      if (res.verdict === 'ERRORED' || res.verdict === 'INVALID_SIGNATURE') {
+        if (res.verdict === 'INVALID_SIGNATURE') {
+          sawInvalidSignature = true
+        } else {
+          return res
+        }
+      }
       lastErr = res.details ?? lastErr
     }
-    return { verdict: 'UNKNOWN_KEY', details: lastErr }
+    return { verdict: sawInvalidSignature ? 'INVALID_SIGNATURE' : 'UNKNOWN_KEY', details: lastErr }
   } catch (e: any) {
     logger.error({ err: e }, 'SSH verifier failed')
     return { verdict: 'ERRORED', details: e?.message ?? String(e) }
@@ -142,6 +153,17 @@ function runSshKeygenYVerify (args: SshArgs): Promise<VerifyResult> {
         return
       }
       const text = combined.toLowerCase()
+      // Parse-level failures: the signature blob itself is malformed, so
+      // ssh-keygen never reaches the cryptographic check. Treat as ERRORED
+      // (subprocess-level fault) rather than INVALID_SIGNATURE (legitimately
+      // bad sig over a good blob).
+      if (text.includes("couldn't parse signature")
+          || text.includes('cannot parse signature')
+          || text.includes('invalid format')
+          || text.includes('sshsig_armor')) {
+        resolve({ verdict: 'ERRORED', details: combined })
+        return
+      }
       if (text.includes('signature verification failed') || text.includes('bad signature')) {
         resolve({ verdict: 'INVALID_SIGNATURE', details: combined })
       } else if (text.includes('no principal matched') || text.includes('not authorized') || text.includes('not found in')) {

--- a/rebom-backend/src/services/signatureVerifier.ts
+++ b/rebom-backend/src/services/signatureVerifier.ts
@@ -1,0 +1,244 @@
+// Signature verification subprocess wrapper for the verifySignature
+// GraphQL mutation. Two formats in v1:
+//
+//   SSH — ssh-keygen -Y verify, allowed_signers built from enrolled keys
+//   GPG — gpg --verify into a transient keyring built from enrolled
+//         ASCII-armoured pubkeys
+//
+// X.509 is not handled here in v1; rearm-backend short-circuits to
+// ERRORED before this resolver is reached.
+//
+// Trust-store assembly happens in rearm-backend; this service is
+// stateless w.r.t. enrolled keys — it accepts whatever wire-format
+// trust store the caller passes in.
+
+import { promises as fs } from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { spawn } from 'child_process'
+import { logger } from '../logger'
+
+export type VerifierVerdict = 'VERIFIED' | 'INVALID_SIGNATURE' | 'UNKNOWN_KEY' | 'ERRORED'
+
+export interface VerifyResult {
+  verdict: VerifierVerdict
+  matchedFingerprint?: string | null
+  details?: string | null
+}
+
+export interface VerifyInput {
+  format: 'SSH' | 'GPG'
+  signatureB64: string
+  payloadB64: string
+  trustStoreB64: string
+  expectedIdentity?: string | null
+}
+
+export async function verifySignature (input: VerifyInput): Promise<VerifyResult> {
+  switch (input.format) {
+    case 'SSH':
+      return verifySsh(input)
+    case 'GPG':
+      return verifyGpg(input)
+    default:
+      return { verdict: 'ERRORED', details: `Unknown format: ${input.format}` }
+  }
+}
+
+// ssh-keygen -Y verify -f allowed_signers -I <identity> -n <namespace>
+// -s <signature> < <payload>
+//
+// Reads the signature blob and payload from temp files. Identity in
+// the allowed_signers must match the -I we pass — when the caller
+// hasn't pinned an identity we sweep the allowed_signers and try
+// each principal until one verifies (so a single endpoint serves
+// the multi-key org case without the caller having to know which
+// key is "the" key).
+async function verifySsh (input: VerifyInput): Promise<VerifyResult> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'verify-ssh-'))
+  try {
+    const sigPath = path.join(tmpDir, 'signature.sig')
+    const payloadPath = path.join(tmpDir, 'payload.bin')
+    const allowedPath = path.join(tmpDir, 'allowed_signers')
+    await fs.writeFile(sigPath, Buffer.from(input.signatureB64, 'base64'))
+    await fs.writeFile(payloadPath, Buffer.from(input.payloadB64, 'base64'))
+    await fs.writeFile(allowedPath, Buffer.from(input.trustStoreB64, 'base64'))
+
+    const allowedSignersContent = (await fs.readFile(allowedPath, 'utf8')).trim()
+    if (!allowedSignersContent) {
+      return { verdict: 'UNKNOWN_KEY', details: 'Empty allowed_signers — no enrolled SSH keys for org' }
+    }
+
+    const identitiesToTry: string[] = input.expectedIdentity
+      ? [input.expectedIdentity]
+      : allowedSignersContent.split('\n')
+          .map((l) => l.split(/\s+/)[0])
+          .filter((s) => !!s && s !== '*')
+
+    if (identitiesToTry.length === 0) {
+      // Allowed_signers had wildcard principals only — ssh-keygen still needs
+      // a concrete -I, so synthesize one (the verifier ignores it when the
+      // entry uses *).
+      identitiesToTry.push('placeholder@reliza')
+    }
+
+    let lastErr = 'no identity verified'
+    for (const identity of identitiesToTry) {
+      const res = await runSshKeygenYVerify({
+        sigPath,
+        payloadPath,
+        allowedSignersPath: allowedPath,
+        identity,
+        namespace: 'git',
+      })
+      if (res.verdict === 'VERIFIED') {
+        return res
+      }
+      lastErr = res.details ?? lastErr
+    }
+    return { verdict: 'UNKNOWN_KEY', details: lastErr }
+  } catch (e: any) {
+    logger.error({ err: e }, 'SSH verifier failed')
+    return { verdict: 'ERRORED', details: e?.message ?? String(e) }
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => null)
+  }
+}
+
+interface SshArgs {
+  sigPath: string
+  payloadPath: string
+  allowedSignersPath: string
+  identity: string
+  namespace: string
+}
+
+function runSshKeygenYVerify (args: SshArgs): Promise<VerifyResult> {
+  return new Promise((resolve) => {
+    const proc = spawn('ssh-keygen', [
+      '-Y', 'verify',
+      '-f', args.allowedSignersPath,
+      '-I', args.identity,
+      '-n', args.namespace,
+      '-s', args.sigPath,
+    ], { stdio: ['pipe', 'pipe', 'pipe'] })
+    fs.readFile(args.payloadPath).then((buf) => {
+      proc.stdin.write(buf)
+      proc.stdin.end()
+    }).catch((e) => proc.kill())
+    let stdout = ''
+    let stderr = ''
+    proc.stdout.on('data', (chunk) => { stdout += chunk })
+    proc.stderr.on('data', (chunk) => { stderr += chunk })
+    proc.on('close', async (code) => {
+      const combined = `${stdout}\n${stderr}`.trim()
+      if (code === 0) {
+        // Compute fingerprint of the matching key for the verdict. The
+        // -Y verify output names the signer but not the fingerprint —
+        // we re-derive by feeding the allowed_signers principal back
+        // through `ssh-keygen -lf` against the line.
+        const fingerprint = await pickFingerprintForIdentity(args.allowedSignersPath, args.identity)
+        resolve({ verdict: 'VERIFIED', matchedFingerprint: fingerprint, details: combined })
+        return
+      }
+      const text = combined.toLowerCase()
+      if (text.includes('signature verification failed') || text.includes('bad signature')) {
+        resolve({ verdict: 'INVALID_SIGNATURE', details: combined })
+      } else if (text.includes('no principal matched') || text.includes('not authorized') || text.includes('not found in')) {
+        resolve({ verdict: 'UNKNOWN_KEY', details: combined })
+      } else {
+        resolve({ verdict: 'ERRORED', details: combined || `ssh-keygen exited ${code}` })
+      }
+    })
+  })
+}
+
+async function pickFingerprintForIdentity (allowedSignersPath: string, identity: string): Promise<string | null> {
+  try {
+    const text = await fs.readFile(allowedSignersPath, 'utf8')
+    const match = text.split('\n').find((l) => {
+      const principal = l.split(/\s+/)[0]
+      return principal === identity || principal === '*'
+    })
+    if (!match) return null
+    const parts = match.split(/\s+/)
+    const keyMaterial = parts.slice(1).join(' ').trim()
+    if (!keyMaterial) return null
+    return await fingerprintSshKey(keyMaterial)
+  } catch (e) {
+    return null
+  }
+}
+
+function fingerprintSshKey (keyLine: string): Promise<string | null> {
+  return new Promise(async (resolve) => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sshfp-'))
+    const keyPath = path.join(tmp, 'k.pub')
+    await fs.writeFile(keyPath, keyLine + '\n')
+    const proc = spawn('ssh-keygen', ['-lf', keyPath])
+    let out = ''
+    proc.stdout.on('data', (chunk) => { out += chunk })
+    proc.on('close', async () => {
+      await fs.rm(tmp, { recursive: true, force: true }).catch(() => null)
+      const parts = out.trim().split(/\s+/)
+      // Output: <bits> SHA256:<fp> <comment> (<type>)
+      resolve(parts[1] ?? null)
+    })
+  })
+}
+
+// gpg --verify <sig> <payload>, with the trust keyring assembled from
+// the concatenated ASCII-armoured pubkeys.
+async function verifyGpg (input: VerifyInput): Promise<VerifyResult> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'verify-gpg-'))
+  try {
+    const sigPath = path.join(tmpDir, 'signature.sig')
+    const payloadPath = path.join(tmpDir, 'payload.bin')
+    const keysPath = path.join(tmpDir, 'pubkeys.asc')
+    await fs.writeFile(sigPath, Buffer.from(input.signatureB64, 'base64'))
+    await fs.writeFile(payloadPath, Buffer.from(input.payloadB64, 'base64'))
+    await fs.writeFile(keysPath, Buffer.from(input.trustStoreB64, 'base64'))
+
+    if ((await fs.readFile(keysPath, 'utf8')).trim() === '') {
+      return { verdict: 'UNKNOWN_KEY', details: 'Empty GPG keyring — no enrolled GPG keys for org' }
+    }
+
+    const gpgHome = path.join(tmpDir, 'gnupg')
+    await fs.mkdir(gpgHome, { mode: 0o700 })
+    const env = { ...process.env, GNUPGHOME: gpgHome }
+
+    // Import enrolled keys.
+    await runProc('gpg', ['--batch', '--import', keysPath], env)
+
+    // Verify; gpg uses status-fd for machine-readable output.
+    const verify = await runProc('gpg', ['--batch', '--status-fd', '1', '--verify', sigPath, payloadPath], env)
+    const combined = `${verify.stdout}\n${verify.stderr}`.trim()
+    const goodSigMatch = /\[GNUPG:\] (?:GOODSIG|VALIDSIG) ([0-9A-Fa-f]+)/.exec(combined)
+    if (goodSigMatch) {
+      return { verdict: 'VERIFIED', matchedFingerprint: goodSigMatch[1].toUpperCase(), details: combined }
+    }
+    if (/BADSIG|ERRSIG/.test(combined)) {
+      return { verdict: 'INVALID_SIGNATURE', details: combined }
+    }
+    if (/NO_PUBKEY|NODATA|FAILURE/.test(combined)) {
+      return { verdict: 'UNKNOWN_KEY', details: combined }
+    }
+    return { verdict: 'ERRORED', details: combined }
+  } catch (e: any) {
+    logger.error({ err: e }, 'GPG verifier failed')
+    return { verdict: 'ERRORED', details: e?.message ?? String(e) }
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => null)
+  }
+}
+
+function runProc (cmd: string, args: string[], env: NodeJS.ProcessEnv): Promise<{ stdout: string, stderr: string, code: number | null }> {
+  return new Promise((resolve) => {
+    const proc = spawn(cmd, args, { env })
+    let stdout = ''
+    let stderr = ''
+    proc.stdout.on('data', (chunk) => { stdout += chunk })
+    proc.stderr.on('data', (chunk) => { stderr += chunk })
+    proc.on('close', (code) => resolve({ stdout, stderr, code }))
+  })
+}

--- a/ui/src/components/AiAgentPolicyView.vue
+++ b/ui/src/components/AiAgentPolicyView.vue
@@ -230,7 +230,8 @@ const variableDocs: VariableDoc[] = [
     { name: 'session.title',             snippet: 'session.title',                                                           display: 'session.title',             desc: 'string — agent-supplied title' },
     { name: 'session.clientSessionId',   snippet: 'session.clientSessionId',                                                 display: 'session.clientSessionId',   desc: 'string — agent-supplied session id' },
     { name: 'session.artifacts',         snippet: 'session.artifacts',                                                       display: 'session.artifacts',         desc: 'list of <code>{ uuid, type, displayIdentifier, bomFormat, tags[] }</code>' },
-    { name: 'session.commits',           snippet: 'session.commits',                                                         display: 'session.commits',           desc: 'list&lt;string&gt; — SCE uuids' },
+    { name: 'session.commits',           snippet: 'session.commits',                                                         display: 'session.commits',           desc: 'list of <code>{ uuid, commit, vcsBranch, commitAuthor, commitEmail, agent, agentSession, signature }</code>' },
+    { name: 'session.commits[].signature', snippet: 'session.commits[0].signature.state',                                    display: 'session.commits[].signature', desc: 'object — <code>{ state, format, signedByOwnerType, signedByOwnerUuid, keyFingerprint, verifiedAt }</code>. <code>state</code> ∈ { UNSIGNED, VERIFIED, INVALID_SIGNATURE, UNKNOWN_KEY, KEY_REVOKED, WRONG_SIGNER, PENDING, ERRORED }' },
     { name: 'agent.name',                snippet: 'agent.name',                                                              display: 'agent.name',                desc: 'string — display name' },
     { name: 'agent.agentType',           snippet: 'agent.agentType',                                                         display: 'agent.agentType',           desc: 'string — <code>ROOT</code> / <code>SUB</code>' },
     { name: 'agent.agentIdentity',       snippet: 'agent.agentIdentity',                                                     display: 'agent.agentIdentity',       desc: 'string — identity-scope uuid' },
@@ -252,6 +253,10 @@ const snippetDocs: SnippetDoc[] = [
       cel: 'model.name == "claude-opus-4-7" || model.name == "claude-sonnet-4-6"' },
     { label: 'No more than 20 commits per session',
       cel: 'size(session.commits) <= 20' },
+    { label: 'All commits verified-signed',
+      cel: 'session.commits.all(c, c.signature.state == "VERIFIED")' },
+    { label: 'All commits signed by session agent',
+      cel: 'session.commits.all(c, c.signature.state == "VERIFIED" && c.signature.signedByOwnerType == "AGENT" && c.signature.signedByOwnerUuid == agent.uuid)' },
 ]
 
 // Full-form scaffolds. Each one overwrites every field.
@@ -290,6 +295,20 @@ const samples = [
         kind: 'OUTPUT',
         severity: 'WARN',
         cel: 'size(session.commits) <= 20',
+    },
+    {
+        name: 'All commits verified-signed',
+        description: 'Every commit attributed to this session must have a VERIFIED signature against an enrolled key.',
+        kind: 'OUTPUT',
+        severity: 'BLOCK',
+        cel: 'session.commits.all(c, c.signature.state == "VERIFIED")',
+    },
+    {
+        name: 'Commits signed by session agent',
+        description: 'Cryptographic agentic attribution — every commit in the session must be VERIFIED and signed by a key enrolled to this session\u2019s agent (not a committer key, not another agent).',
+        kind: 'OUTPUT',
+        severity: 'BLOCK',
+        cel: 'session.commits.all(c, c.signature.state == "VERIFIED" && c.signature.signedByOwnerType == "AGENT" && c.signature.signedByOwnerUuid == agent.uuid)',
     },
 ]
 

--- a/ui/src/components/AiAgentSessionView.vue
+++ b/ui/src/components/AiAgentSessionView.vue
@@ -85,7 +85,7 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NBreadcrumb, NBreadcrumbItem, NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, NButton, DataTableColumns, useNotification } from 'naive-ui'
+import { NBreadcrumb, NBreadcrumbItem, NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, NButton, NTooltip, DataTableColumns, useNotification } from 'naive-ui'
 import { fetchArrayBufferWithAuth } from '@/utils/fetchClient'
 
 const store = useStore()
@@ -232,6 +232,28 @@ function openPolicy (uuid: string) {
     })
 }
 
+function renderSignatureBadge (sig: any) {
+    if (!sig || !sig.state || sig.state === 'UNSIGNED') {
+        return h(NTag, { size: 'tiny', type: 'default' }, { default: () => 'unsigned' })
+    }
+    const state = sig.state as string
+    const tone: 'success' | 'warning' | 'error' | 'default' =
+        state === 'VERIFIED' ? 'success'
+        : state === 'INVALID_SIGNATURE' || state === 'WRONG_SIGNER' || state === 'ERRORED' ? 'error'
+        : state === 'UNKNOWN_KEY' || state === 'KEY_REVOKED' ? 'warning'
+        : 'default'
+    const tip = [
+        sig.format ? `format: ${sig.format}` : '',
+        sig.signedByOwnerType ? `owner: ${sig.signedByOwnerType}` : '',
+        sig.keyFingerprint ? `fp: ${sig.keyFingerprint}` : '',
+        sig.verifiedAt ? `verified: ${new Date(sig.verifiedAt).toLocaleString('en-CA')}` : '',
+    ].filter(Boolean).join(' · ')
+    return h(NTooltip, {}, {
+        trigger: () => h(NTag, { size: 'tiny', type: tone, bordered: false }, { default: () => state }),
+        default: () => tip || state,
+    })
+}
+
 const commitColumns: DataTableColumns<any> = [
     {
         title: 'Commit',
@@ -247,6 +269,12 @@ const commitColumns: DataTableColumns<any> = [
         },
     },
     { title: 'Branch', key: 'vcsBranch', render: (row: any) => row.vcsBranch ? h('code', null, row.vcsBranch) : '—' },
+    {
+        title: 'Signature',
+        key: 'signature',
+        width: 130,
+        render: (row: any) => renderSignatureBadge(row.signature),
+    },
     {
         title: 'Message',
         key: 'commitMessage',

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -42,6 +42,14 @@
                     :pagination="{ pageSize: 10 }"
                 />
             </n-tab-pane>
+            <n-tab-pane name="keys" tab="Signing keys">
+                <SigningKeyManager
+                    v-if="agent?.org && agent?.uuid"
+                    :org="agent.org"
+                    owner-type="AGENT"
+                    :owner-uuid="agent.uuid"
+                />
+            </n-tab-pane>
             <n-tab-pane name="metadata" tab="Metadata">
                 <n-descriptions :column="1" bordered label-placement="left" label-align="left" :label-style="metaLabelStyle">
                     <n-descriptions-item label="UUID"><code>{{ agent.uuid }}</code></n-descriptions-item>
@@ -81,6 +89,7 @@ import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NBreadcrumb, NBreadcrumbItem, NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, NButton, NInput, DataTableColumns, useNotification } from 'naive-ui'
 import SessionTable from './AiAgentSessionTable.vue'
+import SigningKeyManager from './SigningKeyManager.vue'
 
 const store = useStore()
 const route = useRoute()

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -8,7 +8,10 @@
                     produce artifacts, commits, pull requests and releases.
                 </p>
             </div>
-            <n-button quaternary @click="openPolicies">Manage policies →</n-button>
+            <n-space>
+                <n-button quaternary @click="openCommitters">Manage committers →</n-button>
+                <n-button quaternary @click="openPolicies">Manage policies →</n-button>
+            </n-space>
         </div>
 
         <n-spin v-if="loading" size="small"/>
@@ -137,6 +140,10 @@ function openSession (uuid: string) {
 
 function openPolicies () {
     router.push({ name: 'AiAgentPoliciesOfOrg', params: { orguuid: orgUuid.value } })
+}
+
+function openCommitters () {
+    router.push({ name: 'CommittersOfOrg', params: { orguuid: orgUuid.value } })
 }
 
 const sessionColumns: DataTableColumns<any> = [

--- a/ui/src/components/CommitterView.vue
+++ b/ui/src/components/CommitterView.vue
@@ -1,0 +1,89 @@
+<template>
+    <div class="committerView" v-if="committer">
+        <n-breadcrumb separator="›" class="crumbs">
+            <n-breadcrumb-item @click="openAgentsOfOrg">AI Agents</n-breadcrumb-item>
+            <n-breadcrumb-item @click="openCommitters">Committers</n-breadcrumb-item>
+            <n-breadcrumb-item>{{ committer.name }}</n-breadcrumb-item>
+        </n-breadcrumb>
+
+        <div class="hero">
+            <h3>{{ committer.name }}</h3>
+            <n-tag size="small" :type="committer.status === 'ACTIVE' ? 'success' : 'default'">{{ committer.status }}</n-tag>
+        </div>
+
+        <n-descriptions :column="1" bordered label-placement="left" label-align="left" :label-style="metaLabelStyle">
+            <n-descriptions-item label="UUID"><code>{{ committer.uuid }}</code></n-descriptions-item>
+            <n-descriptions-item label="Email"><code>{{ committer.email }}</code></n-descriptions-item>
+            <n-descriptions-item label="Aliases">
+                <span v-if="committer.aliases?.length">
+                    <code v-for="a in committer.aliases" :key="a" style="margin-right: 6px;">{{ a }}</code>
+                </span>
+                <span v-else class="dim">—</span>
+            </n-descriptions-item>
+            <n-descriptions-item label="Linked user">
+                <code v-if="committer.user">{{ committer.user }}</code>
+                <span v-else class="dim">— (external contributor)</span>
+            </n-descriptions-item>
+            <n-descriptions-item label="Created">{{ formatDate(committer.createdDate) }}</n-descriptions-item>
+        </n-descriptions>
+
+        <SigningKeyManager
+            v-if="committer.org"
+            :org="committer.org"
+            owner-type="COMMITTER"
+            :owner-uuid="committer.uuid"
+            style="margin-top: 16px;"
+        />
+    </div>
+    <n-spin v-else size="small"/>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import { NBreadcrumb, NBreadcrumbItem, NDescriptions, NDescriptionsItem, NSpin, NTag, useNotification } from 'naive-ui'
+import SigningKeyManager from './SigningKeyManager.vue'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+const notification = useNotification()
+
+const uuid = computed(() => route.params.uuid as string)
+const committer = ref<any>(null)
+const metaLabelStyle = { width: '180px' }
+
+onMounted(load)
+
+async function load () {
+    try {
+        committer.value = await store.dispatch('fetchCommitter', uuid.value)
+    } catch (e: any) {
+        notification.error({ content: `Failed to load committer: ${e?.message ?? e}` })
+    }
+}
+
+function openAgentsOfOrg () {
+    if (committer.value?.org) router.push({ name: 'AiAgentsOfOrg', params: { orguuid: committer.value.org } })
+    else router.back()
+}
+
+function openCommitters () {
+    if (committer.value?.org) router.push({ name: 'CommittersOfOrg', params: { orguuid: committer.value.org } })
+    else router.back()
+}
+
+function formatDate (s: any) {
+    return s ? new Date(s).toLocaleString('en-CA') : '—'
+}
+</script>
+
+<style scoped>
+.committerView { padding: 16px; }
+.crumbs { margin-bottom: 12px; font-size: 13px; }
+.crumbs :deep(.n-breadcrumb-item__link) { cursor: pointer; }
+.hero { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+.hero h3 { margin: 0; }
+.dim { color: var(--n-text-color-3, #666); }
+</style>

--- a/ui/src/components/CommittersOfOrg.vue
+++ b/ui/src/components/CommittersOfOrg.vue
@@ -1,0 +1,223 @@
+<template>
+    <div class="committersOfOrg">
+        <n-breadcrumb separator="›" class="crumbs">
+            <n-breadcrumb-item @click="openAgentsOfOrg">AI Agents</n-breadcrumb-item>
+            <n-breadcrumb-item>Committers</n-breadcrumb-item>
+        </n-breadcrumb>
+        <div class="head">
+            <div class="title-row">
+                <h4>Committers</h4>
+                <n-tooltip trigger="hover" :width="380" placement="bottom-start">
+                    <template #trigger>
+                        <n-icon size="16" class="info-icon">
+                            <QuestionCircle20Regular/>
+                        </n-icon>
+                    </template>
+                    Natural-person (or external-bot) commit authors the verifier
+                    resolves a signed commit back to. Each committer owns one or
+                    more enrolled signing keys; CEL approval policies can require
+                    "all commits in this release must be signed by an approved
+                    committer".
+                </n-tooltip>
+            </div>
+            <n-button @click="createNew" type="primary">+ New committer</n-button>
+        </div>
+
+        <n-spin v-if="loading" size="small"/>
+        <div v-else>
+            <div v-if="!committers.length" class="empty">
+                No committers enrolled yet. Click <strong>New committer</strong> to add one.
+            </div>
+            <n-data-table v-else :columns="columns" :data="committers" :pagination="{ pageSize: 25 }"/>
+        </div>
+
+        <!-- Create / edit dialog -->
+        <n-modal v-model:show="showDialog" preset="card" :title="dialogTitle" style="width: 560px;">
+            <n-form label-placement="top">
+                <n-form-item label="Name" required>
+                    <n-input v-model:value="draft.name" placeholder="e.g. Alex Doe"/>
+                </n-form-item>
+                <n-form-item label="Email" required>
+                    <n-input v-model:value="draft.email" placeholder="alex@example.com"/>
+                </n-form-item>
+                <n-form-item label="Aliases (comma-separated)">
+                    <n-input v-model:value="draft.aliasesText" placeholder="alex@old.example.com"/>
+                </n-form-item>
+                <n-form-item label="Linked ReARM user UUID (optional)">
+                    <n-input v-model:value="draft.user" placeholder="leave blank for external contributor"/>
+                </n-form-item>
+            </n-form>
+            <template #footer>
+                <n-space>
+                    <n-button @click="showDialog = false">Cancel</n-button>
+                    <n-button type="primary" :loading="saving" @click="saveDraft">Save</n-button>
+                </n-space>
+            </template>
+        </n-modal>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import {
+    NBreadcrumb, NBreadcrumbItem, NButton, NDataTable, NForm, NFormItem,
+    NIcon, NInput, NModal, NPopconfirm, NSpace, NSpin, NTag, NTooltip,
+    DataTableColumns, useNotification,
+} from 'naive-ui'
+import { QuestionCircle20Regular } from '@vicons/fluent'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+const notification = useNotification()
+
+const orgUuid = computed(() => route.params.orguuid as string)
+const committers = ref<any[]>([])
+const loading = ref<boolean>(true)
+const showDialog = ref<boolean>(false)
+const saving = ref<boolean>(false)
+const draft = ref<{ uuid?: string, name: string, email: string, aliasesText: string, user: string }>({
+    name: '', email: '', aliasesText: '', user: '',
+})
+
+const dialogTitle = computed(() => draft.value.uuid ? 'Edit committer' : 'New committer')
+
+onMounted(load)
+
+async function load () {
+    loading.value = true
+    try {
+        committers.value = await store.dispatch('fetchCommittersOfOrg', orgUuid.value) || []
+    } catch (e: any) {
+        notification.error({ content: `Failed to load committers: ${e?.message ?? e}` })
+    } finally {
+        loading.value = false
+    }
+}
+
+function openAgentsOfOrg () {
+    router.push({ name: 'AiAgentsOfOrg', params: { orguuid: orgUuid.value } })
+}
+
+function createNew () {
+    draft.value = { name: '', email: '', aliasesText: '', user: '' }
+    showDialog.value = true
+}
+
+function edit (row: any) {
+    draft.value = {
+        uuid: row.uuid,
+        name: row.name ?? '',
+        email: row.email ?? '',
+        aliasesText: (row.aliases ?? []).join(', '),
+        user: row.user ?? '',
+    }
+    showDialog.value = true
+}
+
+async function saveDraft () {
+    if (!draft.value.name.trim() || !draft.value.email.trim()) {
+        notification.warning({ content: 'Name and email are required' })
+        return
+    }
+    saving.value = true
+    try {
+        const input: any = {
+            org: orgUuid.value,
+            name: draft.value.name.trim(),
+            email: draft.value.email.trim().toLowerCase(),
+        }
+        if (draft.value.uuid) input.uuid = draft.value.uuid
+        if (draft.value.user.trim()) input.user = draft.value.user.trim()
+        const aliases = draft.value.aliasesText.split(',').map((a) => a.trim().toLowerCase()).filter(Boolean)
+        if (aliases.length) input.aliases = aliases
+        const saved = await store.dispatch('upsertCommitter', input)
+        notification.success({ content: `Saved "${saved.name}"` })
+        showDialog.value = false
+        await load()
+    } catch (e: any) {
+        notification.error({ content: `Save failed: ${e?.message ?? e}` })
+    } finally {
+        saving.value = false
+    }
+}
+
+async function archive (row: any) {
+    try {
+        await store.dispatch('archiveCommitter', row.uuid)
+        notification.success({ content: `Archived "${row.name}"` })
+        await load()
+    } catch (e: any) {
+        notification.error({ content: `Archive failed: ${e?.message ?? e}` })
+    }
+}
+
+function openCommitter (uuid: string) {
+    router.push({ name: 'CommitterView', params: { uuid } })
+}
+
+function formatDate (s: any) {
+    return s ? new Date(s).toLocaleString('en-CA') : '—'
+}
+
+const columns = computed<DataTableColumns<any>>(() => [
+    {
+        title: 'Name',
+        key: 'name',
+        render: (row: any) => h('a', {
+            href: '#',
+            onClick: (e: Event) => { e.preventDefault(); openCommitter(row.uuid) },
+        }, row.name),
+    },
+    { title: 'Email', key: 'email', render: (row: any) => h('code', null, row.email) },
+    {
+        title: 'Keys',
+        key: 'keys',
+        width: 90,
+        render: (row: any) => {
+            const ks = row.signingKeys ?? []
+            const active = ks.filter((k: any) => !k.revokedAt).length
+            return `${active} active${ks.length > active ? ` / ${ks.length} total` : ''}`
+        },
+    },
+    {
+        title: 'Status',
+        key: 'status',
+        width: 110,
+        render: (row: any) => h(NTag, { size: 'small', type: row.status === 'ACTIVE' ? 'success' : 'default' },
+            { default: () => row.status }),
+    },
+    { title: 'Created', key: 'createdDate', width: 170, render: (row: any) => formatDate(row.createdDate) },
+    {
+        title: '',
+        key: 'actions',
+        width: 160,
+        render: (row: any) => h(NSpace, { size: 'small' }, {
+            default: () => [
+                h(NButton, { size: 'tiny', quaternary: true, onClick: () => edit(row) }, { default: () => 'Edit' }),
+                row.status === 'ACTIVE'
+                    ? h(NPopconfirm, {
+                        onPositiveClick: () => archive(row),
+                    }, {
+                        trigger: () => h(NButton, { size: 'tiny', quaternary: true, type: 'warning' }, { default: () => 'Archive' }),
+                        default: () => `Archive "${row.name}"? Past verdicts keep their owner uuid; new verdicts won't bind to a revoked-only committer.`,
+                    })
+                    : null,
+            ].filter(Boolean),
+        }),
+    },
+])
+</script>
+
+<style scoped>
+.committersOfOrg { padding: 16px; }
+.crumbs { margin-bottom: 12px; font-size: 13px; }
+.crumbs :deep(.n-breadcrumb-item__link) { cursor: pointer; }
+.head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 16px; }
+.title-row { display: flex; align-items: center; gap: 8px; }
+.title-row h4 { margin: 0; }
+.info-icon { color: #888; cursor: help; }
+.empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 12px 0; }
+</style>

--- a/ui/src/components/SigningKeyManager.vue
+++ b/ui/src/components/SigningKeyManager.vue
@@ -1,0 +1,204 @@
+<template>
+    <div class="signingKeyManager">
+        <div class="head">
+            <div class="title-row">
+                <h5>Signing keys</h5>
+                <n-tooltip trigger="hover" :width="380" placement="bottom-start">
+                    <template #trigger>
+                        <n-icon size="14" class="info-icon">
+                            <QuestionCircle20Regular/>
+                        </n-icon>
+                    </template>
+                    Public keys the verifier matches signatures against. The
+                    fingerprint is the trust anchor — ReARM never trusts the
+                    public key embedded in a signature blob, only what's
+                    enrolled here. Revoked keys keep verifying historical
+                    SCEs but never bind new commits.
+                </n-tooltip>
+            </div>
+            <n-button size="small" type="primary" @click="showEnroll = true">+ Enrol key</n-button>
+        </div>
+        <div v-if="!keys.length" class="empty">No keys enrolled.</div>
+        <n-data-table v-else :columns="columns" :data="keys" :pagination="{ pageSize: 10 }" size="small"/>
+
+        <n-modal v-model:show="showEnroll" preset="card" title="Enrol public key" style="width: 640px;">
+            <n-form label-placement="top">
+                <n-form-item label="Format" required>
+                    <n-radio-group v-model:value="draft.format">
+                        <n-radio-button value="SSH">SSH</n-radio-button>
+                        <n-radio-button value="GPG">GPG</n-radio-button>
+                    </n-radio-group>
+                </n-form-item>
+                <n-form-item label="Public key" required>
+                    <n-input v-model:value="draft.pubKey" type="textarea" :rows="6"
+                             :placeholder="draft.format === 'SSH'
+                                 ? 'ssh-ed25519 AAAAC3... user@example.com'
+                                 : '-----BEGIN PGP PUBLIC KEY BLOCK-----\\n…\\n-----END PGP PUBLIC KEY BLOCK-----'"
+                             style="font-family: monospace;"/>
+                </n-form-item>
+                <n-form-item required>
+                    <template #label>
+                        Fingerprint
+                        <n-tooltip trigger="hover" :width="320">
+                            <template #trigger>
+                                <n-icon size="12" class="info-icon"><QuestionCircle20Regular/></n-icon>
+                            </template>
+                            SSH: SHA256:&lt;base64&gt; (from <code>ssh-keygen -lf</code>).<br>
+                            GPG: long key id (16 hex chars uppercase).<br>
+                            Auto-derived from the pubkey is not done in the
+                            web UI in v1 — paste the value from your local
+                            tool, or use <code>rearm agent enrollkey</code> /
+                            <code>rearm committer enrollkey</code> on the CLI.
+                        </n-tooltip>
+                    </template>
+                    <n-input v-model:value="draft.fingerprint"
+                             :placeholder="draft.format === 'SSH' ? 'SHA256:...' : '0123456789ABCDEF'"/>
+                </n-form-item>
+                <n-form-item :label="`Identity${draft.format === 'SSH' ? ' (required for SSH)' : ' (optional)'}`">
+                    <n-input v-model:value="draft.identity" placeholder="email or principal"/>
+                </n-form-item>
+            </n-form>
+            <template #footer>
+                <n-space>
+                    <n-button @click="showEnroll = false">Cancel</n-button>
+                    <n-button type="primary" :loading="enrolling" :disabled="!canEnrol" @click="enrol">Enrol</n-button>
+                </n-space>
+            </template>
+        </n-modal>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref, watch } from 'vue'
+import { useStore } from 'vuex'
+import {
+    NButton, NDataTable, NForm, NFormItem, NIcon, NInput, NModal, NPopconfirm,
+    NRadioButton, NRadioGroup, NSpace, NTag, NTooltip,
+    DataTableColumns, useNotification,
+} from 'naive-ui'
+import { QuestionCircle20Regular } from '@vicons/fluent'
+
+const props = defineProps<{
+    org: string,
+    ownerType: 'AGENT' | 'COMMITTER',
+    ownerUuid: string,
+}>()
+
+const store = useStore()
+const notification = useNotification()
+
+const keys = ref<any[]>([])
+const showEnroll = ref<boolean>(false)
+const enrolling = ref<boolean>(false)
+const draft = ref<{ format: 'SSH' | 'GPG', pubKey: string, fingerprint: string, identity: string }>({
+    format: 'SSH', pubKey: '', fingerprint: '', identity: '',
+})
+
+const canEnrol = computed(() => !!draft.value.pubKey.trim()
+    && !!draft.value.fingerprint.trim()
+    && (draft.value.format !== 'SSH' || !!draft.value.identity.trim()))
+
+onMounted(load)
+watch(() => props.ownerUuid, load)
+
+async function load () {
+    if (!props.org || !props.ownerType || !props.ownerUuid) return
+    try {
+        keys.value = await store.dispatch('fetchSigningKeysOfOwner', {
+            orgUuid: props.org,
+            ownerType: props.ownerType,
+            ownerUuid: props.ownerUuid,
+        }) || []
+    } catch (e: any) {
+        notification.error({ content: `Failed to load keys: ${e?.message ?? e}` })
+    }
+}
+
+async function enrol () {
+    enrolling.value = true
+    try {
+        const input: any = {
+            org: props.org,
+            format: draft.value.format,
+            ownerType: props.ownerType,
+            ownerUuid: props.ownerUuid,
+            fingerprint: draft.value.fingerprint.trim(),
+            pubKey: draft.value.pubKey.trim(),
+        }
+        if (draft.value.identity.trim()) input.identity = draft.value.identity.trim()
+        const saved = await store.dispatch('enrollSigningKey', input)
+        notification.success({ content: `Enrolled ${saved.format} key ${saved.fingerprint}` })
+        showEnroll.value = false
+        draft.value = { format: 'SSH', pubKey: '', fingerprint: '', identity: '' }
+        await load()
+    } catch (e: any) {
+        notification.error({ content: `Enrol failed: ${e?.message ?? e}`, duration: 8000 })
+    } finally {
+        enrolling.value = false
+    }
+}
+
+async function revoke (row: any) {
+    try {
+        await store.dispatch('revokeSigningKey', row.uuid)
+        notification.success({ content: `Revoked key ${row.fingerprint}` })
+        await load()
+    } catch (e: any) {
+        notification.error({ content: `Revoke failed: ${e?.message ?? e}` })
+    }
+}
+
+function formatDate (s: any) {
+    return s ? new Date(s).toLocaleString('en-CA') : '—'
+}
+
+const columns = computed<DataTableColumns<any>>(() => [
+    {
+        title: 'Format',
+        key: 'format',
+        width: 80,
+        render: (row: any) => h(NTag, { size: 'small', type: row.format === 'SSH' ? 'info' : 'default' },
+            { default: () => row.format }),
+    },
+    {
+        title: 'Fingerprint',
+        key: 'fingerprint',
+        render: (row: any) => h('code', { class: 'fp' }, row.fingerprint),
+    },
+    {
+        title: 'Identity',
+        key: 'identity',
+        render: (row: any) => row.identity ? h('code', null, row.identity) : '—',
+    },
+    {
+        title: 'Status',
+        key: 'status',
+        width: 110,
+        render: (row: any) => row.revokedAt
+            ? h(NTag, { size: 'tiny', type: 'error' }, { default: () => `REVOKED ${formatDate(row.revokedAt)}` })
+            : h(NTag, { size: 'tiny', type: 'success' }, { default: () => 'ACTIVE' }),
+    },
+    { title: 'Enrolled', key: 'createdDate', width: 170, render: (row: any) => formatDate(row.createdDate) },
+    {
+        title: '',
+        key: 'actions',
+        width: 100,
+        render: (row: any) => row.revokedAt ? null : h(NPopconfirm, {
+            onPositiveClick: () => revoke(row),
+        }, {
+            trigger: () => h(NButton, { size: 'tiny', quaternary: true, type: 'error' }, { default: () => 'Revoke' }),
+            default: () => `Revoke this key? Past verdicts keep their VERIFIED state; future commits signed with this key will land KEY_REVOKED.`,
+        }),
+    },
+])
+</script>
+
+<style scoped>
+.signingKeyManager { padding: 8px 0; }
+.head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
+.title-row { display: flex; align-items: center; gap: 6px; }
+.title-row h5 { margin: 0; }
+.info-icon { color: #888; cursor: help; }
+.empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 8px 0; }
+:deep(.fp) { font-size: 11px; word-break: break-all; }
+</style>

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -75,6 +75,16 @@ const routes : any[] = [
         component: () => import('@/components/AiAgentPolicyView.vue')
     },
     {
+        path: '/committersOfOrg/:orguuid',
+        name: 'CommittersOfOrg',
+        component: () => import('@/components/CommittersOfOrg.vue')
+    },
+    {
+        path: '/committer/:uuid',
+        name: 'CommitterView',
+        component: () => import('@/components/CommitterView.vue')
+    },
+    {
         path: '/secretsOfOrg/:orguuid',
         name: 'SecretsOfOrg',
         component: () => import('@/components/SecretsOfOrg.vue')

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -2192,6 +2192,14 @@ const storeObject : any = {
                                     name
                                 }
                             }
+                            signature {
+                                state
+                                format
+                                signedByOwnerType
+                                signedByOwnerUuid
+                                keyFingerprint
+                                verifiedAt
+                            }
                         }
                     }`,
                 variables: { sceUuid: uuid },
@@ -2313,6 +2321,107 @@ const storeObject : any = {
                 variables: { uuid }
             })
             return response.data.deleteAgentPolicy
+        },
+
+        // ---- Committers / signing keys / verifications ----
+
+        async fetchCommittersOfOrg (context: any, orgUuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query committersOfOrg($orgUuid: ID!) {
+                        committersOfOrg(orgUuid: $orgUuid) {
+                            uuid org name email user aliases status createdDate
+                            signingKeys { uuid format fingerprint identity createdDate revokedAt }
+                        }
+                    }`,
+                variables: { orgUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.committersOfOrg
+        },
+        async fetchCommitter (context: any, uuid: string) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query committer($uuid: ID!) {
+                        committer(uuid: $uuid) {
+                            uuid org name email user aliases status createdDate
+                            signingKeys { uuid format fingerprint identity pubKey createdDate revokedAt firstSeenAt }
+                        }
+                    }`,
+                variables: { uuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.committer
+        },
+        async upsertCommitter (context: any, input: any) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation upsertCommitter($input: CommitterInput!) {
+                        upsertCommitter(input: $input) {
+                            uuid org name email user aliases status createdDate
+                        }
+                    }`,
+                variables: { input }
+            })
+            return response.data.upsertCommitter
+        },
+        async archiveCommitter (context: any, uuid: string) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation archiveCommitter($uuid: ID!) {
+                        archiveCommitter(uuid: $uuid) { uuid status }
+                    }`,
+                variables: { uuid }
+            })
+            return response.data.archiveCommitter
+        },
+
+        async fetchSigningKeysOfOwner (context: any, payload: { orgUuid: string, ownerType: string, ownerUuid: string }) {
+            const response = await graphqlClient.query({
+                query: gql`
+                    query signingKeysOfOwner($orgUuid: ID!, $ownerType: SigningKeyOwnerType!, $ownerUuid: ID!) {
+                        signingKeysOfOwner(orgUuid: $orgUuid, ownerType: $ownerType, ownerUuid: $ownerUuid) {
+                            uuid format ownerType ownerUuid fingerprint identity pubKey createdDate revokedAt firstSeenAt
+                        }
+                    }`,
+                variables: payload,
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.signingKeysOfOwner
+        },
+        async enrollSigningKey (context: any, input: any) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation enrollSigningKey($input: SigningKeyInput!) {
+                        enrollSigningKey(input: $input) {
+                            uuid format ownerType ownerUuid fingerprint identity createdDate
+                        }
+                    }`,
+                variables: { input }
+            })
+            return response.data.enrollSigningKey
+        },
+        async revokeSigningKey (context: any, uuid: string) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation revokeSigningKey($uuid: ID!) {
+                        revokeSigningKey(uuid: $uuid) { uuid revokedAt }
+                    }`,
+                variables: { uuid }
+            })
+            return response.data.revokeSigningKey
+        },
+        async verifySignature (context: any, input: any) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation verifySignature($input: VerifySignatureInput!) {
+                        verifySignature(input: $input) {
+                            uuid verdict ownerType ownerUuid keyFingerprint format details verifiedAt
+                        }
+                    }`,
+                variables: { input }
+            })
+            return response.data.verifySignature
         },
     },
 }


### PR DESCRIPTION
## Summary

Companion PR to relizaio/rearm-saas#85. Adds the cryptographic-check end of the commit-signature verification pipeline as a GraphQL mutation on rebom-backend. rearm-backend calls into it via the existing RebomService channel (no new public REST surface).

## What is in this draft

- New GraphQL mutation verifySignature(input: VerifySignatureInput!) with VerifySignatureResult / VerifierSignatureFormat / VerifierVerdict types.
- signatureVerifier.ts service: SSH path shells out to ssh-keygen -Y verify against an inline allowed_signers file; GPG path imports concatenated ASCII-armoured pubkeys into a transient keyring and runs gpg --status-fd 1 --verify.
- Dockerfile runtime image picks up openssh-keygen + gnupg.

## Design notes

- Stateless w.r.t. ReARM's keystore — trust store is passed inline as base64 by rearm-backend. rebom-backend never opens a connection to the ReARM DB and never holds long-lived keys.
- SSH multi-key sweep — when the caller does not pin expectedIdentity, the resolver tries every principal in allowed_signers until one verifies. This means a single rebom endpoint serves the multi-enrolled-key case without the caller having to know which key is right.
- Matched fingerprint is computed by re-feeding the allowed_signers line through ssh-keygen -lf (the -Y verify output names the principal but not the fingerprint).

## Follow-ups

- Sigstore X.509 verification — same shape (`format: X509`) but trust anchored at CA certs rather than per-key. Wired in for v2; relizaio/rearm-saas#85 short-circuits to ERRORED for now.
- Image / SBOM signature attestation — same mutation, just feed it the right artifact bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)