### PR TITLE
Deprecate ReleaseInputProg.sceArts (silently ignored by addReleaseProgrammatic)

### DIFF
--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -948,6 +948,19 @@ public class ReleaseDatafetcher {
 
 		Map<String, Object> progReleaseInput = dfe.getArgument("release");
 
+		// Deprecated input: ReleaseInputProg.sceArts has been silently ignored
+		// since this resolver was written — the SCE-attached artifact path is
+		// sourceCodeEntry.artifacts (or commits[i].artifacts). Log loud enough
+		// to track remaining callers so we can drop the schema field once the
+		// CLI and SDKs catch up.
+		if (progReleaseInput.containsKey("sceArts")) {
+			Object scea = progReleaseInput.get("sceArts");
+			int count = (scea instanceof java.util.Collection) ? ((java.util.Collection<?>) scea).size() : 0;
+			if (count > 0) {
+				log.warn("Deprecated ReleaseInputProg.sceArts received with {} entries; nest under sourceCodeEntry.artifacts (or commits[i].artifacts) instead — this field is ignored.", count);
+			}
+		}
+
 		// First, try to resolve component normally
 		UUID componentId = null;
 		try {

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -2866,7 +2866,14 @@ input ReleaseInputProg {
 	outboundDeliverables: [DeliverableInput]
 	endpoint: String
 	commits: [SourceCodeEntryInput]
-	sceArts: [ArtifactInput]
+	"""
+	DEPRECATED — silently dropped by addReleaseProgrammatic. The resolver
+	only consumes source-code-entry artifacts from `sourceCodeEntry.artifacts`
+	(or each `commits[i].artifacts` for multi-commit inputs). Nest the
+	artifacts there instead. The server logs a WARN whenever this field
+	is supplied so we can track remaining callers before removing it.
+	"""
+	sceArts: [ArtifactInput] @deprecated(reason: "Nest SCE artifacts under sourceCodeEntry.artifacts (or commits[i].artifacts); this top-level field is ignored by addReleaseProgrammatic.")
 	identifiers: [IdentifierInput]
 	vcsUri: String
 	repoPath: String


### PR DESCRIPTION
## Summary
Parity with relizaio/rearm-saas: deprecate `ReleaseInputProg.sceArts` on the CE schema and add a WARN log when callers send it. See that PR for the full rationale; both CE and Pro share the same resolver layout for this mutation, so the deprecation needs to land in both.

## Test plan
- [x] Schema parses.
- [x] No behavioural change — additive `containsKey(\"sceArts\")` check + WARN.