### PR TITLE
feat(ui-agent-policy): CLOSE kind — verdict locks at session close

### DIFF
--- a/ui/src/components/AiAgentPoliciesOfOrg.vue
+++ b/ui/src/components/AiAgentPoliciesOfOrg.vue
@@ -16,8 +16,11 @@
                     CEL rules evaluated against every agent session in this org —
                     <strong>INPUT</strong> policies gate session init;
                     <strong>OUTPUT</strong> policies harden when a commit is
-                    attributed. Open the editor and expand
-                    <em>Sample policies</em> for starter scaffolds.
+                    attributed; <strong>CLOSE</strong> policies stay AWAITING
+                    until the session closes (use for gates whose satisfying
+                    artifact arrives after the last commit — e.g. a FINAL
+                    report). Open the editor and expand <em>Sample policies</em>
+                    for starter scaffolds.
                 </n-tooltip>
             </div>
             <n-space>
@@ -116,29 +119,52 @@ async function populateDefaults () {
     if (populating.value) return
     populating.value = true
     try {
-        // Single starter policy: every agent session must file an
-        // orientation report (AGENTIC_REPORT artifact) before any of
-        // its commits can be attributed. OUTPUT + BLOCK because the
-        // report normally arrives during the session; gating session
-        // init (INPUT) would be too early.
-        const input = {
-            uuid: null,
-            org: orgUuid.value,
-            name: 'Require Orientation Report',
-            description: 'Reject agent sessions that have not filed an AGENTIC_REPORT artifact (orientation report) by the time their commits are attributed.',
-            kind: 'OUTPUT',
-            severity: 'BLOCK',
-            cel: '!session.artifacts.exists(a, a.type == "AGENTIC_REPORT")',
-            enabled: true
-        }
-        await store.dispatch('upsertAgentPolicy', input)
-        notification.success({ content: 'Seeded "Require Orientation Report".' })
+        // Two starter policies bracketing the session timeline:
+        //   1. Orientation report at OUTPUT — the agent is expected to
+        //      file this near the start, so it should be in place by
+        //      the time the first commit is attributed. OUTPUT hardens
+        //      the verdict at commit-attribution time.
+        //   2. Final report at CLOSE — the FINAL-phase AGENTIC_REPORT is
+        //      by definition filed after the agent's last commit, so an
+        //      OUTPUT-kind rule would deterministically FAIL at commit
+        //      attribution. CLOSE keeps the verdict AWAITING until
+        //      session close, giving the report time to land.
+        const seeds = [
+            {
+                uuid: null,
+                org: orgUuid.value,
+                name: 'Require Orientation Report',
+                description: 'Reject agent sessions that have not filed an orientation-phase AGENTIC_REPORT (tag agenticPhase=ORIENTATION) by the time their commits are attributed.',
+                kind: 'OUTPUT',
+                severity: 'BLOCK',
+                cel: '!session.artifacts.exists(a, a.type == "AGENTIC_REPORT" && a.tags.exists(t, t.key == "agenticPhase" && t.value == "ORIENTATION"))',
+                enabled: true,
+            },
+            {
+                uuid: null,
+                org: orgUuid.value,
+                name: 'Require Final Report',
+                description: 'Reject agent sessions that close without a final-phase AGENTIC_REPORT (tag agenticPhase=FINAL). CLOSE kind — the FINAL report arrives after the agent\'s last commit, so this verdict only locks at session close.',
+                kind: 'CLOSE',
+                severity: 'BLOCK',
+                cel: '!session.artifacts.exists(a, a.type == "AGENTIC_REPORT" && a.tags.exists(t, t.key == "agenticPhase" && t.value == "FINAL"))',
+                enabled: true,
+            },
+        ]
+        for (const s of seeds) await store.dispatch('upsertAgentPolicy', s)
+        notification.success({ content: 'Seeded "Require Orientation Report" + "Require Final Report".' })
         await load()
     } catch (e: any) {
         notification.error({ content: `Populate failed: ${e?.message ?? e}` })
     } finally {
         populating.value = false
     }
+}
+
+function kindTagType (kind: string): 'info' | 'success' | 'default' {
+    if (kind === 'INPUT') return 'info'
+    if (kind === 'CLOSE') return 'success'
+    return 'default'
 }
 
 async function remove (row: any) {
@@ -160,7 +186,7 @@ const columns = computed<DataTableColumns<any>>(() => [
         title: 'Kind',
         key: 'kind',
         width: 100,
-        render: (row: any) => h(NTag, { size: 'small', type: row.kind === 'INPUT' ? 'info' : 'default' },
+        render: (row: any) => h(NTag, { size: 'small', type: kindTagType(row.kind) },
             { default: () => row.kind }),
     },
     {

--- a/ui/src/components/AiAgentPolicyView.vue
+++ b/ui/src/components/AiAgentPolicyView.vue
@@ -34,7 +34,7 @@
                 <n-radio-group v-model:value="form.kind">
                     <n-radio-button v-for="opt in kindOptions" :key="opt.value" :value="opt.value">
                         {{ opt.value }}
-                        <n-tooltip trigger="hover">
+                        <n-tooltip trigger="hover" :style="{ maxWidth: '420px' }" placement="bottom-start">
                             <template #trigger>
                                 <n-icon size="14" class="opt-help">
                                     <QuestionCircle20Regular/>
@@ -50,7 +50,7 @@
                 <n-radio-group v-model:value="form.severity">
                     <n-radio-button v-for="opt in severityOptions" :key="opt.value" :value="opt.value">
                         {{ opt.value }}
-                        <n-tooltip trigger="hover">
+                        <n-tooltip trigger="hover" :style="{ maxWidth: '420px' }" placement="bottom-start">
                             <template #trigger>
                                 <n-icon size="14" class="opt-help">
                                     <QuestionCircle20Regular/>

--- a/ui/src/components/AiAgentPolicyView.vue
+++ b/ui/src/components/AiAgentPolicyView.vue
@@ -133,7 +133,7 @@
                     </n-alert>
                     <div class="samples">
                         <n-button v-for="s in samples" :key="s.name" size="small" @click="applySample(s)">
-                            <n-tag size="tiny" :type="s.kind === 'INPUT' ? 'info' : 'default'" style="margin-right: 4px;">{{ s.kind }}</n-tag>
+                            <n-tag size="tiny" :type="kindTagType(s.kind)" style="margin-right: 4px;">{{ s.kind }}</n-tag>
                             <n-tag size="tiny" :type="s.severity === 'BLOCK' ? 'error' : 'warning'" style="margin-right: 6px;">{{ s.severity }}</n-tag>
                             {{ s.name }}
                         </n-button>
@@ -215,7 +215,11 @@ const kindOptions = [
     },
     {
         value: 'OUTPUT',
-        help: '<strong>OUTPUT</strong> — postcondition on session work. Checked at init (records PENDING — soft signal to the agent), re-checked when an artifact attaches, hardens to FAILED when a commit is attributed without satisfying the CEL. Use for "agent must produce X" rules.',
+        help: '<strong>OUTPUT</strong> — postcondition on session work. Checked at init (records AWAITING — soft signal to the agent), re-checked when an artifact attaches, hardens to FAILED when a commit is attributed without satisfying the CEL. Use for "agent must produce X by commit-time" rules (e.g. orientation report).',
+    },
+    {
+        value: 'CLOSE',
+        help: '<strong>CLOSE</strong> — postcondition that stays AWAITING through the entire session lifetime and only locks its verdict at session close. Use when the satisfying artifact arrives <em>after</em> the agent\'s last commit — e.g. a FINAL <code>AGENTIC_REPORT</code> tag the agent files as its closing step. OUTPUT would deterministically FAIL such a rule at commit-attribution time.',
     },
 ]
 
@@ -285,15 +289,15 @@ const samples = [
     },
     {
         name: 'Final report required',
-        description: 'Session must produce a final-phase AGENTIC_REPORT before commits land.',
-        kind: 'OUTPUT',
+        description: 'Session must produce a final-phase AGENTIC_REPORT before close. CLOSE kind — the FINAL report is by definition filed after the agent\'s last commit, so OUTPUT would FAIL it at commit-attribution.',
+        kind: 'CLOSE',
         severity: 'BLOCK',
         cel: '!session.artifacts.exists(a, a.type == "AGENTIC_REPORT" && a.tags.exists(t, t.key == "agenticPhase" && t.value == "FINAL"))',
     },
     {
         name: 'Any AGENTIC_REPORT artifact required',
-        description: 'Looser variant — any AGENTIC_REPORT artifact (no phase distinction).',
-        kind: 'OUTPUT',
+        description: 'Looser variant — any AGENTIC_REPORT artifact (no phase distinction). CLOSE kind so a report filed after the last commit still counts.',
+        kind: 'CLOSE',
         severity: 'BLOCK',
         cel: '!session.artifacts.exists(a, a.type == "AGENTIC_REPORT")',
     },
@@ -372,6 +376,12 @@ function applySample (s: any) {
     form.value.kind = s.kind
     form.value.severity = s.severity
     form.value.cel = s.cel
+}
+
+function kindTagType (kind: string): 'info' | 'success' | 'default' {
+    if (kind === 'INPUT') return 'info'
+    if (kind === 'CLOSE') return 'success'
+    return 'default'
 }
 
 async function save () {

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -509,6 +509,20 @@
                                                         <code v-if="gie.celExpression">{{ gie.celExpression }}</code>
                                                         <span v-else class="text-muted">(none — rule will not fire)</span>
                                                     </div>
+                                                    <!-- Default actions — visible whenever the local override
+                                                         is OFF so operators can see the actions the rule will
+                                                         fire by default. Hidden when the override is engaged
+                                                         (the n-select below takes over and shows the local set). -->
+                                                    <div v-if="!getGlobalInputEventRef(gie.uuid)?.overrideOutputEventsLocally"
+                                                         style="margin-left: 28px; margin-top: 4px; font-size: 12px;">
+                                                        <span class="text-muted" style="margin-right: 6px;">Default actions:</span>
+                                                        <template v-if="gie.outputEvents && gie.outputEvents.length">
+                                                            <n-tag v-for="oeUuid in gie.outputEvents" :key="oeUuid" size="small" round style="margin-right: 4px;">
+                                                                {{ resolveGlobalOutputEventName(oeUuid) }}
+                                                            </n-tag>
+                                                        </template>
+                                                        <span v-else class="text-muted">(none)</span>
+                                                    </div>
                                                     <div v-if="isGlobalInputEventEnabled(gie.uuid)" style="margin-left: 28px; margin-top: 8px;">
                                                         <div style="display: flex; align-items: center; gap: 8px;">
                                                             <n-switch
@@ -1960,6 +1974,16 @@ const allOutputEventsForOverride = computed((): any[] => {
 function isGlobalInputEventEnabled (uuid: string): boolean {
     const ref = getGlobalInputEventRef(uuid)
     return !ref || !ref.disabled
+}
+
+// Resolve an output-event uuid (as carried in a policy rule's
+// `outputEvents` list) to its operator-facing name. Defaults the
+// label to a uuid prefix when the event is missing from the
+// resolved policy — keeps the row legible while still flagging that
+// something is off.
+function resolveGlobalOutputEventName (uuid: string): string {
+    const oe = policyGlobalOutputEvents.value.find((e: any) => e.uuid === uuid)
+    return oe?.name || (uuid ? `(missing: ${uuid.slice(0, 8)})` : '(missing)')
 }
 
 function getGlobalInputEventRef (uuid: string): any {


### PR DESCRIPTION
## Summary

Pairs with rearm-saas PR #136 (backend CLOSE PolicyKind). Adds the new
kind to the agent-policy editor's radio selector + tag rendering, and
seeds a **Require Final Report** CLOSE-kind default alongside the
existing OUTPUT-kind **Require Orientation Report**.

**Why CLOSE matters.** A policy whose satisfying artifact arrives
*after* the agent's last commit (e.g. a FINAL-phase \`AGENTIC_REPORT\`)
deterministically fails on the OUTPUT kind because OUTPUT hardens its
verdict at commit-attribution time. CLOSE keeps the verdict AWAITING
until the session closes, letting late artifacts satisfy the rule.

## Changes

- \`AiAgentPolicyView.vue\` — CLOSE in \`kindOptions\` with help text; sample
  scaffolds for FINAL / any-AGENTIC_REPORT moved to CLOSE so the starter
  tells the truth about lifecycle timing; INIT-phase wording in the OUTPUT
  help updated from PENDING → AWAITING to match the backend's
  \`PolicyState\` enum
- \`AiAgentPoliciesOfOrg.vue\` — Kind column tag handles CLOSE (success
  tone); Populate Defaults now seeds **both** orientation (OUTPUT) and
  final report (CLOSE); page-level tooltip describes the three kinds

## Test plan

- [ ] Edit a policy: kind selector shows INPUT / OUTPUT / CLOSE; hovering
      each radio button surfaces the right help blurb
- [ ] Sample list: "Final report required" and "Any AGENTIC_REPORT
      artifact required" carry the CLOSE tag; clicking either populates
      the form with \`kind=CLOSE\`
- [ ] Policies-of-org table: existing CLOSE rows show a green
      "CLOSE" tag in the Kind column
- [ ] Empty-state Populate Defaults seeds two policies — both visible
      after the populate (orientation OUTPUT, final CLOSE)
- [ ] Session view's policy-events table renders \`kind=CLOSE\` rows in
      the Kind column without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)