### PR TITLE
feat(ui): redesign Integrations page — Catalog / Webhooks / PR Validation

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -1,0 +1,1183 @@
+<template>
+    <div class="org-integrations">
+        <!-- Segmented sub-tab pill control. OSS hides Webhooks + PR Validation
+             (same scope as the previous "CI Integrations" + Webhooks hide). -->
+        <div class="subtab-bar">
+            <button class="subtab-pill" :class="{ active: subTab === 'catalog' }" @click="switchSubTab('catalog')">
+                <n-icon size="16" class="subtab-icon"><LayoutGrid /></n-icon>
+                <span>Catalog</span>
+                <span class="subtab-count" v-if="catalogActiveCount > 0">{{ catalogActiveCount }} active</span>
+            </button>
+            <button v-if="showCiFeatures" class="subtab-pill" :class="{ active: subTab === 'webhooks' }" @click="switchSubTab('webhooks')">
+                <n-icon size="16" class="subtab-icon"><PlugConnected /></n-icon>
+                <span>Webhooks</span>
+            </button>
+            <button v-if="showCiFeatures" class="subtab-pill" :class="{ active: subTab === 'pr-validation' }" @click="switchSubTab('pr-validation')">
+                <n-icon size="16" class="subtab-icon"><ShieldCheck /></n-icon>
+                <span>PR Validation</span>
+            </button>
+        </div>
+
+        <!-- ============================== CATALOG ============================== -->
+        <div v-if="subTab === 'catalog'" class="catalog">
+            <div class="catalog-header">
+                <h2 class="catalog-h2">Connected systems</h2>
+                <div class="catalog-sub">Configure integrations that connect ReARM to your CI, source control, messaging and security tooling. You can add multiple instances of CI / source-control kinds.</div>
+            </div>
+
+            <template v-for="section in visibleSections" :key="section.id">
+                <div class="catalog-section-header">
+                    <span class="section-label">{{ section.label }}</span>
+                    <span class="section-dot">·</span>
+                    <span class="section-desc">{{ section.desc }}</span>
+                </div>
+                <div class="catalog-grid">
+                    <div
+                        v-for="card in section.cards"
+                        :key="card.id"
+                        class="card"
+                        :class="{ 'card-configured': isCardConfigured(card), 'card-available': !isCardConfigured(card) }"
+                    >
+                        <!-- card header: logo + title + vendor + status pill -->
+                        <div class="card-head">
+                            <div class="logo" :style="{ background: card.logoBg }">
+                                <n-icon v-if="card.iconComponent" size="22" color="#fff"><component :is="card.iconComponent" /></n-icon>
+                                <span v-else class="logo-mark">{{ card.logoMark }}</span>
+                            </div>
+                            <div class="card-title-block">
+                                <div class="card-name">{{ card.name }}</div>
+                                <div class="card-vendor">{{ card.vendor }}</div>
+                            </div>
+                            <span class="pill" :class="cardStatusClass(card)">
+                                <span class="ddot" />
+                                {{ cardStatusLabel(card) }}
+                            </span>
+                        </div>
+
+                        <!-- AVAILABLE state -->
+                        <template v-if="!isCardConfigured(card)">
+                            <div class="card-desc">{{ card.description }}</div>
+                            <div class="card-foot">
+                                <span class="muted-12">Not configured</span>
+                                <n-button size="small" @click="openAddForCard(card)">
+                                    <template #icon><n-icon><CirclePlus /></n-icon></template>
+                                    Add
+                                </n-button>
+                            </div>
+                        </template>
+
+                        <!-- CONFIGURED state — instance rows -->
+                        <template v-else>
+                            <div class="instance-list">
+                                <!-- single-instance kinds (Slack/Teams/DT/BEAR) -->
+                                <template v-if="!card.multiInstance">
+                                    <div class="instance-row">
+                                        <div class="instance-status"><span class="ddot ok" /></div>
+                                        <div class="instance-body">
+                                            <div class="instance-name">{{ singleInstanceLabel(card) }}</div>
+                                            <div v-if="card.id === 'BEAR' && bearIntegration?.uri" class="instance-meta">
+                                                <span class="instance-scope">{{ bearIntegration.uri }}</span>
+                                            </div>
+                                        </div>
+                                        <div class="instance-actions">
+                                            <!-- DT admin actions — preserved from the old design. Role-gated. -->
+                                            <template v-if="card.id === 'DEPENDENCYTRACK'">
+                                                <n-icon v-if="isOrgAdmin" class="instance-icon" size="20" title="Synchronize D-Track Projects" @click="syncDtrackProjects"><Refresh /></n-icon>
+                                                <n-icon v-if="isGlobalAdmin" class="instance-icon" size="20" title="Re-upload D-Track Projects" @click="refreshDtrackProjects"><ArrowUpload24Regular /></n-icon>
+                                                <n-icon v-if="isGlobalAdmin" class="instance-icon" size="20" title="Cleanup D-Track Projects" @click="cleanupDtrackProjects"><Clean /></n-icon>
+                                                <n-icon v-if="isGlobalAdmin" class="instance-icon" size="20" title="Re-cleanup D-Track Projects" @click="recleanupDtrackProjects"><DeleteDismiss24Regular /></n-icon>
+                                            </template>
+                                            <n-icon v-if="card.id === 'BEAR'" class="instance-icon" size="20" title="Edit BEAR Integration" @click="openBearEditModal"><EditIcon /></n-icon>
+                                            <n-icon
+                                                class="instance-icon danger"
+                                                size="20"
+                                                :title="`Delete ${card.name} integration`"
+                                                @click="card.id === 'BEAR' ? deleteBearIntegration() : onDeleteBaseInstance(card)"
+                                            ><Trash /></n-icon>
+                                        </div>
+                                    </div>
+                                </template>
+
+                                <!-- multi-instance CI kinds (GitHub/GitLab/Jenkins/ADO) -->
+                                <template v-else>
+                                    <div v-for="inst in ciInstancesForCard(card)" :key="inst.uuid" class="instance-row">
+                                        <div class="instance-status"><span class="ddot ok" /></div>
+                                        <div class="instance-body">
+                                            <div class="instance-name">{{ inst.note || '(unnamed)' }}</div>
+                                            <div v-if="inst.capabilities && inst.capabilities.length" class="caps">
+                                                <span v-for="c in inst.capabilities" :key="c" class="cap-chip">{{ c }}</span>
+                                            </div>
+                                        </div>
+                                        <div class="instance-actions">
+                                            <n-icon v-if="card.id === 'GITHUB'" class="instance-icon" size="20" title="Edit integration" @click="openEditCiIntegrationModal(inst)"><EditIcon /></n-icon>
+                                        </div>
+                                    </div>
+                                </template>
+                            </div>
+
+                            <!-- + Add another for multi-instance only -->
+                            <button v-if="card.multiInstance" class="add-another" @click="openAddForCard(card)">
+                                <n-icon size="14"><CirclePlus /></n-icon>
+                                <span>Add another {{ card.name }}</span>
+                            </button>
+                        </template>
+                    </div>
+                </div>
+            </template>
+        </div>
+
+        <!-- ============================== WEBHOOKS ============================== -->
+        <div v-if="subTab === 'webhooks' && showCiFeatures" class="webhooks-pane">
+            <div class="info-banner">
+                <n-icon size="20"><ShieldCheck /></n-icon>
+                <div>
+                    <div class="info-banner-title">Inbound webhooks</div>
+                    <div class="info-banner-body">
+                        Each webhook is bound to a CI integration with the <span class="cap-chip">WEBHOOK</span> capability.
+                        <template v-if="webhookCapableInstances.length">
+                            Available:
+                            <strong v-for="(n, i) in webhookCapableInstances" :key="n">
+                                <span v-if="i > 0">, </span>{{ n }}
+                            </strong>.
+                        </template>
+                        <template v-else>
+                            No webhook-capable CI integrations configured. Add one from the Catalog first.
+                        </template>
+                    </div>
+                </div>
+            </div>
+            <WebhooksOfOrg :orguuid="orguuid" />
+        </div>
+
+        <!-- ============================== PR VALIDATION ============================== -->
+        <div v-if="subTab === 'pr-validation' && showCiFeatures" class="pr-validation-pane">
+            <div class="info-banner">
+                <n-icon size="20"><ShieldCheck /></n-icon>
+                <div>
+                    <div class="info-banner-title">Global PR validation rules</div>
+                    <div class="info-banner-body">
+                        Route incoming pull-request events to a CI integration with the <span class="cap-chip">PR_VALIDATE</span> capability.
+                        <template v-if="prValidateCapableInstances.length">
+                            Available:
+                            <strong v-for="(n, i) in prValidateCapableInstances" :key="n">
+                                <span v-if="i > 0">, </span>{{ n }}
+                            </strong>.
+                        </template>
+                        <template v-else>
+                            No PR-validate-capable CI integrations configured. Add one from the Catalog first.
+                        </template>
+                    </div>
+                </div>
+            </div>
+            <OrgGlobalPrValidationRules :orgUuid="orguuid" :isWritable="isWritable" />
+        </div>
+
+        <!-- ================================= MODALS ================================= -->
+
+        <!-- Slack -->
+        <n-modal v-model:show="showSlackModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 600px" size="huge" title="Add Slack integration" :bordered="false" role="dialog" aria-modal="true">
+                <n-form>
+                    <n-form-item label="Secret" description="Slack integration secret">
+                        <n-input type="password" v-model:value="createIntegrationObject.secret" required placeholder="Enter Slack integration secret" />
+                    </n-form-item>
+                    <n-space>
+                        <n-button @click="onAddBaseIntegration('SLACK')" type="success">Submit</n-button>
+                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- MS Teams -->
+        <n-modal v-model:show="showMsteamsModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 600px" size="huge" title="Add MS Teams integration" :bordered="false" role="dialog" aria-modal="true">
+                <n-form>
+                    <n-form-item label="Secret" description="MS Teams integration URI">
+                        <n-input type="password" v-model:value="createIntegrationObject.secret" required placeholder="Enter MS Teams integration URI" />
+                    </n-form-item>
+                    <n-space>
+                        <n-button @click="onAddBaseIntegration('MSTEAMS')" type="success">Submit</n-button>
+                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- Dependency-Track -->
+        <n-modal v-model:show="showDtModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 600px" size="huge" title="Add Dependency-Track Integration" :bordered="false" role="dialog" aria-modal="true">
+                <n-form>
+                    <n-form-item label="Dependency-Track API Server URI">
+                        <n-input v-model:value="createIntegrationObject.uri" required placeholder="Enter Dependency-Track API Server URI" />
+                    </n-form-item>
+                    <n-form-item label="Dependency-Track Frontend URI">
+                        <n-input v-model:value="createIntegrationObject.frontendUri" required placeholder="Enter Dependency-Track Frontend URI" />
+                    </n-form-item>
+                    <n-form-item label="API Key">
+                        <n-input type="password" v-model:value="createIntegrationObject.secret" required placeholder="Enter Dependency-Track API Key" />
+                    </n-form-item>
+                    <n-space>
+                        <n-button @click="onAddBaseIntegration('DEPENDENCYTRACK')" type="success">Submit</n-button>
+                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- BEAR -->
+        <n-modal v-model:show="showBearModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 600px" size="huge" :title="bearIntegration && bearIntegration.configured ? 'Edit BEAR Integration' : 'Add BEAR Integration'" :bordered="false" role="dialog" aria-modal="true">
+                <n-form>
+                    <n-form-item v-if="bearIntegration && bearIntegration.configured" label="Update Mode">
+                        <n-checkbox v-model:checked="bearForm.updateSkipPatternsOnly">
+                            Update skip patterns only (don't modify URI/API Key)
+                        </n-checkbox>
+                    </n-form-item>
+                    <n-form-item v-if="!bearForm.updateSkipPatternsOnly || !bearIntegration || !bearIntegration.configured" label="BEAR URI">
+                        <n-input v-model:value="bearForm.uri" required placeholder="Enter BEAR URI" />
+                    </n-form-item>
+                    <n-form-item v-if="!bearForm.updateSkipPatternsOnly || !bearIntegration || !bearIntegration.configured" label="API Key">
+                        <n-input type="password" v-model:value="bearForm.apiKey" required placeholder="Enter BEAR API Key" />
+                    </n-form-item>
+                    <n-form-item label="Skip Patterns">
+                        <n-dynamic-input v-model:value="bearForm.skipPatterns" placeholder="Enter skip pattern" />
+                    </n-form-item>
+                    <n-space>
+                        <n-button @click="onSetBearIntegration" type="success">Submit</n-button>
+                        <n-button @click="resetBearForm" type="error">Reset</n-button>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- CI Integration ADD (GitHub / GitLab / Jenkins / ADO) -->
+        <n-modal v-if="showCiFeatures" v-model:show="showCiAddModal" preset="dialog" :show-icon="false" style="width: 90%">
+            <n-card style="max-width: 800px; width: 100%" size="huge" :title="addModalTitle" :bordered="false" role="dialog" aria-modal="true">
+                <n-form :model="createIntegrationObject">
+                    <n-space vertical size="large">
+                        <n-form-item label="Description" path="note">
+                            <n-input v-model:value="createIntegrationObject.note" required placeholder="Enter Description" />
+                        </n-form-item>
+                        <n-form-item label="CI Type" path="createIntegrationObject.type">
+                            <n-radio-group v-model:value="createIntegrationObject.type" name="ciIntegrationType">
+                                <n-radio-button label="GitHub" value="GITHUB" />
+                                <n-radio-button label="GitLab" value="GITLAB" />
+                                <n-radio-button label="Jenkins" value="JENKINS" />
+                                <n-radio-button label="Azure DevOps" value="ADO" />
+                            </n-radio-group>
+                        </n-form-item>
+                        <n-form-item
+                            v-if="createIntegrationObject.type === 'GITHUB'"
+                            label="Capabilities"
+                            description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK: receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch."
+                        >
+                            <n-checkbox-group v-model:value="createIntegrationObject.capabilities">
+                                <n-space>
+                                    <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
+                                    <n-checkbox value="PR_VALIDATE" label="PR Validate" />
+                                    <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                </n-space>
+                            </n-checkbox-group>
+                        </n-form-item>
+                        <n-form-item
+                            v-if="createIntegrationObject.type === 'GITHUB'"
+                            label="GitHub Private Key"
+                            description="Paste the .pem GitHub provides, upload the file directly, or paste a pre-converted DER base64 blob. Backend normalizes all three."
+                        >
+                            <n-space vertical style="width: 100%;">
+                                <n-radio-group v-model:value="secretInputMode" name="githubSecretInputMode">
+                                    <n-radio-button label="Upload .pem" value="upload" />
+                                    <n-radio-button label="Paste" value="paste" />
+                                </n-radio-group>
+                                <n-input
+                                    v-if="secretInputMode === 'paste'"
+                                    type="textarea"
+                                    v-model:value="createIntegrationObject.secret"
+                                    required
+                                    :autosize="{ minRows: 6, maxRows: 18 }"
+                                    style="width: 100%; font-family: monospace; font-size: 12px;"
+                                    placeholder="Paste the contents of the .pem file (-----BEGIN RSA PRIVATE KEY----- ...) or DER base64."
+                                />
+                                <n-upload v-else :default-upload="false" :max="1" accept=".pem,.txt,.key,application/x-pem-file" :show-file-list="false" @change="onSecretFileChange">
+                                    <n-upload-trigger #="{ handleClick }" abstract>
+                                        <n-button @click="handleClick">Choose .pem file</n-button>
+                                    </n-upload-trigger>
+                                </n-upload>
+                                <n-text v-if="secretInputMode === 'upload' && uploadedSecretFileName" depth="3" style="font-size: 12px;">
+                                    Loaded: {{ uploadedSecretFileName }} ({{ createIntegrationObject.secret.length }} chars)
+                                </n-text>
+                            </n-space>
+                        </n-form-item>
+                        <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" label="GitHub Application ID" description="GitHub Application ID">
+                            <n-input type="number" v-model:value="createIntegrationObject.schedule" required placeholder="Enter GitHub Application ID" />
+                        </n-form-item>
+
+                        <n-form-item v-if="createIntegrationObject.type === 'GITLAB'" label="GitLab Authentication Token">
+                            <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter GitLab Authentication Token" />
+                        </n-form-item>
+
+                        <n-form-item v-if="createIntegrationObject.type === 'JENKINS'" label="Jenkins URI">
+                            <n-input v-model:value="createIntegrationObject.uri" required placeholder="Jenkins Home URI (i.e. https://jenkins.localhost)" />
+                        </n-form-item>
+                        <n-form-item v-if="createIntegrationObject.type === 'JENKINS'" label="Jenkins Token">
+                            <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter Jenkins Token" />
+                        </n-form-item>
+
+                        <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Client ID">
+                            <n-input v-model:value="createIntegrationObject.client" required placeholder="Enter Client ID" />
+                        </n-form-item>
+                        <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Client Secret">
+                            <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter Client Secret" />
+                        </n-form-item>
+                        <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Tenant ID">
+                            <n-input v-model:value="createIntegrationObject.tenant" required placeholder="Enter Tenant ID" />
+                        </n-form-item>
+                        <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Azure DevOps Organization Name">
+                            <n-input v-model:value="createIntegrationObject.uri" required placeholder="Enter Azure DevOps organization name" />
+                        </n-form-item>
+
+                        <n-space>
+                            <n-button @click="addCiIntegration" type="success">Save</n-button>
+                            <n-button @click="showCiAddModal = false" type="default">Cancel</n-button>
+                        </n-space>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- CI Integration EDIT (GitHub only) -->
+        <n-modal v-if="showCiFeatures" v-model:show="showCiEditModal" preset="dialog" :show-icon="false" style="width: 90%">
+            <n-card
+                style="width: 700px"
+                size="huge"
+                :title="'Edit CI Integration - ' + (editCiIntegrationObject.note || '')"
+                :bordered="false"
+                role="dialog"
+                aria-modal="true"
+            >
+                <n-form :model="editCiIntegrationObject">
+                    <n-space vertical size="large">
+                        <n-form-item label="Type">
+                            <n-text>{{ editCiIntegrationObject.type }}</n-text>
+                        </n-form-item>
+                        <n-form-item label="Capabilities" description="Reduce or expand without re-creating the integration.">
+                            <n-checkbox-group v-model:value="editCiIntegrationObject.capabilities">
+                                <n-space>
+                                    <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
+                                    <n-checkbox value="PR_VALIDATE" label="PR Validate" />
+                                    <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                </n-space>
+                            </n-checkbox-group>
+                        </n-form-item>
+                        <n-text depth="3" style="font-size: 13px;">
+                            To add or modify the inbound webhook (slug, secret) attached to this integration,
+                            use the Webhooks sub-tab.
+                        </n-text>
+                        <n-space>
+                            <n-button :loading="editCiIntegrationLoading" @click="saveEditCiIntegration" type="success">Save</n-button>
+                            <n-button @click="showCiEditModal = false" type="default">Cancel</n-button>
+                        </n-space>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, onMounted, Ref, ComputedRef, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+    NIcon, NButton, NCard, NModal, NForm, NFormItem, NInput, NCheckbox, NCheckboxGroup,
+    NRadioGroup, NRadioButton, NSpace, NText, NDynamicInput, NUpload, NUploadTrigger
+} from 'naive-ui'
+import {
+    Edit as EditIcon, Trash, Refresh, CirclePlus,
+    BrandGithub, BrandGitlab, BrandSlack,
+    PlugConnected, ShieldCheck, LayoutGrid
+} from '@vicons/tabler'
+import { Clean } from '@vicons/carbon'
+import { ArrowUpload24Regular, DeleteDismiss24Regular } from '@vicons/fluent'
+import gql from 'graphql-tag'
+import { FetchPolicy } from '@apollo/client'
+import Swal from 'sweetalert2'
+import graphqlClient from '../utils/graphql'
+import commonFunctions from '../utils/commonFunctions'
+import WebhooksOfOrg from './WebhooksOfOrg.vue'
+import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
+import { useNotification, NotificationType } from 'naive-ui'
+
+const props = defineProps<{
+    orguuid: string
+    isWritable: boolean
+    isOrgAdmin: boolean
+    isGlobalAdmin: boolean
+    installationType: string
+}>()
+
+const route = useRoute()
+const router = useRouter()
+const notification = useNotification()
+const notify = (type: NotificationType, title: string, content: string) => {
+    notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
+}
+
+const showCiFeatures = computed(() => props.installationType !== 'OSS')
+const orguuid = computed(() => props.orguuid)
+const isOrgAdmin = computed(() => props.isOrgAdmin)
+const isGlobalAdmin = computed(() => props.isGlobalAdmin)
+const isWritable = computed(() => props.isWritable)
+
+// ---- Sub-tab state, URL-synced ---------------------------------------------
+type SubTab = 'catalog' | 'webhooks' | 'pr-validation'
+const subTab = ref<SubTab>((route.query.integrationsTab as SubTab) || 'catalog')
+
+async function switchSubTab(t: SubTab) {
+    if (t !== 'catalog' && !showCiFeatures.value) return
+    subTab.value = t
+    await router.push({ query: { ...route.query, integrationsTab: t } })
+}
+
+// ---- Data refs lifted from OrgSettings -------------------------------------
+const configuredIntegrations: Ref<string[]> = ref([])
+const ciIntegrations: Ref<any[]> = ref([])
+const bearIntegration: Ref<any> = ref(null)
+
+const createIntegrationObject: Ref<any> = ref({
+    org: orguuid.value,
+    uri: '', frontendUri: '', identifier: 'base',
+    secret: '', type: '', note: '',
+    tenant: '', client: '', schedule: '',
+    capabilities: []
+})
+
+const secretInputMode = ref<'paste' | 'upload'>('upload')
+const uploadedSecretFileName = ref('')
+
+const bearForm = ref({
+    uri: '',
+    apiKey: '',
+    skipPatterns: [] as string[],
+    updateSkipPatternsOnly: true
+})
+
+const showSlackModal = ref(false)
+const showMsteamsModal = ref(false)
+const showDtModal = ref(false)
+const showBearModal = ref(false)
+const showCiAddModal = ref(false)
+const showCiEditModal = ref(false)
+
+const editCiIntegrationObject: Ref<any> = ref({
+    uuid: '', type: '', note: '', capabilities: [] as string[]
+})
+const editCiIntegrationLoading = ref(false)
+
+// ---- Card config -----------------------------------------------------------
+// We keep the brand color + icon mapping co-located so it's easy to add
+// kinds later. iconComponent wins over logoMark — falls back to a monogram
+// when @vicons doesn't have a brand icon for the kind.
+type Category = 'messaging' | 'ci' | 'security'
+interface CardConfig {
+    id: 'SLACK' | 'MSTEAMS' | 'GITHUB' | 'GITLAB' | 'JENKINS' | 'ADO' | 'DEPENDENCYTRACK' | 'BEAR'
+    name: string
+    vendor: string
+    category: Category
+    description: string
+    logoBg: string
+    logoMark?: string
+    iconComponent?: any
+    multiInstance: boolean
+}
+
+const CARDS: CardConfig[] = [
+    // Messaging
+    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Push release notifications and approval-state changes to a Slack channel.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: false },
+    { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Push release notifications to a Microsoft Teams channel.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: false },
+    // CI/CD & Source Control
+    { id: 'GITHUB', name: 'GitHub', vendor: 'GitHub', category: 'ci', description: 'GitHub App for PR validation, inbound webhooks, and repository_dispatch.', logoBg: '#1F2328', iconComponent: BrandGithub, multiInstance: true },
+    { id: 'GITLAB', name: 'GitLab', vendor: 'GitLab', category: 'ci', description: 'GitLab project access for pipeline triggers and SCM links.', logoBg: '#FC6D26', iconComponent: BrandGitlab, multiInstance: true },
+    { id: 'JENKINS', name: 'Jenkins', vendor: 'Jenkins', category: 'ci', description: 'Trigger Jenkins jobs and ingest pipeline state.', logoBg: '#D33833', logoMark: 'J', multiInstance: true },
+    { id: 'ADO', name: 'Azure DevOps', vendor: 'Microsoft', category: 'ci', description: 'Trigger Azure DevOps pipelines and ingest pipeline state.', logoBg: '#0078D4', logoMark: 'AZ', multiInstance: true },
+    // Security & Compliance
+    { id: 'DEPENDENCYTRACK', name: 'Dependency-Track', vendor: 'OWASP', category: 'security', description: 'Push SBOMs and pull vulnerability + policy findings.', logoBg: '#1B4E72', logoMark: 'DT', multiInstance: false },
+    { id: 'BEAR', name: 'BEAR', vendor: 'Reliza', category: 'security', description: 'BOM enrichment and risk-signal service.', logoBg: '#22332B', logoMark: 'BR', multiInstance: false }
+]
+
+const SECTIONS = [
+    { id: 'messaging', label: 'Messaging & Notifications', desc: 'Push release events to your team chat' },
+    { id: 'ci', label: 'CI/CD & Source Control', desc: 'PR validation, status checks, and pipeline integration' },
+    { id: 'security', label: 'Security & Compliance', desc: 'SBOMs, vulnerability findings, and risk signals' }
+]
+
+const visibleSections = computed(() => {
+    return SECTIONS
+        .filter(s => s.id !== 'ci' || showCiFeatures.value)
+        .map(s => ({ ...s, cards: CARDS.filter(c => c.category === s.id) }))
+})
+
+// ---- Card status helpers ---------------------------------------------------
+function isCardConfigured(card: CardConfig): boolean {
+    if (card.id === 'BEAR') return !!(bearIntegration.value && bearIntegration.value.configured)
+    if (card.multiInstance) return ciInstancesForCard(card).length > 0
+    return configuredIntegrations.value.includes(card.id)
+}
+
+function ciInstancesForCard(card: CardConfig): any[] {
+    return ciIntegrations.value.filter((i: any) => i.type === card.id)
+}
+
+function cardStatusLabel(card: CardConfig): string {
+    if (!isCardConfigured(card)) return 'Available'
+    if (card.multiInstance) {
+        const n = ciInstancesForCard(card).length
+        return n > 1 ? `${n} active` : 'Active'
+    }
+    return 'Active'
+}
+
+function cardStatusClass(card: CardConfig): string {
+    return isCardConfigured(card) ? 'pill-success' : 'pill-neutral'
+}
+
+function singleInstanceLabel(card: CardConfig): string {
+    if (card.id === 'BEAR') return 'Configured'
+    return 'Configured'
+}
+
+const catalogActiveCount = computed(() => {
+    let n = 0
+    for (const c of CARDS) {
+        if (c.multiInstance) n += ciInstancesForCard(c).length
+        else if (isCardConfigured(c)) n += 1
+    }
+    return n
+})
+
+// ---- Capability-aware info banner data -------------------------------------
+const webhookCapableInstances = computed(() =>
+    ciIntegrations.value
+        .filter((i: any) => (i.capabilities || []).includes('WEBHOOK'))
+        .map((i: any) => `${kindLabel(i.type)} · ${i.note || '(unnamed)'}`)
+)
+
+const prValidateCapableInstances = computed(() =>
+    ciIntegrations.value
+        .filter((i: any) => (i.capabilities || []).includes('PR_VALIDATE'))
+        .map((i: any) => `${kindLabel(i.type)} · ${i.note || '(unnamed)'}`)
+)
+
+function kindLabel(t: string): string {
+    const map: Record<string, string> = {
+        GITHUB: 'GitHub', GITLAB: 'GitLab', JENKINS: 'Jenkins', ADO: 'Azure DevOps'
+    }
+    return map[t] || t
+}
+
+// ---- Modal openers ---------------------------------------------------------
+function openAddForCard(card: CardConfig) {
+    if (card.id === 'SLACK') { showSlackModal.value = true; return }
+    if (card.id === 'MSTEAMS') { showMsteamsModal.value = true; return }
+    if (card.id === 'DEPENDENCYTRACK') { showDtModal.value = true; return }
+    if (card.id === 'BEAR') { openBearAddModal(); return }
+    // CI types
+    resetCreateIntegrationObject()
+    createIntegrationObject.value.type = card.id
+    showCiAddModal.value = true
+}
+
+function openBearAddModal() {
+    bearForm.value = { uri: '', apiKey: '', skipPatterns: [], updateSkipPatternsOnly: false }
+    showBearModal.value = true
+}
+
+function openBearEditModal() {
+    bearForm.value = {
+        uri: bearIntegration.value?.uri || '',
+        apiKey: '',
+        skipPatterns: bearIntegration.value?.skipPatterns || [],
+        updateSkipPatternsOnly: true
+    }
+    showBearModal.value = true
+}
+
+function openEditCiIntegrationModal(row: any) {
+    editCiIntegrationObject.value = {
+        uuid: row.uuid, type: row.type, note: row.note,
+        capabilities: [...(row.capabilities || [])]
+    }
+    showCiEditModal.value = true
+}
+
+const addModalTitle = computed(() => {
+    const t = createIntegrationObject.value.type
+    if (!t) return 'Add CI Integration'
+    return `Add ${kindLabel(t)} Integration`
+})
+
+// ---- Mutations -------------------------------------------------------------
+function resetCreateIntegrationObject() {
+    createIntegrationObject.value = {
+        org: orguuid.value,
+        uri: '', frontendUri: '', identifier: 'base',
+        secret: '', type: '', note: '',
+        tenant: '', client: '', schedule: '',
+        capabilities: []
+    }
+    uploadedSecretFileName.value = ''
+}
+
+function resetBearForm() {
+    bearForm.value = {
+        uri: bearIntegration.value?.uri || '',
+        apiKey: '',
+        skipPatterns: bearIntegration.value?.skipPatterns || [],
+        updateSkipPatternsOnly: true
+    }
+}
+
+async function onSecretFileChange(options: any) {
+    const fileInfo = options.file
+    if (fileInfo && fileInfo.file) {
+        createIntegrationObject.value.secret = await fileInfo.file.text()
+        uploadedSecretFileName.value = fileInfo.file.name || fileInfo.name || ''
+    }
+}
+
+async function onAddBaseIntegration(type: string) {
+    createIntegrationObject.value.type = type
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation createIntegration($integration: IntegrationInput!) {
+                    createIntegration(integration: $integration) { uuid }
+                }`,
+            variables: { integration: createIntegrationObject.value }
+        })
+        if (resp.data?.createIntegration?.uuid) await loadConfiguredIntegrations(false)
+        notify('success', 'Integration Added', `${kindLabel(type) || type} integration added.`)
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        resetCreateIntegrationObject()
+        showSlackModal.value = false
+        showMsteamsModal.value = false
+        showDtModal.value = false
+    }
+}
+
+async function addCiIntegration() {
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation createTriggerIntegration($integration: IntegrationInput!) {
+                    createTriggerIntegration(integration: $integration) { uuid }
+                }`,
+            variables: { integration: createIntegrationObject.value }
+        })
+        if (resp.data?.createTriggerIntegration?.uuid) await loadCiIntegrations(false)
+        notify('success', 'Integration Added', `${kindLabel(createIntegrationObject.value.type)} integration added.`)
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        resetCreateIntegrationObject()
+        showCiAddModal.value = false
+    }
+}
+
+async function saveEditCiIntegration() {
+    editCiIntegrationLoading.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateIntegrationCapabilities($uuid: ID!, $capabilities: [IntegrationCapability!]!) {
+                    updateIntegrationCapabilities(uuid: $uuid, capabilities: $capabilities) { uuid capabilities }
+                }`,
+            variables: {
+                uuid: editCiIntegrationObject.value.uuid,
+                capabilities: editCiIntegrationObject.value.capabilities
+            },
+            fetchPolicy: 'no-cache'
+        })
+        showCiEditModal.value = false
+        await loadCiIntegrations(false)
+        notify('success', 'Integration Updated', 'Capabilities saved.')
+    } catch (e: any) {
+        notify('error', 'Failed to save integration', e?.message || String(e))
+    } finally {
+        editCiIntegrationLoading.value = false
+    }
+}
+
+async function onDeleteBaseInstance(card: CardConfig) {
+    const result = await Swal.fire({
+        title: `Delete ${card.name} integration?`,
+        text: 'This will remove the integration configuration.',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Yes, delete'
+    })
+    if (!result.isConfirmed) return
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation deleteBaseIntegration($org: ID!, $type: IntegrationType!) {
+                    deleteBaseIntegration(org: $org, type: $type)
+                }`,
+            variables: { org: orguuid.value, type: card.id }
+        })
+        await loadConfiguredIntegrations(false)
+        notify('success', 'Deleted', `${card.name} integration removed.`)
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    }
+}
+
+async function onSetBearIntegration() {
+    try {
+        let resp
+        if (bearForm.value.updateSkipPatternsOnly && bearIntegration.value?.configured) {
+            resp = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation updateBearSkipPatterns($org: ID!, $skipPatterns: [String]) {
+                        updateBearSkipPatterns(org: $org, skipPatterns: $skipPatterns) {
+                            uri configured skipPatterns
+                        }
+                    }`,
+                variables: { org: orguuid.value, skipPatterns: bearForm.value.skipPatterns }
+            })
+            if (resp.data?.updateBearSkipPatterns) bearIntegration.value = resp.data.updateBearSkipPatterns
+            notify('success', 'Success', 'BEAR skip patterns updated.')
+        } else {
+            resp = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setBearIntegration($org: ID!, $uri: String!, $apiKey: String!, $skipPatterns: [String]) {
+                        setBearIntegration(org: $org, uri: $uri, apiKey: $apiKey, skipPatterns: $skipPatterns) {
+                            uri configured skipPatterns
+                        }
+                    }`,
+                variables: {
+                    org: orguuid.value,
+                    uri: bearForm.value.uri,
+                    apiKey: bearForm.value.apiKey,
+                    skipPatterns: bearForm.value.skipPatterns
+                }
+            })
+            if (resp.data?.setBearIntegration) bearIntegration.value = resp.data.setBearIntegration
+            notify('success', 'Success', 'BEAR integration configured.')
+        }
+        showBearModal.value = false
+        bearForm.value.apiKey = ''
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    }
+}
+
+// BEAR isn't part of the IntegrationType enum (it has its own
+// setBearIntegration / deleteBearIntegration mutations), so the BEAR row's
+// trash icon routes here instead of onDeleteBaseInstance.
+async function deleteBearIntegration() {
+    const confirm = await Swal.fire({
+        title: 'Delete BEAR Integration?',
+        text: 'This will remove the BEAR integration configuration.',
+        icon: 'warning', showCancelButton: true, confirmButtonText: 'Yes, delete it'
+    })
+    if (!confirm.isConfirmed) return
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation deleteBearIntegration($org: ID!) { deleteBearIntegration(org: $org) }`,
+            variables: { org: orguuid.value }
+        })
+        bearIntegration.value = null
+        bearForm.value = { uri: '', apiKey: '', skipPatterns: [], updateSkipPatternsOnly: true }
+        notify('success', 'Deleted', 'BEAR integration removed.')
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    }
+}
+
+// ---- DT admin actions (preserved from old design) --------------------------
+async function syncDtrackProjects() {
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation syncDtrackProjects($orgUuid: ID!) { syncDtrackProjects(orgUuid: $orgUuid) }`,
+            variables: { orgUuid: orguuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        if (resp.data?.syncDtrackProjects) {
+            notify('success', 'D-Track Projects Sync', 'Successfully synchronized.')
+        } else {
+            notify('warning', 'D-Track Projects Sync', 'Completed but returned false.')
+        }
+    } catch (err: any) {
+        notify('error', 'Sync Failed', err.message || 'Failed to sync.')
+    }
+}
+
+async function refreshDtrackProjects() {
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation refreshDtrackProjects($orgUuid: ID!) { refreshDtrackProjects(orgUuid: $orgUuid) }`,
+            variables: { orgUuid: orguuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        if (resp.data?.refreshDtrackProjects) {
+            notify('success', 'D-Track Projects Refresh', 'Successfully refreshed.')
+        } else {
+            notify('warning', 'D-Track Projects Refresh', 'Completed but returned false.')
+        }
+    } catch (err: any) {
+        notify('error', 'Refresh Failed', err.message || 'Failed to refresh.')
+    }
+}
+
+async function cleanupDtrackProjects() {
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation cleanupDtrackProjects($orgUuid: ID!) { cleanupDtrackProjects(orgUuid: $orgUuid) }`,
+            variables: { orgUuid: orguuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        if (resp.data?.cleanupDtrackProjects) {
+            notify('success', 'D-Track Projects Cleanup', 'Successfully cleaned up.')
+        } else {
+            notify('warning', 'D-Track Projects Cleanup', 'Completed but returned false.')
+        }
+    } catch (err: any) {
+        notify('error', 'Cleanup Failed', err.message || 'Failed to cleanup.')
+    }
+}
+
+async function recleanupDtrackProjects() {
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation recleanupDtrackProjects($orgUuid: ID!) { recleanupDtrackProjects(orgUuid: $orgUuid) }`,
+            variables: { orgUuid: orguuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        if (resp.data?.recleanupDtrackProjects) {
+            notify('success', 'D-Track Projects Re-cleanup', 'Successfully re-cleaned up.')
+        } else {
+            notify('warning', 'D-Track Projects Re-cleanup', 'Completed but returned false.')
+        }
+    } catch (err: any) {
+        notify('error', 'Re-cleanup Failed', err.message || 'Failed to re-cleanup.')
+    }
+}
+
+// ---- Data loaders ----------------------------------------------------------
+async function loadConfiguredIntegrations(useCache: boolean) {
+    const cachePolicy: FetchPolicy = useCache ? 'cache-first' : 'network-only'
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query configuredBaseIntegrations($org: ID!) {
+                    configuredBaseIntegrations(org: $org)
+                }`,
+            variables: { org: orguuid.value },
+            fetchPolicy: cachePolicy
+        })
+        if (resp.data?.configuredBaseIntegrations) {
+            configuredIntegrations.value = resp.data.configuredBaseIntegrations
+        }
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+async function loadCiIntegrations(useCache: boolean) {
+    if (!showCiFeatures.value) return
+    const cachePolicy: FetchPolicy = useCache ? 'cache-first' : 'network-only'
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query ciIntegrations($org: ID!) {
+                    ciIntegrations(org: $org) {
+                        uuid identifier org isEnabled type note capabilities
+                    }
+                }`,
+            variables: { org: orguuid.value },
+            fetchPolicy: cachePolicy
+        })
+        if (resp.data?.ciIntegrations) ciIntegrations.value = resp.data.ciIntegrations
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+async function loadBearIntegration() {
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query getBearIntegration($org: ID!) {
+                    getBearIntegration(org: $org) { uri configured skipPatterns }
+                }`,
+            variables: { org: orguuid.value },
+            fetchPolicy: 'network-only'
+        })
+        if (resp.data?.getBearIntegration) {
+            bearIntegration.value = resp.data.getBearIntegration
+            if (bearIntegration.value.configured) {
+                bearForm.value.uri = bearIntegration.value.uri || ''
+                bearForm.value.skipPatterns = bearIntegration.value.skipPatterns || []
+            }
+        }
+    } catch (err) {
+        console.error(err)
+    }
+}
+
+onMounted(async () => {
+    await Promise.all([
+        loadConfiguredIntegrations(true),
+        loadCiIntegrations(true),
+        loadBearIntegration()
+    ])
+})
+
+watch(() => props.orguuid, async () => {
+    await Promise.all([
+        loadConfiguredIntegrations(false),
+        loadCiIntegrations(false),
+        loadBearIntegration()
+    ])
+})
+</script>
+
+<style scoped>
+/* ============================================================================
+   Design tokens scoped to this component. Mirror /tmp/design tokens but only
+   keep the ones we actually reference in the markup.
+   ========================================================================== */
+.org-integrations {
+    --green:        #2D8F4E;
+    --green-soft:   #E6F4EA;
+    --green-softer: #F1F9F3;
+    --green-border: #DCEEDF;
+    --ink:          #1F2328;
+    --ink-2:        #41464C;
+    --muted:        #6B7280;
+    --muted-2:      #9AA0A6;
+    --line:         #E5E7EB;
+    --line-2:       #EEF0F2;
+    --bg-tint:      #FAFBFB;
+    --chip:         #F3F4F6;
+    --danger:       #C0392B;
+    color: var(--ink);
+}
+
+/* ---- sub-tab bar -------------------------------------------------------- */
+.subtab-bar {
+    display: inline-flex;
+    gap: 4px;
+    background: #F3F5F4;
+    padding: 4px;
+    border-radius: 10px;
+    margin: 12px 0 24px;
+}
+.subtab-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 14px;
+    border: none; background: transparent;
+    border-radius: 7px;
+    font-size: 13px; font-weight: 500;
+    color: var(--ink-2); cursor: pointer;
+    transition: background .12s, color .12s;
+}
+.subtab-pill:hover { color: var(--ink); }
+.subtab-pill.active {
+    background: #FFFFFF;
+    color: var(--ink);
+    box-shadow: 0 1px 2px rgba(16,24,40,.04);
+    font-weight: 600;
+}
+.subtab-icon { display: inline-flex; }
+.subtab-count {
+    font-size: 11px; font-weight: 600;
+    background: var(--green-softer); color: var(--green);
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--green-border);
+}
+
+/* ---- catalog header ----------------------------------------------------- */
+.catalog-header { margin-bottom: 20px; }
+.catalog-h2 { font-size: 17px; font-weight: 600; margin: 0 0 6px; color: var(--ink); }
+.catalog-sub { font-size: 13px; color: var(--muted); max-width: 720px; }
+
+.catalog-section-header {
+    margin: 26px 0 12px;
+    display: flex; align-items: center; gap: 8px;
+    font-size: 11.5px;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--muted);
+}
+.section-label { font-weight: 600; }
+.section-dot { color: var(--muted-2); }
+.section-desc { font-weight: 400; text-transform: none; letter-spacing: 0; font-size: 12px; }
+
+/* ---- card grid ---------------------------------------------------------- */
+.catalog-grid {
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+.card {
+    background: #FFFFFF;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 18px;
+    transition: border-color .12s, box-shadow .12s;
+}
+.card:hover {
+    border-color: #CDD3D9;
+    box-shadow: 0 4px 14px rgba(16,24,40,.06), 0 1px 2px rgba(16,24,40,.04);
+}
+.card-configured { background: #FFFFFF; }
+
+.card-head {
+    display: flex; align-items: center; gap: 12px;
+    margin-bottom: 8px;
+}
+.logo {
+    width: 40px; height: 40px;
+    flex: 0 0 40px;
+    border-radius: 9px;
+    display: inline-flex; align-items: center; justify-content: center;
+    color: #FFFFFF;
+}
+.logo-mark {
+    font-weight: 700; font-size: 14px;
+    letter-spacing: -.02em;
+    font-family: Inter, sans-serif;
+}
+.card-title-block { flex: 1; min-width: 0; }
+.card-name { font-size: 14.5px; font-weight: 600; color: var(--ink); }
+.card-vendor { font-size: 12px; color: var(--muted); }
+
+.pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 11px; font-weight: 500;
+    padding: 3px 9px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--chip);
+    color: var(--ink-2);
+    flex-shrink: 0;
+}
+.pill .ddot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--muted-2);
+}
+.pill-success {
+    background: var(--green-softer);
+    border-color: var(--green-border);
+    color: var(--green);
+}
+.pill-success .ddot { background: var(--green); }
+
+.card-desc {
+    font-size: 12.5px; color: var(--ink-2);
+    margin: 6px 0 14px;
+    line-height: 1.5;
+}
+.card-foot {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 8px;
+    padding-top: 10px;
+    border-top: 1px dashed var(--line);
+}
+.muted-12 { font-size: 12px; color: var(--muted); }
+
+/* ---- instance rows ------------------------------------------------------ */
+.instance-list {
+    display: flex; flex-direction: column;
+    gap: 6px;
+    margin-top: 10px;
+}
+.instance-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--bg-tint);
+    transition: background .12s, border-color .12s;
+}
+.instance-row:hover { background: #FFFFFF; border-color: #CDD3D9; }
+.instance-status { flex-shrink: 0; }
+.ddot.ok {
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--green);
+    display: inline-block;
+    box-shadow: 0 0 0 3px var(--green-softer);
+}
+.instance-body { flex: 1; min-width: 0; }
+.instance-name {
+    font-size: 13.5px; font-weight: 500;
+    color: var(--ink);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.instance-meta {
+    font-size: 11.5px; color: var(--muted);
+    margin-top: 2px;
+}
+.instance-scope { font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace; }
+.caps { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.cap-chip {
+    font-family: 'JetBrains Mono', ui-monospace, Menlo, monospace;
+    font-size: 10.5px; font-weight: 500;
+    background: var(--green-softer);
+    border: 1px solid var(--green-border);
+    color: var(--green);
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+.instance-actions { display: flex; gap: 6px; flex-shrink: 0; }
+.instance-icon {
+    cursor: pointer; color: var(--muted-2);
+    padding: 4px;
+    border-radius: 6px;
+    transition: color .12s, background .12s;
+}
+.instance-icon:hover { color: var(--ink); background: var(--bg-tint); }
+.instance-icon.danger:hover { color: var(--danger); background: #FCEEEC; }
+
+/* ---- + Add another ------------------------------------------------------ */
+.add-another {
+    margin-top: 10px;
+    width: 100%;
+    padding: 10px;
+    background: transparent;
+    border: 1px dashed var(--line);
+    border-radius: 8px;
+    color: var(--muted);
+    font-size: 12.5px; font-weight: 500;
+    display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+    cursor: pointer;
+    transition: color .12s, border-color .12s;
+}
+.add-another:hover { color: var(--green); border-color: var(--green); }
+
+/* ---- info banner -------------------------------------------------------- */
+.info-banner {
+    display: flex; gap: 12px; align-items: flex-start;
+    padding: 14px 16px;
+    background: var(--green-softer);
+    border: 1px solid var(--green-border);
+    color: var(--ink);
+    border-radius: 12px;
+    margin-bottom: 18px;
+}
+.info-banner > .n-icon { color: var(--green); flex-shrink: 0; }
+.info-banner-title { font-weight: 600; font-size: 13.5px; margin-bottom: 2px; }
+.info-banner-body { font-size: 12.5px; color: var(--ink-2); line-height: 1.5; }
+
+.webhooks-pane, .pr-validation-pane { padding-top: 4px; }
+</style>

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -146,7 +146,7 @@
                     </div>
                 </div>
             </div>
-            <WebhooksOfOrg :orguuid="orguuid" />
+            <WebhooksOfOrg :orguuid="orguuid" :ci-integrations="ciIntegrations" />
         </div>
 
         <!-- ============================== PR VALIDATION ============================== -->
@@ -493,13 +493,13 @@ interface CardConfig {
 
 const CARDS: CardConfig[] = [
     // Messaging
-    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Push release notifications and approval-state changes to a Slack channel.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: false },
+    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Push release notifications to a Slack channel.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: false },
     { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Push release notifications to a Microsoft Teams channel.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: false },
     // CI/CD & Source Control
     { id: 'GITHUB', name: 'GitHub', vendor: 'GitHub', category: 'ci', description: 'GitHub App for PR validation, inbound webhooks, and repository_dispatch.', logoBg: '#1F2328', iconComponent: BrandGithub, multiInstance: true },
-    { id: 'GITLAB', name: 'GitLab', vendor: 'GitLab', category: 'ci', description: 'GitLab project access for pipeline triggers and SCM links.', logoBg: '#FC6D26', iconComponent: BrandGitlab, multiInstance: true },
-    { id: 'JENKINS', name: 'Jenkins', vendor: 'Jenkins', category: 'ci', description: 'Trigger Jenkins jobs and ingest pipeline state.', logoBg: '#D33833', logoMark: 'J', multiInstance: true },
-    { id: 'ADO', name: 'Azure DevOps', vendor: 'Microsoft', category: 'ci', description: 'Trigger Azure DevOps pipelines and ingest pipeline state.', logoBg: '#0078D4', logoMark: 'AZ', multiInstance: true },
+    { id: 'GITLAB', name: 'GitLab', vendor: 'GitLab', category: 'ci', description: 'Trigger GitLab pipelines.', logoBg: '#FC6D26', iconComponent: BrandGitlab, multiInstance: true },
+    { id: 'JENKINS', name: 'Jenkins', vendor: 'Jenkins', category: 'ci', description: 'Trigger Jenkins jobs.', logoBg: '#D33833', logoMark: 'J', multiInstance: true },
+    { id: 'ADO', name: 'Azure DevOps', vendor: 'Microsoft', category: 'ci', description: 'Trigger Azure DevOps pipelines.', logoBg: '#0078D4', logoMark: 'AZ', multiInstance: true },
     // Security & Compliance
     { id: 'DEPENDENCYTRACK', name: 'Dependency-Track', vendor: 'OWASP', category: 'security', description: 'Push SBOMs and pull vulnerability + policy findings.', logoBg: '#1B4E72', logoMark: 'DT', multiInstance: false },
     { id: 'BEAR', name: 'BEAR', vendor: 'Reliza', category: 'security', description: 'BOM enrichment and risk-signal service.', logoBg: '#22332B', logoMark: 'BR', multiInstance: false }

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -110,6 +110,7 @@
                                         </div>
                                         <div class="instance-actions">
                                             <n-icon v-if="card.id === 'GITHUB'" class="instance-icon" size="20" title="Edit integration" @click="openEditCiIntegrationModal(inst)"><EditIcon /></n-icon>
+                                            <n-icon class="instance-icon danger" size="20" title="Delete integration" @click="onDeleteCiInstance(inst)"><Trash /></n-icon>
                                         </div>
                                     </div>
                                 </template>
@@ -707,6 +708,44 @@ async function saveEditCiIntegration() {
         notify('error', 'Failed to save integration', e?.message || String(e))
     } finally {
         editCiIntegrationLoading.value = false
+    }
+}
+
+// CI integration delete. Server-side hard-block: deleteCiIntegration
+// refuses when webhooks, PR validation rules, per-VCS overrides, or
+// approval-policy actions still reference the integration. The error
+// message carries a per-category breakdown — surface it verbatim so
+// the user knows exactly where to clean up.
+async function onDeleteCiInstance(inst: any) {
+    const label = `${kindLabel(inst.type)}${inst.note ? ` (${inst.note})` : ''}`
+    const confirm = await Swal.fire({
+        title: `Delete ${label}?`,
+        text: 'This integration will only be removed if nothing references it (webhooks, PR validation rules, per-VCS overrides, approval-policy actions).',
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Yes, delete',
+        cancelButtonText: 'Cancel'
+    })
+    if (!confirm.isConfirmed) return
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation deleteCiIntegration($uuid: ID!) {
+                    deleteCiIntegration(uuid: $uuid)
+                }`,
+            variables: { uuid: inst.uuid },
+            fetchPolicy: 'no-cache'
+        })
+        await loadCiIntegrations(false)
+        notify('success', 'Deleted', `${label} removed.`)
+    } catch (err: any) {
+        const msg = commonFunctions.parseGraphQLError(err.message) || err?.message || String(err)
+        await Swal.fire({
+            title: 'Cannot delete',
+            text: msg,
+            icon: 'warning',
+            confirmButtonText: 'OK'
+        })
     }
 }
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -3,301 +3,13 @@
         <h4>Organization Settings</h4>
         <n-tabs type="line" :value="currentTab" @update:value="handleTabSwitch">
             <n-tab-pane name="integrations" tab="Integrations" v-if="isOrgAdmin">
-                <div class="integrationsBlock mt-4">
-                    <h5>Organization-Wide Integrations</h5>
-                    <n-space vertical>
-                        <div class="row">
-                            <div v-if="configuredIntegrations.includes('SLACK')">Slack Integration Configured
-                                <n-icon @click="deleteIntegration('SLACK')" class="clickable" title="Delete Slack Integration" size="20"><Trash /></n-icon>
-                            </div>
-                            <div v-else><n-button @click="showOrgSettingsSlackIntegrationModal = true">Add Slack Integration</n-button></div>
-                            <n-modal 
-                                v-model:show="showOrgSettingsSlackIntegrationModal"
-                                preset="dialog"
-                                :show-icon="false" >
-                                <n-card style="width: 600px" size="huge" title="Add slack integration" :bordered="false"
-                                    role="dialog" aria-modal="true">
-
-                                    <n-form>
-                                        <n-form-item id="org_settings_create_slack_integration_secret_group" label="Secret"
-                                            label-for="org_settings_create_slack_integration_secret"
-                                            description="Slack integration secret">
-                                            <n-input type="password" id="org_settings_create_slack_integration_secret"
-                                                v-model:value="createIntegrationObject.secret" required
-                                                placeholder="Enter Slack integration secret" />
-                                        </n-form-item>
-                                        <n-button @click="onAddIntegration('SLACK')" type="success">Submit</n-button>
-                                        <n-button type="error" @click="resetCreateIntegrationObject">Reset</n-button>
-                                    </n-form>
-                                </n-card>
-                            </n-modal>
-                        </div>
-                        <div class="row pt-2">
-                            <div v-if="configuredIntegrations.includes('MSTEAMS')">MS Teams integration configured
-                                <n-icon @click="deleteIntegration('MSTEAMS')" class="clickable" title="Delete MS Teams Integration" size="20"><Trash /></n-icon>
-                            </div>
-                            <div v-else><n-button @click="showOrgSettingsMsteamsIntegrationModal = true">Add MS Teams Integration</n-button></div>
-                            <n-modal
-                                v-model:show="showOrgSettingsMsteamsIntegrationModal"
-                                preset="dialog"
-                                :show-icon="false" >
-                                <n-card style="width: 600px" size="huge" title="Add MS Teams integration" :bordered="false"
-                                    role="dialog" aria-modal="true">
-                                    <n-form @submit="onAddIntegration('MSTEAMS')">
-                                        <n-form-item id="org_settings_create_msteams_integration_secret_group" label="Secret"
-                                            label-for="org_settings_create_msteams_integration_secret"
-                                            description="MS Teams integration URI">
-                                            <n-input type="password" id="org_settings_create_msteams_integration_secret"
-                                                v-model:value="createIntegrationObject.secret" required
-                                                placeholder="Enter MS Teams integration URI" />
-                                        </n-form-item>
-                                        <n-button @click="onAddIntegration('MSTEAMS')" type="success">Submit</n-button>
-                                        <n-button type="error" @click="resetCreateIntegrationObject">Reset</n-button>
-                                    </n-form>
-                                </n-card>
-                            </n-modal>
-                        </div>
-                        <div class="row pt-2">
-                            <div v-if="configuredIntegrations.includes('DEPENDENCYTRACK')">
-                                <div>
-                                    Dependency-Track integration configured
-                                    <n-icon v-if="isOrgAdmin" @click="deleteIntegration('DEPENDENCYTRACK')" class="clickable" title="Delete Dependency-Track Integration" size="20"><Trash /></n-icon>
-                                    <n-icon v-if="isOrgAdmin" class="clickable" size="24" title="Synchronize D-Track Projects" @click="syncDtrackProjects" style="margin-left: 8px; ">
-                                        <Refresh />
-                                    </n-icon>
-                                    <n-icon v-if="isGlobalAdmin" class="clickable" size="24" title="Re-upload D-Track Projects" @click="refreshDtrackProjects" style="margin-left: 8px; ">
-                                        <ArrowUpload24Regular />
-                                    </n-icon>
-                                    <n-icon v-if="isGlobalAdmin" class="clickable" size="24" title="Cleanup D-Track Projects" @click="cleanupDtrackProjects" style="margin-left: 8px; ">
-                                        <Clean />
-                                    </n-icon>
-                                    <n-icon v-if="isGlobalAdmin" class="clickable" size="24" title="Re-cleanup D-Track Projects" @click="recleanupDtrackProjects" style="margin-left: 8px; ">
-                                        <DeleteDismiss24Regular />
-                                    </n-icon>
-                                </div>
-                                <div v-if="false" style="margin-top: 8px;">
-                                    <n-button @click="syncDtrackStatus" :loading="syncingDtrackStatus" type="primary" size="small">
-                                        Sync Dependency-Track Status for All Artifacts
-                                    </n-button>
-                                </div>
-                            </div>
-                            <div v-else><n-button @click="showOrgSettingsDependencyTrackIntegrationModal = true">Add Dependency-Track Integration</n-button></div>
-                            <n-modal
-                                v-model:show="showOrgSettingsDependencyTrackIntegrationModal"
-                                preset="dialog"
-                                :show-icon="false" >
-                                <n-card style="width: 600px" size="huge" title="Add Dependency-Track Integration" :bordered="false"
-                                    role="dialog" aria-modal="true">
-                                    <n-form @submit="onAddIntegration('DEPENDENCYTRACK')">
-                                        <n-form-item id="org_settings_create_dependency_track_integration_uri_group" label="Dependency-Track API Server URI"
-                                            label-for="org_settings_create_dependency_track_integration_uri"
-                                            description="Dependency-Track API Server URI">
-                                            <n-input id="org_settings_create_dependency_track_integration_uri"
-                                                v-model:value="createIntegrationObject.uri" required
-                                                placeholder="Enter Dependency-Track API Server URI" />
-                                        </n-form-item>
-                                        <n-form-item id="org_settings_create_dependency_track_integration_frontenduri_group" label="Dependency-Track Frontend URI"
-                                            label-for="org_settings_create_dependency_track_integration_frontenduri"
-                                            description="Dependency-Track API Server Frontend URI">
-                                            <n-input id="org_settings_create_dependency_track_integration_frontenduri"
-                                                v-model:value="createIntegrationObject.frontendUri" required
-                                                placeholder="Enter Dependency-Track Frontend URI" />
-                                        </n-form-item>
-                                        <n-form-item id="org_settings_create_dependency_track_integration_secret_group" label="API Key"
-                                            label-for="org_settings_create_dependency_track_integration_secret"
-                                            description="Dependency-Track API Key">
-                                            <n-input type="password" id="org_settings_create_dependency_track_integration_secret"
-                                                v-model:value="createIntegrationObject.secret" required
-                                                placeholder="Enter Dependency-Track API Key" />
-                                        </n-form-item>
-                                        <n-button @click="onAddIntegration('DEPENDENCYTRACK')" type="success">Submit</n-button>
-                                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
-                                    </n-form>
-                                </n-card>
-                            </n-modal>
-                        </div>
-                        <div class="row pt-2">
-                            <div v-if="bearIntegration && bearIntegration.configured">BEAR Integration Configured
-                                <n-icon @click="showBearIntegrationModal = true" class="clickable" title="Edit BEAR Integration" size="20"><EditIcon /></n-icon>
-                                <n-icon @click="deleteBearIntegration" class="clickable" title="Delete BEAR Integration" size="20"><Trash /></n-icon>
-                            </div>
-                            <div v-else><n-button @click="showBearIntegrationModal = true">Add BEAR Integration</n-button></div>
-                            <n-modal
-                                v-model:show="showBearIntegrationModal"
-                                preset="dialog"
-                                :show-icon="false" >
-                                <n-card style="width: 600px" size="huge" :title="bearIntegration && bearIntegration.configured ? 'Edit BEAR Integration' : 'Add BEAR Integration'" :bordered="false"
-                                    role="dialog" aria-modal="true">
-                                    <n-form>
-                                        <n-form-item v-if="bearIntegration && bearIntegration.configured" label="Update Mode">
-                                            <n-checkbox v-model:checked="bearForm.updateSkipPatternsOnly">
-                                                Update skip patterns only (don't modify URI/API Key)
-                                            </n-checkbox>
-                                        </n-form-item>
-                                        <n-form-item label="BEAR URI" v-if="!bearForm.updateSkipPatternsOnly || !bearIntegration || !bearIntegration.configured">
-                                            <n-input v-model:value="bearForm.uri" required
-                                                placeholder="Enter BEAR URI" />
-                                        </n-form-item>
-                                        <n-form-item label="API Key" v-if="!bearForm.updateSkipPatternsOnly || !bearIntegration || !bearIntegration.configured">
-                                            <n-input type="password" v-model:value="bearForm.apiKey" required
-                                                placeholder="Enter BEAR API Key" />
-                                        </n-form-item>
-                                        <n-form-item label="Skip Patterns">
-                                            <n-dynamic-input v-model:value="bearForm.skipPatterns"
-                                                placeholder="Enter skip pattern" />
-                                        </n-form-item>
-                                        <n-button @click="onSetBearIntegration" type="success">Submit</n-button>
-                                        <n-button type="error" @click="resetBearForm">Reset</n-button>
-                                    </n-form>
-                                </n-card>
-                            </n-modal>
-                        </div>
-                    </n-space>
-                    <template v-if="myUser.installationType !== 'OSS'">
-                        <h5>CI Integrations</h5>
-                        <n-data-table :columns="ciIntegrationTableFields" :data="ciIntegrations" :row-key="dataTableRowKey"></n-data-table>
-                        <n-button @click="showCIIntegrationModal=true">Add CI Integration</n-button>
-
-                        <div style="margin-top: 24px;">
-                            <WebhooksOfOrg :orguuid="orgResolved" />
-                        </div>
-                    </template>
-                </div>
-                <n-modal
-                    v-if="myUser.installationType !== 'OSS'"
-                    v-model:show="showCIIntegrationModal"
-                    preset="dialog"
-                    :show-icon="false"
-                    style="width: 90%"
-                >
-                    <n-form :model="createIntegrationObject">
-                        <h2>Add or Update CI Integration</h2>
-                        <n-space vertical size="large">
-                            <n-form-item label="Description" path="note">
-                                <n-input v-model:value="createIntegrationObject.note" required placeholder="Enter Description" />
-                            </n-form-item>
-                            <n-form-item label="CI Type" path="createIntegrationObject.type">
-                                <n-radio-group v-model:value="createIntegrationObject.type" name="ciIntegrationType">
-                                    <n-radio-button label="GitHub" value="GITHUB" />
-                                    <n-radio-button label="GitLab" value="GITLAB" />
-                                    <n-radio-button label="Jenkins" value="JENKINS" />
-                                    <n-radio-button label="Azure DevOps" value="ADO" />
-                                </n-radio-group>
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" label="Capabilities"
-                                description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK: receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch.">
-                                <n-checkbox-group v-model:value="createIntegrationObject.capabilities">
-                                    <n-space>
-                                        <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
-                                        <n-checkbox value="PR_VALIDATE" label="PR Validate" />
-                                        <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
-                                    </n-space>
-                                </n-checkbox-group>
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_secret_group" label="GitHub Private Key"
-                                label-for="org_settings_create_github_integration_secret"
-                                description="Paste the .pem GitHub provides, upload the file directly, or paste a pre-converted DER base64 blob. Backend normalizes all three.">
-                                <n-space vertical style="width: 100%;">
-                                    <n-radio-group v-model:value="secretInputMode" name="githubSecretInputMode">
-                                        <n-radio-button label="Upload .pem" value="upload" />
-                                        <n-radio-button label="Paste" value="paste" />
-                                    </n-radio-group>
-                                    <n-input v-if="secretInputMode === 'paste'" type="textarea" id="org_settings_create_github_integration_secret"
-                                        v-model:value="createIntegrationObject.secret" required
-                                        :autosize="{ minRows: 6, maxRows: 18 }"
-                                        style="width: 100%; font-family: monospace; font-size: 12px;"
-                                        placeholder="Paste the contents of the .pem file (-----BEGIN RSA PRIVATE KEY----- ...) or DER base64." />
-                                    <n-upload v-else :default-upload="false" :max="1" accept=".pem,.txt,.key,application/x-pem-file" :show-file-list="false" @change="onSecretFileChange">
-                                        <n-upload-trigger #="{ handleClick }" abstract>
-                                            <n-button @click="handleClick">Choose .pem file</n-button>
-                                        </n-upload-trigger>
-                                    </n-upload>
-                                    <n-text v-if="secretInputMode === 'upload' && uploadedSecretFileName" depth="3" style="font-size: 12px;">
-                                        Loaded: {{ uploadedSecretFileName }} ({{ createIntegrationObject.secret.length }} chars)
-                                    </n-text>
-                                </n-space>
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITHUB'" id="org_settings_create_github_integration_appid_group" label="GitHub Application ID"
-                                label-for="org_settings_create_github_integration_appid"
-                                description="GitHub Application ID">
-                                <n-input type="number" id="org_settings_create_github_integration_appid"
-                                    v-model:value="createIntegrationObject.schedule" required
-                                    placeholder="Enter GitHub Application ID" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'GITLAB'" label="GitLab Authentication Token" path="createIntegrationObject.secret">
-                                <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter GitLab Authentication Token" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'INTEGRATION_TRIGGER' && createIntegrationObject.type === 'JENKINS'" label="Jenkins Token" path="createIntegrationObject.secret">
-                                <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter Jenkins Token" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'JENKINS'" label="Jenkins URI" path="createIntegrationObject.uri">
-                                <n-input v-model:value="createIntegrationObject.uri" required placeholder="Jenkins Home URI (i.e. https://jenkins.localhost)" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'JENKINS'" label="Jenkins Token" path="createIntegrationObject.secret">
-                                <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter Jenkins Token" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Client ID" path="createIntegrationObject.client">
-                                <n-input v-model:value="createIntegrationObject.client" required placeholder="Enter Client ID" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Client Secret" path="createIntegrationObject.secret">
-                                <n-input v-model:value="createIntegrationObject.secret" required placeholder="Enter Client Secret" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Tenant ID" path="createIntegrationObject.tenant">
-                                <n-input v-model:value="createIntegrationObject.tenant" required placeholder="Enter Tenant ID" />
-                            </n-form-item>
-                            <n-form-item v-if="createIntegrationObject.type === 'ADO'" label="Azure DevOps Organization Name" path="integrationObject.uri">
-                                <n-input v-model:value="createIntegrationObject.uri" required placeholder="Enter Azure DevOps organization name" />
-                            </n-form-item>
-                            <n-button @click="addCiIntegration" type="success">
-                                Save
-                            </n-button>
-                        </n-space>
-                    </n-form>
-                </n-modal>
-
-                <!-- Edit CI Integration modal — GITHUB only for v1. Capabilities
-                     are always editable; if a Webhook is wired to the integration,
-                     slug + secret rotation surface inline so the operator doesn't
-                     have to bounce between two screens. -->
-                <n-modal
-                    v-if="myUser.installationType !== 'OSS'"
-                    v-model:show="showEditCiIntegrationModal"
-                    preset="dialog"
-                    :show-icon="false"
-                    style="width: 90%"
-                >
-                    <n-card style="width: 700px" size="huge"
-                        :title="'Edit CI Integration - ' + (editCiIntegrationObject.note || '')"
-                        :borderd="false" role="dialog" aria-modal="true">
-                        <n-form :model="editCiIntegrationObject">
-                            <n-space vertical size="large">
-                                <n-form-item label="Type">
-                                    <n-text>{{ editCiIntegrationObject.type }}</n-text>
-                                </n-form-item>
-                                <n-form-item label="Capabilities"
-                                    description="What this GitHub App is wired up to do. Reduce or expand without re-creating the integration.">
-                                    <n-checkbox-group v-model:value="editCiIntegrationObject.capabilities">
-                                        <n-space>
-                                            <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
-                                            <n-checkbox value="PR_VALIDATE" label="PR Validate" />
-                                            <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
-                                        </n-space>
-                                    </n-checkbox-group>
-                                </n-form-item>
-
-                                <n-text depth="3" style="font-size: 13px;">
-                                    To add or modify the inbound webhook (slug, secret) attached to this integration,
-                                    use the Webhooks (inbound) section below.
-                                </n-text>
-
-                                <n-space>
-                                    <n-button :loading="editCiIntegrationLoading" @click="saveEditCiIntegration" type="success">Save</n-button>
-                                    <n-button @click="showEditCiIntegrationModal=false" type="default">Cancel</n-button>
-                                </n-space>
-                            </n-space>
-                        </n-form>
-                    </n-card>
-                </n-modal>
+                <OrgIntegrations
+                    :orguuid="orgResolved"
+                    :is-writable="isWritable"
+                    :is-org-admin="isOrgAdmin"
+                    :is-global-admin="isGlobalAdmin"
+                    :installation-type="myUser.installationType"
+                />
             </n-tab-pane>
 
             <n-tab-pane name="committers" tab="Committers" v-if="myUser.installationType !== 'OSS'">
@@ -869,9 +581,8 @@
                     </template>
                     </n-tab-pane>
 
-                    <n-tab-pane name="globalPrValidation" tab="Global PR Validation" v-if="isOrgAdmin">
-                        <OrgGlobalPrValidationRules :orgUuid="orgResolved" :isWritable="isWritable"/>
-                    </n-tab-pane>
+                    <!-- Global PR Validation has moved to Integrations → PR Validation
+                         sub-tab; it's conceptually integration plumbing, not a policy. -->
 
                     <n-tab-pane name="globalPolicyAssignment" tab="Global Policy Assignment" v-if="isOrgAdmin">
                         <OrgGlobalApprovalPolicyRules :orgUuid="orgResolved" :isWritable="isWritable"/>
@@ -1349,14 +1060,13 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
 </template>
   
 <script lang="ts" setup>
-import { NSpace, NIcon, NCheckbox, NCheckboxGroup, NDropdown, NInput, NModal, NCard, NDataTable, NForm, NInputGroup, NButton, NFormItem, NSelect, NRadioGroup, NRadioButton, NTabs, NTabPane, NTooltip, NotificationType, useNotification, NFlex, NH5, NText, NGrid, NGi, DataTableColumns, NDynamicInput, NSwitch, NInputNumber, NAlert, NRadio, NDivider, NUpload, NUploadTrigger } from 'naive-ui'
+import { NSpace, NIcon, NCheckbox, NCheckboxGroup, NDropdown, NInput, NModal, NCard, NDataTable, NForm, NInputGroup, NButton, NFormItem, NSelect, NRadioGroup, NRadioButton, NTabs, NTabPane, NTooltip, NotificationType, useNotification, NFlex, NH5, NText, NGrid, NGi, DataTableColumns, NDynamicInput, NSwitch, NInputNumber, NAlert, NRadio, NDivider } from 'naive-ui'
 import { ComputedRef, h, ref, Ref, computed, onMounted, reactive } from 'vue'
 import type { SelectOption } from 'naive-ui'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import { Edit as EditIcon, Trash, LockOpen, CirclePlus, Eye, QuestionMark, Refresh, Search, FolderPlus, Package, Clipboard } from '@vicons/tabler'
-import { Clean } from '@vicons/carbon'
-import { Info20Regular, Edit24Regular, DeleteDismiss24Regular, ArrowUpload24Regular, Power20Regular } from '@vicons/fluent'
+import { Edit as EditIcon, Trash, LockOpen, CirclePlus, Eye, QuestionMark, Search, FolderPlus, Package, Clipboard } from '@vicons/tabler'
+import { Info20Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import Swal, { SweetAlertOptions } from 'sweetalert2'
@@ -1372,8 +1082,7 @@ import DownloadLogView from './DownloadLogView.vue'
 import CreateApprovalPolicy from './CreateApprovalPolicy.vue'
 import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
-import WebhooksOfOrg from './WebhooksOfOrg.vue'
-import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
+import OrgIntegrations from './OrgIntegrations.vue'
 import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
 import AiAgentPoliciesOfOrg from './AiAgentPoliciesOfOrg.vue'
 import CommittersOfOrg from './CommittersOfOrg.vue'
@@ -1406,9 +1115,7 @@ onMounted(async () => {
 
 async function loadTabSpecificData (tabName: string) {
     if (tabName === "integrations") {
-        loadConfiguredIntegrations(true)
-        if (myUser.value.installationType !== 'OSS') loadCiIntegrations(true)
-        loadBearIntegration()
+        // OrgIntegrations loads its own data on mount; nothing to prefetch here.
     } else if (tabName === "users") {
         await Promise.all([
             loadUsers(),
@@ -1501,22 +1208,8 @@ const showUserApiKeyModal = ref(false)
 
 const showOrgRegistryTokenModal = ref(false)
 
-const showOrgSettingsSlackIntegrationModal = ref(false)
-
-const showOrgSettingsMsteamsIntegrationModal = ref(false)
-
-const showOrgSettingsDependencyTrackIntegrationModal = ref(false)
-
-const showBearIntegrationModal = ref(false)
-const bearIntegration: Ref<any> = ref(null)
-const bearForm = ref({
-    uri: '',
-    apiKey: '',
-    skipPatterns: [] as string[],
-    updateSkipPatternsOnly: true
-})
-
-const showOrgSettingsGitHubIntegrationModal = ref(false)
+// Integration modal toggles, form state, and load helpers all moved to
+// OrgIntegrations.vue.
 
 const showComponentRegistryModal = ref(false)
 
@@ -1527,8 +1220,6 @@ const showCreateApprovalEntry = ref(false)
 const showCreateApprovalRole = ref(false)
 const showPopulateApprovalDefaultsModal = ref(false)
 const populateApprovalDefaultsProcessing = ref(false)
-
-const showCIIntegrationModal = ref(false)
 
 const showCreatePerspectiveModal = ref(false)
 const showEditPerspectiveModal = ref(false)
@@ -2007,101 +1698,9 @@ const robotName: Ref<string> = ref('')
 const selectedKey: Ref<any> = ref({})
 const selectedUser: Ref<any> = ref({})
 const selectedUserType: Ref<string> = ref('')
-const configuredIntegrations: Ref<any[]> = ref([])
+// ciIntegrations stays here — the Policies tab's global-output-events
+// selector (ciIntegrationsForGlobalSelect) still reads it.
 const ciIntegrations: Ref<any[]> = ref([])
-const syncingDtrackStatus: Ref<boolean> = ref(false)
-const createIntegrationObject: Ref<any> = ref({
-    org: orgResolved.value,
-    uri: '',
-    frontendUri: '',
-    identifier: 'base',
-    secret: '',
-    type: '',
-    note: '',
-    tenant: '',
-    client: '',
-    schedule: '',
-    capabilities: []
-})
-
-// Toggles between uploading the GitHub-provided .pem file directly
-// (default) and pasting its contents into a textarea. Backend
-// normalizes PEM and DER-base64 to the same canonical form.
-const secretInputMode: Ref<'paste' | 'upload'> = ref('upload')
-const uploadedSecretFileName: Ref<string> = ref('')
-
-async function onSecretFileChange (options: any) {
-    const fileInfo = options.file
-    if (fileInfo && fileInfo.file) {
-        createIntegrationObject.value.secret = await fileInfo.file.text()
-        uploadedSecretFileName.value = fileInfo.file.name || fileInfo.name || ''
-    }
-}
-
-function resetCreateIntegrationObject() {
-    createIntegrationObject.value = {
-        org: orgResolved.value,
-        uri: '',
-        frontendUri: '',
-        identifier: 'base',
-        secret: '',
-        type: '',
-        note: '',
-        tenant: '',
-        client: '',
-        schedule: '',
-        capabilities: []
-    }
-    uploadedSecretFileName.value = ''
-}
-
-// ---- Edit GitHub CI Integration --------------------------------------------
-// Only capabilities are editable from this modal. Webhook fields (slug,
-// secret) are deliberately scoped to the Webhook entity itself — see the
-// Webhooks (inbound) section's edit flow.
-const editCiIntegrationObject: Ref<any> = ref({
-    uuid: '',
-    type: '',
-    note: '',
-    capabilities: [] as string[]
-})
-const showEditCiIntegrationModal: Ref<boolean> = ref(false)
-const editCiIntegrationLoading: Ref<boolean> = ref(false)
-
-function openEditCiIntegrationModal(row: any) {
-    editCiIntegrationObject.value = {
-        uuid: row.uuid,
-        type: row.type,
-        note: row.note,
-        capabilities: [...(row.capabilities || [])]
-    }
-    showEditCiIntegrationModal.value = true
-}
-
-async function saveEditCiIntegration() {
-    const obj = editCiIntegrationObject.value
-    editCiIntegrationLoading.value = true
-    try {
-        await graphqlClient.mutate({
-            mutation: gql`
-                mutation updateIntegrationCapabilities($uuid: ID!, $capabilities: [IntegrationCapability!]!) {
-                    updateIntegrationCapabilities(uuid: $uuid, capabilities: $capabilities) {
-                        uuid capabilities
-                    }
-                }`,
-            variables: { uuid: obj.uuid, capabilities: obj.capabilities },
-            fetchPolicy: 'no-cache'
-        })
-        showEditCiIntegrationModal.value = false
-        await loadCiIntegrations(false)
-    } catch (e: any) {
-        const msg = e?.message || String(e)
-        alert('Failed to save integration: ' + msg)
-        console.error(e)
-    } finally {
-        editCiIntegrationLoading.value = false
-    }
-}
 
 
 const users: Ref<any[]> = ref([])
@@ -3174,40 +2773,8 @@ const userGroupFields = [
     }
 ]
 
-const ciIntegrationTableFields = [
-    {
-        key: 'note',
-        title: 'Description'
-    },
-    {
-        key: 'type',
-        title: 'Type'
-    },
-    {
-        key: 'capabilities',
-        title: 'Capabilities',
-        render: (row: any) => {
-            const caps = (row.capabilities || []) as string[]
-            return caps.length === 0 ? '—' : caps.join(', ')
-        }
-    },
-    {
-        key: 'controls',
-        title: 'Actions',
-        render: (row: any) => {
-            // Edit only on GITHUB for now — that's the only type with
-            // capabilities to manage and the only one with a webhook
-            // counterpart that may need slug/secret rotation.
-            if (row.type !== 'GITHUB') return '—'
-            return h(NIcon, {
-                title: 'Edit integration',
-                class: 'clickable',
-                size: 22,
-                onClick: () => openEditCiIntegrationModal(row)
-            }, () => h(EditIcon))
-        }
-    }
-]
+// ciIntegrationTableFields moved to OrgIntegrations.vue (now renders as
+// per-card instance rows rather than a single flat table).
 
 const props = defineProps<{
     orguuid?: string
@@ -3804,181 +3371,8 @@ async function saveOrgSettings() {
     }
 }
 
-async function refreshDtrackProjects() {
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation refreshDtrackProjects($orgUuid: ID!) {
-                    refreshDtrackProjects(orgUuid: $orgUuid)
-                }`,
-            variables: {
-                orgUuid: orgResolved.value
-            },
-            fetchPolicy: 'no-cache'
-        })
-        
-        const result = (resp.data as any)?.refreshDtrackProjects
-        if (result) {
-            notify('success', 'D-Track Projects Refresh', 'Successfully refreshed Dependency-Track projects.')
-        } else {
-            notify('warning', 'D-Track Projects Refresh', 'Refresh completed but returned false.')
-        }
-    } catch (err: any) {
-        notify('error', 'D-Track Projects Refresh Failed', err.message || 'Failed to refresh Dependency-Track projects.')
-    }
-}
-
-async function cleanupDtrackProjects() {
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation cleanupDtrackProjects($orgUuid: ID!) {
-                    cleanupDtrackProjects(orgUuid: $orgUuid)
-                }`,
-            variables: {
-                orgUuid: orgResolved.value
-            },
-            fetchPolicy: 'no-cache'
-        })
-        
-        const result = (resp.data as any)?.cleanupDtrackProjects
-        if (result) {
-            notify('success', 'D-Track Projects Cleanup', 'Successfully cleaned up Dependency-Track projects.')
-        } else {
-            notify('warning', 'D-Track Projects Cleanup', 'Cleanup completed but returned false.')
-        }
-    } catch (err: any) {
-        notify('error', 'D-Track Projects Cleanup Failed', err.message || 'Failed to cleanup Dependency-Track projects.')
-    }
-}
-
-async function recleanupDtrackProjects() {
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation recleanupDtrackProjects($orgUuid: ID!) {
-                    recleanupDtrackProjects(orgUuid: $orgUuid)
-                }`,
-            variables: {
-                orgUuid: orgResolved.value
-            },
-            fetchPolicy: 'no-cache'
-        })
-        
-        const result = (resp.data as any)?.recleanupDtrackProjects
-        if (result) {
-            notify('success', 'D-Track Projects Re-cleanup', 'Successfully re-cleaned up Dependency-Track projects.')
-        } else {
-            notify('warning', 'D-Track Projects Re-cleanup', 'Re-cleanup completed but returned false.')
-        }
-    } catch (err: any) {
-        notify('error', 'D-Track Projects Re-cleanup Failed', err.message || 'Failed to re-cleanup Dependency-Track projects.')
-    }
-}
-
-async function syncDtrackProjects() {
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation syncDtrackProjects($orgUuid: ID!) {
-                    syncDtrackProjects(orgUuid: $orgUuid)
-                }`,
-            variables: {
-                orgUuid: orgResolved.value
-            },
-            fetchPolicy: 'no-cache'
-        })
-        
-        const result = (resp.data as any)?.syncDtrackProjects
-        if (result) {
-            notify('success', 'D-Track Projects Sync', 'Successfully synchronized Dependency-Track projects.')
-        } else {
-            notify('warning', 'D-Track Projects Sync', 'Sync completed but returned false.')
-        }
-    } catch (err: any) {
-        notify('error', 'D-Track Projects Sync Failed', err.message || 'Failed to synchronize Dependency-Track projects.')
-    }
-}
-
-async function syncDtrackStatus() {
-    syncingDtrackStatus.value = true
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation syncDtrackStatus($orgUuid: ID!) {
-                    syncDtrackStatus(orgUuid: $orgUuid) {
-                        successCount
-                        failedArtifactUuids
-                    }
-                }`,
-            variables: {
-                orgUuid: orgResolved.value
-            },
-            fetchPolicy: 'no-cache'
-        })
-        
-        if (resp.data && resp.data.syncDtrackStatus) {
-            const result = resp.data.syncDtrackStatus
-            const failedCount = result.failedArtifactUuids ? result.failedArtifactUuids.length : 0
-            
-            if (failedCount === 0) {
-                notification.success({
-                    title: 'Sync Complete',
-                    content: `Successfully synced ${result.successCount} artifact(s) with Dependency-Track.`,
-                    duration: 5000
-                })
-            } else {
-                notification.warning({
-                    title: 'Sync Partially Complete',
-                    content: `Synced ${result.successCount} artifact(s). Failed to sync ${failedCount} artifact(s).`,
-                    duration: 7000
-                })
-                
-                // Show SweetAlert with failed artifact UUIDs
-                const failedUuidsHtml = result.failedArtifactUuids
-                    .map((uuid: string) => `<div style="text-align: left; font-family: monospace; padding: 2px 0;">${uuid}</div>`)
-                    .join('')
-                
-                await Swal.fire({
-                    icon: 'warning',
-                    title: 'Partial Sync Failure',
-                    html: `<div style="margin-bottom: 10px;">Failed to sync ${failedCount} artifact(s):</div><div style="max-height: 300px; overflow-y: auto; border: 1px solid #ddd; padding: 10px; border-radius: 4px;">${failedUuidsHtml}</div>`,
-                    confirmButtonText: 'OK'
-                })
-            }
-        }
-    } catch (err: any) {
-        notification.error({
-            title: 'Sync Failed',
-            content: err.message || 'Failed to sync Dependency-Track status. Please try again later.',
-            duration: 5000
-        })
-        
-        // Show SweetAlert with error details
-        await Swal.fire({
-            icon: 'error',
-            title: 'Sync Failed',
-            text: err.message || 'Failed to sync Dependency-Track status. Please try again later or contact support.',
-            confirmButtonText: 'OK'
-        })
-    } finally {
-        syncingDtrackStatus.value = false
-    }
-}
-
-async function deleteIntegration(type: string) {
-    await graphqlClient.mutate({
-        mutation: gql`
-                mutation deleteBaseIntegration($org: ID!, $type: IntegrationType!) {
-                    deleteBaseIntegration(org: $org, type: $type)
-                }`,
-        variables: {
-            'org': orgResolved.value,
-            type
-        }
-    })
-    loadConfiguredIntegrations(false)
-}
+// D-Track / base-integration / BEAR / CI-integration mutations all moved to
+// OrgIntegrations.vue (the Integrations tab owns its own data layer now).
 
 async function deleteKey(uuid: string) {
     const onSwalConfirm = async function () {
@@ -4807,28 +4201,6 @@ function initializeResourceGroup() {
     }
 }
 
-async function loadConfiguredIntegrations(useCache: boolean) {
-    let cachePolicy: FetchPolicy = "network-only"
-    if (useCache) cachePolicy = "cache-first"
-    try {
-        const resp = await graphqlClient.query({
-            query: gql`
-                          query configuredBaseIntegrations($org: ID!) {
-                              configuredBaseIntegrations(org: $org)
-                          }`,
-            variables: {
-                org: orgResolved.value
-            },
-            fetchPolicy: cachePolicy
-        })
-        if (resp.data && resp.data.configuredBaseIntegrations) {
-            configuredIntegrations.value = resp.data.configuredBaseIntegrations
-        }
-    } catch (err) { 
-        console.error(err)
-    }
-}
-
 async function loadCiIntegrations(useCache: boolean) {
     if (myUser.value && myUser.value.installationType !== 'OSS') {
         let cachePolicy: FetchPolicy = "network-only"
@@ -4858,123 +4230,6 @@ async function loadCiIntegrations(useCache: boolean) {
         } catch (err) { 
             console.error(err)
         }
-    }
-}
-
-async function loadBearIntegration() {
-    try {
-        const resp = await graphqlClient.query({
-            query: gql`
-                query getBearIntegration($org: ID!) {
-                    getBearIntegration(org: $org) {
-                        uri
-                        configured
-                        skipPatterns
-                    }
-                }`,
-            variables: {
-                org: orgResolved.value
-            },
-            fetchPolicy: 'network-only'
-        })
-        if (resp.data && resp.data.getBearIntegration) {
-            bearIntegration.value = resp.data.getBearIntegration
-            if (bearIntegration.value.configured) {
-                bearForm.value.uri = bearIntegration.value.uri || ''
-                bearForm.value.skipPatterns = bearIntegration.value.skipPatterns || []
-            }
-        }
-    } catch (err) {
-        console.error(err)
-    }
-}
-
-async function onSetBearIntegration() {
-    try {
-        let resp
-        if (bearForm.value.updateSkipPatternsOnly && bearIntegration.value && bearIntegration.value.configured) {
-            // Update skip patterns only
-            resp = await graphqlClient.mutate({
-                mutation: gql`
-                    mutation updateBearSkipPatterns($org: ID!, $skipPatterns: [String]) {
-                        updateBearSkipPatterns(org: $org, skipPatterns: $skipPatterns) {
-                            uri
-                            configured
-                            skipPatterns
-                        }
-                    }`,
-                variables: {
-                    org: orgResolved.value,
-                    skipPatterns: bearForm.value.skipPatterns
-                }
-            })
-            if (resp.data && resp.data.updateBearSkipPatterns) {
-                bearIntegration.value = resp.data.updateBearSkipPatterns
-            }
-            notify('success', 'Success', 'BEAR skip patterns updated successfully.')
-        } else {
-            // Full integration update
-            resp = await graphqlClient.mutate({
-                mutation: gql`
-                    mutation setBearIntegration($org: ID!, $uri: String!, $apiKey: String!, $skipPatterns: [String]) {
-                        setBearIntegration(org: $org, uri: $uri, apiKey: $apiKey, skipPatterns: $skipPatterns) {
-                            uri
-                            configured
-                            skipPatterns
-                        }
-                    }`,
-                variables: {
-                    org: orgResolved.value,
-                    uri: bearForm.value.uri,
-                    apiKey: bearForm.value.apiKey,
-                    skipPatterns: bearForm.value.skipPatterns
-                }
-            })
-            if (resp.data && resp.data.setBearIntegration) {
-                bearIntegration.value = resp.data.setBearIntegration
-            }
-            notify('success', 'Success', 'BEAR integration configured successfully.')
-        }
-        showBearIntegrationModal.value = false
-        bearForm.value.apiKey = ''
-    } catch (err: any) {
-        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
-    }
-}
-
-function resetBearForm() {
-    bearForm.value = {
-        uri: bearIntegration.value?.uri || '',
-        apiKey: '',
-        skipPatterns: bearIntegration.value?.skipPatterns || [],
-        updateSkipPatternsOnly: true
-    }
-}
-
-async function deleteBearIntegration() {
-    const confirmResult = await Swal.fire({
-        title: 'Delete BEAR Integration?',
-        text: 'This will remove the BEAR integration configuration.',
-        icon: 'warning',
-        showCancelButton: true,
-        confirmButtonText: 'Yes, delete it'
-    })
-    if (!confirmResult.isConfirmed) return
-    try {
-        await graphqlClient.mutate({
-            mutation: gql`
-                mutation deleteBearIntegration($org: ID!) {
-                    deleteBearIntegration(org: $org)
-                }`,
-            variables: {
-                org: orgResolved.value
-            }
-        })
-        bearIntegration.value = null
-        bearForm.value = { uri: '', apiKey: '', skipPatterns: [] }
-        notify('success', 'Deleted', 'BEAR integration has been removed.')
-    } catch (err: any) {
-        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     }
 }
 
@@ -5074,50 +4329,6 @@ function formatValuesForApiKeys (apiKeyEntry: any) {
         updEntry['updatedByName'] = ''
     }
     return updEntry
-}
-
-async function onAddIntegration(type: string) {
-    createIntegrationObject.value.type = type
-    const resp = await graphqlClient.mutate({
-        mutation: gql`
-                      mutation createIntegration($integration: IntegrationInput!) {
-                          createIntegration(integration: $integration) {
-                              uuid
-                          }
-                      }`,
-        variables: {
-            'integration': createIntegrationObject.value
-        }
-    })
-    
-    if (resp.data.createIntegration && resp.data.createIntegration.uuid) await loadConfiguredIntegrations(false)
-
-    resetCreateIntegrationObject()
-
-    showOrgSettingsSlackIntegrationModal.value = false
-    showOrgSettingsGitHubIntegrationModal.value = false
-    showOrgSettingsMsteamsIntegrationModal.value = false
-    showOrgSettingsDependencyTrackIntegrationModal.value = false
-}
-
-async function addCiIntegration() {
-    const resp = await graphqlClient.mutate({
-        mutation: gql`
-                      mutation createTriggerIntegration($integration: IntegrationInput!) {
-                          createTriggerIntegration(integration: $integration) {
-                              uuid
-                          }
-                      }`,
-        variables: {
-            'integration': createIntegrationObject.value
-        }
-    })
-    
-    if (resp.data.createTriggerIntegration && resp.data.createTriggerIntegration.uuid) await loadCiIntegrations(false)
-
-    resetCreateIntegrationObject()
-
-    showCIIntegrationModal.value = false
 }
 
 async function removeUser(userUuid: string) {

--- a/ui/src/components/WebhooksOfOrg.vue
+++ b/ui/src/components/WebhooksOfOrg.vue
@@ -108,15 +108,25 @@ const notify = (type: NotificationType, title: string, content: string) => {
     notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
 }
 
+// ciIntegrations is sourced from the parent (OrgIntegrations) so the
+// "Add Webhook" button unlocks the moment the user adds a WEBHOOK-
+// capable GitHub integration on the Catalog sub-tab. Previously this
+// component fetched once on mount and stayed stale until F5.
 const props = defineProps<{
     orguuid?: string
+    ciIntegrations?: any[]
 }>()
 
 const myorg: ComputedRef<any> = computed(() => store.getters.myorg)
 const orgResolved = ref('')
 
 const webhooks: Ref<any[]> = ref([])
-const ciIntegrations: Ref<any[]> = ref([])
+const localCiIntegrations: Ref<any[]> = ref([])
+// Prefer the prop; only fall back to a self-fetched list if the parent
+// didn't pass one (defensive — every current call site passes the prop).
+const effectiveCiIntegrations = computed(() =>
+    props.ciIntegrations ?? localCiIntegrations.value
+)
 
 // Public base URL for the webhook reception path. Origin is the same
 // as the UI itself — agent-scully or whatever the user is logged into.
@@ -126,7 +136,7 @@ function previewUrl(slug: string): string {
 }
 
 const webhookCapableIntegrationOptions = computed(() => {
-    return ciIntegrations.value
+    return effectiveCiIntegrations.value
         .filter((ci: any) => ci.type === 'GITHUB' && (ci.capabilities || []).includes('WEBHOOK'))
         .map((ci: any) => ({ label: `${ci.note || ci.identifier} (${ci.uuid.substring(0, 8)})`, value: ci.uuid }))
 })
@@ -258,6 +268,8 @@ async function loadWebhooks() {
 }
 
 async function loadCiIntegrations() {
+    // Skipped when the parent supplies ciIntegrations via prop.
+    if (props.ciIntegrations) return
     try {
         const resp = await graphqlClient.query({
             query: gql`
@@ -269,7 +281,7 @@ async function loadCiIntegrations() {
             variables: { org: orgResolved.value },
             fetchPolicy: 'no-cache'
         })
-        ciIntegrations.value = resp.data?.ciIntegrations || []
+        localCiIntegrations.value = resp.data?.ciIntegrations || []
     } catch (e: any) {
         console.error(e)
     }


### PR DESCRIPTION
## Summary

Splits **Organization Settings → Integrations** into three sub-tabs and moves **Global PR Validation** out of *Policies* to sit alongside Webhooks under the new shell.

- **Catalog** — grid of cards grouped by category (Messaging & Notifications · CI/CD & Source Control · Security & Compliance). One card per integration kind; CI cards list one row per configured instance with a dashed "+ Add another \<Kind\>" affordance. Org-wide kinds stay single-instance.
- **Webhooks** — existing `WebhooksOfOrg` mounted under a capability-aware info banner that names the CI instances carrying the `WEBHOOK` capability.
- **PR Validation** — existing `OrgGlobalPrValidationRules` (moved from Policies) under a banner naming the `PR_VALIDATE`-capable instances.

## Preserved end-to-end (no functional regressions)

- Dependency-Track admin actions: **Sync** / **Re-upload** / **Cleanup** / **Re-cleanup**, with their existing role gates (orgAdmin / globalAdmin).
- BEAR edit modal with **"Update skip patterns only"** mode + skip-patterns dynamic input. BEAR uses its dedicated `deleteBearIntegration` mutation (not `deleteBaseIntegration` — BEAR isn't in the `IntegrationType` enum).
- GitHub edit modal with capability checkboxes (`PR_VALIDATE` · `WEBHOOK` · `WORKFLOW_DISPATCH` — backend-accurate, ignores the design's placeholder `STATUS_REPORT`).
- GitHub CI add form retains all three private-key paths: paste PEM textarea, upload `.pem` file, paste pre-converted DER.
- GitLab / Jenkins / ADO per-type CI add forms.
- OSS-mode hides the Webhooks + PR Validation sub-tabs **and** the CI/CD section of Catalog (matches the prior OSS hide of CI Integrations + Webhooks).

## Dropped (not implemented in backend)

- Bitbucket, Jira, ServiceNow → the entire **Ticketing** category from the design is omitted.

## Scope notes

- **Edit support — Plan A (preserve current state).** Only kinds that have an edit modal today (GitHub, BEAR) keep one. GitLab / Jenkins / ADO / Slack / Teams / DT remain delete-and-re-add.
- **CI per-instance delete is intentionally absent.** The backend's `deleteBaseIntegration(org, type)` only matches `identifier='base'` and is ambiguous over multiple CI instances of the same type — the previous UI also doesn't surface a CI-row delete. Plan A preserves that.
- **Icons.** Brand icons from `@vicons/tabler` where available (`BrandGithub` / `BrandGitlab` / `BrandSlack`); letter-monogram fallbacks per design for Teams (`T`), Jenkins (`J`), Azure DevOps (`AZ`), Dependency-Track (`DT`), BEAR (`BR`).

## File-level change

- New `ui/src/components/OrgIntegrations.vue` — self-contained: 3-sub-tab shell, catalog grid, all five integration modals (Slack · Teams · DT · BEAR · CI add · CI edit), DT admin actions, capability-aware banners, plus the loaders for `configuredBaseIntegrations` / `ciIntegrations` / `getBearIntegration`.
- `ui/src/components/OrgSettings.vue` — Integrations tab content collapsed to a single `<OrgIntegrations …>` mount; Policies' `globalPrValidation` tab pane removed; ~810 lines of inline integration markup, refs, modals, DT mutations, and BEAR/base-integration helpers lifted out. `ciIntegrations` + `loadCiIntegrations` stay because the Policies tab's `ciIntegrationsForGlobalSelect` still reads them.

## Test plan

- [ ] Login as an org admin (non-OSS): Integrations tab opens on Catalog; cards render with brand colors + icons/monograms.
- [ ] Slack / Teams / DT / BEAR add flows: each modal opens and saves; card flips to "Active" with the proper instance row.
- [ ] DT card admin actions: Sync (orgAdmin) and Re-upload / Cleanup / Re-cleanup (globalAdmin only) — visible per role, mutations fire, notifications appear.
- [ ] BEAR card: open Edit → "Update skip patterns only" toggle is pre-checked; toggling it off reveals URI + API Key fields. Skip patterns persist after save.
- [ ] GitHub add: all three private-key entry modes work (paste / upload / paste DER); capabilities checkboxes write through.
- [ ] GitHub edit: capability checkboxes pre-populate from the instance; save writes via `updateIntegrationCapabilities`.
- [ ] GitLab / Jenkins / ADO add: per-type fields render correctly; integration appears in its card after save.
- [ ] Sub-tab nav: URL gains `?integrationsTab=webhooks` / `…=pr-validation`; deep-link works; reload preserves sub-tab.
- [ ] Webhooks sub-tab: info banner lists `WEBHOOK`-capable instances (or fallback CTA when none).
- [ ] PR Validation sub-tab: info banner lists `PR_VALIDATE`-capable instances. Rules CRUD works the same as before.
- [ ] OSS mode: Webhooks + PR Validation sub-tabs are hidden; CI/CD section of Catalog is hidden; only Messaging + Security cards visible.
- [ ] Policies tab: `Global PR Validation` inner tab is gone; other policy sub-tabs unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)