### PR TITLE
fix(instance-view): export side-by-side release as OBOM via GraphQL

### DIFF
--- a/ui/src/components/ReleaseRevision.vue
+++ b/ui/src/components/ReleaseRevision.vue
@@ -2,8 +2,8 @@
     <div class="container">
         <div class="instanceView" v-if="release && release.version">
             <h5 v-if="release">Release: {{release.componentDetails.name}}, version {{release.version}}
-                <a :href="'/api/manual/v1/release/exportAsBom/' + releaseUuid" target="_blank" rel="noopener noreferrer">
-                    <n-icon class="clickable icons" title="Show as CycloneDX JSON" size="20"><Download /></n-icon>
+                <a href="#" @click.prevent="exportReleaseObom">
+                    <n-icon class="clickable icons" title="Export as OBOM (CycloneDX JSON)" size="20"><Download /></n-icon>
                 </a>
             </h5>
             <div v-if="release" class="mb-3 settingsBlock">
@@ -277,6 +277,29 @@ const diffedProducts: ComputedRef<any[]> = computed((): any => {
     }
     return diffedProducts
 })
+
+const exportReleaseObom = async function () {
+    try {
+        const gqlResp: any = await graphqlClient.query({
+            query: gql`
+                query exportAsObomManual($releaseUuid: ID!) {
+                    exportAsObomManual(releaseUuid: $releaseUuid)
+                }
+            `,
+            variables: { releaseUuid: releaseUuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        const fileName = releaseUuid.value + '-obom.json'
+        const blob = new Blob([gqlResp.data.exportAsObomManual], { type: 'application/json' })
+        const link = document.createElement('a')
+        link.href = window.URL.createObjectURL(blob)
+        link.download = fileName
+        link.click()
+        notify('info', 'Processing Download', 'Your OBOM is being downloaded...')
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    }
+}
 
 const copyToClipboard = async function (text: string) {
     try {


### PR DESCRIPTION
## Summary

In the instance-view side-by-side release comparison (`ReleaseRevision.vue`), the per-release "export" download icon linked to `/api/manual/v1/release/exportAsBom/<uuid>` — a REST endpoint that is **not implemented**, so clicking it (notably on the right-side release when comparing non-matched releases) 404'd.

Replace the broken link with the `exportAsObomManual` GraphQL query plus a client-side Blob download, mirroring the OBOM export already used in `ReleaseView.vue` (`exportReleaseObom`). The icon now downloads `<release-uuid>-obom.json`.

## Changes

- `ui/src/components/ReleaseRevision.vue`
  - Anchor `:href="'/api/manual/v1/release/exportAsBom/' + releaseUuid"` → `@click.prevent="exportReleaseObom"`.
  - New `exportReleaseObom()` running `exportAsObomManual(releaseUuid)` and triggering a Blob download; errors surfaced via the existing `notify` helper.

## Test plan

- [ ] Open an instance, compare two revisions where a release exists on one side but not the other (non-matched).
- [ ] Click the download icon on each side's release header — both download a valid CycloneDX OBOM JSON (no 404).
- [ ] Confirm the file is named `<release-uuid>-obom.json` and contains the OBOM.
