### PR TITLE
feat(ui-approval-rules): create new action inline from rule modal

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -465,211 +465,6 @@
                                                 <n-data-table :data="policyGlobalOutputEvents" :columns="outputTriggerTableFieldsReadOnly" :row-key="dataTableUuidRowKey" />
                                             </template>
                                         </div>
-                                        <n-modal
-                                            v-model:show="showCreateOutputTriggerModal"
-                                            preset="dialog"
-                                            :show-icon="false"
-                                            style="width: 90%"
-                                        >
-                                            <n-form :model="outputTrigger">
-                                                <h2>Add or Update Action</h2>
-                                                <n-space vertical size="large">
-                                                    <n-form-item label="Name" path="name">
-                                                        <n-input v-model:value="outputTrigger.name" required placeholder="Enter name" />
-                                                    </n-form-item>
-                                                    <n-form-item label="Type" path="type">
-                                                        <n-select v-model:value="outputTrigger.type" required 
-                                                            v-on:update:value="value => {if (value === 'EMAIL_NOTIFICATION') loadUsers()}"
-                                                            :options="outputTriggerTypeOptions" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'RELEASE_LIFECYCLE_CHANGE'" label="Lifecycle To Change To" path="toReleaseLifecycle">
-                                                        <n-select v-model:value="outputTrigger.toReleaseLifecycle" required :options="outputTriggerLifecycleOptions" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER'" label="Choose CI Integration" path="integration">
-                                                        <n-select
-                                                            v-model:value="outputTrigger.integration"
-                                                            placeholder="Select Integration"
-                                                            :options="ciIntegrationsForSelect" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Installation ID" path="schedule">
-                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Name of GitHub Actions Event" path="eventType">
-                                                        <n-input v-model:value="outputTrigger.eventType" placeholder="Enter Name of GitHub Actions Event" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Optional Client Payload JSON" path="clientPayload">
-                                                        <n-input v-model:value="outputTrigger.clientPayload" required placeholder="Enter Additional Optional Client Payload JSON" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITLAB'" label="GitLab Schedule Id" path="schedule">
-                                                        <n-input type="number" v-model:value="outputTrigger.schedule" required placeholder="Enter numeric GitLab Schedule Id" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && (selectedCiIntegration.type === 'GITHUB' || selectedCiIntegration.type === 'GITLAB')" label="CI Repository (override)" path="vcs">
-                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
-                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
-                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
-                                                                Override active. Component VCS will not be used for this trigger.
-                                                            </span>
-                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
-                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
-                                                            </span>
-                                                            <span v-else style="font-size: 12px; color: #c95900;">
-                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
-                                                            </span>
-                                                        </div>
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'JENKINS'" label="Jenkins Job Name" path="schedule">
-                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Jenkins Job Name" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Azure DevOps Project Name" path="eventType">
-                                                        <n-input v-model:value="outputTrigger.eventType" required placeholder="Enter Azure DevOps project name" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Pipeline Definition ID" path="schedule">
-                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter Pipeline Definition ID" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Optional Parameters" path="clientPayload">
-                                                        <n-input v-model:value="outputTrigger.clientPayload" placeholder="Enter Optional Parameters (JSON)" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Choose Validation Integration" path="integration">
-                                                        <n-select
-                                                            v-model:value="outputTrigger.integration"
-                                                            placeholder="Select GitHub Validate Integration"
-                                                            :options="validationIntegrationsForSelect" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
-                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="VCS Repository (override)" path="vcs">
-                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
-                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
-                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
-                                                                Override active. Component VCS will not be used for this trigger.
-                                                            </span>
-                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
-                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
-                                                            </span>
-                                                            <span v-else style="font-size: 12px; color: #c95900;">
-                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
-                                                            </span>
-                                                        </div>
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
-                                                        <n-select v-model:value="outputTrigger.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="clientPayload">
-                                                        <template #label>
-                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
-                                                                Optional Output JSON (title / summary / text)
-                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
-                                                                    <template #trigger>
-                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
-                                                                    </template>
-                                                                    Static JSON. When set, ReARM sends this as the GitHub check-run "output" verbatim — title, summary and text fields all replace ReARM's defaults (including the auto metrics summary). Leave empty to keep defaults. Use the Dynamic CEL field below if you need per-release values.
-                                                                </n-tooltip>
-                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerClientPayloadDefault">
-                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
-                                                                    Use template
-                                                                </n-button>
-                                                            </span>
-                                                        </template>
-                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder='{"title":"...","summary":"...","text":"..."}' />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="celClientPayload">
-                                                        <template #label>
-                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
-                                                                Dynamic output (CEL string expression)
-                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
-                                                                    <template #trigger>
-                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
-                                                                    </template>
-                                                                    CEL expression evaluated at fire time against the release. Result must be a JSON string with title / summary / text — it overwrites the Optional Output JSON above for this dispatch. Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
-                                                                </n-tooltip>
-                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerCelClientPayloadDefault">
-                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
-                                                                    Use template
-                                                                </n-button>
-                                                            </span>
-                                                        </template>
-                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
-                                                        <n-input v-model:value="outputTrigger.checkName" :placeholder="'Defaults to rearm/' + (updatedComponent.name || '<component>')" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Choose Validation Integration" path="integration">
-                                                        <n-select
-                                                            v-model:value="outputTrigger.integration"
-                                                            placeholder="Select GitHub Validate Integration"
-                                                            :options="validationIntegrationsForSelect" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Installation ID" path="schedule">
-                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="clientPayload">
-                                                        <template #label>
-                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
-                                                                Optional Comment Suffix (markdown)
-                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
-                                                                    <template #trigger>
-                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
-                                                                    </template>
-                                                                    Static markdown appended to ReARM's auto-generated PR comment body (header / metrics / PR conditions are kept). Use this for organisation-wide footers — links to runbooks, escalation contacts, etc. Leave empty to use the default body unchanged.
-                                                                </n-tooltip>
-                                                            </span>
-                                                        </template>
-                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder="### See also&#10;- [Runbook](https://...)" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="celClientPayload">
-                                                        <template #label>
-                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
-                                                                Dynamic Comment Suffix (CEL string expression)
-                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
-                                                                    <template #trigger>
-                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
-                                                                    </template>
-                                                                    CEL expression evaluated at fire time. Result must be a markdown string. Appended to the auto-generated body — additive, not a replacement (contrast with External Validation, which substitutes). Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
-                                                                </n-tooltip>
-                                                            </span>
-                                                        </template>
-                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"_Triggered for release " + release.version + "._"' />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Users to notify" path="users">
-                                                        <n-select v-model:value="outputTrigger.users" tag multiple required :options="users" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Email Message Contents" path="notificationMessage">
-                                                        <n-input v-model:value="outputTrigger.notificationMessage" placeholder="Email Message Contents (i.e. 'Release ready to ship.')" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Dynamic message (CEL string expression)" path="celClientPayload">
-                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"Release " + release.version + " reached " + release.lifecycle' />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER'" label="Dynamic client payload (CEL string expression)" path="celClientPayload">
-                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"refs/tags/" + release.version' />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT'" label="Include Suppressed Vulnerabilities" path="includeSuppressed">
-                                                        <n-switch v-model:value="outputTrigger.includeSuppressed" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT'" label="Snapshot tagging">
-                                                        <n-radio-group v-model:value="snapshotMode">
-                                                            <n-space>
-                                                                <n-radio value="NONE">None (date-stamped)</n-radio>
-                                                                <n-radio value="APPROVAL">Tag by approval entry</n-radio>
-                                                                <n-radio value="LIFECYCLE">Tag by lifecycle</n-radio>
-                                                            </n-space>
-                                                        </n-radio-group>
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT' && snapshotMode === 'APPROVAL'" label="Snapshot approval entry">
-                                                        <n-select v-model:value="outputTrigger.snapshotApprovalEntry" :options="approvalEntryOptionsForTriggers" placeholder="Select approval entry" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT' && snapshotMode === 'LIFECYCLE'" label="Snapshot lifecycle">
-                                                        <n-select v-model:value="outputTrigger.snapshotLifecycle" :options="outputTriggerLifecycleOptions" placeholder="Select lifecycle" />
-                                                    </n-form-item>
-                                                    <n-form-item v-if="outputTrigger.type === 'ADD_APPROVED_ENVIRONMENT'" label="Approved Environment" path="approvedEnvironment">
-                                                        <n-select v-model:value="outputTrigger.approvedEnvironment" filterable :options="environmentTypeOptions" placeholder="Select an environment (e.g. UAT)" />
-                                                    </n-form-item>
-                                                    <n-button @click="addOutputTrigger" type="success">
-                                                        Save
-                                                    </n-button>
-                                                </n-space>
-                                            </n-form>
-                                        </n-modal>
                                     </n-tab-pane>
                                     <n-tab-pane name="Input Events" tab="Rules" v-if="myUser.installationType !== 'OSS'">
                                         <h4 style="margin-bottom: 8px;">{{ words.componentFirstUpper }} Local Rules</h4>
@@ -922,6 +717,212 @@
                                         </div>
                                     </n-tab-pane>
                                 </n-tabs>
+
+                                        <n-modal
+                                            v-model:show="showCreateOutputTriggerModal"
+                                            preset="dialog"
+                                            :show-icon="false"
+                                            style="width: 90%"
+                                        >
+                                            <n-form :model="outputTrigger">
+                                                <h2>Add or Update Action</h2>
+                                                <n-space vertical size="large">
+                                                    <n-form-item label="Name" path="name">
+                                                        <n-input v-model:value="outputTrigger.name" required placeholder="Enter name" />
+                                                    </n-form-item>
+                                                    <n-form-item label="Type" path="type">
+                                                        <n-select v-model:value="outputTrigger.type" required 
+                                                            v-on:update:value="value => {if (value === 'EMAIL_NOTIFICATION') loadUsers()}"
+                                                            :options="outputTriggerTypeOptions" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'RELEASE_LIFECYCLE_CHANGE'" label="Lifecycle To Change To" path="toReleaseLifecycle">
+                                                        <n-select v-model:value="outputTrigger.toReleaseLifecycle" required :options="outputTriggerLifecycleOptions" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER'" label="Choose CI Integration" path="integration">
+                                                        <n-select
+                                                            v-model:value="outputTrigger.integration"
+                                                            placeholder="Select Integration"
+                                                            :options="ciIntegrationsForSelect" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Installation ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Name of GitHub Actions Event" path="eventType">
+                                                        <n-input v-model:value="outputTrigger.eventType" placeholder="Enter Name of GitHub Actions Event" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITHUB'" label="Optional Client Payload JSON" path="clientPayload">
+                                                        <n-input v-model:value="outputTrigger.clientPayload" required placeholder="Enter Additional Optional Client Payload JSON" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'GITLAB'" label="GitLab Schedule Id" path="schedule">
+                                                        <n-input type="number" v-model:value="outputTrigger.schedule" required placeholder="Enter numeric GitLab Schedule Id" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && (selectedCiIntegration.type === 'GITHUB' || selectedCiIntegration.type === 'GITLAB')" label="CI Repository (override)" path="vcs">
+                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
+                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
+                                                                Override active. Component VCS will not be used for this trigger.
+                                                            </span>
+                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
+                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
+                                                            </span>
+                                                            <span v-else style="font-size: 12px; color: #c95900;">
+                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
+                                                            </span>
+                                                        </div>
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'JENKINS'" label="Jenkins Job Name" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Jenkins Job Name" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Azure DevOps Project Name" path="eventType">
+                                                        <n-input v-model:value="outputTrigger.eventType" required placeholder="Enter Azure DevOps project name" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Pipeline Definition ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter Pipeline Definition ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER' && selectedCiIntegration && selectedCiIntegration.type === 'ADO'" label="Optional Parameters" path="clientPayload">
+                                                        <n-input v-model:value="outputTrigger.clientPayload" placeholder="Enter Optional Parameters (JSON)" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Choose Validation Integration" path="integration">
+                                                        <n-select
+                                                            v-model:value="outputTrigger.integration"
+                                                            placeholder="Select GitHub Validate Integration"
+                                                            :options="validationIntegrationsForSelect" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Installation ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="VCS Repository (override)" path="vcs">
+                                                        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+                                                            <n-select :options="vcsRepos" v-model:value="outputTrigger.vcs" placeholder="Leave empty to use the component's VCS" clearable />
+                                                            <span v-if="outputTrigger.vcs" style="font-size: 12px; color: #888;">
+                                                                Override active. Component VCS will not be used for this trigger.
+                                                            </span>
+                                                            <span v-else-if="updatedComponent.vcs" style="font-size: 12px; color: #888;">
+                                                                Will use component's VCS at fire time: {{ getVcsRepoObjById(updatedComponent.vcs)?.uri || updatedComponent.vcs }}
+                                                            </span>
+                                                            <span v-else style="font-size: 12px; color: #c95900;">
+                                                                ⚠ Component has no VCS configured — pick an override here, or set a VCS on the component, otherwise this trigger cannot be saved.
+                                                            </span>
+                                                        </div>
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Conclusion" path="eventType">
+                                                        <n-select v-model:value="outputTrigger.eventType" required :options="externalValidationConclusionOptions" placeholder="Select check-run conclusion" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="clientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Optional Output JSON (title / summary / text)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    Static JSON. When set, ReARM sends this as the GitHub check-run "output" verbatim — title, summary and text fields all replace ReARM's defaults (including the auto metrics summary). Leave empty to keep defaults. Use the Dynamic CEL field below if you need per-release values.
+                                                                </n-tooltip>
+                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerClientPayloadDefault">
+                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                                    Use template
+                                                                </n-button>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder='{"title":"...","summary":"...","text":"..."}' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" path="celClientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Dynamic output (CEL string expression)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    CEL expression evaluated at fire time against the release. Result must be a JSON string with title / summary / text — it overwrites the Optional Output JSON above for this dispatch. Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
+                                                                </n-tooltip>
+                                                                <n-button text type="primary" size="tiny" @click="populateOutputTriggerCelClientPayloadDefault">
+                                                                    <template #icon><n-icon><Clipboard /></n-icon></template>
+                                                                    Use template
+                                                                </n-button>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"{\"title\":\"ReARM verdict: \" + ...}"' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EXTERNAL_VALIDATION'" label="Override Check Name (optional)" path="checkName">
+                                                        <n-input v-model:value="outputTrigger.checkName" :placeholder="'Defaults to rearm/' + (updatedComponent.name || '<component>')" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Choose Validation Integration" path="integration">
+                                                        <n-select
+                                                            v-model:value="outputTrigger.integration"
+                                                            placeholder="Select GitHub Validate Integration"
+                                                            :options="validationIntegrationsForSelect" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" label="Installation ID" path="schedule">
+                                                        <n-input v-model:value="outputTrigger.schedule" required placeholder="Enter GitHub Installation ID" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="clientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Optional Comment Suffix (markdown)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    Static markdown appended to ReARM's auto-generated PR comment body (header / metrics / PR conditions are kept). Use this for organisation-wide footers — links to runbooks, escalation contacts, etc. Leave empty to use the default body unchanged.
+                                                                </n-tooltip>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.clientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" placeholder="### See also&#10;- [Runbook](https://...)" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'PR_COMMENT'" path="celClientPayload">
+                                                        <template #label>
+                                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                                                Dynamic Comment Suffix (CEL string expression)
+                                                                <n-tooltip trigger="hover" style="max-width: 360px;">
+                                                                    <template #trigger>
+                                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                                    </template>
+                                                                    CEL expression evaluated at fire time. Result must be a markdown string. Appended to the auto-generated body — additive, not a replacement (contrast with External Validation, which substitutes). Available bindings: release.version, release.lifecycle, release.criticalVulns, release.highVulns, release.mediumVulns, release.lowVulns, release.securityViolations, release.licenseViolations, release.operationalViolations.
+                                                                </n-tooltip>
+                                                            </span>
+                                                        </template>
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" type="textarea" :autosize="{ minRows: 2, maxRows: 8 }" style="font-family: monospace;" placeholder='"_Triggered for release " + release.version + "._"' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Users to notify" path="users">
+                                                        <n-select v-model:value="outputTrigger.users" tag multiple required :options="users" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Email Message Contents" path="notificationMessage">
+                                                        <n-input v-model:value="outputTrigger.notificationMessage" placeholder="Email Message Contents (i.e. 'Release ready to ship.')" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'EMAIL_NOTIFICATION'" label="Dynamic message (CEL string expression)" path="celClientPayload">
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"Release " + release.version + " reached " + release.lifecycle' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'INTEGRATION_TRIGGER'" label="Dynamic client payload (CEL string expression)" path="celClientPayload">
+                                                        <n-input v-model:value="outputTrigger.celClientPayload" style="font-family: monospace;" placeholder='"refs/tags/" + release.version' />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT'" label="Include Suppressed Vulnerabilities" path="includeSuppressed">
+                                                        <n-switch v-model:value="outputTrigger.includeSuppressed" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT'" label="Snapshot tagging">
+                                                        <n-radio-group v-model:value="snapshotMode">
+                                                            <n-space>
+                                                                <n-radio value="NONE">None (date-stamped)</n-radio>
+                                                                <n-radio value="APPROVAL">Tag by approval entry</n-radio>
+                                                                <n-radio value="LIFECYCLE">Tag by lifecycle</n-radio>
+                                                            </n-space>
+                                                        </n-radio-group>
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT' && snapshotMode === 'APPROVAL'" label="Snapshot approval entry">
+                                                        <n-select v-model:value="outputTrigger.snapshotApprovalEntry" :options="approvalEntryOptionsForTriggers" placeholder="Select approval entry" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'VDR_SNAPSHOT_ARTIFACT' && snapshotMode === 'LIFECYCLE'" label="Snapshot lifecycle">
+                                                        <n-select v-model:value="outputTrigger.snapshotLifecycle" :options="outputTriggerLifecycleOptions" placeholder="Select lifecycle" />
+                                                    </n-form-item>
+                                                    <n-form-item v-if="outputTrigger.type === 'ADD_APPROVED_ENVIRONMENT'" label="Approved Environment" path="approvedEnvironment">
+                                                        <n-select v-model:value="outputTrigger.approvedEnvironment" filterable :options="environmentTypeOptions" placeholder="Select an environment (e.g. UAT)" />
+                                                    </n-form-item>
+                                                    <n-button @click="addOutputTrigger" type="success">
+                                                        Save
+                                                    </n-button>
+                                                </n-space>
+                                            </n-form>
+                                        </n-modal>
                             </n-modal>
                             <n-modal
                                 v-model:show="showCloneBranchModal"

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -818,15 +818,30 @@
                                                     </n-form-item>
                                                     <n-form-item path="inputTrigger.outputEvents">
                                                         <template #label><strong>Actions when condition is met</strong></template>
-                                                        <n-select v-model:value="inputTrigger.outputEvents"
-                                                        :options="outputTriggersForInputForm" multiple
-                                                        placeholder="Fired when the condition above is TRUE" />
+                                                        <n-space vertical size="small" style="width: 100%;">
+                                                            <n-select v-model:value="inputTrigger.outputEvents"
+                                                            :options="outputTriggersForInputForm" multiple
+                                                            placeholder="Fired when the condition above is TRUE" />
+                                                            <!-- Inline action create — creates a local
+                                                                 component-level action and attaches its
+                                                                 (temp) uuid back to the rule's true-branch
+                                                                 list. The real uuid is assigned by the
+                                                                 server when the user hits Save Changes. -->
+                                                            <n-button v-if="isWritable" size="tiny" dashed @click="openCreateActionFromRule('true')">
+                                                                + Create new action
+                                                            </n-button>
+                                                        </n-space>
                                                     </n-form-item>
                                                     <n-form-item path="inputTrigger.outputEventsOnFalse">
                                                         <template #label><strong>Actions when condition is NOT met (optional)</strong></template>
-                                                        <n-select v-model:value="inputTrigger.outputEventsOnFalse"
-                                                        :options="outputTriggersForInputForm" multiple
-                                                        placeholder="Optional — fired when the condition above is FALSE. Lets you express 'else B' in one rule." />
+                                                        <n-space vertical size="small" style="width: 100%;">
+                                                            <n-select v-model:value="inputTrigger.outputEventsOnFalse"
+                                                            :options="outputTriggersForInputForm" multiple
+                                                            placeholder="Optional — fired when the condition above is FALSE. Lets you express 'else B' in one rule." />
+                                                            <n-button v-if="isWritable" size="tiny" dashed @click="openCreateActionFromRule('false')">
+                                                                + Create new action
+                                                            </n-button>
+                                                        </n-space>
                                                     </n-form-item>
                                                     <n-button @click="addInputTrigger" type="success">
                                                         Save
@@ -2818,6 +2833,20 @@ const tagFields: any[] = [
     }
 ]
 
+// "+ Create new action" inside the Local Rule modal sets this before
+// opening the action-create modal so addOutputTrigger can attach the
+// new (temp-uuid) entry back to the rule's outputEvents list. Local
+// actions get a temp uuid client-side; the real uuid is assigned
+// when the user hits Save Changes at the bottom of the tab.
+const pendingActionAttachBranch = ref<null | 'true' | 'false'>(null)
+
+function openCreateActionFromRule (branch: 'true' | 'false') {
+    pendingActionAttachBranch.value = branch
+    resetOutputTrigger()
+    loadEnvTypes()
+    showCreateOutputTriggerModal.value = true
+}
+
 async function addOutputTrigger () {
     if (!updatedComponent.value.outputTriggers) {
         updatedComponent.value.outputTriggers = []
@@ -2863,6 +2892,7 @@ async function addOutputTrigger () {
         return
     }
 
+    let isNewAction = false
     if (outputTriggerToPush.uuid) {
         // Check if trigger with this UUID already exists
         const existingIndex = updatedComponent.value.outputTriggers.findIndex((ot: any) => ot.uuid === outputTriggerToPush.uuid)
@@ -2872,13 +2902,29 @@ async function addOutputTrigger () {
         } else {
             // Add new trigger
             updatedComponent.value.outputTriggers.push(outputTriggerToPush)
+            isNewAction = true
         }
     } else {
         // Add new trigger - generate temporary UUID for client-side tracking
         outputTriggerToPush.uuid = 'temp-' + Date.now() + '-' + crypto.randomUUID()
         updatedComponent.value.outputTriggers.push(outputTriggerToPush)
+        isNewAction = true
     }
-    
+
+    // If this modal was opened from a rule's "+ Create new action" button,
+    // attach the new action's uuid to the rule's outputEvents /
+    // outputEventsOnFalse list. The temp uuid is what the rule references
+    // until the user hits Save Changes; the backend rewrites both refs
+    // and the trigger uuid in the same updateComponent call.
+    if (isNewAction && pendingActionAttachBranch.value) {
+        const target = pendingActionAttachBranch.value === 'true' ? 'outputEvents' : 'outputEventsOnFalse'
+        const list: string[] = (inputTrigger.value as any)[target] || []
+        if (!list.includes(outputTriggerToPush.uuid)) {
+            ;(inputTrigger.value as any)[target] = [...list, outputTriggerToPush.uuid]
+        }
+    }
+    pendingActionAttachBranch.value = null
+
     resetOutputTrigger()
     showCreateOutputTriggerModal.value = false
 }

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -2182,6 +2182,37 @@ function stripGraphQLMetadata(triggers: any[], stripScope: boolean = false) {
 }
 
 async function saveTriggers() {
+    // New output triggers added inline from "+ Create new action" inside a
+    // rule modal carry a temp-prefixed uuid that the rule references via
+    // outputEvents / outputEventsOnFalse. stripGraphQLMetadata rewrites
+    // the trigger's own uuid to "" so the server generates a fresh one,
+    // but it does NOT rewrite the references inside rules — leaving the
+    // rule pointing at a non-existent temp uuid and the backend choking
+    // with SERVICE_ERROR. Before stripping, remap each temp uuid on an
+    // output trigger to a real client-generated UUID (which the backend
+    // respects on updateComponent), and rewrite the same uuid in every
+    // rule's outputEvents/outputEventsOnFalse so the binding survives.
+    const tempToRealUuid: Record<string, string> = {}
+    if (updatedComponent.value.outputTriggers) {
+        for (const t of updatedComponent.value.outputTriggers) {
+            if (t.uuid && typeof t.uuid === 'string' && t.uuid.startsWith('temp-')) {
+                const real = crypto.randomUUID()
+                tempToRealUuid[t.uuid] = real
+                t.uuid = real
+            }
+        }
+    }
+    if (Object.keys(tempToRealUuid).length > 0 && updatedComponent.value.releaseInputTriggers) {
+        for (const rule of updatedComponent.value.releaseInputTriggers) {
+            if (Array.isArray(rule.outputEvents)) {
+                rule.outputEvents = rule.outputEvents.map((uuid: string) => tempToRealUuid[uuid] || uuid)
+            }
+            if (Array.isArray(rule.outputEventsOnFalse)) {
+                rule.outputEventsOnFalse = rule.outputEventsOnFalse.map((uuid: string) => tempToRealUuid[uuid] || uuid)
+            }
+        }
+    }
+
     // Strip scope and __typename before saving to backend
     updatedComponent.value.outputTriggers = stripGraphQLMetadata(updatedComponent.value.outputTriggers, true)
     updatedComponent.value.releaseInputTriggers = stripGraphQLMetadata(updatedComponent.value.releaseInputTriggers, true)

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -262,15 +262,27 @@
                                     </n-form-item>
                                     <n-form-item path="globalInputEvent.outputEvents">
                                         <template #label><strong>Actions when condition is met</strong></template>
-                                        <n-select v-model:value="globalInputEvent.outputEvents"
-                                        :options="globalOutputEventsForInputForm" multiple
-                                        placeholder="Fired when the condition above is TRUE" />
+                                        <n-space vertical size="small" style="width: 100%;">
+                                            <n-select v-model:value="globalInputEvent.outputEvents"
+                                            :options="globalOutputEventsForInputForm" multiple
+                                            placeholder="Fired when the condition above is TRUE" />
+                                            <!-- Inline action create — saves the action immediately and
+                                                 attaches its uuid back to the rule's true-branch list. -->
+                                            <n-button v-if="isWritable" size="tiny" dashed @click="openCreateActionFromRule('true')">
+                                                + Create new action
+                                            </n-button>
+                                        </n-space>
                                     </n-form-item>
                                     <n-form-item path="globalInputEvent.outputEventsOnFalse">
                                         <template #label><strong>Actions when condition is NOT met (optional)</strong></template>
-                                        <n-select v-model:value="globalInputEvent.outputEventsOnFalse"
-                                        :options="globalOutputEventsForInputForm" multiple
-                                        placeholder="Optional — fired when the condition above is FALSE. Lets you express 'else B' in one rule." />
+                                        <n-space vertical size="small" style="width: 100%;">
+                                            <n-select v-model:value="globalInputEvent.outputEventsOnFalse"
+                                            :options="globalOutputEventsForInputForm" multiple
+                                            placeholder="Optional — fired when the condition above is FALSE. Lets you express 'else B' in one rule." />
+                                            <n-button v-if="isWritable" size="tiny" dashed @click="openCreateActionFromRule('false')">
+                                                + Create new action
+                                            </n-button>
+                                        </n-space>
                                     </n-form-item>
                                     <n-button @click="addGlobalInputEvent" type="success">Save</n-button>
                                 </n-space>
@@ -5416,6 +5428,24 @@ async function saveGlobalInputEvents () {
     }
 }
 
+// "+ Create new action" inside the rule modal sets this to 'true' or
+// 'false' before opening the action-create modal. After save, the
+// addGlobalOutputEvent handler diffs the post-save uuid list against
+// this snapshot to find the new entry and appends its uuid back to
+// the rule's outputEvents / outputEventsOnFalse.
+const pendingActionAttachBranch = ref<null | 'true' | 'false'>(null)
+const pendingActionAttachUuidsBefore = ref<string[]>([])
+
+function openCreateActionFromRule (branch: 'true' | 'false') {
+    pendingActionAttachBranch.value = branch
+    pendingActionAttachUuidsBefore.value = globalOutputEvents.value
+        .map((e: any) => e.uuid)
+        .filter((u: any) => !!u)
+    resetGlobalOutputEvent()
+    loadEnvironmentTypesForOutputEvents()
+    showCreateGlobalOutputEventModal.value = true
+}
+
 function addGlobalOutputEvent () {
     const eventToPush = commonFunctions.deepCopy(globalOutputEvent.value)
     if (eventToPush.type === 'VDR_SNAPSHOT_ARTIFACT') {
@@ -5451,7 +5481,26 @@ function addGlobalOutputEvent () {
     } else {
         globalOutputEvents.value.push(eventToPush)
     }
-    saveGlobalOutputEvents()
+    // Await save so we can read back the server-assigned uuid for any
+    // newly-created entry. Then if this modal was opened from a rule's
+    // "+ Create new action" button, attach the new uuid to the rule's
+    // outputEvents / outputEventsOnFalse list.
+    const branch = pendingActionAttachBranch.value
+    const beforeUuids = new Set(pendingActionAttachUuidsBefore.value)
+    pendingActionAttachBranch.value = null
+    pendingActionAttachUuidsBefore.value = []
+    saveGlobalOutputEvents().then(() => {
+        if (branch) {
+            const newOne = globalOutputEvents.value.find((e: any) => e.uuid && !beforeUuids.has(e.uuid))
+            if (newOne && newOne.uuid) {
+                const target = branch === 'true' ? 'outputEvents' : 'outputEventsOnFalse'
+                const list: string[] = globalInputEvent.value[target] || []
+                if (!list.includes(newOne.uuid)) {
+                    globalInputEvent.value[target] = [...list, newOne.uuid]
+                }
+            }
+        }
+    })
     resetGlobalOutputEvent()
     showCreateGlobalOutputEventModal.value = false
 }


### PR DESCRIPTION
## Summary

Adds a **"+ Create new action"** affordance under each Actions selector inside the rule modal. Saves you from closing the rule modal, walking to the Actions tab, creating the action, and re-opening the rule just to reference it.

UI-only — same backend mutations as the standalone Action create flow.

## Scope

- **Global rules → global actions.** Org Settings → Policies → Approval Policies → policy-wide rule modal: clicking "+ Create new action" under either Actions selector opens the standard policy-wide action editor, saves via `setGlobalOutputEvents`, then auto-attaches the new action's server-assigned uuid to the rule's `outputEvents` / `outputEventsOnFalse` array before the rule modal re-renders.
- **Local rules → local actions.** Component View → Rules → local rule modal: same affordance, but the new action is a component-level outputTrigger. It gets a temp uuid client-side (same path as the existing "Add Action" button); the rule references that temp uuid until the user hits **Save Changes** at the bottom of the tab, which sends both sides in one `updateComponent` call.

## Implementation notes

- `pendingActionAttachBranch` ref tracks which Actions list (`true` or `false`) the create flow was opened from.
- OrgSettings additionally captures a `pendingActionAttachUuidsBefore` snapshot of existing uuids — needed because `setGlobalOutputEvents` rewrites the entire list with server uuids, so the new entry is identified by uuid diff against the snapshot.
- Standalone "+ Add Policy-Wide Action" / "+ Add Action" buttons keep working unchanged; the new inline button just sets the attach state before opening the same modal.

## Test plan

### Org Settings policy-wide
- [ ] Open a policy, click "+ Add Policy-Wide Rule" → modal opens.
- [ ] Click "+ Create new action" under "Actions when condition is met" → action-create modal opens on top.
- [ ] Fill in name/type/etc., Save. Action-create modal closes; rule modal still open; the new action's name appears in the "Actions when condition is met" multi-select.
- [ ] Same flow on "Actions when condition is NOT met (optional)" → attached to the else branch only.
- [ ] Save the rule. New rule + new action both persist.
- [ ] Re-open Approval Policy → Actions tab. The new action is listed.

### Component-local rules
- [ ] Open a component → Rules tab → "+ Add Rule".
- [ ] Click "+ Create new action" → local action modal opens.
- [ ] Save the new action. Rule modal still open, the new (temp-uuid) action selected.
- [ ] Save the rule.
- [ ] Bottom "Save Changes" button lights up — click → updateComponent persists both rule and action together, server returns real uuids.
- [ ] Component → Actions tab shows the new action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)