### PR TITLE
feat(ui-approval-rules): per-rule enable/disable + globally-disabled badge

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -689,17 +689,21 @@
                                             </div>
                                             <div v-else>
                                                 <p class="text-muted" style="font-size: 0.9em; margin-bottom: 6px;">Policy-wide rules apply to this {{ words.component }} by default. Toggle a rule off to opt out, or override its actions locally.</p>
-                                                <div v-for="gie in policyGlobalInputEvents" :key="gie.uuid" class="mb-3" style="border: 1px solid #e0e0e0; border-radius: 6px; padding: 12px;">
-                                                    <div style="display: flex; align-items: center; gap: 8px;">
+                                                <div v-for="gie in policyGlobalInputEvents" :key="gie.uuid" class="mb-3" style="border: 1px solid #e0e0e0; border-radius: 6px; padding: 12px;" :style="{ opacity: gie.enabled === false ? 0.7 : 1 }">
+                                                    <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
                                                         <n-switch
                                                             :value="isGlobalInputEventEnabled(gie.uuid)"
                                                             @update:value="(val: boolean) => toggleGlobalInputEventRef(gie.uuid, val)"
                                                             :disabled="!isWritable"
                                                         />
                                                         <strong>{{ gie.name }}</strong>
+                                                        <n-tag v-if="gie.enabled === false" type="warning" size="small" round>Globally disabled</n-tag>
                                                         <span class="text-muted" style="font-size: 0.85em;">
                                                             ({{ gie.outputEvents?.length || 0 }} default action{{ gie.outputEvents?.length !== 1 ? 's' : '' }})
                                                         </span>
+                                                    </div>
+                                                    <div v-if="gie.enabled === false" style="margin-left: 28px; margin-top: 6px; font-size: 12px;" class="text-muted">
+                                                        Disabled at the policy level — this rule will not fire for this {{ words.component }} regardless of the toggle above.
                                                     </div>
                                                     <div style="margin-left: 28px; margin-top: 4px; font-size: 12px;">
                                                         <span class="text-muted" style="margin-right: 6px;">Condition:</span>
@@ -762,6 +766,12 @@
                                             <n-form :model="inputTrigger">
                                                 <h2>Add or Update Trigger Event</h2>
                                                 <n-space vertical size="large">
+                                                    <n-form-item label="Enabled" path="enabled">
+                                                        <n-switch v-model:value="inputTrigger.enabled" />
+                                                        <n-text depth="3" style="font-size: 12px; margin-left: 10px;">
+                                                            Disabled rules are skipped at evaluation time.
+                                                        </n-text>
+                                                    </n-form-item>
                                                     <n-form-item label="Name" path="name">
                                                         <n-input v-model:value="inputTrigger.name" required placeholder="Enter name" />
                                                     </n-form-item>
@@ -773,7 +783,7 @@
                                                         />
                                                     </n-form-item>
                                                     <n-form-item label="Actions" path="inputTrigger.outputEvents">
-                                                        <n-select v-model:value="inputTrigger.outputEvents" 
+                                                        <n-select v-model:value="inputTrigger.outputEvents"
                                                         :options="outputTriggersForInputForm" multiple />
                                                     </n-form-item>
                                                     <n-button @click="addInputTrigger" type="success">
@@ -930,7 +940,7 @@ export default {
 import { ComputedRef, ref, Ref, computed, h, Component, onMounted } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NAlert, NIcon, NModal, NTabs, NTabPane, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, NSpace, NRadio, NRadioGroup, NDataTable, NotificationType, useNotification, NCheckbox, NCheckboxGroup, NSwitch, NTooltip, DataTableColumns, NDynamicInput, NGrid, NGi, FormInst, FormRules } from 'naive-ui'
+import { NAlert, NIcon, NModal, NTabs, NTabPane, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, NSpace, NRadio, NRadioGroup, NDataTable, NotificationType, useNotification, NCheckbox, NCheckboxGroup, NSwitch, NTag, NText, NTooltip, DataTableColumns, NDynamicInput, NGrid, NGi, FormInst, FormRules } from 'naive-ui'
 import commonFunctions from '../utils/commonFunctions'
 import ComponentAnalytics from './ComponentAnalytics.vue'
 import ChangelogView from './ChangelogView.vue'
@@ -1765,7 +1775,8 @@ const inputTrigger: Ref<InputTriggerEvent> = ref({
     uuid: '',
     name: '',
     celExpression: '',
-    outputEvents: []
+    outputEvents: [],
+    enabled: true
 })
 const celExpressionError = ref('')
 
@@ -1774,7 +1785,8 @@ function resetInputTrigger () {
         uuid: '',
         name: '',
         celExpression: '',
-        outputEvents: []
+        outputEvents: [],
+        enabled: true
     }
     celExpressionError.value = ''
 }
@@ -2862,6 +2874,21 @@ function editInputTrigger (trigger: any) {
     showCreateInputTriggerModal.value = true
 }
 
+// Quick-toggle helper bound to the per-row Enabled switch on the Local
+// Rules table. Mirrors the dialog edit path: flip the field, persist
+// via the same updateComponent mutation saveTriggers uses for everything
+// else on this tab.
+async function toggleLocalInputTriggerEnabled (row: any, val: boolean) {
+    if (!updatedComponent.value.releaseInputTriggers) return
+    const idx = updatedComponent.value.releaseInputTriggers.findIndex((t: any) => t.uuid === row.uuid)
+    if (idx < 0) return
+    updatedComponent.value.releaseInputTriggers[idx] = {
+        ...updatedComponent.value.releaseInputTriggers[idx],
+        enabled: val
+    }
+    await saveTriggers()
+}
+
 async function addInputTrigger () {
     if (!updatedComponent.value.releaseInputTriggers) {
         updatedComponent.value.releaseInputTriggers = []
@@ -2985,6 +3012,19 @@ const outputTriggerTableFieldsReadOnly: DataTableColumns<any> = [
 ]
 
 const inputTriggerTableFields: DataTableColumns<any> = [
+    {
+        key: 'enabled',
+        title: 'Enabled',
+        width: 90,
+        render: (row: any) => {
+            const checked = row.enabled !== false
+            return h(NSwitch, {
+                value: checked,
+                disabled: !isWritable.value,
+                'onUpdate:value': (v: boolean) => toggleLocalInputTriggerEnabled(row, v)
+            })
+        }
+    },
     {
         key: 'name',
         title: 'Name'

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -2875,10 +2875,12 @@ function editInputTrigger (trigger: any) {
 }
 
 // Quick-toggle helper bound to the per-row Enabled switch on the Local
-// Rules table. Mirrors the dialog edit path: flip the field, persist
-// via the same updateComponent mutation saveTriggers uses for everything
-// else on this tab.
-async function toggleLocalInputTriggerEnabled (row: any, val: boolean) {
+// Rules table. Mutates updatedComponent only — persistence happens via
+// the Save Changes button at the bottom of the tab, matching the rest
+// of the editing surface (add / edit modal / delete all defer to the
+// same button). Switch change shows up in hasTriggerChanges, which is
+// what gates the button's visibility.
+function toggleLocalInputTriggerEnabled (row: any, val: boolean) {
     if (!updatedComponent.value.releaseInputTriggers) return
     const idx = updatedComponent.value.releaseInputTriggers.findIndex((t: any) => t.uuid === row.uuid)
     if (idx < 0) return
@@ -2886,7 +2888,6 @@ async function toggleLocalInputTriggerEnabled (row: any, val: boolean) {
         ...updatedComponent.value.releaseInputTriggers[idx],
         enabled: val
     }
-    await saveTriggers()
 }
 
 async function addInputTrigger () {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -559,6 +559,12 @@
                             <n-form :model="globalInputEvent">
                                 <h2>{{ globalInputEvent.uuid ? 'Edit' : 'Add' }} Policy-Wide Rule</h2>
                                 <n-space vertical size="large">
+                                    <n-form-item label="Enabled" path="enabled">
+                                        <n-switch v-model:value="globalInputEvent.enabled" />
+                                        <n-text depth="3" style="font-size: 12px; margin-left: 10px;">
+                                            Disabled rules never fire for any component using this policy, regardless of per-component opt-out.
+                                        </n-text>
+                                    </n-form-item>
                                     <n-form-item label="Name" path="name">
                                         <n-input v-model:value="globalInputEvent.name" required placeholder="Enter name" />
                                     </n-form-item>
@@ -570,7 +576,7 @@
                                         />
                                     </n-form-item>
                                     <n-form-item label="Actions" path="globalInputEvent.outputEvents">
-                                        <n-select v-model:value="globalInputEvent.outputEvents" 
+                                        <n-select v-model:value="globalInputEvent.outputEvents"
                                         :options="globalOutputEventsForInputForm" multiple />
                                     </n-form-item>
                                     <n-button @click="addGlobalInputEvent" type="success">Save</n-button>
@@ -5081,7 +5087,8 @@ const globalInputEvent: Ref<InputTriggerEvent> = ref({
     uuid: '',
     name: '',
     celExpression: '',
-    outputEvents: []
+    outputEvents: [],
+    enabled: true
 })
 
 const globalCelExpressionError = ref('')
@@ -5091,7 +5098,8 @@ function resetGlobalInputEvent () {
         uuid: '',
         name: '',
         celExpression: '',
-        outputEvents: []
+        outputEvents: [],
+        enabled: true
     }
     globalCelExpressionError.value = ''
 }
@@ -5213,6 +5221,7 @@ async function fetchApprovalPolicies () {
                         celExpression
                         outputEvents
                         scope
+                        enabled
                     }
                     globalOutputEvents {
                         uuid
@@ -5348,7 +5357,8 @@ async function saveGlobalInputEvents () {
             uuid: e.uuid || undefined,
             name: e.name,
             celExpression: e.celExpression || null,
-            outputEvents: e.outputEvents || []
+            outputEvents: e.outputEvents || [],
+            enabled: e.enabled !== false  // default true; preserve explicit false
         }))
         const resp = await graphqlClient.mutate({
             mutation: gql`
@@ -5361,6 +5371,7 @@ async function saveGlobalInputEvents () {
                             celExpression
                             outputEvents
                             scope
+                            enabled
                         }
                     }
                 }`,
@@ -5469,6 +5480,17 @@ async function deleteGlobalOutputEvent (uuid: string, name?: string) {
     await commonFunctions.swalWrapper(onSwalConfirm, swalData, notify)
 }
 
+// Quick-toggle helper bound to the per-row switch in the Policy-Wide
+// Rules table — flips the flag and writes the whole list back in one go
+// so the on-row toggle behaves the same as opening the modal and
+// saving.
+function toggleGlobalInputEventEnabled (row: any, val: boolean) {
+    const idx = globalInputEvents.value.findIndex((e: any) => e.uuid === row.uuid)
+    if (idx < 0) return
+    globalInputEvents.value[idx] = { ...globalInputEvents.value[idx], enabled: val }
+    saveGlobalInputEvents()
+}
+
 function addGlobalInputEvent () {
     const eventToPush = commonFunctions.deepCopy(globalInputEvent.value)
     const validation = validateInputTrigger(eventToPush)
@@ -5570,6 +5592,20 @@ const globalOutputEventTableFields: DataTableColumns<any> = [
 ]
 
 const globalInputEventTableFields: DataTableColumns<any> = [
+    {
+        key: 'enabled',
+        title: 'Enabled',
+        width: 90,
+        render: (row: any) => {
+            // Default true when field absent (older stored events).
+            const checked = row.enabled !== false
+            return h(NSwitch, {
+                value: checked,
+                disabled: !isWritable.value,
+                'onUpdate:value': (v: boolean) => toggleGlobalInputEventEnabled(row, v)
+            })
+        }
+    },
     {
         key: 'name',
         title: 'Name'

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1324,6 +1324,7 @@ const storeObject : any = {
                                         name
                                         celExpression
                                         outputEvents
+                                        enabled
                                     }
                                     globalOutputEvents {
                                         uuid

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -721,6 +721,7 @@ const COMPONENT_FULL_DATA = `
             celExpression
             outputEvents
             scope
+            enabled
         }
         globalOutputEvents {
             uuid
@@ -767,6 +768,7 @@ const COMPONENT_FULL_DATA = `
         celExpression
         outputEvents
         scope
+        enabled
     }
     globalInputEventRefs {
         uuid

--- a/ui/src/utils/triggerTypes.ts
+++ b/ui/src/utils/triggerTypes.ts
@@ -5,6 +5,7 @@ export type InputTriggerEvent = {
     name: string;
     celExpression: string | null;
     outputEvents: string[];
+    enabled?: boolean;
 }
 
 export type OutputTriggerEvent = {


### PR DESCRIPTION
## Summary

Surfaces the enable/disable toggle for approval-policy input events that the rearm-saas backend PR adds. Three new toggles + one status indicator.

Pairs with relizaio/rearm-saas#128 (`enabled` field + evaluation gates).

## What's new

### 1. Org Settings → Policies → Policy-Wide Rules

Two surfaces:

- **Enabled toggle in the add/edit modal**, with a hint reminding the user that disabled rules never fire for any component using the policy.
- **Per-row Enabled switch column** on the rules table for quick toggling without opening the modal. Persists immediately via the existing `setGlobalInputEvents` mutation.

Mutation request body and the policy-load query now carry `enabled` on `ReleaseInputEvent` fields.

### 2. Component View → Rules → \<Component\> Local Rules

Same shape as the policy-wide table:

- **Enabled toggle in the add/edit modal.**
- **Per-row Enabled switch column** on the local-rules table. Persists via `updateComponent` (the same mutation the rest of the tab already uses).

### 3. Component View → Rules → Policy-Wide Rules section (refs)

- **"Globally disabled" warning tag** rendered next to the rule name when the policy-level rule has `enabled=false`.
- Row dims to 0.7 opacity and a helper line explains that the per-component opt-out toggle above doesn't do anything while the rule is globally disabled.
- The per-component opt-out switch **stays interactive** in that state so operators can pre-stage their preference for when the global rule is re-enabled (locked in earlier with the user during scoping — choice A in the design questions).

### GraphQL plumbing

`enabled` is added to every read site that surfaces global input events:

- `ui/src/utils/graphqlQueries.ts`: component fragment (`approvalPolicyDetails.globalInputEvents` + `releaseInputTriggers`).
- `ui/src/store.ts`: `fetchEffectiveApprovalPolicy` resolver.
- `ui/src/components/OrgSettings.vue`: approval-policies-of-org loader + `setGlobalInputEvents` round-trip.

The `InputTriggerEvent` TS type gains an optional `enabled?: boolean`.

## Test plan

Requires rearm-saas#128 deployed alongside. Once both are live:

- [ ] Org Settings → Policies → pick a policy → Policy-Wide Rules: add a new rule → modal shows the Enabled toggle (defaults on) → save → row appears with the switch on.
- [ ] Flip the on-row switch off → rule persists as `enabled=false`, no page refresh needed.
- [ ] On a release that previously fired the rule, re-trigger evaluation → rule no longer fires (matches backend gate).
- [ ] Visit a component using that policy → Rules tab → Policy-Wide Rules section shows the rule with the "Globally disabled" tag and the dimmed row.
- [ ] Flip the per-component opt-out toggle on/off — the toggle works (writes to globalInputEventRefs) but the rule still doesn't fire because the global flag wins.
- [ ] Re-enable the rule at policy level → tag disappears, per-component opt-out behavior resumes as before.
- [ ] Component → Rules tab → \<Component\> Local Rules: same flow on a local rule. Disabled local rules don't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)