### PR TITLE
fix(ui): drop release.type from instance-page diff query — fixes 400

### DIFF
--- a/ui/src/components/ReleaseRevision.vue
+++ b/ui/src/components/ReleaseRevision.vue
@@ -7,8 +7,7 @@
                 </a>
             </h5>
             <div v-if="release" class="mb-3 settingsBlock">
-                <h6>Parent Type: {{ release.componentDetails.type }}</h6>
-                <h6>Release Type: {{ release.type }}</h6>
+                <h6>Type: {{ release.componentDetails.type }}</h6>
                 <h6><span v-if="release.componentDetails.type === 'PRODUCT'">{{ featureSetLabel }}: </span><span v-else>Branch: </span> {{ release.branchDetails.name }}</h6>
             </div>
             <div v-if="release" class="matchedProductBlock">
@@ -129,7 +128,6 @@ const RELEASE_DIFF_QUERY = gql`
             uuid
             version
             org
-            type
             componentDetails { uuid name type resourceGroup }
             branchDetails { uuid name }
             parentReleases {
@@ -144,7 +142,6 @@ const PARENT_RELEASES_DIFF_QUERY = gql`
         releases(orgFilter: $orgId, releaseFilter: $releaseIds) {
             uuid
             version
-            type
             componentDetails { uuid name type resourceGroup }
             branchDetails { uuid name }
             sourceCodeEntryDetails {


### PR DESCRIPTION
## Summary

The instance page's side-by-side diff view (\`SideBySide → ReleaseRevision\`) was returning HTTP 400 on every load. Both \`FetchReleaseForDiff\` and \`FetchParentReleasesForDiff\` selected \`release.type\`, but \`Release\` has no \`type\` field on the backend schema (only \`Component\` does). DGS rejected the queries on schema validation.

## Change

- Drop the \`type\` selector from both queries.
- In the template, collapse the redundant \"Parent Type\" + \"Release Type\" rows into a single \"Type\" row. (Both would have resolved to the same value via \`componentDetails.type\` — see backend \`type Release\` in \`schema.graphqls\`; releases inherit type from their component.)

No backend change needed — the schema is correct as-is.

## Test plan

- [ ] Load the instance page; confirm \`FetchReleaseForDiff\` and \`FetchParentReleasesForDiff\` return 200
- [ ] Confirm the side-by-side diff view renders \`Type:\`, the feature-set/branch row, and the component-comparison list

🤖 Generated with [Claude Code](https://claude.com/claude-code)