### PR TITLE
feat(ui): ComponentKind.JOB — picker option + JOB badge on deployed releases

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -311,7 +311,7 @@
                                         </div>
                                         <div class="versionSchemaBlock" v-if="updatedComponent && componentData && (componentData.type === 'COMPONENT') && myUser.installationType === 'SAAS'">
                                             <label  id="componentKindLabel" for="componentKind">Component Kind</label>
-                                            <n-select v-if="isWritable" v-on:update:value="updateComponentKind" :options="[{label: 'Generic', value: 'GENERIC'}, {label: 'Helm', value: 'HELM'}]" v-model:value="updatedComponent.kind" clearable />
+                                            <n-select v-if="isWritable" v-on:update:value="updateComponentKind" :options="[{label: 'Generic', value: 'GENERIC'}, {label: 'Helm', value: 'HELM'}, {label: 'Job / CronJob', value: 'JOB'}]" v-model:value="updatedComponent.kind" clearable />
                                             <n-input v-if="!isWritable" type="text" :value="updatedComponent.kind" readonly/>
                                         </div>
                                         <div class="versionSchemaBlock" v-if="(updatedComponent && componentData && updatedComponent.kind === 'HELM' && updatedComponent.authentication  && myUser.installationType === 'SAAS')">

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -982,6 +982,7 @@ const parseDeployedReleases = function (releases: any) {
                     component: deployedRl.componentDetails.name,
                     componentUuid: deployedRl.componentDetails.uuid,
                     componentType: deployedRl.componentDetails.type,
+                    componentKind: deployedRl.componentDetails.kind,
                     index: index,
                     namespace: rl.namespace,
                     state: rl.state,
@@ -1749,9 +1750,9 @@ const deployedReleaseFeilds: any[] = [
         key: 'component',
         title: 'Component',
         render: (row: any) => {
-            let el
+            const els: any[] = []
             if (row.componentType === 'COMPONENT') {
-                el = h(
+                els.push(h(
                     RouterLink,
                     {
                         to: {
@@ -1763,12 +1764,24 @@ const deployedReleaseFeilds: any[] = [
                         }
                     },
                     { default: () => row.component }
-                )
-            }else {
-                el = row.component
+                ))
+            } else {
+                els.push(row.component)
             }
-            
-            return el
+            // JOB-kind badge — schedule-driven workloads (k8s Job /
+            // CronJob etc.). Backend's product-release match treats
+            // these like TRANSIENT deps so the deployed version may
+            // legitimately lag the target until the job next runs.
+            if (row.componentKind === 'JOB') {
+                els.push(h(NTooltip, { trigger: 'hover', placement: 'top', style: { maxWidth: '320px' } }, {
+                    trigger: () => h('span', {
+                        class: 'jobBadge',
+                        style: 'margin-left: 8px; padding: 1px 6px; border-radius: 4px; background: #e8f1ff; color: #1f5ad3; font-size: 11px; font-weight: 600;'
+                    }, 'JOB'),
+                    default: () => 'Schedule-driven workload. The deployed version may lag the target product release until the job next runs.'
+                }))
+            }
+            return h('span', { style: 'display: inline-flex; align-items: center;' }, els)
         }
     },
     {

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -62,6 +62,7 @@ const MULTI_RELEASE_GQL_DATA = `
         uuid
         name
         type
+        kind
         resourceGroup
     }
     ticketDetails {


### PR DESCRIPTION
## Summary

Pairs with the rearm-saas backend change that adds \`JOB\` to \`ComponentKind\` and treats job-kind components like \`TRANSIENT\`-status deps in product-release matching.

- Component edit page: kind dropdown gets a third option, **Job / CronJob**, next to Generic and Helm.
- Deployed Component Releases (instance page): when the deployed release's component is JOB-kind, render a \`JOB\` badge next to the component name with a tooltip explaining the workload is schedule-driven and the deployed version may legitimately lag the target until the job next runs. Makes it visible *why* the product still shows as matched even with a stale-looking job version.
- \`componentDetails\` GraphQL fragment now includes \`kind\` so the row knows what to render.

## Deferred

Pending-update badge (showing the actual vs target version diff on JOB rows) — requires walking the target product release's \`parentReleases\` which isn't on the current Instance fragment. Will follow if needed.

## Test plan

- [ ] Edit a component; set kind to Job / CronJob; reload — kind persists
- [ ] Open an instance with a JOB-kind deployed component → table shows the JOB badge with hover tooltip
- [ ] Non-JOB rows render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)