### PR TITLE
feat(ui): surface DependencyTrack fetch-failure backoff state on artifact view

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -4817,6 +4817,10 @@ function renderArtifactFactsColumn (row: any) {
     if (row.metrics && row.metrics.dtrackSubmissionFailed) factContent.push(h('li', { style: 'color: red;' }, 'DependencyTrack submission failed'))
     if (row.metrics && row.metrics.dtrackSubmissionFailed && row.metrics.dtrackSubmissionFailureReason) factContent.push(h('li', { style: 'color: red;' }, `DependencyTrack failure reason: ${row.metrics.dtrackSubmissionFailureReason}`))
     if (row.metrics && row.metrics.dtrackSubmissionAttempts > 0) factContent.push(h('li', `DependencyTrack submission attempts: ${row.metrics.dtrackSubmissionAttempts}`))
+    if (row.metrics && row.metrics.dtrackFetchStatus === 'FAILED') factContent.push(h('li', { style: 'color: red;' }, 'DependencyTrack vuln-scan refresh failed'))
+    if (row.metrics && row.metrics.dtrackFetchStatus === 'FAILED' && row.metrics.dtrackFetchFailureReason) factContent.push(h('li', { style: 'color: red;' }, `DependencyTrack refresh failure reason: ${row.metrics.dtrackFetchFailureReason}`))
+    if (row.metrics && row.metrics.dtrackFetchFailureCount > 0) factContent.push(h('li', `DependencyTrack refresh failure count: ${row.metrics.dtrackFetchFailureCount}`))
+    if (row.metrics && row.metrics.dtrackFetchSkipUntil) factContent.push(h('li', `DependencyTrack next refresh attempt: ${new Date(row.metrics.dtrackFetchSkipUntil).toLocaleString('en-Ca', { hour12: false })}`))
     if (row.artifactDetails && row.artifactDetails.length) {
         row.artifactDetails.forEach((ad: any) => {
             const adChildren: any[] = [h('span', `${ad.type}: `), h('a', {class: 'clickable', onClick: () => downloadArtifact(ad, true)}, 'download')]
@@ -4977,6 +4981,21 @@ function renderDtrackPill (row: any): any {
     if (m.dtrackSubmissionFailed) {
         const reason = m.dtrackSubmissionFailureReason ? `: ${m.dtrackSubmissionFailureReason}` : ''
         return h(NTag, { type: 'error', size: 'small', round: true, title: `DependencyTrack submission failed${reason}` }, () => 'Scan failed')
+    }
+    // Fetch-side failure: BOM was successfully submitted (we have a DT project) but
+    // the backend couldn't read vulnerabilities back. If firstScanned exists, the
+    // artifact still has a previous good scan's data — make it explicit that the
+    // numbers below are stale, not authoritative.
+    if (m.dtrackFetchStatus === 'FAILED') {
+        const reason = m.dtrackFetchFailureReason ? `: ${m.dtrackFetchFailureReason}` : ''
+        const retryAt = m.dtrackFetchSkipUntil
+            ? ` — next retry at ${new Date(m.dtrackFetchSkipUntil).toLocaleString('en-Ca', { hour12: false })}`
+            : ''
+        const stale = m.lastScanned
+            ? ` (showing stale data from ${new Date(m.lastScanned).toLocaleString('en-Ca', { hour12: false })})`
+            : ''
+        const label = m.firstScanned ? 'Scan refresh failed' : 'Scan fetch failed'
+        return h(NTag, { type: 'error', size: 'small', round: true, title: `DependencyTrack fetch failed${reason}${retryAt}${stale}` }, () => label)
     }
     if (m.firstScanned) {
         return h(NTag, { type: 'success', size: 'small', round: true, title: 'Dependency-Track scan complete' }, () => 'Scan done')

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -293,6 +293,10 @@ const ARTIFACT_DETAIL_DATA_SINGLE = `
         dtrackSubmissionFailed
         dtrackSubmissionAttempts
         dtrackSubmissionFailureReason
+        dtrackFetchStatus
+        dtrackFetchFailureCount
+        dtrackFetchFailureReason
+        dtrackFetchSkipUntil
         critical
         high
         medium
@@ -357,6 +361,10 @@ const ARTIFACT_DETAIL_DATA = `
         dtrackSubmissionFailed
         dtrackSubmissionAttempts
         dtrackSubmissionFailureReason
+        dtrackFetchStatus
+        dtrackFetchFailureCount
+        dtrackFetchFailureReason
+        dtrackFetchSkipUntil
         lastScanned
         firstScanned
         critical


### PR DESCRIPTION
## Summary

The ReARM backend now records per-artifact DependencyTrack fetch-failure state (`dtrackFetchStatus`, `dtrackFetchFailureCount`, `dtrackFetchFailureReason`, `dtrackFetchSkipUntil`) when the paginated vuln/violation drain throws — preserving the artifact's previous good vulnerability list across transient DT outages instead of overwriting it with empty data.

This UI change adds the corresponding visual signal so operators can see *why* the displayed vuln counts may be stale, instead of trusting them as authoritative.

- `ARTIFACT_DETAIL_DATA` and `ARTIFACT_DETAIL_DATA_SINGLE` GraphQL fragments now select the four new fields on `DependencyTrackMetrics`.
- `renderDtrackPill` grows a new red badge:
  - **"Scan refresh failed"** when a previous scan completed (`firstScanned` set) — the displayed counts are stale, retry is pending.
  - **"Scan fetch failed"** when no prior scan completed — first fetch attempt failed.
  - Tooltip carries the failure reason, the next retry timestamp, and an explicit *"showing stale data from <ts>"* hint.
- `renderArtifactFactsColumn` mirrors the existing `dtrackSubmission*` fields' rendering style for the fetch-failure trio plus the next-retry timestamp.

## Rendering priority

The pill rendering is a priority-ordered switch. Fetch-failure check sits AFTER submission-failure (a submission-failed artifact never has fetch state) and BEFORE the success/scanning/pending fallbacks (so a previously-scanned artifact with a fresh fetch failure shows the failure instead of the stale "Scan done").

## Test plan

- [x] `npm run build` — clean (existing chunk-size warning unrelated).
- [ ] CI: full build pipeline.
- [ ] Manual sandbox check: query an artifact whose backend metrics have been set to `dtrackFetchStatus=FAILED` (verified e2e against the sandbox in the backend PR); confirm the "Scan refresh failed" pill appears and the tooltip shows the retry timestamp + stale-data warning.

## Dependencies

- Depends on the backend backoff fields landing first; without them the GraphQL fragment selects will return null and `renderDtrackPill` falls back to the existing success/pending branches (i.e., this PR is backward-compatible — if the backend doesn't have the fields yet, behavior is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)