### PR TITLE
feat(ui): render Instance Agent Data through PrismEditor (read-only JSON)

### DIFF
--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -198,7 +198,13 @@
             style="width: 90%;"
             title="Instance Agent Data"
         >
-            <div><pre style="white-space: pre-wrap;"> {{ updatedInstance.agentData }} </pre></div>
+            <prism-editor
+                class="editor agentDataEditor"
+                v-model="prettyAgentData"
+                :highlight="jsonHighlighter"
+                :readonly="true"
+                line-numbers
+            ></prism-editor>
         </n-modal>
         <n-modal
             v-model:show="showProductPublicVersionModal"
@@ -1368,6 +1374,29 @@ const highlighter = function (code: string) {
     return prism.highlight(code, prism.languages[lang], lang)
 }
 
+// Pretty-printed JSON for the Agent Data modal. The watcher ships a
+// JSON string in updatedInstance.agentData; we re-parse + indent so
+// PrismEditor renders it readable instead of a single squashed line.
+// Falls back to the raw string when the payload isn't valid JSON
+// (legacy data, or a watcher mode that ships YAML / plain text).
+const prettyAgentData = computed<string>({
+    get() {
+        const raw = updatedInstance.value && updatedInstance.value.agentData
+        if (!raw) return ''
+        try {
+            return JSON.stringify(JSON.parse(raw), null, 2)
+        } catch {
+            return raw
+        }
+    },
+    // Editor is :readonly so writes never fire, but v-model still
+    // demands a setter — no-op.
+    set() {}
+})
+const jsonHighlighter = function (code: string) {
+    return prism.highlight(code, prism.languages.json, 'json')
+}
+
 // n-data-table
 const matchedProductFields: any[] = [
     {
@@ -2287,6 +2316,10 @@ await onCreate()
     line-height: 1.5;
     padding: 5px;
   }
+.agentDataEditor {
+    max-height: 70vh;
+    overflow: auto;
+}
 .dangerZone {
     margin-top: 32px;
     padding-top: 16px;


### PR DESCRIPTION
## Summary

The Instance Agent Data modal previously rendered the watcher payload as a bare \`<pre>{{ updatedInstance.agentData }}</pre>\` — single squashed JSON blob with no indentation or syntax colouring. For larger payloads (multiple pods × containers × volumeMounts) effectively unreadable.

Now uses the same \`PrismEditor\` already used by the property editor in this file, configured \`:readonly="true"\`. A \`prettyAgentData\` computed runs \`JSON.parse + JSON.stringify(_, null, 2)\` so the content is properly indented; falls back to the raw string when the payload isn't valid JSON, so legacy / non-JSON watcher payloads still render without crashing.

\`jsonHighlighter\` is a thin wrapper around Prism's JSON grammar — kept separate from the existing \`highlighter\` helper (which is property-editor-specific and looks at \`focusedProperty.dataType\`).

A 70vh \`max-height\` + \`overflow: auto\` on the editor keeps the modal sized to viewport instead of growing arbitrarily for large dumps.

## Test plan

- [ ] Open an instance with watcher-reported agent data → click the info icon → modal shows pretty-printed JSON with syntax highlighting + line numbers, read-only.
- [ ] Open an instance with no agent data → modal renders empty editor (no crash).
- [ ] If the watcher reports invalid JSON for any reason, modal shows the raw string verbatim (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)