### PR TITLE
docs(docsite): refresh agentic workflow — left menu + per-agent self-enrolment + CLOSE/FINAL alignment

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -17,6 +17,7 @@ function sidebar() {
         {text: 'Installation', link: '/installation/'},
         {text: 'Concepts', link: '/concepts/'},        
         {text: 'Workflows', link: '/workflows/', items: [
+          {text: 'Bootstrap an AI Agent', link: '/workflows/agentic'},
           {text: 'Bundling & Auto-Integrate', link: '/workflows/bundling'},
           {text: 'License Compliance', link: '/workflows/license-compliance'},
           {text: 'Auditing Findings', link: '/workflows/auditing-findings'},

--- a/documentation_site/docs/integrations/rearmcli.md
+++ b/documentation_site/docs/integrations/rearmcli.md
@@ -3,3 +3,10 @@
 Open source Rearm CLI project can be found at <https://github.com/relizaio/rearm-cli>. Documentation can be found in the same repository.
 
 This project provides variety of common integration scenarios with Reliza's ReARM and can be used in any home-made or 3rd party tool.
+
+The CLI also carries the **`rearm agent`** subcommand family
+(`session init / show / touch / close / add-artifact / inbox`,
+plus `enrollkey`) — these are what an AI coding agent runs against
+a ReARM Pro instance after the operator hands it the FREEFORM
+`AGENT` key. See [Bootstrap an AI Agent](../workflows/agentic) for
+the operator-facing setup and the agent-side contract URL.

--- a/documentation_site/docs/workflows/agentic.md
+++ b/documentation_site/docs/workflows/agentic.md
@@ -10,9 +10,26 @@ The agent itself **does not need to read this page** — its contract lives at `
 
 ## Prerequisites
 
+The operator's setup is intentionally minimal — two things, both
+one-time per agent identity:
+
 1. **A ReARM Pro org** the agent will work under.
-2. **A FREEFORM API key** scoped to that org with `PermissionFunction.AGENT` at `ORGANIZATION` scope. `ESSENTIAL_READ` is the minimum permission type — the agent surface intentionally accepts the floor so an agent-flow key doesn't have to carry broader rights. Mint the key from **Settings → API Keys → Add FREEFORM key** in the ReARM UI, then attach the `AGENT` function on the org scope from the permissions panel. The plaintext secret is shown **only once** on creation — capture it immediately into your secret store.
-3. **An SSH or GPG signing key for the agent**, enrolled under the agent identity via `rearm agent enrollkey`. Without an enrolled key the agent's commits won't pass the signed-commit gate. The agent can self-enrol its own pub key on first run using the same FREEFORM AGENT key from step 2 (an intentional carve-out — `enrollSigningKeyProgrammatic` only allows an agent key to attach a key to its own identity, never another agent's) so the operator doesn't have to pre-provision this.
+2. **A FREEFORM API key** scoped to that org with `PermissionFunction.AGENT` at `ORGANIZATION` scope. `ESSENTIAL_READ` is the minimum permission type — the agent surface intentionally accepts the floor so an agent-flow key doesn't have to carry broader rights. Mint the key from **Org Settings → API Keys → Add FREEFORM key** in the ReARM UI, then attach the `AGENT` function on the org scope from the permissions panel. The plaintext secret is shown **only once** on creation — capture it immediately into your secret store.
+
+That's it. **You do not provision a signing key for the agent.** The
+agent generates and self-enrols its own SSH or GPG key on first run
+(via `rearm agent enrollkey`, using the same FREEFORM `AGENT` key
+from step 2 — an intentional carve-out where an agent key can attach
+a public key to *its own* identity but never another agent's). This
+keeps the private signing material on the agent host where it lives
+naturally and never has to cross into the operator's control —
+treat the operator role as "key issuer" for the API surface, not
+"key custodian" for commit signing.
+
+The agent-side contract for this — when it happens, what it sends,
+how rotation works — is documented at the agent contract URL
+(`$REARM_URL/api/agents/orientation.md` §2.4); operators don't need
+to read it, the agent does.
 
 ## Starting an agent
 
@@ -43,11 +60,52 @@ Standard secrets-manager practice applies. Don't bake the API key into shell his
 
 Once pointed at the orientation doc:
 
-1. **Init a session** with a unique `clientSessionId` and the agent's display name + model.
-2. **Submit an orientation artifact** (`AGENTIC_REPORT`) describing the plan. Without this, the org's default "Orientation report required" policy will reject every commit the agent produces.
-3. **Author signed, trailered commits**. The trailers (`ReARM-Agentic-Session:` + `ReARM-Agent:`) are how ReARM attributes each commit back to the session. Without them, commits are unattributed and the session-policy gates can fire.
-4. **Poll the inbox** every 30-60 seconds while waiting on downstream events — release lifecycle changes, human approval/disapproval verdicts, new session policy verdicts. The orientation doc describes the polling shape (`agentSessionInboxProgrammatic`) and the cursor semantics.
-5. **Close the session** when work is complete. Or just stop polling; idle sessions autoclose.
+1. **Init a session** with a unique `clientSessionId` and the agent's display name + model. The `init` response carries `policyEvents[]` — one entry per active agent policy in the org with its current verdict (`PASSED` / `AWAITING` / `FAILED` / `WARNING`). The agent reads this to learn what the org expects of this session.
+2. **Self-enrol a signing key** on first run (once per agent identity). The agent generates an SSH or GPG keypair on its own host and attaches the public half via `rearm agent enrollkey`. See [Prerequisites](#prerequisites).
+3. **Submit an orientation artifact** (`AGENTIC_REPORT`, tag `agenticPhase=ORIENTATION`) if the org's policies require one. The canonical case is a policy whose CEL pattern is `!session.artifacts.exists(a, a.type == "AGENTIC_REPORT" && ... ORIENTATION ...)` — when present, the orientation artifact must land *before* the agent's commits, or the policy hardens to `FAILED` at commit-attribution time. The agent decides whether one is required by reading `policyEvents[]` from `init`.
+4. **Author signed, trailered commits**. The trailers (`ReARM-Agentic-Session:` + `ReARM-Agent:`) are how ReARM attributes each commit back to the session. Without them, commits are unattributed and session-policy gates can fire.
+5. **Poll the inbox** every 60 seconds while waiting on downstream events — release lifecycle changes, human approval/disapproval verdicts, post-init policy verdicts. The orientation doc describes the polling shape (`agentSessionInboxProgrammatic`) and the cursor semantics, and explicitly tells the agent not to poll mid-task (only between major tasks).
+6. **Submit a final report** (`AGENTIC_REPORT`, tag `agenticPhase=FINAL`) just before closing. Recommended in every session for the operator's audit; *required* when the org has enabled a `CLOSE`-kind policy gating on it (see [Agent policies](#agent-policies)).
+7. **Close the session** with `rearm agent session close <uuid>` when work is complete. This locks `CLOSE`-kind policy verdicts to their final value (a missing FINAL report → `FAILED` here, which downstream release-side gates can read via `release.agentSessions.exists(s, s.hasFailedPolicy)`).
+
+## Agent policies
+
+Operators configure CEL-based **agent policies** (Org Settings →
+Policies → AI Agent Policies tab) that ReARM evaluates against each
+session. Three kinds, distinguished by *when* their verdict locks:
+
+| Kind     | Lifecycle phase verdict locks                                  | Typical use                                                                                  |
+| -------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `INPUT`  | At `session init`. `BLOCK`-severity failures refuse the session outright (status `BLOCKED`). | Allowlists you want enforced before any work happens — model, agent identity, branch.        |
+| `OUTPUT` | At commit-attribution time. Verdict hardens when the first commit attributed to the session lands. | "Agent must produce X by commit-time" — e.g. the orientation report.                          |
+| `CLOSE`  | At `session close`. Stays `AWAITING` for the whole session and only locks on close. | Gates that depend on artifacts the agent files at the very end — e.g. the FINAL report tag.   |
+
+`CLOSE` exists for the case where the satisfying artifact arrives
+*after* the agent's last commit. An `OUTPUT`-kind rule on a FINAL
+report would deterministically harden to `FAILED` at commit-
+attribution (the report hasn't been filed yet); a `CLOSE`-kind rule
+lets the session keep the verdict `AWAITING` until close, so a
+correctly-behaved agent can land it just before exit and pass.
+
+Each policy has a `BLOCK` or `WARN` severity:
+
+- `BLOCK` — failure hardens to `FAILED` on the session.
+  Downstream release gates can read
+  `release.agentSessions.exists(s, s.hasFailedPolicy)` and reject
+  the release; `BLOCK` `INPUT` policies refuse the session at init.
+- `WARN` — failure records a `WARNING` verdict on the session log
+  but never blocks anything.
+
+Each session's `policyEvents[]` (visible in the UI session view and
+returned on `init` / `show` / `close` to the agent) records the
+current verdict per policy with the evaluation timestamp, so the
+audit trail captures both the rule and its outcome.
+
+Policies are entirely operator-configurable — there is no built-in
+"default" set. The **Populate Defaults** button on the AI Agent
+Policies page seeds a sensible starter pair (orientation OUTPUT +
+final-report CLOSE) for a brand-new org; edit / disable / replace
+freely.
 
 ## Closed-loop disapproval → fix
 
@@ -58,9 +116,9 @@ The canonical demo:
 3. Agent polls the inbox, sees an `APPROVAL` event with `newValue=DISAPPROVED` and the reviewer's comment in `reason`.
 4. Agent **stays in the same session**, addresses the comment, pushes a new signed commit on the same branch (PR auto-updates).
 5. Reviewer hits **Approve**.
-6. Agent sees the `APPROVED` event, closes the session.
+6. Agent attaches a FINAL report and closes the session.
 
-Every step is in the audit trail: session row, commits with their attribution, releases with `updateEvents[].message` carrying the rejection reason, approval events with comments. The orientation artifact attached at step 1 is what allowed any of this to happen.
+Every step is in the audit trail: session row, commits with their attribution, releases with `updateEvents[].message` carrying the rejection reason, approval events with comments. The orientation artifact at step 1 and the final report at step 6 bracket the session's audit story.
 
 ## When the agent will stop
 
@@ -80,10 +138,12 @@ Each step shows up as a queryable row:
 | -------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | Session opened                         | `agent_sessions` row, `status = OPEN`                                                                       |
 | Session blocked by INPUT policy        | `agent_sessions` row, `status = BLOCKED`, `policyEvents[]` with the failing verdict                          |
-| Orientation artifact attached          | `agent_sessions.artifacts[]` + `agent_sessions.policyEvents[]` (PASSED entry on orientation policy)          |
+| Orientation artifact attached          | `agent_sessions.artifacts[]` + `agent_sessions.policyEvents[]` (PASSED entry on the orientation policy)      |
 | Commit attributed                      | `source_code_entries.{agent, agentSession, attributionState}`                                                |
 | Release lifecycle change by CEL gate   | `releases.update_events[]` with `rus=LIFECYCLE`, `message="Triggered by '…' (CEL: …)"`                       |
 | Human approval / disapproval           | `releases.approval_events[]` with `state`, `comment`, `wu.lastUpdatedBy`                                     |
+| FINAL report attached                  | `agent_sessions.artifacts[]` with tag `agenticPhase=FINAL`                                                   |
+| Session closed                         | `agent_sessions.status = CLOSED`, `closedAt` set; `CLOSE`-kind verdicts lock here                            |
 | PR linked to session                   | `pull_requests.commits[]` includes an SCE attributed to the session; resolved via `Session.pullRequests`     |
 | Agent retried after BLOCKED            | New `agent_sessions` row with `parentSession` pointing at the prior BLOCKED row                              |
 
@@ -95,12 +155,13 @@ Worth being honest about so you don't build expectations around things that don'
 
 - **Signed commits only verify SSH and GPG.** X.509 / sigstore (cosign keyless, Gitsign) signatures land with verdict `ERRORED` — the verdict row is still written so the audit trail is honest, but the signed-commit gate won't pass for them. If your team signs with sigstore, plan to enrol SSH or GPG keys for ReARM-attributed work until the X.509 verifier ships.
 - **No VSA emission.** ReARM records its verification verdict per signature internally, but does not yet mint a [SLSA Verification Summary Attestation](https://slsa.dev/spec/v1.0/verification_summary) ("ReARM verified release R passed policy P at time T") that downstream consumers can pin against. If you need a portable, signed verdict to hand off to a registry / deploy gate, that piece is on the roadmap, not in v1.
-- **No outbound webhooks** scoped per agent. The agent polls; ReARM doesn't push. Polling at 30-60s is plenty for any reviewer-driven workflow.
+- **No outbound webhooks** scoped per agent. The agent polls; ReARM doesn't push. Polling at the orientation doc's prescribed 60-second cadence is plenty for any reviewer-driven workflow.
 - **No `rearm agent spawn`** in the published CLI. Sub-agent registration is on the API but the convenience command isn't shipped yet; sub-agents currently stamp the root agent's uuid in their trailers.
-- **No model-card auto-attach.** If a policy checks `model.modelCard != ""`, the operator must attach a model card via `rearm agent model attach` before the agent's session init will pass.
+- **No model-card auto-attach.** ReARM auto-registers a `ModelOntology` row on first session init for any (name, version, vendor) tuple it hasn't seen, but the row's `modelCard` field is left empty. If a policy checks `model.modelCard != ""`, an operator must attach the card on the `ModelOntology` row from the ReARM UI before the agent's session init will pass — the agent can't do it.
 
 ## Reference
 
-- **Agent contract**: `$REARM_URL/api/agents/orientation.md` — pinned to the backend version.
+- **Agent contract**: `$REARM_URL/api/agents/orientation.md` — pinned to the backend version (Pro and CE serve the same document; Pro-only sections are labelled). The agent fetches this on startup; operators don't need to read it, but it's the source of truth on the agent's side of the contract — phase semantics, policy verdicts, signing-key enrolment cadence, and the precise CLI commands the agent will run.
 - **CEL surface for agent policies**: `session.*`, `agent.*`, `model.*` — explore via the CEL helper picker inside the policy editor; every helper carries a tooltip with its return shape and an example.
-- **Component-level CEL gates** that interact with agent sessions: `release.agentSessions[].hasFailedPolicy`, `release.commits[].attribution.state`, `release.commits[].signature.state`. The first two are agentic-specific; the third is the signed-commits gate.
+- **Component-level CEL gates** that interact with agent sessions: `release.agentSessions[].hasFailedPolicy`, `release.commits[].attribution.state`, `release.commits[].signature.state`. The first two are agentic-specific; the third is the [signed-commits gate](../concepts/) (works on any commit, not just agent ones).
+- **ReARM CLI**: [`rearm agent ...`](../integrations/rearmcli) subcommands are what the agent uses — `session init / show / touch / close / add-artifact / inbox` and `agent enrollkey`. The CLI is the only sanctioned programmatic surface (raw HTTP is WAF-blocked in many deployments); operators don't run these by hand, but the help output is the quickest way to see the current command surface.

--- a/documentation_site/docs/workflows/index.md
+++ b/documentation_site/docs/workflows/index.md
@@ -4,6 +4,7 @@ sidebarDepth: 2
 
 # ReARM Workflows
 
+- [Bootstrap an AI Agent](./agentic)
 - [Bundling & Auto-Integrate](./bundling)
 - [License Compliance](./license-compliance)
 - [Auditing Findings](./auditing-findings)


### PR DESCRIPTION
## Summary

Operator-side docsite refresh for the agentic workflow. Four parts:

1. **Sidebar exposure.** `workflows/agentic` was reachable only by direct URL — added to the Workflows sidebar block in `.vitepress/config.mjs` and to `workflows/index.md`.
2. **Self-enrol clarification.** Prerequisites #3 led with "an SSH or GPG signing key for the agent, enrolled via `rearm agent enrollkey`" and only mentioned the agent self-enrols at the tail of the same paragraph. Reframed: two operator-side prerequisites (org + FREEFORM `AGENT` key), explicit "you do not provision a signing key", short rationale on the key-issuer vs key-custodian split.
3. **Cross-links.** `integrations/rearmcli.md` now points at the agentic workflow; `workflows/agentic.md` Reference block points back at the CLI page; both reference `$REARM_URL/api/agents/orientation.md` with the §-level subsection an operator might want.
4. **Design re-verify** against the live `/api/agents/orientation.md` (`last_updated: 2026-05-27`):
   - New **Agent policies** section explaining `INPUT` / `OUTPUT` / `CLOSE` kinds + `BLOCK`/`WARN` severity, with the rationale for `CLOSE`.
   - **"What the agent does on its own"** expanded from 5 to 7 steps to include self-enrol + FINAL report. Polling cadence 30-60s → 60s, picked up the "between major tasks, not mid-task" guidance.
   - Orientation policy wording softened from "the org's default policy will reject every commit" to "if the org's policies require one … the policy hardens to FAILED" (policies are operator-configurable, no built-in defaults; **Populate Defaults** is a seed button, not policy-as-product).
   - Audit-trail table: added rows for **FINAL report attached** and **Session closed**; closed-loop demo now ends with attach FINAL + close.
   - v1 "no `rearm agent model attach`" item rewritten — that CLI command never existed; the actual state is auto-registered `ModelOntology` with an empty `modelCard` field that operators populate via the UI.

## Test plan

- [ ] `docs/.vitepress/config.mjs` — Bootstrap an AI Agent appears first under Workflows in the left sidebar
- [ ] `/workflows/agentic` renders cleanly (no broken cross-link); CEL code blocks fall back to `txt` highlighter (pre-existing, harmless)
- [ ] Live orientation contract URL still resolves on the user's deployment

## Provenance

This PR was authored end-to-end by an AI coding agent under ReARM session `docsite-agentic-cleanup-1779929956` (agent `703fbe71-…`). The commit carries the standard `ReARM-Agentic-Session` + `ReARM-Agent` trailers. Final session report will be filed on the session before close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)