### PR TITLE
fix(ui-integrations): pin CI Type in add modal to the card the user clicked

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -257,16 +257,14 @@
             <n-card style="max-width: 800px; width: 100%" size="huge" :title="addModalTitle" :bordered="false" role="dialog" aria-modal="true">
                 <n-form :model="createIntegrationObject">
                     <n-space vertical size="large">
+                        <!-- CI Type is pinned by the card the user opened
+                             this modal from (set in openAddForCard). The
+                             modal title already reflects the choice; a
+                             switcher here would let the user accidentally
+                             switch between, say, GitHub and Jenkins forms
+                             mid-edit, which is what triggered this fix. -->
                         <n-form-item label="Description" path="note">
                             <n-input v-model:value="createIntegrationObject.note" required placeholder="Enter Description" />
-                        </n-form-item>
-                        <n-form-item label="CI Type" path="createIntegrationObject.type">
-                            <n-radio-group v-model:value="createIntegrationObject.type" name="ciIntegrationType">
-                                <n-radio-button label="GitHub" value="GITHUB" />
-                                <n-radio-button label="GitLab" value="GITLAB" />
-                                <n-radio-button label="Jenkins" value="JENKINS" />
-                                <n-radio-button label="Azure DevOps" value="ADO" />
-                            </n-radio-group>
                         </n-form-item>
                         <n-form-item
                             v-if="createIntegrationObject.type === 'GITHUB'"


### PR DESCRIPTION
## Summary

The add-CI-integration modal still had a **CI Type** radio group at the top of the form, even though the type is already locked in by `openAddForCard()` based on which catalog card the user clicked. The switcher made it possible to accidentally pick a different type mid-edit (e.g. open from the GitHub card, change to Jenkins) — the form fields below swapped to the Jenkins shape but the modal title kept saying "Add GitHub Integration". Confusing and the wrong default.

Fix: drop the form-item entirely. `createIntegrationObject.type` is still set by `openAddForCard`, the per-type form items keep their `v-if` conditions on `createIntegrationObject.type`, and the modal title (`Add GitHub Integration` / `Add GitLab Integration` / …) is the canonical type indicator.

## Test plan

- [ ] Open Integrations → click **GitHub** card → **+ Add** (or **+ Add another GitHub**). Modal opens with title "Add GitHub Integration", no CI Type radio group, GitHub-specific form fields (capability checkboxes, PEM upload, App ID).
- [ ] Same for GitLab → GitLab token form.
- [ ] Same for Jenkins → URI + token form.
- [ ] Same for Azure DevOps → Client ID / Secret / Tenant / Org Name.
- [ ] Save flow unchanged — `createTriggerIntegration` payload still carries the correct `type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)