### PR TITLE
feat(ui): agent UI polish — hero limit + all-agents table + nav reorder + model display

### DIFF
--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -40,7 +40,7 @@
                     <n-tag size="small" :type="agent.agentType === 'ROOT' ? 'info' : 'default'">{{ agent.agentType }}</n-tag>
                     <n-tag v-if="agent.status === 'ARCHIVED'" size="small" type="default">ARCHIVED</n-tag>
                     <span v-if="agent.model" class="dim">
-                        {{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version ? ' @ ' + agent.model.version : '' }}</code>
+                        {{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code>
                     </span>
                     <span class="dim" v-if="agent.lastActivityAt">
                         last activity {{ formatDate(agent.lastActivityAt) }}
@@ -116,7 +116,7 @@
                     <n-descriptions-item label="Type">{{ agent.agentType }}</n-descriptions-item>
                     <n-descriptions-item label="Status">{{ agent.status }}</n-descriptions-item>
                     <n-descriptions-item label="Model">
-                        <span v-if="agent.model">{{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version ? ' @ ' + agent.model.version : '' }}</code></span>
+                        <span v-if="agent.model">{{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code></span>
                         <span v-else class="dim">—</span>
                     </n-descriptions-item>
                     <n-descriptions-item label="Created">{{ formatDate(agent.createdDate) }}</n-descriptions-item>
@@ -216,7 +216,7 @@ const siblingColumns: DataTableColumns<any> = [
         title: 'Model',
         key: 'model',
         render: (row: any) => row.model
-            ? `${row.model.publisher} · ${row.model.name}${row.model.version ? ' @ ' + row.model.version : ''}`
+            ? `${row.model.publisher} · ${row.model.name}${row.model.version && row.model.version !== 'unknown' ? ' @ ' + row.model.version : ''}`
             : '—',
     },
     { title: 'Created', key: 'createdDate', render: (row: any) => formatDate(row.createdDate) },

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -108,8 +108,30 @@
                             <div><span class="acard__num">{{ a.subAgents?.length ?? 0 }}</span><span class="acard__lab">sub-agents</span></div>
                         </div>
                         <div class="acard__seen">
-                            <span><span class="acard__lab">first seen</span> {{ formatDate(a.createdDate) }}</span>
-                            <span><span class="acard__lab">last seen</span> {{ formatDate(a.lastActivityAt) }}</span>
+                            <span>
+                                <span class="acard__lab">first seen</span>
+                                {{ formatDate(a.createdDate) }}
+                                <n-tooltip v-if="a.createdDate" trigger="hover" placement="top">
+                                    <template #trigger>
+                                        <n-icon class="acard__info" :size="13" @click.stop>
+                                            <Info20Regular/>
+                                        </n-icon>
+                                    </template>
+                                    {{ formatDateTimePrecise(a.createdDate) }}
+                                </n-tooltip>
+                            </span>
+                            <span>
+                                <span class="acard__lab">last seen</span>
+                                {{ formatDate(a.lastActivityAt) }}
+                                <n-tooltip v-if="a.lastActivityAt" trigger="hover" placement="top">
+                                    <template #trigger>
+                                        <n-icon class="acard__info" :size="13" @click.stop>
+                                            <Info20Regular/>
+                                        </n-icon>
+                                    </template>
+                                    {{ formatDateTimePrecise(a.lastActivityAt) }}
+                                </n-tooltip>
+                            </span>
                         </div>
                     </n-card>
                 </div>
@@ -132,7 +154,8 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NButton, NCard, NDataTable, NSpace, NSpin, NTag, NTooltip, DataTableColumns } from 'naive-ui'
+import { NButton, NCard, NDataTable, NIcon, NSpace, NSpin, NTag, NTooltip, DataTableColumns } from 'naive-ui'
+import { Info20Regular } from '@vicons/fluent'
 
 const store = useStore()
 const route = useRoute()
@@ -165,6 +188,20 @@ function formatDate (iso: string | null | undefined): string {
     if (!iso) return '—'
     const d = new Date(iso)
     return isNaN(d.getTime()) ? '—' : d.toLocaleDateString('en-CA')
+}
+
+// Second-precision tooltip variant — the visible card text stays at
+// day granularity to keep the row dense, the tooltip surfaces the
+// exact moment for users who care about ordering bursts of activity.
+function formatDateTimePrecise (iso: string | null | undefined): string {
+    if (!iso) return ''
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return ''
+    return d.toLocaleString('en-CA', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hour12: false,
+    })
 }
 
 const identityCounts = computed<Record<string, number>>(() => {
@@ -273,6 +310,8 @@ const sessionColumns: DataTableColumns<any> = [
 .acard__lab { font-size: 11px; color: var(--n-text-color-3, #666); text-transform: uppercase; letter-spacing: 0.04em; }
 .acard__seen { display: flex; gap: 16px; margin-top: 10px; font-size: 12px; color: var(--n-text-color-3, #666); }
 .acard__seen .acard__lab { margin-right: 6px; }
+.acard__info { vertical-align: middle; margin-left: 4px; color: var(--n-text-color-3, #999); cursor: help; }
+.acard__info:hover { color: var(--n-text-color-2, #555); }
 .section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
 .empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 12px 0; }
 </style>

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -253,7 +253,11 @@ const sessionColumns: DataTableColumns<any> = [
 .kpi__l { text-transform: uppercase; font-size: 11px; letter-spacing: 0.06em; color: var(--n-text-color-3, #666); }
 .kpi__v { font-size: 32px; font-weight: 600; margin-top: 4px; }
 .kpi__d { font-size: 12px; color: var(--n-text-color-3, #666); margin-top: 2px; }
-.agent-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-top: 8px; }
+/* Cap at 4 cards per row so each card has room to breathe. The
+ * max(280px, …) keeps the auto-fit floor on narrow screens — once the
+ * viewport drops below ~1130px the 23% lower bound stops winning and
+ * the grid falls back to as many 280px-min cards as fit. */
+.agent-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(max(280px, 23%), 1fr)); gap: 12px; margin-top: 8px; }
 .acard__top { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
 .acard__mark { width: 36px; height: 36px; border-radius: 8px; color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 18px; flex-shrink: 0; }
 .acard__head { flex: 1; min-width: 0; }

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -40,13 +40,22 @@
 
             <!-- Agent card grid -->
             <div>
-                <h5>Registered agents</h5>
+                <div class="section-head">
+                    <h5>Registered agents</h5>
+                    <n-button
+                        v-if="rootAgents.length > HERO_LIMIT"
+                        quaternary size="small"
+                        @click="openAllAgents"
+                    >
+                        See all {{ rootAgents.length }} →
+                    </n-button>
+                </div>
                 <div v-if="agents.length === 0" class="empty">
                     No agents yet. Sessions auto-register an agent on first init.
                 </div>
                 <div class="agent-grid" v-else>
                     <n-card
-                        v-for="a in rootAgents"
+                        v-for="a in heroAgents"
                         :key="a.uuid"
                         class="acard"
                         size="small"
@@ -86,7 +95,7 @@
                                     </n-tooltip>
                                 </div>
                                 <div class="acard__sub" v-if="a.model">
-                                    {{ a.model.publisher }} · <code>{{ a.model.name }}{{ a.model.version ? ' @ ' + a.model.version : '' }}</code>
+                                    {{ a.model.publisher }} · <code>{{ a.model.name }}{{ a.model.version && a.model.version !== 'unknown' ? ' @ ' + a.model.version : '' }}</code>
                                 </div>
                             </div>
                             <n-tag v-if="a.status === 'ARCHIVED'" size="small" type="default">
@@ -97,6 +106,10 @@
                             <div><span class="acard__num">{{ a.sessionCounts?.openSessions ?? 0 }}</span><span class="acard__lab">open</span></div>
                             <div><span class="acard__num">{{ a.sessionCounts?.closedSessions ?? 0 }}</span><span class="acard__lab">closed</span></div>
                             <div><span class="acard__num">{{ a.subAgents?.length ?? 0 }}</span><span class="acard__lab">sub-agents</span></div>
+                        </div>
+                        <div class="acard__seen">
+                            <span><span class="acard__lab">first seen</span> {{ formatDate(a.createdDate) }}</span>
+                            <span><span class="acard__lab">last seen</span> {{ formatDate(a.lastActivityAt) }}</span>
                         </div>
                     </n-card>
                 </div>
@@ -131,7 +144,28 @@ const kpis = ref<any>(null)
 const agents = ref<any[]>([])
 const openSessions = ref<any[]>([])
 
+const HERO_LIMIT = 8
+
 const rootAgents = computed(() => agents.value.filter(a => a.agentType === 'ROOT'))
+
+// Hero shows the 8 most recently active agents — abandoned agents
+// shouldn't crowd out live ones once the org grows past a handful.
+// "See all" link surfaces the rest in a dedicated table view.
+const heroAgents = computed(() =>
+    [...rootAgents.value]
+        .sort((a, b) => {
+            const lhs = a.lastActivityAt ?? a.createdDate ?? ''
+            const rhs = b.lastActivityAt ?? b.createdDate ?? ''
+            return rhs.localeCompare(lhs)
+        })
+        .slice(0, HERO_LIMIT)
+)
+
+function formatDate (iso: string | null | undefined): string {
+    if (!iso) return '—'
+    const d = new Date(iso)
+    return isNaN(d.getTime()) ? '—' : d.toLocaleDateString('en-CA')
+}
 
 const identityCounts = computed<Record<string, number>>(() => {
     const m: Record<string, number> = {}
@@ -173,6 +207,10 @@ async function refreshAll () {
 
 function openAgent (uuid: string) {
     router.push({ name: 'AiAgentView', params: { uuid } })
+}
+
+function openAllAgents () {
+    router.push({ name: 'AiAgentsTableOfOrg', params: { orguuid: orgUuid.value } })
 }
 
 function openSession (uuid: string) {
@@ -229,5 +267,8 @@ const sessionColumns: DataTableColumns<any> = [
 .acard__row { display: flex; gap: 24px; }
 .acard__num { font-size: 22px; font-weight: 600; margin-right: 6px; }
 .acard__lab { font-size: 11px; color: var(--n-text-color-3, #666); text-transform: uppercase; letter-spacing: 0.04em; }
+.acard__seen { display: flex; gap: 16px; margin-top: 10px; font-size: 12px; color: var(--n-text-color-3, #666); }
+.acard__seen .acard__lab { margin-right: 6px; }
+.section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
 .empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 12px 0; }
 </style>

--- a/ui/src/components/AiAgentsTableOfOrg.vue
+++ b/ui/src/components/AiAgentsTableOfOrg.vue
@@ -1,5 +1,9 @@
 <template>
     <div class="aiAgentsTable">
+        <n-breadcrumb separator="›" class="crumbs">
+            <n-breadcrumb-item @click="back">AI Agents</n-breadcrumb-item>
+            <n-breadcrumb-item>All Agents</n-breadcrumb-item>
+        </n-breadcrumb>
         <div class="page-head">
             <div>
                 <h4>All AI Agents</h4>
@@ -8,7 +12,6 @@
                     haven't been active recently. Sortable by any column.
                 </p>
             </div>
-            <n-button quaternary @click="back">← Back to overview</n-button>
         </div>
 
         <n-spin v-if="loading" size="small"/>
@@ -27,7 +30,7 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NButton, NDataTable, NSpin, NTag, DataTableColumns } from 'naive-ui'
+import { NBreadcrumb, NBreadcrumbItem, NDataTable, NSpin, NTag, DataTableColumns } from 'naive-ui'
 
 const store = useStore()
 const route = useRoute()
@@ -72,7 +75,10 @@ function formatDate (iso: string | null | undefined): string {
 function modelDisplay (m: any): string {
     if (!m) return '—'
     const tail = m.version && m.version !== 'unknown' ? ` @ ${m.version}` : ''
-    return `${m.publisher ?? ''} · ${m.name ?? ''}${tail}`.replace(/^· /, '')
+    // Publisher is optional — drop the " · " separator when it's missing
+    // so we don't render a leading dot when only the name is known.
+    const head = [m.publisher, m.name].filter(Boolean).join(' · ')
+    return `${head}${tail}`
 }
 
 function shortUuid (u: string | null | undefined): string {
@@ -84,10 +90,7 @@ const columns: DataTableColumns<any> = [
         title: 'Name',
         key: 'name',
         sorter: 'default',
-        render: (row: any) => h('div', { class: 'name-cell' }, [
-            h('span', { class: 'mark', style: { background: row.color || '#888' } }, row.iconKind || '◆'),
-            h('span', { class: 'name-text' }, row.name),
-        ]),
+        render: (row: any) => h('span', { class: 'name-text' }, row.name),
     },
     {
         title: 'Model',
@@ -143,8 +146,8 @@ const columns: DataTableColumns<any> = [
 <style scoped>
 .aiAgentsTable { padding: 16px; }
 .sub { color: var(--n-text-color-3, #666); font-size: 13px; margin-bottom: 16px; }
+.crumbs { margin-bottom: 12px; }
+.crumbs :deep(.n-breadcrumb-item:first-child .n-breadcrumb-item__link) { cursor: pointer; }
 .page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
-.name-cell { display: flex; align-items: center; gap: 8px; }
-.mark { display: inline-flex; width: 22px; height: 22px; border-radius: 5px; color: white; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
 .name-text { font-weight: 500; }
 </style>

--- a/ui/src/components/AiAgentsTableOfOrg.vue
+++ b/ui/src/components/AiAgentsTableOfOrg.vue
@@ -1,0 +1,150 @@
+<template>
+    <div class="aiAgentsTable">
+        <div class="page-head">
+            <div>
+                <h4>All AI Agents</h4>
+                <p class="sub">
+                    Every agent registered to this workspace, including those that
+                    haven't been active recently. Sortable by any column.
+                </p>
+            </div>
+            <n-button quaternary @click="back">← Back to overview</n-button>
+        </div>
+
+        <n-spin v-if="loading" size="small"/>
+
+        <n-data-table
+            v-else
+            :columns="columns"
+            :data="rootAgents"
+            :pagination="{ pageSize: 25 }"
+            :row-props="rowProps"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, ref } from 'vue'
+import { useStore } from 'vuex'
+import { useRoute, useRouter } from 'vue-router'
+import { NButton, NDataTable, NSpin, NTag, DataTableColumns } from 'naive-ui'
+
+const store = useStore()
+const route = useRoute()
+const router = useRouter()
+
+const orgUuid = computed(() => route.params.orguuid as string)
+const loading = ref<boolean>(false)
+const agents = ref<any[]>([])
+
+const rootAgents = computed(() => agents.value.filter(a => a.agentType === 'ROOT'))
+
+onMounted(async () => {
+    loading.value = true
+    try {
+        agents.value = await store.dispatch('fetchAgentsOfOrg', orgUuid.value) ?? []
+    } finally {
+        loading.value = false
+    }
+})
+
+function back () {
+    router.push({ name: 'AiAgentsOfOrg', params: { orguuid: orgUuid.value } })
+}
+
+function openAgent (uuid: string) {
+    router.push({ name: 'AiAgentView', params: { uuid } })
+}
+
+function rowProps (row: any) {
+    return {
+        style: 'cursor: pointer;',
+        onClick: () => openAgent(row.uuid),
+    }
+}
+
+function formatDate (iso: string | null | undefined): string {
+    if (!iso) return '—'
+    const d = new Date(iso)
+    return isNaN(d.getTime()) ? '—' : d.toLocaleDateString('en-CA')
+}
+
+function modelDisplay (m: any): string {
+    if (!m) return '—'
+    const tail = m.version && m.version !== 'unknown' ? ` @ ${m.version}` : ''
+    return `${m.publisher ?? ''} · ${m.name ?? ''}${tail}`.replace(/^· /, '')
+}
+
+function shortUuid (u: string | null | undefined): string {
+    return u ? `${u.slice(0, 8)}…${u.slice(-4)}` : ''
+}
+
+const columns: DataTableColumns<any> = [
+    {
+        title: 'Name',
+        key: 'name',
+        sorter: 'default',
+        render: (row: any) => h('div', { class: 'name-cell' }, [
+            h('span', { class: 'mark', style: { background: row.color || '#888' } }, row.iconKind || '◆'),
+            h('span', { class: 'name-text' }, row.name),
+        ]),
+    },
+    {
+        title: 'Model',
+        key: 'model',
+        sorter: (a: any, b: any) => modelDisplay(a.model).localeCompare(modelDisplay(b.model)),
+        render: (row: any) => modelDisplay(row.model),
+    },
+    {
+        title: 'Identity',
+        key: 'agentIdentity',
+        render: (row: any) => row.agentIdentity ? h('code', null, shortUuid(row.agentIdentity)) : '—',
+    },
+    {
+        title: 'Status',
+        key: 'status',
+        sorter: 'default',
+        render: (row: any) => h(NTag, { size: 'small', type: row.status === 'ARCHIVED' ? 'default' : 'success' }, () => row.status ?? 'ACTIVE'),
+    },
+    {
+        title: 'Sessions',
+        key: 'sessions',
+        sorter: (a: any, b: any) =>
+            (a.sessionCounts?.openSessions ?? 0) + (a.sessionCounts?.closedSessions ?? 0)
+            - ((b.sessionCounts?.openSessions ?? 0) + (b.sessionCounts?.closedSessions ?? 0)),
+        render: (row: any) => {
+            const open = row.sessionCounts?.openSessions ?? 0
+            const closed = row.sessionCounts?.closedSessions ?? 0
+            return `${open} open · ${closed} closed`
+        },
+    },
+    {
+        title: 'Sub-agents',
+        key: 'subAgents',
+        sorter: (a: any, b: any) => (a.subAgents?.length ?? 0) - (b.subAgents?.length ?? 0),
+        render: (row: any) => row.subAgents?.length ?? 0,
+    },
+    {
+        title: 'First seen',
+        key: 'createdDate',
+        sorter: (a: any, b: any) => (a.createdDate ?? '').localeCompare(b.createdDate ?? ''),
+        render: (row: any) => formatDate(row.createdDate),
+    },
+    {
+        title: 'Last seen',
+        key: 'lastActivityAt',
+        sorter: (a: any, b: any) => (a.lastActivityAt ?? '').localeCompare(b.lastActivityAt ?? ''),
+        defaultSortOrder: 'descend',
+        render: (row: any) => formatDate(row.lastActivityAt),
+    },
+]
+</script>
+
+<style scoped>
+.aiAgentsTable { padding: 16px; }
+.sub { color: var(--n-text-color-3, #666); font-size: 13px; margin-bottom: 16px; }
+.page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+.name-cell { display: flex; align-items: center; gap: 8px; }
+.mark { display: inline-flex; width: 22px; height: 22px; border-radius: 5px; color: white; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+.name-text { font-weight: 500; }
+</style>

--- a/ui/src/components/AiAgentsTableOfOrg.vue
+++ b/ui/src/components/AiAgentsTableOfOrg.vue
@@ -30,7 +30,8 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NBreadcrumb, NBreadcrumbItem, NDataTable, NSpin, NTag, DataTableColumns } from 'naive-ui'
+import { NBreadcrumb, NBreadcrumbItem, NDataTable, NIcon, NSpin, NTag, NTooltip, DataTableColumns } from 'naive-ui'
+import { Info20Regular } from '@vicons/fluent'
 
 const store = useStore()
 const route = useRoute()
@@ -70,6 +71,31 @@ function formatDate (iso: string | null | undefined): string {
     if (!iso) return '—'
     const d = new Date(iso)
     return isNaN(d.getTime()) ? '—' : d.toLocaleDateString('en-CA')
+}
+
+function formatDateTimePrecise (iso: string | null | undefined): string {
+    if (!iso) return ''
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return ''
+    return d.toLocaleString('en-CA', {
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit',
+        hour12: false,
+    })
+}
+
+// Date cell with second-precision tooltip on an info icon. Column
+// stays sortable on the raw ISO via the column's `sorter` — this
+// helper is purely the render side.
+function dateCell (iso: string | null | undefined) {
+    if (!iso) return h('span', null, '—')
+    return h('span', { class: 'date-cell' }, [
+        formatDate(iso),
+        h(NTooltip, { trigger: 'hover', placement: 'top' }, {
+            trigger: () => h(NIcon, { class: 'date-cell__info', size: 13, onClick: (e: Event) => e.stopPropagation() }, () => h(Info20Regular)),
+            default: () => formatDateTimePrecise(iso),
+        }),
+    ])
 }
 
 function modelDisplay (m: any): string {
@@ -131,14 +157,14 @@ const columns: DataTableColumns<any> = [
         title: 'First seen',
         key: 'createdDate',
         sorter: (a: any, b: any) => (a.createdDate ?? '').localeCompare(b.createdDate ?? ''),
-        render: (row: any) => formatDate(row.createdDate),
+        render: (row: any) => dateCell(row.createdDate),
     },
     {
         title: 'Last seen',
         key: 'lastActivityAt',
         sorter: (a: any, b: any) => (a.lastActivityAt ?? '').localeCompare(b.lastActivityAt ?? ''),
         defaultSortOrder: 'descend',
-        render: (row: any) => formatDate(row.lastActivityAt),
+        render: (row: any) => dateCell(row.lastActivityAt),
     },
 ]
 </script>
@@ -150,4 +176,7 @@ const columns: DataTableColumns<any> = [
 .crumbs :deep(.n-breadcrumb-item:first-child .n-breadcrumb-item__link) { cursor: pointer; }
 .page-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
 .name-text { font-weight: 500; }
+.date-cell { display: inline-flex; align-items: center; gap: 4px; }
+.date-cell__info { color: var(--n-text-color-3, #999); cursor: help; vertical-align: middle; }
+.date-cell__info:hover { color: var(--n-text-color-2, #555); }
 </style>

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -105,6 +105,21 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
                     RouterLink,
                     {
                         to: {
+                            name: 'AiAgentsOfOrg',
+                            params: {orguuid: org}
+                        }
+                    },
+                    { default: () => 'AI Agents' }
+                ),
+            key: 'aiAgents',
+            icon: renderIcon(Robot)
+        },
+        {
+            label: () =>
+                h(
+                    RouterLink,
+                    {
+                        to: {
                             name: 'VcsReposOfOrg',
                             params: {orguuid: org}
                         }
@@ -128,21 +143,6 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
                 ),
             key: 'pullRequests',
             icon: renderIcon(GitPullRequest)
-        },
-        {
-            label: () =>
-                h(
-                    RouterLink,
-                    {
-                        to: {
-                            name: 'AiAgentsOfOrg',
-                            params: {orguuid: org}
-                        }
-                    },
-                    { default: () => 'AI Agents' }
-                ),
-            key: 'aiAgents',
-            icon: renderIcon(Robot)
         },
 
     ]
@@ -256,6 +256,7 @@ const routeToMenuKey: Record<string, string> = {
     'PullRequestsOfOrg': 'pullRequests',
     'PullRequestView': 'pullRequests',
     'AiAgentsOfOrg': 'aiAgents',
+    'AiAgentsTableOfOrg': 'aiAgents',
     'AiAgentView': 'aiAgents',
     'AiAgentSessionView': 'aiAgents',
     'AiAgentPoliciesOfOrg': 'aiAgents',

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -55,6 +55,11 @@ const routes : any[] = [
         component: () => import('@/components/AiAgentsOfOrg.vue')
     },
     {
+        path: '/aiAgentsTableOfOrg/:orguuid',
+        name: 'AiAgentsTableOfOrg',
+        component: () => import('@/components/AiAgentsTableOfOrg.vue')
+    },
+    {
         path: '/aiAgent/:uuid',
         name: 'AiAgentView',
         component: () => import('@/components/AiAgentView.vue')


### PR DESCRIPTION
## Summary

Four user-facing AI Agents surface changes (all on the merged-main agentic foundation):

1. **Hero page** caps registered-agents grid at 8 (sorted by most-recently-active); each card adds *first seen* + *last seen* dates; \"See all N →\" link surfaces overflow.
2. **New all-agents table page** (\`/aiAgentsTableOfOrg/:orguuid\`) — sortable Naive UI data table with every column we have. Linked from the hero \"See all\".
3. **\"ModelName @ unknown\" cleanup** — when ModelOntology.version is the literal \"unknown\", drop the suffix. Five render sites touched.
4. **Left nav reorder** — AI Agents moves above VCS so it sits directly under Products.

## Test plan
- [ ] Visual check on hero page when registered-agent count > 8 (sandbox has more than that already)
- [ ] All-agents table page renders + sortable by Last seen (default desc)
- [ ] Agents created with no model version display as just the name (no \" @ unknown\")
- [ ] Nav highlights AI Agents on both \`/aiAgentsOfOrg\` and \`/aiAgentsTableOfOrg\` routes