### PR TITLE
sync(backend): DT-fetch resilience + bundled backend changes from rearm-core main

### DIFF
--- a/backend/src/main/java/io/reliza/model/ArtifactData.java
+++ b/backend/src/main/java/io/reliza/model/ArtifactData.java
@@ -240,6 +240,18 @@ public class ArtifactData extends RelizaDataParent implements RelizaObject {
     	private Boolean dtrackSubmissionFailed = false;
     	private Integer dtrackSubmissionAttempts = 0;
     	private String dtrackSubmissionFailureReason;
+    	// FETCH-side failure tracking (distinct from the SUBMISSION-side trio above).
+    	// Populated by SharedArtifactService.markArtifactDtrackFetchFailed when the
+    	// paginated vuln/violation drain from DTrack throws; cleared by
+    	// resetArtifactDtrackFetchFailedState on the next successful drain. The
+    	// scheduler-pickup SQL filters on dtrackFetchSkipUntil to avoid re-attempting
+    	// during the backoff window. ISO-8601 String (not ZonedDateTime) so the
+    	// SQL ::timestamptz cast in the scheduler filter parses cleanly.
+    	public static final int FETCH_FAILURE_REASON_MAX_LEN = 512;
+    	private DtrackFetchStatus dtrackFetchStatus;
+    	private Integer dtrackFetchFailureCount;
+    	private String dtrackFetchFailureReason;
+    	private String dtrackFetchSkipUntil;
     	private ZonedDateTime uploadDate;
     	
     	public static DependencyTrackIntegration fromReleaseMetricsDto(ReleaseMetricsDto rmd) {

--- a/backend/src/main/java/io/reliza/model/DtrackFetchStatus.java
+++ b/backend/src/main/java/io/reliza/model/DtrackFetchStatus.java
@@ -1,0 +1,26 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.model;
+
+/**
+ * Per-artifact lifecycle of the ReARM-side fetch from Dependency-Track's
+ * vulnerability / violation endpoints (distinct from the SUBMISSION side, which
+ * is tracked separately by {@code dtrackSubmissionFailed} / {@code dtrackSubmissionAttempts}
+ * on the same {@link ArtifactData.DependencyTrackIntegration}).
+ *
+ * <p>The fetch is paginated and can fail mid-drain (HTTP/parse). When it does,
+ * the artifact stays on its previous good vulnerability list and the scheduler
+ * stops re-attempting until the backoff window elapses — see
+ * {@code dtrackFetchSkipUntil} on {@link ArtifactData.DependencyTrackIntegration}
+ * and {@code BackoffPolicy.dtrackFetchSkipSeconds}.
+ */
+public enum DtrackFetchStatus {
+    /** Default for never-attempted artifacts. Treated as eligible by the scheduler. */
+    PENDING,
+    /** Most recent fetch attempt completed. Cleared failure state. */
+    OK,
+    /** Most recent fetch attempt threw. {@code dtrackFetchSkipUntil} pushes the next attempt out. */
+    FAILED
+}

--- a/backend/src/main/java/io/reliza/repositories/ArtifactRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ArtifactRepository.java
@@ -41,6 +41,20 @@ public interface ArtifactRepository extends CrudRepository<Artifact, UUID> {
 			value = VariableQueries.FIND_ARTIFACTS_BY_DTRACK_PROJECTS,
 			nativeQuery = true)
 	List<Artifact> findArtifactsByDtrackProjects(List<String> dtrackProjectIds);
+
+	@Query(
+			value = VariableQueries.FIND_ARTIFACT_UUIDS_BY_DTRACK_PROJECTS,
+			nativeQuery = true)
+	List<UUID> findArtifactUuidsByDtrackProjects(List<String> dtrackProjectIds);
+
+	@Modifying
+	@Transactional
+	@Query(
+			value = VariableQueries.MARK_ARTIFACTS_DTRACK_PROJECT_DELETED,
+			nativeQuery = true)
+	int markArtifactsAsDtrackProjectDeleted(
+			@Param("orgUuidAsString") String orgUuidAsString,
+			@Param("dtrackProjectIds") List<String> dtrackProjectIds);
 	
 	@Query(
 			value = VariableQueries.LIST_ACTIVE_RELEASE_ARTIFACT_UUIDS,

--- a/backend/src/main/java/io/reliza/repositories/VariableQueries.java
+++ b/backend/src/main/java/io/reliza/repositories/VariableQueries.java
@@ -207,9 +207,19 @@ class VariableQueries {
 	// up front triggered Hibernate dirty-checking snapshots that deep-copy
 	// the metrics JSONB via serialize→bytes→deserialize, large enough on
 	// projects with thousands of vulns to OOM the scheduler thread.
+	// dtrackFetchSkipUntil filter excludes artifacts whose last fetch attempt
+	// threw and whose backoff window hasn't elapsed. Most rows have no fetch
+	// failure history (skipUntil IS NULL) so the filter is essentially a
+	// no-op on the happy path; only artifacts actively in backoff are excluded.
+	// Storage is flat at metrics->>'dtrackFetchSkipUntil' (DependencyTrackIntegration
+	// fields serialize at the top level of metrics, mirroring dtrackSubmissionFailed).
+	// ISO-8601 string cast to timestamptz matches FlowControl's sbomReconcileSkipUntil
+	// pattern in ReleaseRepository.findUuidsOfReleasesPendingSbomReconcile.
 	protected static final String LIST_INITIAL_ARTIFACT_UUIDS_PENDING_DEPENDENCY_TRACK = """
 			select uuid from rearm.artifacts a where a.metrics->>'lastScanned' is null
 			and a.metrics->>'uploadToken' is not null
+			and (a.metrics->>'dtrackFetchSkipUntil' is null
+				or (a.metrics->>'dtrackFetchSkipUntil')::timestamptz < now())
 			order by a.record_data->>'createdDate' asc
 			limit :limit
 		""";
@@ -244,6 +254,30 @@ class VariableQueries {
 	
 	protected static final String FIND_ARTIFACTS_BY_DTRACK_PROJECTS = """
 			select * from rearm.artifacts a where a.metrics->>'dependencyTrackProject' in (:dtrackProjectIds)
+		""";
+
+	// UUID-only sibling of FIND_ARTIFACTS_BY_DTRACK_PROJECTS. Used by
+	// callers (syncUnsyncedDependencyTrackData, findReleaseDatasByDtrackProjects)
+	// that only need the artifact identities — loading the full Artifact
+	// entity row fired Hibernate's snapshot deep-copy on the metrics JSONB
+	// column for every result, which contributed to the same heap-pressure
+	// pattern PR #92 / #94 closed elsewhere.
+	protected static final String FIND_ARTIFACT_UUIDS_BY_DTRACK_PROJECTS = """
+			select a.uuid from rearm.artifacts a where a.metrics->>'dependencyTrackProject' in (:dtrackProjectIds)
+		""";
+
+	// Stamps {"dtrackProjectDeleted": true} on the metrics JSONB of every
+	// artifact whose dependencyTrackProject matches one of the given ids
+	// for the given org. Used by IntegrationService.markArtifactsWithDeletedProjects
+	// in the daily DT-cleanup cron — pure SQL UPDATE so we don't load
+	// (or snapshot, or re-serialize) the artifact rows, which was a
+	// significant heap-pressure source. The org filter ensures cross-org
+	// project-id collisions (theoretical) can't bleed across tenants.
+	protected static final String MARK_ARTIFACTS_DTRACK_PROJECT_DELETED = """
+			update rearm.artifacts
+			set metrics = jsonb_set(metrics, '{dtrackProjectDeleted}', 'true'::jsonb)
+			where record_data->>'org' = :orgUuidAsString
+			  and metrics->>'dependencyTrackProject' in (:dtrackProjectIds)
 		""";
 	
 	protected static final String LIST_DISTINCT_DTRACK_PROJECTS_BY_ORG = """

--- a/backend/src/main/java/io/reliza/service/ArtifactService.java
+++ b/backend/src/main/java/io/reliza/service/ArtifactService.java
@@ -225,6 +225,36 @@ public class ArtifactService {
 		List<String> dtrackProjectsForQuery = uniqueDtrackProjects.stream().map(x -> x.toString()).toList();
 		return repository.findArtifactsByDtrackProjects(dtrackProjectsForQuery);
 	}
+
+	/**
+	 * UUID-only sibling of {@link #listArtifactsByDtrackProjects(Collection)}.
+	 * Use when the caller only needs the artifact identities —
+	 * materializing the full {@link Artifact} fires Hibernate's JSONB
+	 * snapshot deep-copy on the {@code metrics} column for every result,
+	 * which has been a heap-pressure source on large sweeps (see PR #92 /
+	 * #94 for the equivalent pattern on other batch loops).
+	 */
+	public List<UUID> listArtifactUuidsByDtrackProjects (Collection<UUID> dtrackProjects) {
+		Set<UUID> uniqueDtrackProjects = new HashSet<>(dtrackProjects);
+		List<String> dtrackProjectsForQuery = uniqueDtrackProjects.stream().map(x -> x.toString()).toList();
+		return repository.findArtifactUuidsByDtrackProjects(dtrackProjectsForQuery);
+	}
+
+	/**
+	 * True when the artifact's last fetch failure is still inside the backoff
+	 * window — i.e. now() is before {@code dtrackFetchSkipUntil}. Null or
+	 * unparseable values are treated as "not in backoff" so a corrupted
+	 * timestamp never permanently parks an artifact.
+	 */
+	private static boolean isInDtrackFetchBackoff(String dtrackFetchSkipUntil) {
+		if (dtrackFetchSkipUntil == null || dtrackFetchSkipUntil.isBlank()) return false;
+		try {
+			return ZonedDateTime.parse(dtrackFetchSkipUntil).isAfter(ZonedDateTime.now());
+		} catch (Exception e) {
+			log.warn("Unparseable dtrackFetchSkipUntil ({}); treating as not in backoff", dtrackFetchSkipUntil);
+			return false;
+		}
+	}
 	
 	public List<String> findOrphanedDtrackProjects (UUID orgUuid) {
 		String orgUuidStr = orgUuid.toString();
@@ -1189,18 +1219,36 @@ public class ArtifactService {
 	public boolean fetchDependencyTrackDataForArtifact (Artifact a) throws RelizaException {
 		ZonedDateTime lastScanned = ZonedDateTime.now();
 		ArtifactData ad = ArtifactData.dataFromRecord(a);
-		var dti = integrationService.resolveDependencyTrackProcessingStatus(ad, lastScanned);
+		ArtifactData.DependencyTrackIntegration dti;
+		try {
+			dti = integrationService.resolveDependencyTrackProcessingStatus(ad, lastScanned);
+		} catch (RelizaException e) {
+			// Fetch threw (e.g. transient DTrack outage mid-pagination, or an upstream
+			// 5xx). Record the failure so the scheduler backs off rather than retrying
+			// every tick. The artifact's previous good vulnerabilityDetails are left
+			// untouched — caller chain short-circuits before any persist.
+			sharedArtifactService.markArtifactDtrackFetchFailed(a.getUuid(), e.getMessage());
+			throw e;
+		}
 		boolean doUpdate = false;
 		if (null != dti) {
 			log.debug("PSDEBUG: setting dti to last scanned = " + dti.getLastScanned() + " on artifact = " + a.getUuid());
-			if (null == ad.getMetrics() || null == ad.getMetrics().getLastScanned() || 
+			if (null == ad.getMetrics() || null == ad.getMetrics().getLastScanned() ||
 					ad.getMetrics().getLastScanned().plusSeconds(1).isBefore(dti.getLastScanned())){
 				doUpdate = true;
 				log.debug("PSDEBUG: saving artifact dti on artifact = " + a.getUuid());
 			}
 		}
-			
+
+		// Order matters: updateArtifactDti uses the in-memory `a.metrics` snapshot
+		// loaded at the top of this method and writes the whole JSONB. If we cleared
+		// fetch-failure state before updateArtifactDti ran, the stale in-memory
+		// fetch fields would be re-written and overwrite the clear. Run the reset
+		// AFTER updateArtifactDti so its UPDATE is applied last. Reset itself is a
+		// guarded no-op when state is already clean, so a never-failed artifact
+		// doesn't pay a write per tick.
 		if (doUpdate) sharedArtifactService.updateArtifactDti(a, dti, WhoUpdated.getAutoWhoUpdated());
+		if (null != dti) sharedArtifactService.resetArtifactDtrackFetchFailedState(a.getUuid());
 		return true;
 	}
 
@@ -1241,8 +1289,7 @@ public class ArtifactService {
 		}
 		
 		// Get artifact UUIDs for these projects (not full entities to save memory)
-		List<UUID> artifactUuids = listArtifactsByDtrackProjects(unsyncedProjects)
-				.stream().map(Artifact::getUuid).toList();
+		List<UUID> artifactUuids = listArtifactUuidsByDtrackProjects(unsyncedProjects);
 		log.info("Found {} artifacts to sync for {} unsynced projects in org {}", 
 				artifactUuids.size(), unsyncedProjects.size(), orgUuid);
 		
@@ -1270,7 +1317,21 @@ public class ArtifactService {
 				// Fetch artifact fresh for each iteration to avoid holding all data in memory
 				Optional<Artifact> artifactOpt = repository.findById(artifactUuid);
 				if (artifactOpt.isPresent()) {
-					fetchDependencyTrackDataForArtifact(artifactOpt.get());
+					Artifact artifact = artifactOpt.get();
+					// Skip artifacts whose fetch backoff window hasn't elapsed.
+					// The per-minute initial-fetch loop has the same filter in
+					// SQL (LIST_INITIAL_ARTIFACT_UUIDS_PENDING_DEPENDENCY_TRACK);
+					// this daily-sync loop loads artifacts via the
+					// FIND_ARTIFACT_UUIDS_BY_DTRACK_PROJECTS path, whose
+					// non-UUID sibling has non-scheduler callers, so the
+					// filter lives at the application layer rather than in SQL.
+					ArtifactData ad = ArtifactData.dataFromRecord(artifact);
+					if (ad.getMetrics() != null && isInDtrackFetchBackoff(ad.getMetrics().getDtrackFetchSkipUntil())) {
+						log.debug("Skipping artifact {} in DTrack-fetch backoff (skipUntil={})",
+								artifactUuid, ad.getMetrics().getDtrackFetchSkipUntil());
+						continue;
+					}
+					fetchDependencyTrackDataForArtifact(artifact);
 					processedCount++;
 					log.debug("Successfully processed artifact {} for dependency track sync", artifactUuid);
 				} else {

--- a/backend/src/main/java/io/reliza/service/IntegrationService.java
+++ b/backend/src/main/java/io/reliza/service/IntegrationService.java
@@ -61,7 +61,6 @@ import io.reliza.common.CommonVariables.TableName;
 import io.reliza.common.Utils;
 import io.reliza.exceptions.RelizaException;
 import io.reliza.model.AnalysisScope;
-import io.reliza.model.Artifact;
 import io.reliza.model.ArtifactData;
 import io.reliza.model.ArtifactData.ArtifactType;
 import io.reliza.model.ArtifactData.DependencyTrackIntegration;
@@ -86,6 +85,7 @@ import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilityDto;
 import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilitySeverity;
 import io.reliza.model.dto.TriggerIntegrationInputDto;
 import io.reliza.model.OrganizationData;
+import io.reliza.repositories.ArtifactRepository;
 import io.reliza.repositories.IntegrationRepository;
 import lombok.Data;
 
@@ -108,7 +108,10 @@ public class IntegrationService {
 	@Autowired
 	@Lazy
 	private ArtifactService artifactService;
-	
+
+	@Autowired
+	private ArtifactRepository artifactRepository;
+
 	@Autowired
 	@Lazy
 	private DTrackService dtrackService;
@@ -701,7 +704,7 @@ public class IntegrationService {
 	}
 	
 	private DependencyTrackIntegration obtainDepdencyTrackProjectMetrics (URI dtrackBaseUri,
-			String apiToken, ArtifactData ad, ZonedDateTime lastScanned) throws DatabindException, JacksonException {
+			String apiToken, ArtifactData ad, ZonedDateTime lastScanned) throws DatabindException, JacksonException, RelizaException {
 		String dtrackProject = ad.getMetrics().getDependencyTrackProject();
 		DependencyTrackIntegration dti = new DependencyTrackIntegration();
 		List<VulnerabilityDto> vulnerabilityDetails = fetchDependencyTrackVulnerabilityDetails(
@@ -721,7 +724,9 @@ public class IntegrationService {
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	private record DtrackResolvedLicenseRaw(String licenseId) {}
 	
-	private record DtrackPageResult(List<Object> results, int totalCount) {}
+	// Package-private (not private) so a test subclass can construct
+	// deterministic DtrackPageResult instances.
+	record DtrackPageResult(List<Object> results, int totalCount) {}
 	
 	private static int parseDtrackTotalCountHeader(org.springframework.http.ResponseEntity<?> resp) {
 		String header = resp.getHeaders().getFirst("X-Total-Count");
@@ -782,7 +787,7 @@ public class IntegrationService {
 	private record DtrackViolationRaw (ViolationType type, DtrackComponentRaw component) {}
 	
 	protected List<VulnerabilityDto> fetchDependencyTrackVulnerabilityDetails(URI dtrackBaseUri,
-			String apiToken, String dtrackProject, UUID artifactUuid, UUID orgUuid, ZonedDateTime lastScanned) throws DatabindException, JacksonException {
+			String apiToken, String dtrackProject, UUID artifactUuid, UUID orgUuid, ZonedDateTime lastScanned) throws DatabindException, JacksonException, RelizaException {
 		String baseUri = dtrackBaseUri.toString() + "/api/v1/vulnerability/project/" + dtrackProject;
 		final FindingSourceDto source = new FindingSourceDto(artifactUuid, null, null);
 		// Use lastScanned (DTrack scan time) as attributedAt so findings are included in First Scanned VDR
@@ -955,7 +960,7 @@ public class IntegrationService {
 	}
 	
 	protected List<ViolationDto> fetchDependencyTrackViolationDetails(URI dtrackBaseUri,
-			String apiToken, String dtrackProject, UUID artifactUuid, UUID orgUuid, ZonedDateTime lastScanned) throws DatabindException, JacksonException {
+			String apiToken, String dtrackProject, UUID artifactUuid, UUID orgUuid, ZonedDateTime lastScanned) throws DatabindException, JacksonException, RelizaException {
 		String baseUri = dtrackBaseUri.toString() + "/api/v1/violation/project/" + dtrackProject;
 		final FindingSourceDto source = new FindingSourceDto(artifactUuid, null, null);
 		final Set<FindingSourceDto> sources = Set.of(source);
@@ -1123,13 +1128,13 @@ public class IntegrationService {
 	 * @param existingParams Any existing query parameters (should end with & if not empty, or be empty)
 	 * @return List of all results from all pages
 	 */
-	private List<Object> executeDtrackPaginatedCall(String baseUri, String apiToken, String existingParams) 
-			throws DatabindException, JacksonException {
+	private List<Object> executeDtrackPaginatedCall(String baseUri, String apiToken, String existingParams)
+			throws DatabindException, JacksonException, RelizaException {
 		return executeDtrackPaginatedCall(baseUri, apiToken, existingParams, CommonVariables.DTRACK_DEFAULT_PAGE_SIZE);
 	}
-	
-	private List<Object> executeDtrackPaginatedCall(String baseUri, String apiToken, String existingParams, int pageSize) 
-			throws DatabindException, JacksonException {
+
+	private List<Object> executeDtrackPaginatedCall(String baseUri, String apiToken, String existingParams, int pageSize)
+			throws DatabindException, JacksonException, RelizaException {
 		List<Object> allResults = new ArrayList<>();
 		int pageNumber = 1;
 		boolean hasMorePages = true;
@@ -1163,8 +1168,11 @@ public class IntegrationService {
 	 * @param pageTransformer Function that transforms a page of raw objects into the target type
 	 * @return List of all transformed results from all pages
 	 */
-	private <T> List<T> executeDtrackPaginatedCallWithTransform(String baseUri, String apiToken,
-			String existingParams, Function<List<Object>, List<T>> pageTransformer) {
+	// Package-private (not private) so the pagination loop's
+	// fail-fast-on-exception contract is unit-testable via a subclass that
+	// overrides fetchDtrackPage. See IntegrationServiceDtrackPaginationTest.
+	<T> List<T> executeDtrackPaginatedCallWithTransform(String baseUri, String apiToken,
+			String existingParams, Function<List<Object>, List<T>> pageTransformer) throws RelizaException {
 		List<T> allResults = new ArrayList<>();
 		int pageNumber = 1;
 		int pageSize = CommonVariables.DTRACK_DEFAULT_PAGE_SIZE;
@@ -1192,10 +1200,12 @@ public class IntegrationService {
 		return allResults;
 	}
 	
-	private DtrackPageResult fetchDtrackPage(String baseUri, String apiToken, String existingParams, 
-			String separator, int pageNumber, int pageSize) {
+	// Package-private (not private) so a test subclass can override and
+	// inject deterministic page results / exceptions.
+	DtrackPageResult fetchDtrackPage(String baseUri, String apiToken, String existingParams,
+			String separator, int pageNumber, int pageSize) throws RelizaException {
+		URI dtrackUri = URI.create(baseUri + existingParams + separator + "pageNumber=" + pageNumber + "&pageSize=" + pageSize);
 		try {
-			URI dtrackUri = URI.create(baseUri + existingParams + separator + "pageNumber=" + pageNumber + "&pageSize=" + pageSize);
 			log.debug("Calling DTrack API page fetch: uri = {}", dtrackUri);
 			final long httpStartNs = System.nanoTime();
 			var resp = dtrackWebClient
@@ -1205,27 +1215,36 @@ public class IntegrationService {
 				.retrieve()
 				.toEntity(String.class)
 				.block();
-			
+
+			// Null body is a legitimate empty-page signal (some DTrack endpoints
+			// return an empty body with 200 when the project has no findings).
+			// Distinct from a thrown exception — that path now propagates.
 			if (null == resp.getBody()) {
 				log.warn("Null body from DTrack API for uri = {}", dtrackUri);
 				return null;
 			}
-			
+
 			int totalCount = parseDtrackTotalCountHeader(resp);
-			
+
 			@SuppressWarnings("unchecked")
 			List<Object> pageResults = Utils.OM.readValue(resp.getBody(), List.class);
 			log.debug("DTrack API page fetch completed: uri = {}, pageNumber = {}, pageSize = {}, totalCount = {}, httpMs = {}",
 				dtrackUri, pageNumber, pageSize, totalCount, java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - httpStartNs));
 			return new DtrackPageResult(pageResults, totalCount);
 		} catch (Exception e) {
-			log.error("Error fetching DTrack page {} for uri = {}", pageNumber, baseUri, e);
-			return null;
+			// Previously returned null here — but null is the "no more pages"
+			// signal upstream, so a transient HTTP/parse failure mid-drain
+			// would silently truncate the result list and the caller would
+			// persist an empty vulnerability set, overwriting the artifact's
+			// previous good data. Propagate as a checked exception so the
+			// scheduled-refresh persist site short-circuits instead.
+			log.error("Error fetching DTrack page {} for uri = {}", pageNumber, dtrackUri, e);
+			throw new RelizaException("Error fetching DTrack page " + pageNumber + " for uri " + dtrackUri + ": " + e.getMessage());
 		}
 	}
 	
-	private List<Map<String, Object>> executeDtrackComponentSearch (String baseUri, String apiToken, String queryParams) 
-			throws DatabindException, JacksonException {
+	private List<Map<String, Object>> executeDtrackComponentSearch (String baseUri, String apiToken, String queryParams)
+			throws DatabindException, JacksonException, RelizaException {
 		List<Object> results = executeDtrackPaginatedCall(baseUri, apiToken, queryParams, 400);
 		List<Map<String, Object>> respList = new LinkedList<>();
 		for (Object obj : results) {
@@ -1615,7 +1634,16 @@ public class IntegrationService {
 		cleanupArchivedDtrackProjects(orgUuid);
 	}
 	
-	@Transactional
+	// NOT @Transactional. The cleanup makes per-project HTTP DELETE calls
+	// to an external DT API inside its inner loop — holding an open
+	// Hibernate transaction across those network calls used to keep the
+	// persistence context alive for the entire per-org cleanup (often
+	// minutes), accumulating every Artifact entity loaded by
+	// markArtifactsWithDeletedProjects + their JSONB dirty-snapshots.
+	// That was an OOM contributor at ~03:28 UTC. The mark step now uses
+	// a single SQL UPDATE (no entity load), and the per-DT-call DB writes
+	// inside this loop already carry their own narrower @Transactional
+	// scopes where needed.
 	public DtrackProjectCleanupResult cleanupArchivedDtrackProjects(UUID orgUuid) {
 		log.info("[DTRACK-CLEANUP] Starting cleanup for org {}", orgUuid);
 		
@@ -1844,32 +1872,24 @@ public class IntegrationService {
 	}
 	
 	/**
-	 * Mark all artifacts using the specified DTrack projects as deleted
-	 * This prevents deduplication from reusing deleted project IDs
+	 * Mark all artifacts whose dtrack project matches one of {@code projectIds}
+	 * (scoped to {@code orgUuid}) with {@code metrics.dtrackProjectDeleted = true}.
+	 * Prevents deduplication from reusing already-deleted project IDs.
+	 *
+	 * <p>Single SQL UPDATE — no entity load, no Hibernate snapshot deep-copy
+	 * of the JSONB column, no per-row save round trip. Previous loop-based
+	 * implementation loaded every affected Artifact into the persistence
+	 * context and re-serialized its full metrics blob per save; on the
+	 * daily DT-cleanup cron over a multi-org sweep that produced enough
+	 * transient allocation to OOM the heap (observed 2026-05-23/24).
 	 */
 	private void markArtifactsWithDeletedProjects(UUID orgUuid, List<String> projectIds) {
 		if (projectIds == null || projectIds.isEmpty()) {
 			return;
 		}
-		
-		int totalMarked = 0;
-		for (String projectId : projectIds) {
-			// Convert string project ID to UUID
-			UUID projectUuid = UUID.fromString(projectId);
-			List<Artifact> affectedArtifacts = artifactService.listArtifactsByDtrackProjects(List.of(projectUuid));
-			log.debug("[DTRACK-CLEANUP] Found {} artifacts using project {}", affectedArtifacts.size(), projectId);
-			
-			for (Artifact artifact : affectedArtifacts) {
-				ArtifactData ad = ArtifactData.dataFromRecord(artifact);
-				if (ad.getMetrics() != null && ad.getOrg().equals(orgUuid)) {
-					ad.getMetrics().setDtrackProjectDeleted(true);
-					sharedArtifactService.saveArtifactMetrics(artifact, ad.getMetrics());
-					totalMarked++;
-				}
-			}
-		}
-		
-		log.info("[DTRACK-CLEANUP] Marked {} artifacts as having deleted DTrack projects", totalMarked);
+		int marked = artifactRepository.markArtifactsAsDtrackProjectDeleted(
+				orgUuid.toString(), projectIds);
+		log.info("[DTRACK-CLEANUP] Marked {} artifacts as having deleted DTrack projects", marked);
 	}
 	
 	/**

--- a/backend/src/main/java/io/reliza/service/SharedArtifactService.java
+++ b/backend/src/main/java/io/reliza/service/SharedArtifactService.java
@@ -34,11 +34,13 @@ import io.reliza.model.ArtifactData.BomFormat;
 import io.reliza.model.ArtifactData.DependencyTrackIntegration;
 import io.reliza.model.ArtifactData.DigestRecord;
 import io.reliza.model.ArtifactData.DigestScope;
+import io.reliza.model.DtrackFetchStatus;
 import io.reliza.model.MetricsAudit;
 import io.reliza.model.MetricsAudit.MetricsEntityType;
 import io.reliza.repositories.ArtifactRepository;
 import io.reliza.repositories.MetricsAuditRepository;
 import io.reliza.service.IntegrationService.DependencyTrackUploadResult;
+import io.reliza.util.BackoffPolicy;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -389,6 +391,86 @@ public class SharedArtifactService {
 			dti.setDtrackSubmissionFailureReason(null);
 			saveArtifactMetrics(a, dti);
 		}
+	}
+
+	/**
+	 * Record a Dependency-Track FETCH failure on the artifact's metrics. Bumps
+	 * the failure counter, pushes {@code dtrackFetchSkipUntil} forward by an
+	 * exponential backoff window, and sets status to {@link DtrackFetchStatus#FAILED}.
+	 * The previously-good vulnerabilityDetails list on the artifact is left
+	 * untouched — the contract is "fetch failed, don't overwrite, retry later."
+	 *
+	 * <p>Distinct from {@link #markArtifactDtrackFailed} which is the SUBMISSION-side
+	 * marker (uploads to DT). Both can coexist on the same artifact, e.g. an
+	 * artifact whose initial submission failed AND whose subsequent reattempt at
+	 * fetching metrics also failed.
+	 *
+	 * <p>If a concurrent scheduler tick races and the JPA optimistic-lock
+	 * {@code @Version} on Artifact fires, the exception propagates — the next
+	 * tick will pick the artifact up again, so no retry loop here.
+	 */
+	@Transactional
+	protected void markArtifactDtrackFetchFailed(UUID artifactUuid, String failureReason) {
+		Optional<Artifact> oa = getArtifact(artifactUuid);
+		if (oa.isEmpty()) {
+			log.warn("markArtifactDtrackFetchFailed: artifact not found for uuid {}", artifactUuid);
+			return;
+		}
+		Artifact a = oa.get();
+		ArtifactData ad = ArtifactData.dataFromRecord(a);
+		DependencyTrackIntegration dti = ad.getMetrics();
+		if (dti == null) {
+			dti = new DependencyTrackIntegration();
+			ad.setMetrics(dti);
+		}
+		int currentCount = dti.getDtrackFetchFailureCount() == null ? 0 : dti.getDtrackFetchFailureCount();
+		int nextCount = currentCount + 1;
+		dti.setDtrackFetchStatus(DtrackFetchStatus.FAILED);
+		dti.setDtrackFetchFailureCount(nextCount);
+		dti.setDtrackFetchFailureReason(truncate(failureReason, DependencyTrackIntegration.FETCH_FAILURE_REASON_MAX_LEN));
+		dti.setDtrackFetchSkipUntil(ZonedDateTime.now()
+				.plusSeconds(BackoffPolicy.dtrackFetchSkipSeconds(nextCount))
+				.toString());
+		saveArtifactMetrics(a, dti);
+	}
+
+	/**
+	 * Clear any previously-set fetch-failure state after a successful drain.
+	 * Guarded no-op when state is already clean so the metrics row isn't
+	 * pointlessly bumped on every successful tick.
+	 */
+	@Transactional
+	protected void resetArtifactDtrackFetchFailedState(UUID artifactUuid) {
+		Optional<Artifact> oa = getArtifact(artifactUuid);
+		if (oa.isEmpty()) {
+			log.warn("resetArtifactDtrackFetchFailedState: artifact not found for uuid {}", artifactUuid);
+			return;
+		}
+		Artifact a = oa.get();
+		ArtifactData ad = ArtifactData.dataFromRecord(a);
+		DependencyTrackIntegration dti = ad.getMetrics();
+		if (dti == null) {
+			return;
+		}
+		DtrackFetchStatus status = dti.getDtrackFetchStatus();
+		Integer count = dti.getDtrackFetchFailureCount();
+		String skipUntil = dti.getDtrackFetchSkipUntil();
+		boolean dirty = (status != null && status != DtrackFetchStatus.OK)
+				|| (count != null && count > 0)
+				|| skipUntil != null
+				|| dti.getDtrackFetchFailureReason() != null;
+		if (dirty) {
+			dti.setDtrackFetchStatus(DtrackFetchStatus.OK);
+			dti.setDtrackFetchFailureCount(0);
+			dti.setDtrackFetchFailureReason(null);
+			dti.setDtrackFetchSkipUntil(null);
+			saveArtifactMetrics(a, dti);
+		}
+	}
+
+	private static String truncate(String s, int max) {
+		if (s == null) return null;
+		return s.length() <= max ? s : s.substring(0, max);
 	}
 
 	/**

--- a/backend/src/main/java/io/reliza/service/SharedReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/SharedReleaseService.java
@@ -1150,7 +1150,7 @@ public class SharedReleaseService {
 	public List<ComponentWithBranches> findReleaseDatasByDtrackProjects(Collection<UUID> dtrackProjects, final UUID org) {
 		log.debug("dtrack project size = {}", dtrackProjects.size());
 		long startTime = System.currentTimeMillis();
-		Set<UUID> arts = artifactService.listArtifactsByDtrackProjects(dtrackProjects).stream().map(x -> x.getUuid()).collect(Collectors.toSet());
+		Set<UUID> arts = new HashSet<>(artifactService.listArtifactUuidsByDtrackProjects(dtrackProjects));
 		log.debug("artifacts size = {}", arts.size());
 		long afterArtifacts = System.currentTimeMillis();
 		log.debug("findReleaseDatasByDtrackProjects - listArtifactsByDtrackProjects took {} ms, found {} artifacts", afterArtifacts - startTime, arts.size());

--- a/backend/src/main/java/io/reliza/util/BackoffPolicy.java
+++ b/backend/src/main/java/io/reliza/util/BackoffPolicy.java
@@ -1,0 +1,32 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.util;
+
+/**
+ * Centralized backoff curves for ReARM's async retry flows.
+ *
+ * <p>Currently consumed by the per-artifact Dependency-Track fetch-failure
+ * tracking on {@code ArtifactData.DependencyTrackIntegration}. The dormant
+ * SBOM-reconcile failure path (defined as {@code ReleaseRepository.recordSbomReconcileFailure}
+ * but not yet wired in production) is the next intended consumer — when it
+ * lands, add its curve here rather than inlining the table at the call site.
+ */
+public final class BackoffPolicy {
+
+    private BackoffPolicy() {}
+
+    /**
+     * Exponential backoff for per-artifact Dependency-Track fetch failures:
+     * 1, 2, 4, 8, 16, 32, then 60 minutes (cap).
+     *
+     * @param failureCount post-increment failure count (1 = first failure).
+     * @return seconds to push {@code dtrackFetchSkipUntil} forward by.
+     */
+    public static int dtrackFetchSkipSeconds(int failureCount) {
+        if (failureCount <= 0) return 60;            // defensive — caller should pass >=1
+        if (failureCount >= 7) return 60 * 60;       // cap at 1 hour
+        return (1 << (failureCount - 1)) * 60;       // 1,2,4,8,16,32 minutes
+    }
+}

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -1993,6 +1993,10 @@ type DependencyTrackMetrics {
 	dtrackSubmissionFailed: Boolean
 	dtrackSubmissionAttempts: Int
 	dtrackSubmissionFailureReason: String
+	dtrackFetchStatus: String
+	dtrackFetchFailureCount: Int
+	dtrackFetchFailureReason: String
+	dtrackFetchSkipUntil: String
 	lastScanned: DateTime
 	firstScanned: DateTime
 	critical: Int

--- a/backend/src/test/java/io/reliza/service/IntegrationServiceDtrackPaginationTest.java
+++ b/backend/src/test/java/io/reliza/service/IntegrationServiceDtrackPaginationTest.java
@@ -1,0 +1,107 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.exceptions.RelizaException;
+
+/**
+ * Guards the contract that {@link IntegrationService#executeDtrackPaginatedCallWithTransform}
+ * propagates a thrown {@link RelizaException} from {@link IntegrationService#fetchDtrackPage}
+ * instead of silently truncating the result list.
+ *
+ * <p>Before the silent-failure-stop change, fetchDtrackPage swallowed exceptions and returned
+ * null, which the pagination loop treated as "no more pages" — a mid-drain failure would
+ * silently return the partial list built up to that point, and the caller would persist an
+ * empty/partial vulnerability set, overwriting the artifact's previous good data.
+ */
+class IntegrationServiceDtrackPaginationTest {
+
+    /** Page size used by both the production loop and the fake pages here. Mirrors CommonVariables.DTRACK_DEFAULT_PAGE_SIZE. */
+    private static final int PAGE_SIZE = io.reliza.common.CommonVariables.DTRACK_DEFAULT_PAGE_SIZE;
+
+    /**
+     * Two full pages then a thrown RelizaException must NOT return the two pages — the
+     * exception must propagate. Returning the partial 500 would be the old silent-failure
+     * shape.
+     */
+    @Test
+    void midDrainExceptionPropagatesInsteadOfReturningPartialList() {
+        AtomicInteger calls = new AtomicInteger(0);
+        IntegrationService svc = new IntegrationService(null) {
+            @Override
+            IntegrationService.DtrackPageResult fetchDtrackPage(String baseUri, String apiToken,
+                    String existingParams, String separator, int pageNumber, int pageSize)
+                    throws RelizaException {
+                int n = calls.incrementAndGet();
+                if (n <= 2) {
+                    // Two full pages of opaque objects — enough to keep hasMorePages true.
+                    List<Object> page = new ArrayList<>(pageSize);
+                    for (int i = 0; i < pageSize; i++) page.add("item-page" + n + "-" + i);
+                    return new IntegrationService.DtrackPageResult(page, /*totalCount*/ 0);
+                }
+                // Mid-drain failure (simulated HTTP/parse error). Previously returned null
+                // and the loop exited cleanly; now must throw and propagate.
+                throw new RelizaException("simulated transient DTrack failure on page " + n);
+            }
+        };
+
+        RelizaException ex = assertThrows(RelizaException.class,
+            () -> svc.executeDtrackPaginatedCallWithTransform(
+                "https://dtrack.example/api/v1/vulnerability/project/abc",
+                "fake-token",
+                "",
+                raw -> raw.stream().map(Object::toString).toList()));
+
+        // Exception message echoes the page number so the operator can locate the failure.
+        assertEquals(true, ex.getMessage().contains("page 3"),
+            "exception message should identify the failing page; got: " + ex.getMessage());
+        // Three pages attempted: two succeeded, third threw. No fourth call.
+        assertEquals(3, calls.get(), "loop should have stopped at the throwing page");
+    }
+
+    /**
+     * Null return from fetchDtrackPage (the legitimate empty-body branch, e.g. DTrack
+     * returning 200 with an empty body) must still be treated as end-of-data — not as
+     * an error. Whatever was accumulated up to that point is returned cleanly.
+     */
+    @Test
+    void nullBodyOnNthPageStillTerminatesLoopCleanly() throws RelizaException {
+        AtomicInteger calls = new AtomicInteger(0);
+        IntegrationService svc = new IntegrationService(null) {
+            @Override
+            IntegrationService.DtrackPageResult fetchDtrackPage(String baseUri, String apiToken,
+                    String existingParams, String separator, int pageNumber, int pageSize)
+                    throws RelizaException {
+                int n = calls.incrementAndGet();
+                if (n == 1) {
+                    List<Object> page = new ArrayList<>(pageSize);
+                    for (int i = 0; i < pageSize; i++) page.add("ok-" + i);
+                    return new IntegrationService.DtrackPageResult(page, /*totalCount*/ 0);
+                }
+                // Null body signals end-of-data legitimately (NOT an error).
+                return null;
+            }
+        };
+
+        List<String> out = svc.executeDtrackPaginatedCallWithTransform(
+            "https://dtrack.example/api/v1/vulnerability/project/abc",
+            "fake-token",
+            "",
+            raw -> raw.stream().map(Object::toString).toList());
+
+        assertEquals(PAGE_SIZE, out.size(),
+            "partial page from a null follow-up must be retained as final result");
+        assertEquals(2, calls.get(), "loop should issue a follow-up call then stop on null");
+    }
+}

--- a/backend/src/test/java/io/reliza/service/SharedArtifactServiceFetchFailureTest.java
+++ b/backend/src/test/java/io/reliza/service/SharedArtifactServiceFetchFailureTest.java
@@ -1,0 +1,167 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.Artifact;
+import io.reliza.model.ArtifactData;
+import io.reliza.model.ArtifactData.DependencyTrackIntegration;
+import io.reliza.model.DtrackFetchStatus;
+
+/**
+ * Guards the FETCH-failure-tracking contract on {@code SharedArtifactService}:
+ *   - {@code markArtifactDtrackFetchFailed} bumps the counter, computes the
+ *     skip-until from the exponential backoff curve, sets status FAILED,
+ *     truncates over-long failureReason, and persists.
+ *   - {@code resetArtifactDtrackFetchFailedState} is a guarded no-op when
+ *     state is already clean; on a dirty artifact it clears all four fields
+ *     and persists.
+ */
+class SharedArtifactServiceFetchFailureTest {
+
+    private static SharedArtifactService newSvcCapturing(AtomicReference<DependencyTrackIntegration> savedRef,
+            AtomicInteger saveCount, Artifact backing) {
+        // Empty strings for the @Value-injected URL/namespace; null repository
+        // is fine because every read path goes through getArtifact() which we override.
+        return new SharedArtifactService(null, "", "") {
+            @Override
+            public Optional<Artifact> getArtifact(UUID uuid) {
+                return Optional.of(backing);
+            }
+
+            @Override
+            public void saveArtifactMetrics(Artifact a, DependencyTrackIntegration metrics) {
+                savedRef.set(metrics);
+                saveCount.incrementAndGet();
+            }
+        };
+    }
+
+    private static Artifact artifactWithMetrics(DependencyTrackIntegration dti) {
+        Artifact a = new Artifact();
+        a.setUuid(UUID.randomUUID());
+        // dataFromRecord requires recordData to be populated. Use the minimum
+        // shape ArtifactData.dataFromRecord tolerates.
+        Map<String, Object> rd = new HashMap<>();
+        rd.put("uuid", a.getUuid().toString());
+        a.setRecordData(rd);
+        if (dti != null) {
+            a.setMetrics(io.reliza.common.Utils.OM.convertValue(dti, new tools.jackson.core.type.TypeReference<Map<String, Object>>() {}));
+        }
+        return a;
+    }
+
+    @Test
+    void markSetsFailedStateAndPersists() {
+        AtomicReference<DependencyTrackIntegration> saved = new AtomicReference<>();
+        AtomicInteger saveCount = new AtomicInteger(0);
+        Artifact a = artifactWithMetrics(null);
+        SharedArtifactService svc = newSvcCapturing(saved, saveCount, a);
+
+        ZonedDateTime before = ZonedDateTime.now();
+        svc.markArtifactDtrackFetchFailed(a.getUuid(), "transient 502 from DTrack");
+        ZonedDateTime after = ZonedDateTime.now();
+
+        assertEquals(1, saveCount.get(), "exactly one persist call expected");
+        DependencyTrackIntegration s = saved.get();
+        assertNotNull(s);
+        assertEquals(DtrackFetchStatus.FAILED, s.getDtrackFetchStatus());
+        assertEquals(1, s.getDtrackFetchFailureCount(), "first failure should be count=1");
+        assertEquals("transient 502 from DTrack", s.getDtrackFetchFailureReason());
+        assertNotNull(s.getDtrackFetchSkipUntil(), "skipUntil should be set after a failure");
+
+        // First failure backs off 60 s; skipUntil should be ~now + 60s.
+        ZonedDateTime parsed = ZonedDateTime.parse(s.getDtrackFetchSkipUntil());
+        assertTrue(!parsed.isBefore(before.plusSeconds(60).minusSeconds(2))
+                        && !parsed.isAfter(after.plusSeconds(60).plusSeconds(2)),
+                "skipUntil should be roughly now+60s for first failure; got " + parsed);
+    }
+
+    @Test
+    void markIncrementsExistingFailureCount() {
+        AtomicReference<DependencyTrackIntegration> saved = new AtomicReference<>();
+        AtomicInteger saveCount = new AtomicInteger(0);
+        DependencyTrackIntegration existing = new DependencyTrackIntegration();
+        existing.setDtrackFetchStatus(DtrackFetchStatus.FAILED);
+        existing.setDtrackFetchFailureCount(2);
+        existing.setDtrackFetchSkipUntil(ZonedDateTime.now().minusMinutes(5).toString());
+        Artifact a = artifactWithMetrics(existing);
+        SharedArtifactService svc = newSvcCapturing(saved, saveCount, a);
+
+        svc.markArtifactDtrackFetchFailed(a.getUuid(), "another failure");
+
+        DependencyTrackIntegration s = saved.get();
+        assertEquals(3, s.getDtrackFetchFailureCount(), "count should bump from 2 to 3");
+        // Third failure: 4 minutes (240s). Just confirm it bumped from the earlier value.
+        assertTrue(ZonedDateTime.parse(s.getDtrackFetchSkipUntil()).isAfter(ZonedDateTime.now()),
+                "skipUntil should be in the future after the new failure");
+    }
+
+    @Test
+    void markTruncatesOverlongFailureReason() {
+        AtomicReference<DependencyTrackIntegration> saved = new AtomicReference<>();
+        AtomicInteger saveCount = new AtomicInteger(0);
+        Artifact a = artifactWithMetrics(null);
+        SharedArtifactService svc = newSvcCapturing(saved, saveCount, a);
+
+        String longReason = "x".repeat(DependencyTrackIntegration.FETCH_FAILURE_REASON_MAX_LEN + 200);
+        svc.markArtifactDtrackFetchFailed(a.getUuid(), longReason);
+
+        assertEquals(DependencyTrackIntegration.FETCH_FAILURE_REASON_MAX_LEN,
+                saved.get().getDtrackFetchFailureReason().length(),
+                "failureReason should be truncated to FETCH_FAILURE_REASON_MAX_LEN");
+    }
+
+    @Test
+    void resetOnCleanArtifactIsNoOp() {
+        AtomicReference<DependencyTrackIntegration> saved = new AtomicReference<>();
+        AtomicInteger saveCount = new AtomicInteger(0);
+        DependencyTrackIntegration clean = new DependencyTrackIntegration();
+        // All fetch-failure fields are null/zero — nothing to clear.
+        Artifact a = artifactWithMetrics(clean);
+        SharedArtifactService svc = newSvcCapturing(saved, saveCount, a);
+
+        svc.resetArtifactDtrackFetchFailedState(a.getUuid());
+
+        assertEquals(0, saveCount.get(),
+                "reset on clean artifact should not call saveArtifactMetrics");
+    }
+
+    @Test
+    void resetOnFailedArtifactClearsAllFetchFields() {
+        AtomicReference<DependencyTrackIntegration> saved = new AtomicReference<>();
+        AtomicInteger saveCount = new AtomicInteger(0);
+        DependencyTrackIntegration failed = new DependencyTrackIntegration();
+        failed.setDtrackFetchStatus(DtrackFetchStatus.FAILED);
+        failed.setDtrackFetchFailureCount(5);
+        failed.setDtrackFetchFailureReason("transient 502");
+        failed.setDtrackFetchSkipUntil(ZonedDateTime.now().plusMinutes(10).toString());
+        Artifact a = artifactWithMetrics(failed);
+        SharedArtifactService svc = newSvcCapturing(saved, saveCount, a);
+
+        svc.resetArtifactDtrackFetchFailedState(a.getUuid());
+
+        assertEquals(1, saveCount.get(), "reset on dirty artifact should persist exactly once");
+        DependencyTrackIntegration s = saved.get();
+        assertEquals(DtrackFetchStatus.OK, s.getDtrackFetchStatus());
+        assertEquals(0, s.getDtrackFetchFailureCount());
+        assertNull(s.getDtrackFetchFailureReason());
+        assertNull(s.getDtrackFetchSkipUntil());
+    }
+}

--- a/backend/src/test/java/io/reliza/util/BackoffPolicyTest.java
+++ b/backend/src/test/java/io/reliza/util/BackoffPolicyTest.java
@@ -1,0 +1,48 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the exponential backoff table for per-artifact Dependency-Track
+ * fetch failures: 1, 2, 4, 8, 16, 32 minutes then a 60-minute cap.
+ */
+class BackoffPolicyTest {
+
+    @Test
+    void firstFailureBacksOffOneMinute() {
+        assertEquals(60, BackoffPolicy.dtrackFetchSkipSeconds(1));
+    }
+
+    @Test
+    void exponentialDoubling() {
+        assertEquals(60, BackoffPolicy.dtrackFetchSkipSeconds(1));
+        assertEquals(120, BackoffPolicy.dtrackFetchSkipSeconds(2));
+        assertEquals(240, BackoffPolicy.dtrackFetchSkipSeconds(3));
+        assertEquals(480, BackoffPolicy.dtrackFetchSkipSeconds(4));
+        assertEquals(960, BackoffPolicy.dtrackFetchSkipSeconds(5));
+        assertEquals(1920, BackoffPolicy.dtrackFetchSkipSeconds(6));
+    }
+
+    @Test
+    void capsAtOneHourFromSeventhFailureOnward() {
+        assertEquals(3600, BackoffPolicy.dtrackFetchSkipSeconds(7));
+        assertEquals(3600, BackoffPolicy.dtrackFetchSkipSeconds(8));
+        assertEquals(3600, BackoffPolicy.dtrackFetchSkipSeconds(100));
+        assertEquals(3600, BackoffPolicy.dtrackFetchSkipSeconds(Integer.MAX_VALUE));
+    }
+
+    @Test
+    void defensiveHandlingOfNonPositiveInput() {
+        // Caller should always pass >=1, but if a corrupted count slips through,
+        // a sensible default is better than a negative shift or zero backoff.
+        assertEquals(60, BackoffPolicy.dtrackFetchSkipSeconds(0));
+        assertEquals(60, BackoffPolicy.dtrackFetchSkipSeconds(-1));
+        assertEquals(60, BackoffPolicy.dtrackFetchSkipSeconds(Integer.MIN_VALUE));
+    }
+}


### PR DESCRIPTION
## What this is

Output of `copy-src.sh` against current rearm-core/backend main, mirroring all non-edition-specific backend changes into CE.

## Primary motivation: DT-fetch resilience

CE's UI on main already queries four new GraphQL fields under `DependencyTrackMetrics` (`dtrackFetchStatus`, `dtrackFetchFailureCount`, `dtrackFetchFailureReason`, `dtrackFetchSkipUntil`) — landed in rearm UI PR #71. Without this CE backend sync, every artifact-detail query surfaces a GraphQL validation error for those fields.

The DT-fetch resilience work itself addresses a security-false-negative bug: a transient HTTP/parse failure mid-pagination silently overwrote artifacts with empty vulnerability data instead of preserving the previous good scan. The full design is documented in the original rearm-core PRs (\#114 silent-failure stop, #122 = re-merge of #115 backoff state + GraphQL surfacing). Verified end-to-end on the sandbox during the original work.

## Coverage (delta vs current CE main)

- **IntegrationService**: `fetchDtrackPage` throws `RelizaException` instead of returning null on mid-pagination failure; propagated through `executeDtrackPaginatedCall*`, `executeDtrackComponentSearch`, the vuln/violation fetches, and `obtainDepdencyTrackProjectMetrics`.
- **New types**: `io.reliza.model.DtrackFetchStatus` enum (`PENDING`/`OK`/`FAILED`) and `io.reliza.util.BackoffPolicy` (exponential curve 1→60 min cap).
- **`ArtifactData.DependencyTrackIntegration`**: four new fields + `FETCH_FAILURE_REASON_MAX_LEN=512` constant.
- **`SharedArtifactService`**: `markArtifactDtrackFetchFailed` + `resetArtifactDtrackFetchFailedState` mirroring the existing submission-side trio.
- **`ArtifactService.fetchDependencyTrackDataForArtifact`**: mark on `RelizaException` (re-throwing), reset on success. Reset runs AFTER `updateArtifactDti` to avoid the stale-snapshot overwrite bug found during sandbox testing of the original PR.
- **`syncUnsyncedDependencyTrackData`**: application-layer skip for artifacts in backoff window; also picks up the new `listArtifactUuidsByDtrackProjects` perf path that came in via a separate rearm-core perf PR.
- **`VariableQueries.LIST_INITIAL_ARTIFACT_UUIDS_PENDING_DEPENDENCY_TRACK`**: new `dtrackFetchSkipUntil < now()` clause so the per-minute scheduler honors the backoff.
- **`ArtifactRepository`**: `findArtifactUuidsByDtrackProjects` helper (came along with the perf bundle).
- **`DependencyTrackMetrics` GraphQL**: four new fields auto-mapped via DGS/Jackson from the DTI.
- **Tests**: `BackoffPolicyTest`, `SharedArtifactServiceFetchFailureTest`, `IntegrationServiceDtrackPaginationTest`.

## Verified

- `mvn -DskipTests compile` clean on JDK 25 + Spring Boot 4.
- `mvn -Dtest='BackoffPolicyTest,SharedArtifactServiceFetchFailureTest,IntegrationServiceDtrackPaginationTest' test` — 11/11 pass.

## How produced

```sh
cd ~/rearm-projects/rearm-core/backend && bash copy-src.sh ~/rearm-projects/rearm/backend
```

`copy-src.sh` excludes `oss/` and `saas/` subtrees on both sides so edition-specific code is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)