### PR TITLE
docs(orientation): spell out commit-trailer placement rules

### DIFF
--- a/backend/src/main/resources/static/agents/orientation.md
+++ b/backend/src/main/resources/static/agents/orientation.md
@@ -1,7 +1,7 @@
 ---
 rearm_cli_min: 26.05.8
 rearm_cli_recommended: 26.05.10
-last_updated: 2026-05-20
+last_updated: 2026-05-28
 ---
 
 # ReARM agent orientation
@@ -281,24 +281,81 @@ artifact for the operator's audit.
 
 ### 2.6 Commit trailers
 
-Every commit you author needs the canonical two-line trailer block:
+Every commit you author MUST carry two trailers in the commit
+message's **trailer block** — the final paragraph of the message,
+each trailer on its own line:
 
 ```
 <your normal commit subject>
 
-<your normal commit body>
+<your normal commit body — any length, any structure>
 
-ReARM-Agentic-Session: <clientSessionId-you-picked>
+ReARM-Agentic-Session: <clientSessionId-you-picked-at-init>
 ReARM-Agent: <root-agent-uuid-from-init>
 ```
 
-`ReARM-Agentic-Session` is the **free-form string** you chose at
-`init` (not the row uuid). Both trailers are case-insensitive on the
-key and the value runs to first whitespace. Order doesn't matter,
-both must be present.
+- `ReARM-Agentic-Session` is the **free-form string** you chose at
+  `init` (not the row uuid).
+- `ReARM-Agent` is the root-agent uuid returned by `init`.
+- Keys are case-insensitive; values run to the first whitespace.
+- Order between the two trailers does not matter; both must be
+  present.
 
 Sign the commit with the key you enrolled in §2.4. An unsigned commit
 will be rejected by the signature gate on the component side.
+
+#### Why placement matters — read once, never get it wrong
+
+ReARM extracts these via
+`git log --pretty='… %(trailers:key=ReARM-Agent,key=ReARM-Agentic-Session,unfold,separator=%x20)'`.
+That `%(trailers:…)` placeholder invokes git's **standard trailer
+parser**, which has one hard rule: it only inspects the **last
+paragraph** of the commit message — where "paragraph" means a run of
+non-empty lines bounded by blank lines or the end of the message.
+Anything earlier is body prose and is silently discarded.
+
+If the parser sees no `ReARM-Agent` / `ReARM-Agentic-Session`
+trailers, the `addrelease` call ships only the bare subject and your
+commit lands as `signature=UNKNOWN_KEY`, **unattributed to any agent
+or session** — even though the trailers are visible to a human
+reading the message. There is no second, more lenient parser
+downstream.
+
+#### Self-check before every push
+
+```bash
+git log -1 --format=%B | git interpret-trailers --parse
+```
+
+Both `ReARM-Agentic-Session:` and `ReARM-Agent:` MUST appear in the
+output. If only one appears, or only `Co-Authored-By:` appears, or
+the output is empty — the commit is broken. Amend the commit
+message (`git commit --amend`) and re-check before pushing.
+
+#### Common mistakes that silently break attribution
+
+| What you did                                                              | Why it fails                                                              |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Put both trailers on one line (`ReARM-Agentic-Session: foo ReARM-Agent: bar`) | Git accepts only **one** trailer per line. The second key is treated as the first trailer's value. |
+| Put the trailers at the **top** of the body (right after the subject)     | They're in the first paragraph, not the last — the parser ignores them.   |
+| Put them in the **middle** of the body                                    | Same — only the final paragraph counts as the trailer block.              |
+| Put them at the end but separated from another trailer (e.g. `Co-Authored-By:`) by a blank line | The blank line splits the trailer block in two; only the truly final paragraph is parsed. |
+| Mixed them into a paragraph with prose sentences                          | Git rejects the whole paragraph as non-trailer because most of it isn't `Key: Value`. |
+
+If you include `Co-Authored-By:` or any other trailer (from a coding
+tool's signature, from a hook), **all trailers must live in the same
+final paragraph, contiguous, one per line — no blank lines between
+them**:
+
+```
+... body ...
+
+ReARM-Agentic-Session: auth-bug-fix-1779124086
+ReARM-Agent: 8a44b1ce-7e29-4a6f-9c87-1f0a45e9d8b1
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+#### What ReARM does with valid trailers
 
 The trailers surface back as `SourceCodeEntry.agent` and
 `SourceCodeEntry.agentSession` once a CI run picks up the commit via


### PR DESCRIPTION
## Summary

- Rewrites orientation §2.6 so reading agents cannot misread the canonical commit-trailer format.
- Adds explicit final-paragraph rule, one-trailer-per-line rule, contiguity-with-other-trailers rule, plus a short explanation of git's trailer parser so agents understand the *why*.
- Adds a pre-push self-check (`git interpret-trailers --parse`) and a common-mistakes table covering the variants we observed in the wild.
- CE mirror of the same change in `relizaio/rearm-saas` (same body text, different section number — Pro version is §2.7 because CE doesn't have the final-session-report section).

## Why now

A live agent run authored https://github.com/relizaio/rearm-cli/commit/39c0bf411534d944e6737f702de4dfdda7885878 with the two ReARM trailers concatenated on a single line at the **top** of the commit body, followed by ~30 lines of explanation, then a `Co-Authored-By:` line at the end. `git log --pretty='%(trailers:...)'` (the format used by rearm-actions/initialize) returned **empty** — git's trailer parser only inspects the final paragraph. The addrelease call shipped only the bare subject; the SCE landed as `signature=UNKNOWN_KEY`, unattributed.

Action wiring is correct. The agent simply had room to misread the previous doc's instructions. Tightening the doc closes that gap.

## Test plan

- [ ] Render the doc and skim §2.6 — instructions are unambiguous on placement, line separation, and contiguity with other trailers.
- [ ] Compare with the Pro PR in `relizaio/rearm-saas` (same body text, §2.7 there).
- [ ] Confirm `last_updated` front-matter is bumped to 2026-05-28.