### PR TITLE
fix(ui): surface backend error message on instance save failure

### DIFF
--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -998,9 +998,13 @@ const save = async function () {
         history.value = []
         loadInstanceHistory()
         notify('info', 'SAVED', 'Instance changes saved successfully!')
-    } catch (errOnSave) {
+    } catch (errOnSave: any) {
         console.error(errOnSave)
-        notify('error', 'ERROR', `Could not save instance!`)
+        Swal.fire(
+            'Error!',
+            commonFunctions.parseGraphQLError(errOnSave.message),
+            'error'
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- `InstanceView.save()` catch was showing a generic 'Could not save instance' toast instead of the GraphQL error returned by the backend.
- Switch to the `Swal.fire` + `commonFunctions.parseGraphQLError` pattern already used elsewhere in this view (archiveInstance, etc.) so users see the actual reason — e.g. the new Helm-dependency validation message from the paired rearm-core PR.

## Test plan

- [ ] Attempt to attach a product whose feature set has no Helm component → Swal popup shows the backend message (not 'Could not save instance!')
- [ ] Normal instance edits (rename, namespace change) still work end-to-end
- [ ] Other save failures (network, perms) still surface a usable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)