### PR TITLE
feat(ui): co-locate Policy-Wide rules + actions on Component / Product settings

### DIFF
--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -40,7 +40,7 @@
                     <n-tag size="small" :type="agent.agentType === 'ROOT' ? 'info' : 'default'">{{ agent.agentType }}</n-tag>
                     <n-tag v-if="agent.status === 'ARCHIVED'" size="small" type="default">ARCHIVED</n-tag>
                     <span v-if="agent.model" class="dim">
-                        {{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code>
+                        <template v-if="agent.model.publisher">{{ agent.model.publisher }} · </template><code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code>
                     </span>
                     <span class="dim" v-if="agent.lastActivityAt">
                         last activity {{ formatDate(agent.lastActivityAt) }}
@@ -116,7 +116,7 @@
                     <n-descriptions-item label="Type">{{ agent.agentType }}</n-descriptions-item>
                     <n-descriptions-item label="Status">{{ agent.status }}</n-descriptions-item>
                     <n-descriptions-item label="Model">
-                        <span v-if="agent.model">{{ agent.model.publisher }} · <code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code></span>
+                        <span v-if="agent.model"><template v-if="agent.model.publisher">{{ agent.model.publisher }} · </template><code>{{ agent.model.name }}{{ agent.model.version && agent.model.version !== 'unknown' ? ' @ ' + agent.model.version : '' }}</code></span>
                         <span v-else class="dim">—</span>
                     </n-descriptions-item>
                     <n-descriptions-item label="Created">{{ formatDate(agent.createdDate) }}</n-descriptions-item>
@@ -216,7 +216,7 @@ const siblingColumns: DataTableColumns<any> = [
         title: 'Model',
         key: 'model',
         render: (row: any) => row.model
-            ? `${row.model.publisher} · ${row.model.name}${row.model.version && row.model.version !== 'unknown' ? ' @ ' + row.model.version : ''}`
+            ? `${[row.model.publisher, row.model.name].filter(Boolean).join(' · ')}${row.model.version && row.model.version !== 'unknown' ? ' @ ' + row.model.version : ''}`
             : '—',
     },
     { title: 'Created', key: 'createdDate', render: (row: any) => formatDate(row.createdDate) },

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -279,6 +279,8 @@ const sessionColumns: DataTableColumns<any> = [
     { title: 'Started', key: 'startedAt', render: (row: any) => row.startedAt ? new Date(row.startedAt).toLocaleString('en-CA') : '—' },
     { title: 'Artifacts', key: 'artifacts', width: 110, render: (row: any) => row.artifacts?.length ?? 0 },
     { title: 'Commits', key: 'commits', width: 100, render: (row: any) => row.commits?.length ?? 0 },
+    { title: 'PRs', key: 'pullRequests', width: 80, render: (row: any) => row.pullRequests?.length ?? 0 },
+    { title: 'Releases', key: 'releases', width: 100, render: (row: any) => row.releases?.length ?? 0 },
 ]
 </script>
 

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -95,7 +95,7 @@
                                     </n-tooltip>
                                 </div>
                                 <div class="acard__sub" v-if="a.model">
-                                    {{ a.model.publisher }} · <code>{{ a.model.name }}{{ a.model.version && a.model.version !== 'unknown' ? ' @ ' + a.model.version : '' }}</code>
+                                    <template v-if="a.model.publisher">{{ a.model.publisher }} · </template><code>{{ a.model.name }}{{ a.model.version && a.model.version !== 'unknown' ? ' @ ' + a.model.version : '' }}</code>
                                 </div>
                             </div>
                             <n-tag v-if="a.status === 'ARCHIVED'" size="small" type="default">

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -436,6 +436,23 @@
                                                 </n-button>
                                             </n-space>
                                         </div>
+                                        <!-- Policy-Wide Actions — read-only display. These are owned by
+                                             the approval policy, not the component. The local save
+                                             path (`saveTriggers` → `updateComponent`) only ships local
+                                             `outputTriggers`; policy-wide rows are never round-tripped
+                                             on the component mutation. -->
+                                        <div v-if="hasEffectivePolicy" style="margin-top: 28px;">
+                                            <h4 style="margin-bottom: 8px;">Policy-Wide Actions</h4>
+                                            <p v-if="policyGlobalOutputEvents.length === 0" class="text-muted">
+                                                No policy-wide actions defined on the approval policy.
+                                            </p>
+                                            <template v-else>
+                                                <p class="text-muted" style="font-size: 0.9em; margin-bottom: 6px;">
+                                                    Actions defined on the approval policy. Read-only here — edit them on the policy itself.
+                                                </p>
+                                                <n-data-table :data="policyGlobalOutputEvents" :columns="outputTriggerTableFields" :row-key="dataTableUuidRowKey" />
+                                            </template>
+                                        </div>
                                         <n-modal
                                             v-model:show="showCreateOutputTriggerModal"
                                             preset="dialog"
@@ -647,6 +664,61 @@
                                         <Icon v-if="isWritable" class="clickable" size="25" title="Add Rule" @click="resetInputTrigger(); showCreateInputTriggerModal = true">
                                             <CirclePlus />
                                         </Icon>
+                                        <!-- Policy-Wide Rules — co-located with local rules per
+                                             operator request. Toggle / override widgets save via the
+                                             same `saveTriggers` button below, which ships both
+                                             `releaseInputTriggers` (local) and `globalInputEventRefs`
+                                             (opt-out / override records) on the component mutation. -->
+                                        <div v-if="hasEffectivePolicy" style="margin-top: 28px;">
+                                            <h4 style="margin-bottom: 8px;">Policy-Wide Rules</h4>
+                                            <div v-if="policyGlobalInputEvents.length === 0" class="text-muted">
+                                                No policy-wide rules defined on the approval policy.
+                                            </div>
+                                            <div v-else>
+                                                <p class="text-muted" style="font-size: 0.9em; margin-bottom: 6px;">Policy-wide rules apply to this {{ words.component }} by default. Toggle a rule off to opt out, or override its actions locally.</p>
+                                                <div v-for="gie in policyGlobalInputEvents" :key="gie.uuid" class="mb-3" style="border: 1px solid #e0e0e0; border-radius: 6px; padding: 12px;">
+                                                    <div style="display: flex; align-items: center; gap: 8px;">
+                                                        <n-switch
+                                                            :value="isGlobalInputEventEnabled(gie.uuid)"
+                                                            @update:value="(val: boolean) => toggleGlobalInputEventRef(gie.uuid, val)"
+                                                            :disabled="!isWritable"
+                                                        />
+                                                        <strong>{{ gie.name }}</strong>
+                                                        <span class="text-muted" style="font-size: 0.85em;">
+                                                            ({{ gie.outputEvents?.length || 0 }} default action{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
+                                                        </span>
+                                                    </div>
+                                                    <div v-if="isGlobalInputEventEnabled(gie.uuid)" style="margin-left: 28px; margin-top: 8px;">
+                                                        <div style="display: flex; align-items: center; gap: 8px;">
+                                                            <n-switch
+                                                                :value="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally || false"
+                                                                @update:value="(val: boolean) => toggleOverrideOutputEvents(gie.uuid, val)"
+                                                                :disabled="!isWritable"
+                                                            />
+                                                            <span>Override actions locally</span>
+                                                            <n-button v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally"
+                                                                size="tiny" quaternary type="warning"
+                                                                @click="resetGlobalInputEventOverride(gie.uuid)"
+                                                                :disabled="!isWritable">
+                                                                Reset to Default
+                                                            </n-button>
+                                                        </div>
+                                                        <div v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally" style="margin-top: 8px;">
+                                                            <span style="color: #f0a020; font-size: 0.85em; font-weight: bold;">⚠ Actions are overridden locally</span>
+                                                            <n-select
+                                                                :value="getGlobalInputEventRef(gie.uuid)?.outputEventsOverride || []"
+                                                                @update:value="(val: string[]) => updateOutputEventsOverride(gie.uuid, val)"
+                                                                :options="allOutputEventsForOverride"
+                                                                multiple
+                                                                placeholder="Select actions to use instead"
+                                                                :disabled="!isWritable"
+                                                                style="margin-top: 4px;"
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                         <div class="coreSettingsActions" v-if="hasTriggerChanges && isWritable" style="margin-top: 20px;">
                                             <n-space>
                                                 <n-button type="success" @click="saveTriggers">
@@ -692,71 +764,6 @@
                                                 </n-space>
                                             </n-form>
                                         </n-modal>
-                                    </n-tab-pane>
-                                    <n-tab-pane name="globalTriggerEvents" tab="Policy-Wide Rules" v-if="myUser.installationType !== 'OSS' && hasEffectivePolicy">
-                                        <div v-if="policyGlobalInputEvents.length === 0" class="text-muted mt-2">
-                                            No policy-wide rules defined on the approval policy.
-                                        </div>
-                                        <div v-else>
-                                            <p class="text-muted">Policy-wide rules apply to this {{ words.component }} by default. Toggle a rule off to opt out, or override its actions locally.</p>
-                                            <div v-for="gie in policyGlobalInputEvents" :key="gie.uuid" class="mb-3" style="border: 1px solid #e0e0e0; border-radius: 6px; padding: 12px;">
-                                                <div style="display: flex; align-items: center; gap: 8px;">
-                                                    <n-switch
-                                                        :value="isGlobalInputEventEnabled(gie.uuid)"
-                                                        @update:value="(val: boolean) => toggleGlobalInputEventRef(gie.uuid, val)"
-                                                        :disabled="!isWritable"
-                                                    />
-                                                    <strong>{{ gie.name }}</strong>
-                                                    <span class="text-muted" style="font-size: 0.85em;">
-                                                        ({{ gie.outputEvents?.length || 0 }} default action{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
-                                                    </span>
-                                                </div>
-                                                <div v-if="isGlobalInputEventEnabled(gie.uuid)" style="margin-left: 28px; margin-top: 8px;">
-                                                    <div style="display: flex; align-items: center; gap: 8px;">
-                                                        <n-switch
-                                                            :value="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally || false"
-                                                            @update:value="(val: boolean) => toggleOverrideOutputEvents(gie.uuid, val)"
-                                                            :disabled="!isWritable"
-                                                        />
-                                                        <span>Override actions locally</span>
-                                                        <n-button v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally"
-                                                            size="tiny" quaternary type="warning"
-                                                            @click="resetGlobalInputEventOverride(gie.uuid)"
-                                                            :disabled="!isWritable">
-                                                            Reset to Default
-                                                        </n-button>
-                                                    </div>
-                                                    <div v-if="getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally" style="margin-top: 8px;">
-                                                        <span style="color: #f0a020; font-size: 0.85em; font-weight: bold;">⚠ Actions are overridden locally</span>
-                                                        <n-select
-                                                            :value="getGlobalInputEventRef(gie.uuid)?.outputEventsOverride || []"
-                                                            @update:value="(val: string[]) => updateOutputEventsOverride(gie.uuid, val)"
-                                                            :options="allOutputEventsForOverride"
-                                                            multiple
-                                                            placeholder="Select actions to use instead"
-                                                            :disabled="!isWritable"
-                                                            style="margin-top: 4px;"
-                                                        />
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="coreSettingsActions" v-if="hasTriggerChanges && isWritable" style="margin-top: 20px;">
-                                            <n-space>
-                                                <n-button type="success" @click="saveTriggers">
-                                                    <template #icon>
-                                                        <n-icon><Check /></n-icon>
-                                                    </template>
-                                                    Save Changes
-                                                </n-button>
-                                                <n-button type="warning" @click="resetTriggers">
-                                                    <template #icon>
-                                                        <n-icon><X /></n-icon>
-                                                    </template>
-                                                    Reset Changes
-                                                </n-button>
-                                            </n-space>
-                                        </div>
                                     </n-tab-pane>
                                     <n-tab-pane v-if="false" name="Environment Mapping">
                                         <div v-if="isWritable" class="envBranchMapBlock">

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -428,6 +428,7 @@
                                         </div>
                                     </n-tab-pane>
                                     <n-tab-pane name="outputTriggers" tab="Actions" v-if="myUser.installationType !== 'OSS'">
+                                        <h4 style="margin-bottom: 8px;">{{ words.componentFirstUpper }} Local Actions</h4>
                                         <n-data-table :data="updatedComponent.outputTriggers ? updatedComponent.outputTriggers : []" :columns="outputTriggerTableFields" :row-key="dataTableUuidRowKey" />
                                         <Icon v-if="isWritable" class="clickable" size="25" title="Add Action" @click="resetOutputTrigger(); loadEnvTypes(); showCreateOutputTriggerModal = true">
                                             <CirclePlus />
@@ -462,7 +463,7 @@
                                                 <p class="text-muted" style="font-size: 0.9em; margin-bottom: 6px;">
                                                     Actions defined on the approval policy. Read-only here — edit them on the policy itself.
                                                 </p>
-                                                <n-data-table :data="policyGlobalOutputEvents" :columns="outputTriggerTableFields" :row-key="dataTableUuidRowKey" />
+                                                <n-data-table :data="policyGlobalOutputEvents" :columns="outputTriggerTableFieldsReadOnly" :row-key="dataTableUuidRowKey" />
                                             </template>
                                         </div>
                                         <n-modal
@@ -672,6 +673,7 @@
                                         </n-modal>
                                     </n-tab-pane>
                                     <n-tab-pane name="Input Events" tab="Rules" v-if="myUser.installationType !== 'OSS'">
+                                        <h4 style="margin-bottom: 8px;">{{ words.componentFirstUpper }} Local Rules</h4>
                                         <n-data-table :data="updatedComponent.releaseInputTriggers ? updatedComponent.releaseInputTriggers : []" :columns="inputTriggerTableFields" :row-key="dataTableUuidRowKey" />
                                         <Icon v-if="isWritable" class="clickable" size="25" title="Add Rule" @click="resetInputTrigger(); showCreateInputTriggerModal = true">
                                             <CirclePlus />
@@ -699,6 +701,11 @@
                                                         <span class="text-muted" style="font-size: 0.85em;">
                                                             ({{ gie.outputEvents?.length || 0 }} default action{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
                                                         </span>
+                                                    </div>
+                                                    <div style="margin-left: 28px; margin-top: 4px; font-size: 12px;">
+                                                        <span class="text-muted" style="margin-right: 6px;">Condition:</span>
+                                                        <code v-if="gie.celExpression">{{ gie.celExpression }}</code>
+                                                        <span v-else class="text-muted">(none — rule will not fire)</span>
                                                     </div>
                                                     <div v-if="isGlobalInputEventEnabled(gie.uuid)" style="margin-left: 28px; margin-top: 8px;">
                                                         <div style="display: flex; align-items: center; gap: 8px;">
@@ -2839,6 +2846,9 @@ async function deleteInputTrigger (uuid: string) {
 
 const dataTableUuidRowKey = (row: any) => row.uuid
 
+// Local action columns — used for the editable component-owned table
+// at the top of the Actions tab. No scope column (the table itself is
+// the "local" section; the column was visual noise).
 const outputTriggerTableFields: DataTableColumns<any> = [
     {
         key: 'name',
@@ -2861,43 +2871,51 @@ const outputTriggerTableFields: DataTableColumns<any> = [
         }
     },
     {
-        key: 'scope',
-        title: 'Scope',
-        render: (row: any) => {
-            if (row.scope === 'GLOBAL') return h('span', { style: 'color: #2080f0; font-weight: bold;' }, 'Global')
-            return h('span', 'Local')
-        }
-    },
-    {
         key: 'actions',
         title: 'Actions',
         render: (row: any) => {
-            let els: any[] = []
-            if (isWritable && row.scope !== 'GLOBAL') {
-                const editEl = h(NIcon, {
+            const els: any[] = []
+            if (isWritable.value) {
+                els.push(h(NIcon, {
                     title: 'Edit Trigger',
                     class: 'icons clickable',
                     size: 20,
-                    onClick: () => {
-                        editOutputTrigger(row)
-                    }
-                }, 
-                () => h(Edit)
-                )
-                const deleteEl = h(NIcon, {
+                    onClick: () => editOutputTrigger(row)
+                }, () => h(Edit)))
+                els.push(h(NIcon, {
                     title: 'Delete Trigger',
                     class: 'icons clickable',
                     size: 20,
-                    onClick: () => {
-                        deleteOutputTrigger(row.uuid)
-                    }
-                }, 
-                () => h(Trash)
-                )
-                els.push(editEl, deleteEl)
+                    onClick: () => deleteOutputTrigger(row.uuid)
+                }, () => h(Trash)))
             }
-            if (!els.length) els = [h('div'), row.scope === 'GLOBAL' ? 'Global' : 'N/A']
-            return els
+            return els.length ? els : h('div', 'N/A')
+        }
+    }
+]
+
+// Policy-wide action columns — read-only display in the lower section
+// of the Actions tab. No actions column (edits happen on the policy),
+// no scope column (the table itself is the "policy-wide" section).
+const outputTriggerTableFieldsReadOnly: DataTableColumns<any> = [
+    {
+        key: 'name',
+        title: 'Name'
+    },
+    {
+        key: 'type',
+        title: 'Type',
+        render: (row: any) => {
+            const option = outputTriggerTypeOptions.find(opt => opt.value === row.type)
+            return option ? option.label : row.type
+        }
+    },
+    {
+        key: 'toReleaseLifecycle',
+        title: 'Lifecycle to Change To',
+        render: (row: any) => {
+            const option = outputTriggerLifecycleOptions.find(opt => opt.value === row.toReleaseLifecycle)
+            return option ? option.label : row.toReleaseLifecycle
         }
     }
 ]
@@ -2906,6 +2924,18 @@ const inputTriggerTableFields: DataTableColumns<any> = [
     {
         key: 'name',
         title: 'Name'
+    },
+    {
+        key: 'celExpression',
+        title: 'Condition',
+        render: (row: any) => {
+            if (!row.celExpression) {
+                return h(NAlert, { type: 'warning', style: 'font-size: 12px;' }, {
+                    default: () => 'No CEL expression — rule will not fire. Edit to add a condition.'
+                })
+            }
+            return h('code', { style: 'font-size: 12px;' }, row.celExpression)
+        }
     },
     {
         key: 'outputTriggers',
@@ -2929,64 +2959,25 @@ const inputTriggerTableFields: DataTableColumns<any> = [
         }
     },
     {
-        key: 'facts',
-        title: 'Facts',
-        render: (row: any) => {
-            const els: any[] = []
-            if (!row.celExpression) {
-                els.push(h(NAlert, { type: 'warning', style: 'margin-bottom: 4px;' }, {
-                    default: () => 'This trigger has no CEL expression and will not fire. Add a condition.'
-                }))
-            }
-            const factContent: any[] = [
-                h('div', `UUID: ${row.uuid}`),
-                h('div', `CEL: ${row.celExpression || '(none)'}`)
-            ]
-            els.push(h(NTooltip, { trigger: 'hover' }, {
-                trigger: () => h(NIcon, { class: 'icons', size: 25 }, () => h(Info20Regular)),
-                default: () => h('ul', factContent)
-            }))
-            return h('div', els)
-        }
-    },
-    {
-        key: 'scope',
-        title: 'Scope',
-        render: (row: any) => {
-            if (row.scope === 'GLOBAL') return h('span', { style: 'color: #2080f0; font-weight: bold;' }, 'Global')
-            return h('span', 'Local')
-        }
-    },
-    {
         key: 'actions',
         title: 'Actions',
         render: (row: any) => {
-            let els: any[] = []
-            if (isWritable && row.scope !== 'GLOBAL') {
-                const editEl = h(NIcon, {
+            const els: any[] = []
+            if (isWritable.value) {
+                els.push(h(NIcon, {
                     title: 'Edit Trigger',
                     class: 'icons clickable',
                     size: 20,
-                    onClick: () => {
-                        editInputTrigger(row)
-                    }
-                }, 
-                () => h(Edit)
-                )
-                const deleteEl = h(NIcon, {
+                    onClick: () => editInputTrigger(row)
+                }, () => h(Edit)))
+                els.push(h(NIcon, {
                     title: 'Delete Trigger',
                     class: 'icons clickable',
                     size: 20,
-                    onClick: () => {
-                        deleteInputTrigger(row.uuid)
-                    }
-                }, 
-                () => h(Trash)
-                )
-                els.push(editEl, deleteEl)
+                    onClick: () => deleteInputTrigger(row.uuid)
+                }, () => h(Trash)))
             }
-            if (!els.length) els = [h('div'), row.scope === 'GLOBAL' ? 'Global' : 'N/A']
-            return els
+            return els.length ? els : h('div', 'N/A')
         }
     }
 ]

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -378,11 +378,23 @@
                                                 <div class="provenance-line">
                                                     <strong>Effective policy:</strong>
                                                     <span v-if="effectiveApprovalPolicy.source === 'PER_COMPONENT'">
-                                                        <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        <a v-if="canViewOrgPolicies && effectiveApprovalPolicy.approvalPolicy"
+                                                            :href="policyLink(effectiveApprovalPolicy.approvalPolicy)"
+                                                            target="_blank" rel="noopener"
+                                                            title="Open policy in Org Settings (new tab)">
+                                                            <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        </a>
+                                                        <code v-else>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
                                                         (set directly on this {{ words.component }})
                                                     </span>
                                                     <span v-else-if="effectiveApprovalPolicy.source === 'ORG_RULE'">
-                                                        <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        <a v-if="canViewOrgPolicies && effectiveApprovalPolicy.approvalPolicy"
+                                                            :href="policyLink(effectiveApprovalPolicy.approvalPolicy)"
+                                                            target="_blank" rel="noopener"
+                                                            title="Open policy in Org Settings (new tab)">
+                                                            <code>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
+                                                        </a>
+                                                        <code v-else>{{ effectiveApprovalPolicy.approvalPolicyDetails?.policyName || effectiveApprovalPolicy.approvalPolicy }}</code>
                                                         — inherited from org rule <code>{{ effectiveApprovalPolicy.ruleName }}</code>
                                                     </span>
                                                     <span v-else>none — no per-{{ words.component }} reference and no matching org rule</span>
@@ -1079,6 +1091,19 @@ const isWritable : ComputedRef<boolean> = computed((): boolean => {
     )
     return componentPermission?.type === 'READ_WRITE'
 })
+
+// Org-wide READ_ONLY or above gates the "Effective policy:" deep-link
+// to Org Settings. Users without org-scoped read access wouldn't be
+// able to see the policy detail page anyway, so the link would just
+// land on an empty / 403 view.
+const canViewOrgPolicies : ComputedRef<boolean> = computed((): boolean => {
+    const userPermission = commonFunctions.getUserPermission(orguuid.value, myUser)
+    return ['READ_ONLY', 'READ_WRITE', 'ADMIN'].includes(userPermission.org)
+})
+
+function policyLink (policyUuid: string): string {
+    return `/orgSettings/${orguuid.value}?tab=policies&policyTab=approvalPoliciesInner&policy=${policyUuid}`
+}
 
 const words: Ref<any> = ref({})
 

--- a/ui/src/components/InstancesOfOrg.vue
+++ b/ui/src/components/InstancesOfOrg.vue
@@ -159,14 +159,28 @@ const filterValue: Ref<any> = ref({
     createdBy: ''
 })
 
+// Tooltip body for the URI cell — always carries URI + Environment,
+// appends Cluster when the row resolves to a CLUSTER_INSTANCE that
+// matches an entry in `findInstanceCluster`. Hoisted so the render
+// function stays compact.
+function uriTooltipText (row: any): string {
+    const parts = [`URI: ${row.uri}`, `Environment: ${row.environment}`]
+    if (row.instanceType === InstanceType.CLUSTER_INSTANCE) {
+        const cluster = findInstanceCluster(row.uuid)
+        if (cluster && cluster.name) parts.push(`Cluster: ${cluster.name}`)
+    }
+    return parts.join(', ')
+}
+
 const uriField = reactive<DataTableBaseColumn<any>>({
     key: 'uri',
     title: 'URI',
     // Long URIs (`card-shuffle.psclaude.rearmhq.com`-style) used to wrap
     // and break the column layout. Render as a single ellipsised line
-    // and always surface the full URI + environment in a hover tooltip
-    // — the user wants the tooltip available unconditionally, not only
-    // when the text actually overflows.
+    // and always surface the full URI + environment (+ cluster when
+    // present) in a hover tooltip — the user wants the tooltip
+    // available unconditionally, not only when the text actually
+    // overflows.
     render (row: any) {
         return h(
             NTooltip,
@@ -177,7 +191,7 @@ const uriField = reactive<DataTableBaseColumn<any>>({
                 trigger: () => h('div', {
                     style: 'text-overflow: ellipsis; overflow: hidden; white-space: nowrap; max-width: 100%;'
                 }, row.uri),
-                default: () => `URI: ${row.uri}, Environment: ${row.environment}`
+                default: () => uriTooltipText(row)
             }
         )
     },
@@ -202,20 +216,6 @@ const rowClassName = (row: any) => {
 
 const instanceFields: DataTableColumns<any> = [
     uriField,
-    {
-        key: 'cluster',
-        title: 'Cluster',
-        render: (row: any) => {
-            let clustername = ""
-            if(row.instanceType === InstanceType.CLUSTER_INSTANCE){
-                let cluster = findInstanceCluster(row.uuid)
-                if(cluster && cluster.uuid && cluster.uuid.length){
-                    clustername = cluster.name
-                }
-            }
-            return clustername
-        }
-    },
 ]
 
 const clusetrFields = [

--- a/ui/src/components/InstancesOfOrg.vue
+++ b/ui/src/components/InstancesOfOrg.vue
@@ -162,16 +162,22 @@ const filterValue: Ref<any> = ref({
 const uriField = reactive<DataTableBaseColumn<any>>({
     key: 'uri',
     title: 'URI',
+    // Long URIs (`card-shuffle.psclaude.rearmhq.com`-style) used to wrap
+    // and break the column layout. Render as a single ellipsised line
+    // and always surface the full URI + environment in a hover tooltip
+    // — the user wants the tooltip available unconditionally, not only
+    // when the text actually overflows.
     render (row: any) {
-        // console.log(row)
         return h(
             NTooltip,
             {
                 trigger: 'hover'
-            }, 
+            },
             {
-                trigger: () => row.uri,
-                default: () => 'Environment: ' + row.environment + ', type: ' + ((row.spawnType !== 'MANUAL') ? 'Ephemeral' : 'Persistent')
+                trigger: () => h('div', {
+                    style: 'text-overflow: ellipsis; overflow: hidden; white-space: nowrap; max-width: 100%;'
+                }, row.uri),
+                default: () => `URI: ${row.uri}, Environment: ${row.environment}`
             }
         )
     },
@@ -209,10 +215,6 @@ const instanceFields: DataTableColumns<any> = [
             }
             return clustername
         }
-    },
-    {
-        key: 'namespace',
-        title: 'ns',
     },
 ]
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -5782,7 +5782,13 @@ const approvalPolicyFields: DataTableColumns<any> = [
 
 const approvalPolicyTableData: Ref<any[]> = ref([])
 const approvalPoliciesFullData: Ref<any[]> = ref([])
-const selectedPolicyUuid: Ref<string> = ref('')
+// Deep-link support: `?policy=<uuid>` on the OrgSettings URL pre-
+// selects an approval policy so links from ComponentView's
+// "Effective policy:" provenance line land directly on the right row.
+// The downstream loader (`loadApprovalPolicies()`) checks
+// `selectedPolicyUuid.value` after fetching and runs the side-panel
+// population for the matching policy automatically.
+const selectedPolicyUuid: Ref<string> = ref(route.query.policy as string || '')
 const globalOutputEvents: Ref<any[]> = ref([])
 const globalInputEvents: Ref<any[]> = ref([])
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -6046,9 +6046,18 @@ async function fetchApprovalPolicies () {
                 approvalNames
             }
         })
-        // If a policy was selected, refresh its events
+        // If a policy was selected (either via prior row click or via
+        // the `?policy=<uuid>` deep-link initialiser), populate the
+        // side panel directly. Do NOT call selectPolicyForGlobalEvents
+        // here — that function toggles when called with the already-
+        // selected uuid, which would clear the selection on a
+        // deep-link load.
         if (selectedPolicyUuid.value) {
-            selectPolicyForGlobalEvents(selectedPolicyUuid.value)
+            const policy = approvalPoliciesFullData.value.find((p: any) => p.uuid === selectedPolicyUuid.value)
+            if (policy) {
+                globalOutputEvents.value = policy.globalOutputEvents || []
+                globalInputEvents.value = policy.globalInputEvents || []
+            }
         }
     } else {
         approvalPolicyTableData.value = []

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -252,11 +252,34 @@ const isStaleChunkError = (err: unknown): boolean => {
 }
 
 const RELOAD_GUARD_KEY = 'rearm-stale-chunk-reload-at'
+
+function showReloadToast (): void {
+    if (document.getElementById('rearm-stale-chunk-toast')) return
+    const el = document.createElement('div')
+    el.id = 'rearm-stale-chunk-toast'
+    el.textContent = 'App updated — reloading…'
+    Object.assign(el.style, {
+        position: 'fixed',
+        bottom: '24px',
+        right: '24px',
+        background: '#2080f0',
+        color: '#fff',
+        padding: '10px 16px',
+        borderRadius: '6px',
+        fontSize: '14px',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+        zIndex: '9999',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+    } as Partial<CSSStyleDeclaration>)
+    document.body.appendChild(el)
+}
+
 const reloadOnce = () => {
     const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) || 0)
     if (Date.now() - last < 10_000) return
     sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
-    window.location.reload()
+    showReloadToast()
+    setTimeout(() => window.location.reload(), 800)
 }
 
 Router.onError((err) => {

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -233,6 +233,43 @@ const Router : Router = createRouter({
     routes
 })
 
+// After a backend pod roll the browser's loaded index.js still references
+// the previous chunk hashes; the new pod serves index.html for the missing
+// asset, the browser refuses it on MIME type and the UI freezes mid-nav.
+// Reload once on these errors so the user lands on the fresh bundle.
+const STALE_CHUNK_PATTERNS = [
+    /Failed to fetch dynamically imported module/i,
+    /Loading chunk [\w-]+ failed/i,
+    /Loading CSS chunk [\w-]+ failed/i,
+    /Unable to preload CSS/i,
+    /error loading dynamically imported module/i,
+    /disallowed MIME type/i,
+]
+
+const isStaleChunkError = (err: unknown): boolean => {
+    const msg = err instanceof Error ? err.message : String(err ?? '')
+    return STALE_CHUNK_PATTERNS.some(p => p.test(msg))
+}
+
+const RELOAD_GUARD_KEY = 'rearm-stale-chunk-reload-at'
+const reloadOnce = () => {
+    const last = Number(sessionStorage.getItem(RELOAD_GUARD_KEY) || 0)
+    if (Date.now() - last < 10_000) return
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+    window.location.reload()
+}
+
+Router.onError((err) => {
+    if (isStaleChunkError(err)) reloadOnce()
+})
+
+window.addEventListener('error', (e) => {
+    if (isStaleChunkError(e.error ?? e.message)) reloadOnce()
+})
+window.addEventListener('unhandledrejection', (e) => {
+    if (isStaleChunkError(e.reason)) reloadOnce()
+})
+
 export default {
     name: 'Router',
     // mode: 'history',

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -2119,6 +2119,8 @@ const storeObject : any = {
                             lastActivityAt
                             artifacts
                             commits
+                            releases { uuid }
+                            pullRequests { uuid }
                         }
                     }`,
                 variables: { orgUuid: payload.orgUuid, statuses: payload.statuses ?? null },


### PR DESCRIPTION
## Summary

- **Rules tab**: local rules at the top (unchanged); Policy-Wide Rules section moved in below with its existing opt-out + actions-override widgets. Standalone \"Policy-Wide Rules\" tab removed. Single Save button at the bottom continues to ship local \`releaseInputTriggers\` + local \`globalInputEventRefs\` (opt-out / override records) via \`updateComponent\` — no save-path changes.
- **Actions tab**: new Policy-Wide Actions subsection below the local-actions table, read-only. Data sources \`effectivePolicyDetails.globalOutputEvents\` via the already-computed \`policyGlobalOutputEvents\`. Reuses \`outputTriggerTableFields\` columns config which already hides edit/delete on \`scope === 'GLOBAL'\` rows. Save path untouched — \`saveTriggers\` only serialises local \`outputTriggers\`.

The component-save mutation isolation is the load-bearing constraint: nothing in this change adds policy-wide data to the component update payload. Policy-wide rows live on \`approvalPolicyDetails\` (read side) and are edited on the approval policy itself.

## Test plan
- [ ] Open a component with an effective approval policy — Rules tab shows local + Policy-Wide Rules sections, both interactive (toggle / override on policy-wide rules works as before)
- [ ] Actions tab shows local + Policy-Wide Actions, the latter rendered read-only (\"Global\" badge on the scope column, no edit / delete icons)
- [ ] Save changes on a local rule — confirm via GraphQL trace that \`updateComponent\` payload does NOT contain any policy-wide \`globalInputEvents\` / \`globalOutputEvents\` fields
- [ ] Component with NO effective policy — both subsections hidden, layout looks the same as before