### PR TITLE
chore(backend): sync CE shared backend with rearm-core

### DIFF
--- a/backend/src/main/java/io/reliza/service/ApiKeyService.java
+++ b/backend/src/main/java/io/reliza/service/ApiKeyService.java
@@ -3,8 +3,13 @@
 */
 package io.reliza.service;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.HexFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +21,9 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
@@ -49,20 +57,70 @@ public class ApiKeyService {
 	private GetComponentService getComponentService;;
 
 	private final ApiKeyRepository repository;
-	
+
+	/**
+	 * Cache of successfully-verified (apiKeyUuid, presentedSecret) tuples
+	 * so that subsequent authenticated requests can skip the Argon2
+	 * verification entirely. Argon2 is memory-hard (~16 MB allocation per
+	 * matches() call with the v5_8 defaults) and was OOMing the request
+	 * thread under polling load. TTL is intentionally short (3 minutes)
+	 * to bound the window during which a revoked key would still verify
+	 * if invalidation somehow missed an entry; the deliberate revocation
+	 * paths ({@link #deleteApiKey} and the regeneration branch of
+	 * {@link #setObjectApiKey}) call {@link #invalidateVerificationCacheForKey}
+	 * to evict immediately.
+	 *
+	 * <p>Cache value is just a sentinel {@link Boolean#TRUE} — the key
+	 * carries everything we need to identify the verified combination.
+	 * Cache key is {@code apiKeyUuid + ":" + sha256Hex(presentedSecret)};
+	 * the SHA-256 keeps plaintext API keys out of the cache map.
+	 *
+	 * <p>Negatives are not cached — repeated wrong guesses still pay
+	 * the Argon2 cost, naturally rate-limiting brute-force attempts.
+	 */
+	private static final Duration VERIFICATION_CACHE_TTL = Duration.ofMinutes(3);
+	private final Cache<String, Boolean> verifiedKeyCache = Caffeine.newBuilder()
+			.maximumSize(50_000)
+			.expireAfterWrite(VERIFICATION_CACHE_TTL)
+			.build();
+
     @Autowired
 	public ApiKeyService(ApiKeyRepository repository) {
 	    this.repository = repository;
 	}
-	
+
+	private static String cacheKeyFor(UUID apiKeyUuid, String presentedSecret) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			byte[] hash = md.digest(presentedSecret.getBytes(StandardCharsets.UTF_8));
+			return apiKeyUuid + ":" + HexFormat.of().formatHex(hash);
+		} catch (NoSuchAlgorithmException e) {
+			// SHA-256 is guaranteed available on every JRE; this is unreachable.
+			throw new IllegalStateException("SHA-256 unavailable", e);
+		}
+	}
+
+	/**
+	 * Drop all cached verifications for the given stored ApiKey UUID.
+	 * Called whenever the stored hash changes (revoke / regenerate) so
+	 * that the new hash takes effect immediately rather than waiting
+	 * for the cache TTL.
+	 */
+	private void invalidateVerificationCacheForKey(UUID apiKeyUuid) {
+		if (apiKeyUuid == null) return;
+		String prefix = apiKeyUuid + ":";
+		verifiedKeyCache.asMap().keySet().removeIf(k -> k.startsWith(prefix));
+	}
+
 	public void deleteApiKey(UUID uuid, WhoUpdated wu){
 		Optional<ApiKey> oak = getApiKey(uuid);
 		ApiKey ak = oak.get();
 		ApiKeyData akd = ApiKeyData.dataFromRecord(ak);
 		ak.setApiKey(null);
-		
+
 		Map<String,Object> recordData = Utils.dataToRecord(akd);
 		saveApiKey(ak, recordData, wu);
+		invalidateVerificationCacheForKey(uuid);
 	}
 
 	private Optional<ApiKey> getApiKey (UUID uuid) {
@@ -205,6 +263,10 @@ public class ApiKeyService {
 		akd.setNotes(notes);
 		Map<String,Object> recordData = Utils.dataToRecord(akd);
 		saveApiKey(ak, recordData, wu);
+		// On regeneration the stored hash changes, so the old cached
+		// verifications must not be honored. Safe to call even for
+		// freshly-created keys (no cache entries to evict).
+		invalidateVerificationCacheForKey(ak.getUuid());
 		return apiKeyString;
 	}
 
@@ -248,10 +310,26 @@ public class ApiKeyService {
 		Optional<ApiKey> oak = getApiKeyByObjUuidTypeOrder(ahp.getObjUuid(), ahp.getType(), ahp.getKeyOrder(), orgUuid);
 		
 		if (oak.isPresent()) {
-			Argon2PasswordEncoder encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
 			ApiKey ak = oak.get();
-			if (encoder.matches(ahp.getApiKey(), ak.getApiKey())) {
-				matchingKeyId = oak.get().getUuid();
+			// Cache lookup before paying the Argon2 cost. Argon2PasswordEncoder
+			// .defaultsForSpringSecurity_v5_8() allocates ~16 MB per matches()
+			// call (memory-hard KDF by design); under polling load that
+			// dominated heap and OOMed the request thread. The cache lets
+			// each (apiKeyUuid, presentedSecret) combination skip Argon2
+			// for VERIFICATION_CACHE_TTL after a successful match.
+			String cacheKey = cacheKeyFor(ak.getUuid(), ahp.getApiKey());
+			Boolean cached = verifiedKeyCache.getIfPresent(cacheKey);
+			if (Boolean.TRUE.equals(cached)) {
+				matchingKeyId = ak.getUuid();
+			} else {
+				Argon2PasswordEncoder encoder = Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+				if (encoder.matches(ahp.getApiKey(), ak.getApiKey())) {
+					matchingKeyId = ak.getUuid();
+					verifiedKeyCache.put(cacheKey, Boolean.TRUE);
+				}
+				// Deliberately do NOT cache negatives — repeated wrong
+				// guesses keep paying the Argon2 cost, which provides
+				// natural rate-limiting against brute-force attempts.
 			}
 		}
 		if (matchingKeyId == null) {

--- a/backend/src/main/java/io/reliza/service/ReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseService.java
@@ -1230,15 +1230,110 @@ public class ReleaseService {
 	}
 
 	/**
+	 * Per-VEX-artifact capture taken before {@link ArtifactService#uploadListOfArtifacts}
+	 * runs: the raw document {@code content} (the upload strips the {@code MultipartFile}
+	 * off the map) plus the {@code inputDto} parsed from the input map.
+	 *
+	 * <p>The input DTO is the only carrier of the VEX import-control fields —
+	 * {@code vexScope} / {@code vexImportMode} / {@code userIssuerClassOverride}. Those
+	 * are transient: they are <em>not</em> columns on {@link ArtifactData}, so once the
+	 * artifact is persisted they cannot be recovered from the stored row. They must be
+	 * read off the input before upload and threaded into the dispatch DTO by hand.
+	 */
+	private record VexUpload(byte[] content, ArtifactDto inputDto) {}
+
+	/**
+	 * Capture the raw bytes and input DTO of every VEX artifact in an upload batch
+	 * <em>before</em> {@link ArtifactService#uploadListOfArtifacts} consumes the
+	 * {@code MultipartFile} entries, and verify the VEX-import precondition once if the
+	 * batch contains any VEX.
+	 *
+	 * <p>The returned list is index-aligned with {@code artifactsList} — {@code null}
+	 * for non-VEX entries — and is meant to be handed to {@link #dispatchVexArtifacts}
+	 * after the upload completes.
+	 */
+	private List<VexUpload> captureVexUploads(List<Map<String, Object>> artifactsList, ReleaseData rd) throws RelizaException {
+		List<VexUpload> vexByIndex = new java.util.ArrayList<>(artifactsList.size());
+		for (Map<String, Object> a : artifactsList) {
+			VexUpload vu = null;
+			if (ArtifactType.VEX == parseArtifactType(a.get("type"))) {
+				byte[] bytes = null;
+				Object fileObj = a.get("file");
+				if (fileObj instanceof org.springframework.web.multipart.MultipartFile mf) {
+					try { bytes = mf.getBytes(); }
+					catch (java.io.IOException e) {
+						log.warn("Failed to capture VEX bytes for downstream dispatch: {}", e.getMessage());
+					}
+				}
+				// Parse the input map into an ArtifactDto for the VEX control fields —
+				// mirrors uploadSingleArtifactWithFileFromList's conversion. file /
+				// artifacts are dropped first as they don't round-trip onto the DTO.
+				Map<String, Object> dtoMap = new java.util.HashMap<>(a);
+				dtoMap.remove("file");
+				dtoMap.remove("artifacts");
+				ArtifactDto inputDto = io.reliza.common.Utils.OM.convertValue(dtoMap, ArtifactDto.class);
+				vu = new VexUpload(bytes, inputDto);
+			}
+			vexByIndex.add(vu);
+		}
+
+		// VexImportService precondition: release must have SBOM inventory before any
+		// VEX uploads in this batch. Run once if any of the artifacts is a VEX so we
+		// fail loud at the GraphQL boundary rather than silently dropping the file.
+		if (vexByIndex.stream().anyMatch(v -> v != null && v.content() != null)) {
+			vexImportService.verifyDispatchPreconditions(rd);
+		}
+		return vexByIndex;
+	}
+
+	/**
+	 * Dispatch the inbound VEX import pipeline
+	 * ({@link io.reliza.service.VexImportService#dispatchFromArtifact}) for every VEX
+	 * artifact in an uploaded batch — the same hook the multipart {@code addArtifactManual}
+	 * path runs (see {@code ReleaseDatafetcher#addArtifact}). Without this the CLI /
+	 * rearm-actions upload path silently bypasses VEX import, so vendor VEX submitted
+	 * through automation never produces proposals. See ai-plans/vex_imports/00_overview.md
+	 * §"What VEX import does, in three stages".
+	 *
+	 * <p>{@code vexUploads} comes from {@link #captureVexUploads} and is index-aligned
+	 * with {@code artIds}. Best-effort — a dispatch failure is logged, never blocks the
+	 * upload result.
+	 *
+	 * @param belongsTo binding of the uploaded artifacts (RELEASE / DELIVERABLE / SCE);
+	 *                  drives issuer-class derivation inside {@link VexImportService}.
+	 */
+	private void dispatchVexArtifacts(List<VexUpload> vexUploads, List<UUID> artIds,
+			ReleaseData rd, ArtifactBelongsTo belongsTo, WhoUpdated wu) {
+		for (int i = 0; i < artIds.size() && i < vexUploads.size(); i++) {
+			VexUpload vu = vexUploads.get(i);
+			if (vu == null || vu.content() == null) continue;
+			UUID artId = artIds.get(i);
+			Optional<ArtifactData> oad = artifactService.getArtifactData(artId);
+			if (oad.isEmpty()) continue;
+			// ArtifactDto has no factory from ArtifactData — round-trip through Jackson.
+			// dispatchFromArtifact reads bomFormat / displayIdentifier off the persisted
+			// artifact, plus vexScope / vexImportMode / userIssuerClassOverride — which
+			// are NOT persisted on ArtifactData, so overlay them from the input DTO.
+			ArtifactDto dispatchDto = io.reliza.common.Utils.OM.convertValue(
+				oad.get(), ArtifactDto.class);
+			dispatchDto.setVexScope(vu.inputDto().getVexScope());
+			dispatchDto.setVexImportMode(vu.inputDto().getVexImportMode());
+			dispatchDto.setUserIssuerClassOverride(vu.inputDto().getUserIssuerClassOverride());
+			try {
+				vexImportService.dispatchFromArtifact(
+					artId, dispatchDto, rd, belongsTo, vu.content(), wu);
+			} catch (Exception e) {
+				log.warn("VEX import dispatch failed for artifact {} on release {}: {}",
+					artId, rd.getUuid(), e.getMessage());
+			}
+		}
+	}
+
+	/**
 	 * Process and upload release artifacts, then attach them to the release.
 	 *
-	 * <p>VEX artifacts additionally trigger the inbound import pipeline
-	 * ({@link io.reliza.service.VexImportService#dispatchFromArtifact}) — the
-	 * same hook the multipart {@code addArtifactManual} path runs (see
-	 * {@code ReleaseDatafetcher#addArtifact}). Without this the CLI / rearm-actions
-	 * upload path silently bypasses VEX import, so vendor VEX submitted through
-	 * automation never produces proposals. See ai-plans/vex_imports/00_overview.md
-	 * §"What VEX import does, in three stages".
+	 * <p>VEX artifacts additionally trigger the inbound import pipeline — see
+	 * {@link #dispatchVexArtifacts}.
 	 */
 	@Transactional
 	public void processReleaseArtifacts(List<Map<String, Object>> artifactsList, ReleaseData rd,
@@ -1250,31 +1345,8 @@ public class ReleaseService {
 		String purl = SidPurlUtils.pickPreferredPurl(rd.getIdentifiers())
 				.map(TeaIdentifier::getIdValue).orElse(null);
 
-		// Capture VEX file bytes BEFORE uploadListOfArtifacts consumes the entries —
-		// the upload path removes the MultipartFile from each map and we still need
-		// the bytes downstream for the VEX parser.
-		List<byte[]> vexBytesByIndex = new java.util.ArrayList<>(artifactsList.size());
-		for (Map<String, Object> a : artifactsList) {
-			byte[] bytes = null;
-			if (ArtifactType.VEX == parseArtifactType(a.get("type"))) {
-				Object fileObj = a.get("file");
-				if (fileObj instanceof org.springframework.web.multipart.MultipartFile mf) {
-					try { bytes = mf.getBytes(); }
-					catch (java.io.IOException e) {
-						log.warn("Failed to capture VEX bytes for downstream dispatch: {}", e.getMessage());
-					}
-				}
-			}
-			vexBytesByIndex.add(bytes);
-		}
-
-		// VexImportService precondition: release must have SBOM inventory before any
-		// VEX uploads in this batch. Run once if any of the artifacts is a VEX so we
-		// fail loud at the GraphQL boundary rather than silently dropping the file.
-		boolean anyVex = vexBytesByIndex.stream().anyMatch(b -> b != null);
-		if (anyVex) {
-			vexImportService.verifyDispatchPreconditions(rd);
-		}
+		// Capture VEX uploads before uploadListOfArtifacts consumes the MultipartFile entries.
+		List<VexUpload> vexUploads = captureVexUploads(artifactsList, rd);
 
 		// Upload artifacts
 		List<UUID> artIds = artifactService.uploadListOfArtifacts(
@@ -1288,34 +1360,20 @@ public class ReleaseService {
 			addArtifact(artId, rd.getUuid(), wu);
 		}
 
-		// Now dispatch any VEX artifacts. Mirrors the multipart manual path —
-		// best-effort, never blocks the upload result.
-		for (int i = 0; i < artIds.size() && i < vexBytesByIndex.size(); i++) {
-			byte[] bytes = vexBytesByIndex.get(i);
-			if (bytes == null) continue;
-			UUID artId = artIds.get(i);
-			Optional<ArtifactData> oad = artifactService.getArtifactData(artId);
-			if (oad.isEmpty()) continue;
-			// ArtifactDto has no factory from ArtifactData — round-trip through Jackson.
-			// VexImportService only reads bomFormat / vexScope / vexImportMode /
-			// userIssuerClassOverride / displayIdentifier off the dto.
-			ArtifactDto dispatchDto = io.reliza.common.Utils.OM.convertValue(
-				oad.get(), ArtifactDto.class);
-			try {
-				vexImportService.dispatchFromArtifact(
-					artId, dispatchDto, rd, ArtifactBelongsTo.RELEASE, bytes, wu);
-			} catch (Exception e) {
-				log.warn("VEX import dispatch failed for artifact {} on release {}: {}",
-					artId, rd.getUuid(), e.getMessage());
-			}
-		}
+		dispatchVexArtifacts(vexUploads, artIds, rd, ArtifactBelongsTo.RELEASE, wu);
 	}
 	
 	/**
-	 * Process and upload deliverable artifacts, then attach them to the deliverable
+	 * Process and upload deliverable artifacts, then attach them to the deliverable.
+	 *
+	 * <p>VEX artifacts additionally trigger the inbound import pipeline — see
+	 * {@link #dispatchVexArtifacts}. {@code rd} is the release the upload targets;
+	 * the VEX matcher and the SBOM precondition are release-scoped, so a
+	 * deliverable-bound VEX still resolves against {@code rd}'s inventory — the
+	 * same {@code rd} the multipart manual path passes for DELIVERABLE bindings.
 	 */
 	@Transactional
-	public void processDeliverableArtifacts(List<Map<String, Object>> delArtsList, ComponentData cd, 
+	public void processDeliverableArtifacts(List<Map<String, Object>> delArtsList, ReleaseData rd, ComponentData cd,
 			OrganizationData od, String version, WhoUpdated wu) throws RelizaException {
 		if (null == delArtsList || delArtsList.isEmpty()) {
 			return;
@@ -1352,25 +1410,36 @@ public class ReleaseService {
 				}
 			}
 			
+			// Capture VEX uploads before uploadListOfArtifacts consumes the MultipartFile entries.
+			List<VexUpload> vexUploads = captureVexUploads(artifactsList, rd);
+
 			// Upload artifacts
 			List<UUID> artIds = artifactService.uploadListOfArtifacts(
 				od, artifactsList,
 				new RebomOptions(cd.getName(), od.getName(), version, ArtifactBelongsTo.DELIVERABLE, hash, StripBom.FALSE, purl),
 				wu
 			);
-			
+
 			// Attach artifacts to deliverable
 			for (UUID artId : artIds) {
 				deliverableService.addArtifact(deliverableId, artId, wu);
 			}
+
+			dispatchVexArtifacts(vexUploads, artIds, rd, ArtifactBelongsTo.DELIVERABLE, wu);
 		}
 	}
 	
 	/**
-	 * Process and upload SCE artifacts, then attach them to the source code entry
+	 * Process and upload SCE artifacts, then attach them to the source code entry.
+	 *
+	 * <p>VEX artifacts additionally trigger the inbound import pipeline — see
+	 * {@link #dispatchVexArtifacts}. {@code rd} is the release the upload targets;
+	 * the VEX matcher and the SBOM precondition are release-scoped, so an
+	 * SCE-bound VEX still resolves against {@code rd}'s inventory — the same
+	 * {@code rd} the multipart manual path passes for SCE bindings.
 	 */
 	@Transactional
-	public void processSceArtifacts(List<Map<String, Object>> sceArtsList, ComponentData cd, 
+	public void processSceArtifacts(List<Map<String, Object>> sceArtsList, ReleaseData rd, ComponentData cd,
 			OrganizationData od, String version, WhoUpdated wu) throws RelizaException {
 		if (null == sceArtsList || sceArtsList.isEmpty()) {
 			return;
@@ -1392,18 +1461,23 @@ public class ReleaseService {
 				throw new RelizaException("'artifacts' list cannot be empty in sceArtifacts");
 			}
 			
+			// Capture VEX uploads before uploadListOfArtifacts consumes the MultipartFile entries.
+			List<VexUpload> vexUploads = captureVexUploads(artifactsList, rd);
+
 			// Upload artifacts
 			List<UUID> artIds = artifactService.uploadListOfArtifacts(
 				od, artifactsList,
 				new RebomOptions(cd.getName(), od.getName(), version, ArtifactBelongsTo.SCE, sced.getCommit(), StripBom.FALSE, null),
 				wu
 			);
-			
+
 			// Attach artifacts to SCE
 			for (UUID artId : artIds) {
 				SCEArtifact sceArt = new SCEArtifact(artId, cd.getUuid());
 				sourceCodeEntryService.addArtifact(sceUuid, sceArt, wu);
 			}
+
+			dispatchVexArtifacts(vexUploads, artIds, rd, ArtifactBelongsTo.SCE, wu);
 		}
 	}
 	@Transactional

--- a/backend/src/main/java/io/reliza/service/VexStatementProposalService.java
+++ b/backend/src/main/java/io/reliza/service/VexStatementProposalService.java
@@ -5,9 +5,12 @@
 package io.reliza.service;
 
 import java.time.ZonedDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -17,9 +20,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.reliza.common.CommonVariables.TableName;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.model.ArtifactData;
 import io.reliza.model.ClaimType;
+import io.reliza.model.DeliverableData;
 import io.reliza.model.MitigationAttestationData;
 import io.reliza.model.ProposalStatus;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.SourceCodeEntryData;
+import io.reliza.model.SourceCodeEntryData.SCEArtifact;
+import io.reliza.model.VariantData;
 import io.reliza.model.VexStatementProposal;
 import io.reliza.model.VexStatementProposalData;
 import io.reliza.model.VulnAnalysisData;
@@ -38,6 +47,9 @@ public class VexStatementProposalService {
     @Autowired MitigationAttestationService attestationService;
     @Autowired SharedReleaseService sharedReleaseService;
     @Autowired ArtifactService artifactService;
+    @Autowired GetDeliverableService getDeliverableService;
+    @Autowired GetSourceCodeEntryService getSourceCodeEntryService;
+    @Autowired VariantService variantService;
 
     private final VexStatementProposalRepository repository;
 
@@ -65,26 +77,80 @@ public class VexStatementProposalService {
     }
 
     /**
-     * Lists VEX proposals whose source artifact is attached to the given release —
-     * "what VEX has been uploaded to this release". Decisions whose effect crosses
-     * scope levels (e.g. ORG-scoped proposals affecting many releases) are visible in
-     * the org-wide VEX Proposals inbox; this view is intentionally local.
+     * Lists VEX proposals whose source artifact was uploaded to the given release —
+     * "what VEX has been uploaded here". A VEX artifact can be bound to a release
+     * through several paths, so this walks all of them: the release's own artifacts,
+     * its deliverables (release-level inbound plus each variant's outbound), and its
+     * source code entries (export SCE plus commit SCEs). The deliverable/SCE upload
+     * paths attach the VEX artifact to that child object, not to the release's own
+     * artifact list (see {@code ReleaseService.processDeliverableArtifacts} /
+     * {@code processSceArtifacts}), so a release-artifacts-only walk silently misses
+     * deliverable- and SCE-bound VEX.
+     *
+     * <p>The view stays provenance-local: it answers "which VEX documents were
+     * uploaded against this release", not "which VEX decisions affect it". Proposals
+     * whose effect crosses scope levels (e.g. an ORG-scoped proposal touching many
+     * releases) are surfaced in the org-wide VEX Proposals inbox, not here.
      */
     public List<VexStatementProposalData> listForRelease(UUID org, UUID release) {
-        var rd = sharedReleaseService.getReleaseData(release, org);
-        if (rd.isEmpty() || rd.get().getArtifacts() == null || rd.get().getArtifacts().isEmpty()) {
+        Optional<ReleaseData> ord = sharedReleaseService.getReleaseData(release, org);
+        if (ord.isEmpty()) {
             return List.of();
         }
-        List<String> vexArtifactUuids = rd.get().getArtifacts().stream()
-            .filter(a -> {
-                var ad = artifactService.getArtifactData(a);
-                return ad.isPresent() && ad.get().getType() == io.reliza.model.ArtifactData.ArtifactType.VEX;
-            })
+        List<String> vexArtifactUuids = collectVexArtifactUuids(ord.get()).stream()
             .map(UUID::toString)
             .collect(Collectors.toList());
         if (vexArtifactUuids.isEmpty()) return List.of();
         return repository.findByOrgAndSourceArtifactIn(org.toString(), vexArtifactUuids).stream()
             .map(VexStatementProposalData::dataFromRecord).collect(Collectors.toList());
+    }
+
+    /**
+     * Collects every VEX-typed artifact bound to a release — directly, or through one
+     * of its deliverables or source code entries. Returns a de-duplicated set in
+     * discovery order. Dangling child references are tolerated: a missing deliverable
+     * or SCE is skipped, never thrown (the model carries no DB-level FKs — see
+     * {@code coding_principles.md}).
+     */
+    private Set<UUID> collectVexArtifactUuids(ReleaseData rd) {
+        Set<UUID> candidates = new LinkedHashSet<>();
+        if (rd.getArtifacts() != null) {
+            candidates.addAll(rd.getArtifacts());
+        }
+
+        // Deliverables: release-level inbound + each variant's outbound.
+        Set<UUID> deliverableUuids = new LinkedHashSet<>(rd.getInboundDeliverables());
+        for (VariantData vd : variantService.getVariantsOfRelease(rd.getUuid())) {
+            if (vd.getOutboundDeliverables() != null) {
+                deliverableUuids.addAll(vd.getOutboundDeliverables());
+            }
+        }
+        for (DeliverableData dd : getDeliverableService.getDeliverableDataList(deliverableUuids)) {
+            if (dd.getArtifacts() != null) {
+                candidates.addAll(dd.getArtifacts());
+            }
+        }
+
+        // Source code entries: export SCE + commit SCEs (getAllCommits unions both).
+        Set<UUID> sceUuids = rd.getAllCommits().stream()
+            .filter(Objects::nonNull)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        for (SourceCodeEntryData sced : getSourceCodeEntryService.getSourceCodeEntryDataList(sceUuids)) {
+            if (sced.getArtifacts() != null) {
+                sced.getArtifacts().stream()
+                    .map(SCEArtifact::artifactUuid)
+                    .filter(Objects::nonNull)
+                    .forEach(candidates::add);
+            }
+        }
+
+        // Keep only VEX-typed artifacts: the proposal table only ever keys off a VEX
+        // source artifact, and this trims the IN-list handed to the repository. One
+        // batch lookup — missing artifacts are simply absent from the result.
+        return artifactService.getArtifactDataList(candidates).stream()
+            .filter(ad -> ad.getType() == ArtifactData.ArtifactType.VEX)
+            .map(ArtifactData::getUuid)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @Transactional

--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -1386,13 +1386,13 @@ public class ReleaseDatafetcher {
 		if (addArtifactInput.containsKey("deliverableArtifacts")) {
 			@SuppressWarnings("unchecked")
 			List<Map<String,Object>> delArtsList = (List<Map<String,Object>>) addArtifactInput.get("deliverableArtifacts");
-			releaseService.processDeliverableArtifacts(delArtsList, cd, od, version, wu);
+			releaseService.processDeliverableArtifacts(delArtsList, ord.get(), cd, od, version, wu);
 		}
-		
+
 		if (addArtifactInput.containsKey("sceArtifacts")) {
 			@SuppressWarnings("unchecked")
 			List<Map<String,Object>> sceArtsList = (List<Map<String,Object>>) addArtifactInput.get("sceArtifacts");
-			releaseService.processSceArtifacts(sceArtsList, cd, od, version, wu);
+			releaseService.processSceArtifacts(sceArtsList, ord.get(), cd, od, version, wu);
 		}
 		
 		// Reconcile merged SBOM

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -2513,7 +2513,7 @@ input ArtifactInput {
 	stripBom: StripBomEnum
 	digestRecords: [DigestRecordInput]
 	artifacts: [ArtifactInput]
-# v1.2 VEX-only: how broadly the VEX claim applies. Default ORG when type=VEX.
+# v1.2 VEX-only: how broadly the VEX claim applies. Default COMPONENT when type=VEX.
 	vexScope: AnalysisScope
 # v1.2 VEX-only: AUTO_ACCEPT (default) / STAGE / REJECT.
 	vexImportMode: VexImportMode

--- a/backend/src/test/java/io/reliza/service/VexStatementProposalServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/VexStatementProposalServiceTest.java
@@ -5,16 +5,23 @@
 package io.reliza.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -26,10 +33,16 @@ import io.reliza.exceptions.RelizaException;
 import io.reliza.model.AnalysisJustification;
 import io.reliza.model.AnalysisScope;
 import io.reliza.model.AnalysisState;
+import io.reliza.model.ArtifactData;
+import io.reliza.model.DeliverableData;
 import io.reliza.model.FindingType;
 import io.reliza.model.LocationType;
 import io.reliza.model.ProposalStatus;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.SourceCodeEntryData;
+import io.reliza.model.SourceCodeEntryData.SCEArtifact;
 import io.reliza.model.SourceFormat;
+import io.reliza.model.VariantData;
 import io.reliza.model.VexStatementProposal;
 import io.reliza.model.VexStatementProposalData;
 import io.reliza.model.WhoUpdated;
@@ -41,6 +54,11 @@ class VexStatementProposalServiceTest {
     private VexStatementProposalRepository repo;
     private AuditService audit;
     private VulnAnalysisService vulnService;
+    private SharedReleaseService sharedReleaseService;
+    private ArtifactService artifactService;
+    private GetDeliverableService getDeliverableService;
+    private GetSourceCodeEntryService getSourceCodeEntryService;
+    private VariantService variantService;
     private VexStatementProposalService svc;
 
     @BeforeEach
@@ -48,11 +66,21 @@ class VexStatementProposalServiceTest {
         repo = mock(VexStatementProposalRepository.class);
         audit = mock(AuditService.class);
         vulnService = mock(VulnAnalysisService.class);
+        sharedReleaseService = mock(SharedReleaseService.class);
+        artifactService = mock(ArtifactService.class);
+        getDeliverableService = mock(GetDeliverableService.class);
+        getSourceCodeEntryService = mock(GetSourceCodeEntryService.class);
+        variantService = mock(VariantService.class);
         svc = new VexStatementProposalService(repo);
         svc.auditService = audit;
         svc.vulnAnalysisService = vulnService;
         svc.conditionalPredicate = new ConditionalMitigationPredicate();
         svc.attestationService = mock(MitigationAttestationService.class);
+        svc.sharedReleaseService = sharedReleaseService;
+        svc.artifactService = artifactService;
+        svc.getDeliverableService = getDeliverableService;
+        svc.getSourceCodeEntryService = getSourceCodeEntryService;
+        svc.variantService = variantService;
     }
 
     private VexStatementProposalData newProposal() {
@@ -270,5 +298,109 @@ class VexStatementProposalServiceTest {
         // VulnAnalysis must not have been mutated.
         verify(vulnService, org.mockito.Mockito.never()).createVulnAnalysis(any(), any());
         verify(vulnService, org.mockito.Mockito.never()).updateAnalysisState(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    // --- listForRelease: cross-binding VEX collection ------------------------
+
+    private ArtifactData artifactOfType(UUID uuid, ArtifactData.ArtifactType type) {
+        ArtifactData ad = mock(ArtifactData.class);
+        when(ad.getUuid()).thenReturn(uuid);
+        when(ad.getType()).thenReturn(type);
+        return ad;
+    }
+
+    @Test
+    void listForReleaseReturnsEmptyWhenReleaseAbsent() {
+        UUID org = UUID.randomUUID();
+        UUID release = UUID.randomUUID();
+        when(sharedReleaseService.getReleaseData(release, org)).thenReturn(Optional.empty());
+
+        assertTrue(svc.listForRelease(org, release).isEmpty());
+        verify(repo, never()).findByOrgAndSourceArtifactIn(any(), any());
+    }
+
+    @Test
+    void listForReleaseCollectsVexFromReleaseDeliverablesAndSces() {
+        // Regression guard: a VEX uploaded to a release's deliverable or source code
+        // entry must surface on the per-release VEX tab, not just in the org-wide
+        // inbox. The walk covers release artifacts, inbound + outbound deliverables,
+        // and source code entries; a non-VEX artifact on the release is filtered out.
+        UUID org = UUID.randomUUID();
+        UUID release = UUID.randomUUID();
+
+        UUID releaseVex = UUID.randomUUID();
+        UUID decoyBom = UUID.randomUUID();
+        UUID inboundDeliverableVex = UUID.randomUUID();
+        UUID outboundDeliverableVex = UUID.randomUUID();
+        UUID sceVex = UUID.randomUUID();
+
+        UUID inboundDeliverable = UUID.randomUUID();
+        UUID outboundDeliverable = UUID.randomUUID();
+        UUID exportSce = UUID.randomUUID();
+
+        ReleaseData rd = mock(ReleaseData.class);
+        when(rd.getUuid()).thenReturn(release);
+        when(rd.getArtifacts()).thenReturn(List.of(releaseVex, decoyBom));
+        when(rd.getInboundDeliverables()).thenReturn(List.of(inboundDeliverable));
+        when(rd.getAllCommits()).thenReturn(new LinkedHashSet<>(List.of(exportSce)));
+        when(sharedReleaseService.getReleaseData(release, org)).thenReturn(Optional.of(rd));
+
+        VariantData variant = mock(VariantData.class);
+        when(variant.getOutboundDeliverables()).thenReturn(new LinkedHashSet<>(List.of(outboundDeliverable)));
+        when(variantService.getVariantsOfRelease(release)).thenReturn(List.of(variant));
+
+        DeliverableData inboundDd = mock(DeliverableData.class);
+        when(inboundDd.getArtifacts()).thenReturn(List.of(inboundDeliverableVex));
+        DeliverableData outboundDd = mock(DeliverableData.class);
+        when(outboundDd.getArtifacts()).thenReturn(List.of(outboundDeliverableVex));
+        when(getDeliverableService.getDeliverableDataList(any())).thenReturn(List.of(inboundDd, outboundDd));
+
+        SourceCodeEntryData sced = mock(SourceCodeEntryData.class);
+        when(sced.getArtifacts()).thenReturn(List.of(new SCEArtifact(sceVex, UUID.randomUUID())));
+        when(getSourceCodeEntryService.getSourceCodeEntryDataList(any())).thenReturn(List.of(sced));
+
+        // Build the ArtifactData mocks up front — artifactOfType() itself stubs, so it
+        // must not be called inside an enclosing when(...).thenReturn(...) argument.
+        ArtifactData releaseVexAd = artifactOfType(releaseVex, ArtifactData.ArtifactType.VEX);
+        ArtifactData inboundVexAd = artifactOfType(inboundDeliverableVex, ArtifactData.ArtifactType.VEX);
+        ArtifactData outboundVexAd = artifactOfType(outboundDeliverableVex, ArtifactData.ArtifactType.VEX);
+        ArtifactData sceVexAd = artifactOfType(sceVex, ArtifactData.ArtifactType.VEX);
+        ArtifactData decoyBomAd = artifactOfType(decoyBom, ArtifactData.ArtifactType.BOM);
+        Map<UUID, ArtifactData> artifactsById = Map.of(
+            releaseVex, releaseVexAd, inboundDeliverableVex, inboundVexAd,
+            outboundDeliverableVex, outboundVexAd, sceVex, sceVexAd, decoyBom, decoyBomAd);
+        // Answer like the real findAllById: return only the artifacts actually passed
+        // in. A binding path the traversal misses therefore never reaches the query —
+        // which is exactly what the captor assertions below pin down.
+        when(artifactService.getArtifactDataList(any())).thenAnswer(inv -> {
+            List<ArtifactData> found = new ArrayList<>();
+            for (UUID id : (Iterable<UUID>) inv.getArgument(0)) {
+                ArtifactData ad = artifactsById.get(id);
+                if (ad != null) found.add(ad);
+            }
+            return found;
+        });
+
+        VexStatementProposalData proposal = newProposal();
+        VexStatementProposal e = new VexStatementProposal();
+        e.setUuid(proposal.getUuid());
+        e.setRecordData(proposal.toRecordData());
+        when(repo.findByOrgAndSourceArtifactIn(eq(org.toString()), any())).thenReturn(List.of(e));
+
+        List<VexStatementProposalData> out = svc.listForRelease(org, release);
+        assertEquals(1, out.size());
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
+        verify(repo).findByOrgAndSourceArtifactIn(eq(org.toString()), captor.capture());
+        Collection<String> queried = captor.getValue();
+        // Every binding path's VEX artifact reaches the proposal query...
+        assertTrue(queried.contains(releaseVex.toString()));
+        assertTrue(queried.contains(inboundDeliverableVex.toString()));
+        assertTrue(queried.contains(outboundDeliverableVex.toString()));
+        assertTrue(queried.contains(sceVex.toString()));
+        // ...and the non-VEX artifact is filtered out.
+        assertFalse(queried.contains(decoyBom.toString()));
+        assertEquals(4, queried.size());
     }
 }


### PR DESCRIPTION
## What

Runs `rearm-core/backend/copy-src.sh` — the canonical shared-code mirror — to bring the CE backend's shared `src/` tree back in line with rearm-core. The script excludes `oss/` and `saas/` (each edition owns its own copies) and `VersionAssignmentTest.java`.

Six shared files had drifted; this syncs them. **No deletions, no new files.**

| File | Source of the drift |
|---|---|
| `VexStatementProposalService.java` (+ test) | rearm-saas #95 — `listForRelease` surfaces deliverable/SCE-bound VEX proposals on the per-release VEX tab |
| `ReleaseService.java` | rearm-saas #91 — VEX dispatch from the programmatic deliverable/SCE upload paths |
| `ReleaseDatafetcher.java`, `schema.graphqls` | rearm-saas #91 — `addArtifact` wiring + schema comment |
| `ApiKeyService.java` | rearm-saas #96 — verified-API-key caching; unrelated to VEX, caught by the same mirror |

## Why

The CE backend (`rearm/backend/`) shares all non-`oss`/`saas` code with rearm-core. The four VEX programmatic-import PRs (and #96) landed in rearm-core only, so the shared layer drifted. This is the routine re-sync.

## Verification

- `mvn -q -DskipTests compile` — clean (the mirrored shared code builds against CE's own `oss/` implementations).
- `VexStatementProposalServiceTest` — 10/10 green on the CE build.

The content is a verbatim mirror of code already reviewed and merged in rearm-core (#91, #95, #96), produced mechanically by the sync script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)