### PR TITLE
docs(workflows): document VEX import controls on the programmatic path

### DIFF
--- a/documentation_site/docs/workflows/importing-vex.md
+++ b/documentation_site/docs/workflows/importing-vex.md
@@ -110,7 +110,7 @@ Imported VEX statements are preserved verbatim on the proposal as `sourceStateme
 
 ## Programmatic import
 
-Direct API import isn't exposed as a separate mutation — every VEX import goes through the artifact-upload path. Both the **multipart manual** (`addArtifactManual`, used by the UI) and the **programmatic** (`addArtifactProgrammatic`, used by [rearm-cli](https://github.com/relizaio/rearm-cli) and CI integrations) paths trigger the import pipeline when the artifact's `type` is `VEX`.
+Direct API import isn't exposed as a separate mutation — every VEX import goes through the artifact-upload path. Both the **multipart manual** (`addArtifactManual`, used by the UI) and the **programmatic** (`addArtifactProgrammatic`, used by [rearm-cli](https://github.com/relizaio/rearm-cli) and CI integrations) paths trigger the import pipeline when the artifact's `type` is `VEX` — whether the artifact is attached to the release, a deliverable (`--deliverablearts`), or a source-code entry (`--scearts`).
 
 CI example:
 
@@ -123,9 +123,12 @@ rearm-cli addartifact \
     "type": "VEX",
     "bomFormat": "CYCLONEDX",
     "storedIn": "REARM",
-    "displayIdentifier": "vendor-vex-1"
+    "displayIdentifier": "vendor-vex-1",
+    "vexImportMode": "STAGE"
   }]'
 ```
+
+The three controls the UI upload form exposes — [Scope](#scope), [Import mode](#import-mode), and [Issuer class](#issuer-class) — can be set on the artifact JSON via the optional `vexScope`, `vexImportMode`, and `userIssuerClassOverride` fields. Omit them to accept the defaults (`COMPONENT` scope, `AUTO_ACCEPT` mode, issuer class derived from binding context). These fields require **rearm-cli 26.05 or newer** — older CLI builds silently drop them, so the import falls back to the defaults.
 
 Or fold it into the `addrelease` call via `--releasearts`. The GitHub Actions wrapper [`relizaio/rearm-actions`](https://github.com/relizaio/rearm-actions) does this for you when a VEX file is on the build's artifact list.
 


### PR DESCRIPTION
## Why

The `importing-vex.md` "Programmatic import" section showed only a bare `type=VEX` upload. The optional `vexScope` / `vexImportMode` / `userIssuerClassOverride` fields — the CLI/API equivalents of the UI upload form's **Scope** / **Import mode** / **Issuer class** controls — were undocumented, so automation users had no way to discover them.

## What

- Programmatic example gains `vexImportMode` and a paragraph explaining all three optional fields, cross-linked to their reference sections.
- Notes the **rearm-cli ≥ 26.05** requirement (relizaio/rearm-cli#17 — older CLI builds drop the fields).
- Notes that VEX attached to a deliverable (`--deliverablearts`) or source-code entry (`--scearts`) is imported the same way.

Docs-only; pairs with the backend fix in relizaio/rearm-saas#91 and the CLI change in relizaio/rearm-cli#17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)