### PR TITLE
feat(ui): StatusEnum.JOB — picker option + per-dep tooltip on Actual icon

### DIFF
--- a/ui/src/components/AddComponent.vue
+++ b/ui/src/components/AddComponent.vue
@@ -255,6 +255,7 @@ const addComponentObject = ref({
 const permissionOptions = [
     { label: 'Required', value: 'REQUIRED' },
     { label: 'Transient', value: 'TRANSIENT'},
+    { label: 'Job', value: 'JOB'},
     { label: 'Ignored', value: 'IGNORED'}
 ]
 

--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -1179,7 +1179,7 @@ const patternTableFields: DataTableColumns<any> = [
             h(NTooltip, { trigger: 'hover' }, {
                 trigger: () => h(NIcon, { size: 16, style: { cursor: 'help' } }, { default: () => h(QuestionMark) }),
                 default: () => h('div', { style: { whiteSpace: 'pre-line' } },
-                    'REQUIRED: The dependency is required for the branch to be built.\nIGNORED: The dependency is ignored for the branch to be built.\nTRANSIENT: The dependency is required for the branch to be built, affects matching in the future ReARM DevOps module.'
+                    'REQUIRED: The dependency is required for the branch to be built.\nIGNORED: The dependency is ignored for the branch to be built.\nTRANSIENT: The dependency is required for the branch to be built, affects matching in the future ReARM DevOps module.\nJOB: Schedule-driven workload (k8s Job / CronJob). Included in the instance plan CDX, but excluded from product-release matching so the deployed version is allowed to lag the target until the job next runs.'
                 )
             })
         ]),
@@ -1191,7 +1191,8 @@ const patternTableFields: DataTableColumns<any> = [
                 options: [
                     { label: 'REQUIRED', value: 'REQUIRED' },
                     { label: 'IGNORED', value: 'IGNORED' },
-                    { label: 'TRANSIENT', value: 'TRANSIENT' }
+                    { label: 'TRANSIENT', value: 'TRANSIENT' },
+                    { label: 'JOB', value: 'JOB' }
                 ],
                 onUpdateValue: (val: string) => {
                     row.defaultStatus = val
@@ -1508,7 +1509,8 @@ const effectiveDepTableFields: DataTableColumns<any> = [
                     options: [
                         { label: 'Required', value: 'REQUIRED' },
                         { label: 'Ignored', value: 'IGNORED' },
-                        { label: 'Transient', value: 'TRANSIENT' }
+                        { label: 'Transient', value: 'TRANSIENT' },
+                        { label: 'Job', value: 'JOB' }
                     ],
                     size: 'small'
                 })

--- a/ui/src/components/FeatureSetParticipation.vue
+++ b/ui/src/components/FeatureSetParticipation.vue
@@ -37,11 +37,12 @@ const props = defineProps<{
 const loading = ref(false)
 const rows = ref<any[]>([])
 
-type Status = 'REQUIRED' | 'TRANSIENT' | 'IGNORED'
+type Status = 'REQUIRED' | 'TRANSIENT' | 'JOB' | 'IGNORED'
 
 function statusRank (s: string): number {
-    if (s === 'REQUIRED') return 3
-    if (s === 'TRANSIENT') return 2
+    if (s === 'REQUIRED') return 4
+    if (s === 'TRANSIENT') return 3
+    if (s === 'JOB') return 2
     if (s === 'IGNORED') return 1
     return 0
 }
@@ -101,6 +102,7 @@ function deriveBranchStatus (featureSet: any): Status | null {
 function statusTagType (status: string): 'success' | 'info' | 'warning' | 'default' {
     if (status === 'REQUIRED') return 'success'
     if (status === 'TRANSIENT') return 'info'
+    if (status === 'JOB') return 'info'
     if (status === 'IGNORED') return 'warning'
     return 'default'
 }

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -653,11 +653,11 @@ function buildMatchTooltipBody(row: any) {
         const tag = dep.status && dep.status !== 'REQUIRED'
             ? h('span', { style: 'margin-left: 6px; padding: 1px 6px; border-radius: 4px; background: #e8f1ff; color: #1f5ad3; font-size: 10px; font-weight: 600;' }, dep.status)
             : null
-        lines.push(h('div', { style: 'display: flex; align-items: center; gap: 8px; line-height: 1.5;' }, [
-            h('span', { style: `color: ${iconColor}; font-weight: 700; min-width: 14px;` }, icon),
-            h('span', compName),
+        lines.push(h('div', { style: 'display: flex; align-items: center; gap: 8px; line-height: 1.5; white-space: nowrap;' }, [
+            h('span', { style: `color: ${iconColor}; font-weight: 700; min-width: 14px; flex: 0 0 14px;` }, icon),
+            h('span', { style: 'flex: 0 0 auto;' }, compName),
             tag,
-            h('span', { style: 'color: #666;' }, `: actual ${actV} / target ${tgtV}${note}`)
+            h('span', { style: 'color: #aaa; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis;' }, `actual ${actV} / target ${tgtV}${note}`)
         ]))
     })
     return lines
@@ -1448,7 +1448,8 @@ const matchedProductFields: any[] = [
                 els.push(h(NTooltip, {
                     trigger: 'hover',
                     placement: 'top',
-                    style: { maxWidth: '480px' }
+                    width: 720,
+                    style: { maxWidth: '720px' }
                 }, {
                     trigger: () => h(NIcon, {
                         size: 16,

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -588,6 +588,81 @@ const filteredUnmatchedReleases: ComputedRef<any[]> = computed((): any[] => {
     return list.filter((u: any) => u.namespace === selectedNamespace.value)
 })
 
+// Build the body for the bulls-eye Actual-column tooltip. Lists every
+// feature-set dependency with its target version, the actual deployed
+// version on this instance, and a per-component verdict. JOB-status
+// deps are flagged as "drift OK" (excluded from match by design);
+// TRANSIENT deps still get a check or X based on whether they actually
+// match the target (drift is allowed for them too, but seeing the
+// state is useful). REQUIRED deps drive the green/red overall icon
+// already; the per-row breakdown explains why.
+function buildMatchTooltipBody(row: any) {
+    const lines: any[] = []
+    const headerText = row.notMatchingSince
+        ? `Not matching since ${(new Date(row.notMatchingSince)).toLocaleString('en-CA')}`
+        : 'Matching'
+    lines.push(h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, headerText))
+
+    const deps = (row.featureSetDetails && row.featureSetDetails.dependencies) || []
+    const targetParents = (row.targetReleaseDetails && row.targetReleaseDetails.parentReleases) || []
+    const targetByComponent: Record<string, any> = {}
+    targetParents.forEach((p: any) => {
+        const compUuid = p.releaseDetails && p.releaseDetails.componentDetails && p.releaseDetails.componentDetails.uuid
+        if (compUuid) targetByComponent[compUuid] = p.releaseDetails
+    })
+    const actualReleases = (updatedInstance.value && updatedInstance.value.releases) || []
+    const actualByComponent: Record<string, any> = {}
+    actualReleases.forEach((r: any) => {
+        if (r.namespace !== row.namespace) return
+        const rd = r.releaseDetails
+        const compUuid = rd && rd.componentDetails && rd.componentDetails.uuid
+        if (compUuid && !actualByComponent[compUuid]) actualByComponent[compUuid] = rd
+    })
+
+    if (deps.length === 0) {
+        lines.push(h('div', { style: 'font-style: italic; color: #888;' }, '(feature set has no dependencies)'))
+        return lines
+    }
+
+    deps.forEach((dep: any) => {
+        if (dep.status === 'IGNORED') return // not in CDX, skip
+        const compUuid = dep.uuid
+        const tgt = targetByComponent[compUuid]
+        const act = actualByComponent[compUuid]
+        const compName = (tgt && tgt.componentDetails && tgt.componentDetails.name)
+            || (act && act.componentDetails && act.componentDetails.name)
+            || compUuid
+        const tgtV = tgt ? tgt.version : '—'
+        const actV = act ? act.version : '—'
+        const versionsMatch = tgt && act && tgt.uuid === act.uuid
+        let icon = '✓'
+        let iconColor = '#2da44e'
+        let note = ''
+        if (dep.status === 'JOB') {
+            icon = versionsMatch ? '✓' : '⏳'
+            iconColor = versionsMatch ? '#2da44e' : '#9a6700'
+            note = versionsMatch ? '' : ' (drift OK — schedule-driven, awaiting next run)'
+        } else if (dep.status === 'TRANSIENT') {
+            icon = versionsMatch || !act ? '✓' : '✗'
+            iconColor = (versionsMatch || !act) ? '#2da44e' : '#cf222e'
+            note = !versionsMatch && act ? ' (drift; TRANSIENT match allows asymmetry only)' : ''
+        } else {
+            icon = versionsMatch ? '✓' : '✗'
+            iconColor = versionsMatch ? '#2da44e' : '#cf222e'
+        }
+        const tag = dep.status && dep.status !== 'REQUIRED'
+            ? h('span', { style: 'margin-left: 6px; padding: 1px 6px; border-radius: 4px; background: #e8f1ff; color: #1f5ad3; font-size: 10px; font-weight: 600;' }, dep.status)
+            : null
+        lines.push(h('div', { style: 'display: flex; align-items: center; gap: 8px; line-height: 1.5;' }, [
+            h('span', { style: `color: ${iconColor}; font-weight: 700; min-width: 14px;` }, icon),
+            h('span', compName),
+            tag,
+            h('span', { style: 'color: #666;' }, `: actual ${actV} / target ${tgtV}${note}`)
+        ]))
+    })
+    return lines
+}
+
 const instanceData: ComputedRef<any> = computed((): any => store.getters.instanceById(instanceUuid, -1))
 const instanceWord: ComputedRef<any> = computed((): any => props.instanceType === InstanceType.CLUSTER ? 'Cluster' : 'Instance')
 const cluster: ComputedRef<any> = computed((): any => {
@@ -1371,7 +1446,9 @@ const matchedProductFields: any[] = [
 
             if(row.matchedRelease){
                 els.push(h(NTooltip, {
-                    trigger: 'hover'
+                    trigger: 'hover',
+                    placement: 'top',
+                    style: { maxWidth: '480px' }
                 }, {
                     trigger: () => h(NIcon, {
                         size: 16,
@@ -1379,7 +1456,7 @@ const matchedProductFields: any[] = [
                     }, {
                         default: () => h(Target20Regular)
                     }),
-                    default: () => row.notMatchingSince ? 'Not Matching Since:' + (new Date(row.notMatchingSince)).toLocaleString('en-CA') : 'Matching'
+                    default: () => buildMatchTooltipBody(row)
                 }))
 
                 els.push(h('span', [

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -185,6 +185,17 @@ const INSTANCE_GQL_DATA = `
         targetRelease
         targetReleaseDetails {
             version
+            parentReleases {
+                release
+                releaseDetails {
+                    uuid
+                    version
+                    componentDetails {
+                        uuid
+                        name
+                    }
+                }
+            }
         }
         identifier
         configuration


### PR DESCRIPTION
## Summary

Pairs with rearm-saas \`feat-dep-status-job\` which adds JOB to the dep status enum.

- Adds **JOB** to the dep-status picker in all three places: BranchView's inline editor (two variants) and AddComponent's permissionOptions.
- FeatureSetParticipation status rank / tag-type updated so JOB sorts correctly and renders with the same 'info' tone as TRANSIENT.
- **Bulls-eye Actual-column tooltip** on the Product Releases table now lists every feature-set dep with its target version vs actual deployed version, status tag, and a per-row verdict:
  - ✓ versions agree
  - ✗ REQUIRED dep with drift (the case that drives the overall red icon)
  - ⏳ JOB dep with drift — 'schedule-driven, awaiting next run' (drift is OK by design)
- GraphQL fragment for \`productPlans.targetReleaseDetails\` now pulls \`parentReleases\` with release / component metadata so the tooltip can compute the breakdown client-side without an extra fetch.

The overall green/red icon still drives off \`matchedRelease\` / \`notMatchingSince\` exactly as before — the tooltip just explains *why* the icon is what it is.

## Replaces

Closed PR #82, which exposed the same option on the component-kind picker. JOB is more naturally a per-feature-set dep status, not a component-global property.

## Test plan

- [ ] Edit a feature set's deps: JOB shows up in every status dropdown
- [ ] Open an instance with a JOB-status dep and a target whose JOB version is newer than what's deployed → product map stays matched, tooltip shows ⏳ on that row
- [ ] When all REQUIRED deps agree, overall icon green; tooltip header reads 'Matching'
- [ ] When a REQUIRED dep drifts, overall icon red, tooltip header reads 'Not matching since …', row shows ✗

🤖 Generated with [Claude Code](https://claude.com/claude-code)