### PR TITLE
feat(agent-ui): FREEFORM-key<->agent binding viz + edit signing-key identity

### DIFF
--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -113,6 +113,25 @@
                             </a>
                         </span>
                     </n-descriptions-item>
+                    <n-descriptions-item>
+                        <template #label>
+                            Bound API key(s)
+                            <n-tooltip trigger="hover" :width="320">
+                                <template #trigger>
+                                    <n-icon size="12" class="help-icon"><Info20Regular/></n-icon>
+                                </template>
+                                FREEFORM API key(s) bound to this agent's identity — the
+                                credential an agent runtime authenticates with to drive this
+                                agent. Manage them under Org Settings › Free Form Keys.
+                            </n-tooltip>
+                        </template>
+                        <span v-if="boundApiKeys.length">
+                            <code v-for="(k, idx) in boundApiKeys" :key="k.uuid" class="bound-key">
+                                <span v-if="idx > 0">, </span>{{ apiKeyLabel(k) }}
+                            </code>
+                        </span>
+                        <span v-else class="dim">—</span>
+                    </n-descriptions-item>
                     <n-descriptions-item label="Type">{{ agent.agentType }}</n-descriptions-item>
                     <n-descriptions-item label="Status">{{ agent.status }}</n-descriptions-item>
                     <n-descriptions-item label="Model">
@@ -166,6 +185,14 @@ const savingNotes = ref<boolean>(false)
 
 const openSessions = computed(() => agent.value?.openSessions ?? [])
 const closedSessions = computed(() => agent.value?.closedSessions ?? [])
+
+const boundApiKeys = computed(() => agent.value?.boundApiKeys ?? [])
+
+function apiKeyLabel (k: any): string {
+    let label = (k.type || 'FREEFORM') + '__' + k.object
+    if (k.keyOrder) label += '__ord__' + k.keyOrder
+    return label
+}
 
 const identityShareCount = computed(() => 1 + siblingAgents.value.length)
 

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -2,14 +2,24 @@
     <div class="aiAgentView" v-if="agent">
         <n-breadcrumb separator="›" class="crumbs">
             <n-breadcrumb-item @click="openAgentsOfOrg">AI Agents</n-breadcrumb-item>
-            <n-breadcrumb-item>{{ agent.name }}</n-breadcrumb-item>
+            <n-breadcrumb-item>{{ agentDisplay }}</n-breadcrumb-item>
         </n-breadcrumb>
         <div class="hero">
             <div class="hero__mark" :style="{ background: agent.color || '#888' }">
                 {{ agent.iconKind || '◆' }}
             </div>
             <div class="hero__title">
-                <h3>{{ agent.name }}</h3>
+                <div v-if="!editingName" class="hero__name-row">
+                    <h3>{{ agentDisplay }}</h3>
+                    <n-button v-if="isOrgAdmin" size="tiny" quaternary class="hero__edit-name"
+                              title="Edit display name" @click="startEditName">Edit</n-button>
+                </div>
+                <div v-else class="hero__name-edit">
+                    <n-input v-model:value="nameDraft" size="small" placeholder="Display name (blank = use registration name)"
+                             style="max-width: 320px;" @keyup.enter="saveName"/>
+                    <n-button size="small" type="primary" :loading="savingName" @click="saveName">Save</n-button>
+                    <n-button size="small" quaternary @click="editingName = false">Cancel</n-button>
+                </div>
                 <div class="hero__ids">
                     <n-tooltip trigger="hover">
                         <template #trigger>
@@ -182,6 +192,20 @@ const tab = ref<string>('open')
 const editingNotes = ref<boolean>(false)
 const notesDraft = ref<string>('')
 const savingNotes = ref<boolean>(false)
+const editingName = ref<boolean>(false)
+const nameDraft = ref<string>('')
+const savingName = ref<boolean>(false)
+
+const myUser = computed<any>(() => store.getters.myuser)
+const isOrgAdmin = computed<boolean>(() => {
+    const org = agent.value?.org
+    const perms = myUser.value?.permissions?.permissions
+    if (!org || !perms) return false
+    return perms.some((p: any) => p.org === org && p.object === org
+        && p.scope === 'ORGANIZATION' && p.type === 'ADMIN')
+})
+
+const agentDisplay = computed(() => agent.value?.displayName || agent.value?.name || '')
 
 const openSessions = computed(() => agent.value?.openSessions ?? [])
 const closedSessions = computed(() => agent.value?.closedSessions ?? [])
@@ -291,6 +315,28 @@ async function saveNotes () {
     }
 }
 
+function startEditName () {
+    nameDraft.value = agent.value?.displayName ?? ''
+    editingName.value = true
+}
+
+async function saveName () {
+    savingName.value = true
+    try {
+        const updated = await store.dispatch('setAgentDisplayName', {
+            uuid: agent.value.uuid,
+            displayName: nameDraft.value.trim() || null,
+        })
+        agent.value.displayName = updated.displayName
+        editingName.value = false
+        notification.success({ content: 'Display name saved' })
+    } catch (e: any) {
+        notification.error({ content: `Save failed: ${e?.message ?? e}` })
+    } finally {
+        savingName.value = false
+    }
+}
+
 const subAgentColumns: DataTableColumns<any> = [
     { title: 'Name', key: 'name', render: (row: any) => h('a', { onClick: () => router.push({ name: 'AiAgentView', params: { uuid: row.uuid } }) }, row.name) },
     { title: 'Sessions', key: 'sess', render: (row: any) => (row.sessionCounts?.openSessions ?? 0) + ' open / ' + (row.sessionCounts?.closedSessions ?? 0) + ' closed' },
@@ -305,6 +351,10 @@ const subAgentColumns: DataTableColumns<any> = [
 .hero { display: flex; align-items: center; gap: 16px; margin-bottom: 20px; }
 .hero__mark { width: 56px; height: 56px; border-radius: 12px; color: white; display: flex; align-items: center; justify-content: center; font-size: 28px; font-weight: 600; }
 .hero__title { flex: 1; }
+.hero__name-row { display: flex; align-items: center; gap: 8px; }
+.hero__name-row h3 { margin: 0; }
+.hero__edit-name { align-self: center; }
+.hero__name-edit { display: flex; align-items: center; gap: 6px; }
 .hero__id { font-weight: 400; font-family: monospace; font-size: 14px; color: var(--n-text-color-3, #666); }
 .hero__ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; margin-bottom: 4px; }
 .hero__chip { font-family: monospace; font-size: 11px; padding: 1px 6px; border-radius: 4px; background: var(--n-color-embedded, #f5f5f5); color: var(--n-text-color-2, #555); border: 1px solid transparent; }

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -11,8 +11,8 @@
             <div class="hero__title">
                 <div v-if="!editingName" class="hero__name-row">
                     <h3>{{ agentDisplay }}</h3>
-                    <n-button v-if="isOrgAdmin" size="tiny" quaternary class="hero__edit-name"
-                              title="Edit display name" @click="startEditName">Edit</n-button>
+                    <n-icon v-if="isOrgAdmin" class="hero__edit-name" size="18"
+                            title="Edit display name" @click="startEditName"><EditIcon/></n-icon>
                 </div>
                 <div v-else class="hero__name-edit">
                     <n-input v-model:value="nameDraft" size="small" placeholder="Display name (blank = use registration name)"
@@ -176,6 +176,7 @@ import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NBreadcrumb, NBreadcrumbItem, NTabs, NTabPane, NTag, NDataTable, NSpin, NDescriptions, NDescriptionsItem, NButton, NIcon, NInput, NTooltip, DataTableColumns, useNotification } from 'naive-ui'
 import { Info20Regular } from '@vicons/fluent'
+import { Edit as EditIcon } from '@vicons/tabler'
 import SessionTable from './AiAgentSessionTable.vue'
 import SigningKeyManager from './SigningKeyManager.vue'
 
@@ -353,7 +354,8 @@ const subAgentColumns: DataTableColumns<any> = [
 .hero__title { flex: 1; }
 .hero__name-row { display: flex; align-items: center; gap: 8px; }
 .hero__name-row h3 { margin: 0; }
-.hero__edit-name { align-self: center; }
+.hero__edit-name { align-self: center; cursor: pointer; color: var(--n-text-color-3, #888); }
+.hero__edit-name:hover { color: var(--n-primary-color, #18a058); }
 .hero__name-edit { display: flex; align-items: center; gap: 6px; }
 .hero__id { font-weight: 400; font-family: monospace; font-size: 14px; color: var(--n-text-color-3, #666); }
 .hero__ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; margin-bottom: 4px; }

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -96,6 +96,7 @@
                     :org="agent.org"
                     owner-type="AGENT"
                     :owner-uuid="agent.uuid"
+                    :can-edit-identity="isOrgAdmin"
                 />
             </n-tab-pane>
             <n-tab-pane name="metadata" tab="Metadata">

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -69,8 +69,8 @@
                             <div class="acard__head">
                                 <div class="acard__name">
                                     <span>{{ a.displayName || a.name }}</span>
-                                    <n-button v-if="isOrgAdmin" size="tiny" quaternary class="acard__edit-name"
-                                              title="Edit display name" @click.stop="openEditName(a)">Edit</n-button>
+                                    <n-icon v-if="isOrgAdmin" class="acard__edit-name" size="16"
+                                            title="Edit display name" @click.stop="openEditName(a)"><EditIcon/></n-icon>
                                 </div>
                                 <div class="acard__ids">
                                     <n-tooltip trigger="hover">
@@ -175,6 +175,7 @@ import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NButton, NCard, NDataTable, NIcon, NInput, NModal, NSpace, NSpin, NTag, NTooltip, DataTableColumns, useNotification } from 'naive-ui'
 import { Info20Regular } from '@vicons/fluent'
+import { Edit as EditIcon } from '@vicons/tabler'
 
 const store = useStore()
 const route = useRoute()
@@ -360,7 +361,8 @@ const sessionColumns: DataTableColumns<any> = [
 .acard__mark { width: 36px; height: 36px; border-radius: 8px; color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 18px; flex-shrink: 0; }
 .acard__head { flex: 1; min-width: 0; }
 .acard__name { font-weight: 600; display: flex; align-items: center; gap: 6px; }
-.acard__edit-name { font-weight: 400; }
+.acard__edit-name { cursor: pointer; color: var(--n-text-color-3, #888); }
+.acard__edit-name:hover { color: var(--n-primary-color, #18a058); }
 .edit-name-hint { font-size: 12px; color: var(--n-text-color-3, #666); margin: 8px 0 0; }
 .acard__ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
 .acard__chip { font-family: monospace; font-size: 11px; padding: 1px 6px; border-radius: 4px; background: var(--n-color-embedded, #f5f5f5); color: var(--n-text-color-2, #555); border: 1px solid transparent; }

--- a/ui/src/components/AiAgentsOfOrg.vue
+++ b/ui/src/components/AiAgentsOfOrg.vue
@@ -67,7 +67,11 @@
                                 {{ a.iconKind || '◆' }}
                             </div>
                             <div class="acard__head">
-                                <div class="acard__name">{{ a.name }}</div>
+                                <div class="acard__name">
+                                    <span>{{ a.displayName || a.name }}</span>
+                                    <n-button v-if="isOrgAdmin" size="tiny" quaternary class="acard__edit-name"
+                                              title="Edit display name" @click.stop="openEditName(a)">Edit</n-button>
+                                </div>
                                 <div class="acard__ids">
                                     <n-tooltip trigger="hover">
                                         <template #trigger>
@@ -147,6 +151,21 @@
                 />
             </div>
         </n-space>
+
+        <n-modal v-model:show="showEditName" preset="card" title="Edit agent display name" style="width: 480px;">
+            <n-input v-model:value="nameDraft" placeholder="Display name (blank = use registration name)"
+                     @keyup.enter="saveName"/>
+            <p class="edit-name-hint">
+                Cosmetic label shown in the dashboard. The agent's registration name
+                (supplied by the runtime via --agent-name) is unchanged.
+            </p>
+            <template #footer>
+                <n-space justify="end">
+                    <n-button @click="showEditName = false">Cancel</n-button>
+                    <n-button type="primary" :loading="savingName" @click="saveName">Save</n-button>
+                </n-space>
+            </template>
+        </n-modal>
     </div>
 </template>
 
@@ -154,14 +173,54 @@
 import { computed, h, onMounted, ref } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NButton, NCard, NDataTable, NIcon, NSpace, NSpin, NTag, NTooltip, DataTableColumns } from 'naive-ui'
+import { NButton, NCard, NDataTable, NIcon, NInput, NModal, NSpace, NSpin, NTag, NTooltip, DataTableColumns, useNotification } from 'naive-ui'
 import { Info20Regular } from '@vicons/fluent'
 
 const store = useStore()
 const route = useRoute()
 const router = useRouter()
+const notification = useNotification()
 
 const orgUuid = computed(() => route.params.orguuid as string)
+
+const myUser = computed<any>(() => store.getters.myuser)
+const isOrgAdmin = computed<boolean>(() => {
+    const org = orgUuid.value
+    const perms = myUser.value?.permissions?.permissions
+    if (!org || !perms) return false
+    return perms.some((p: any) => p.org === org && p.object === org
+        && p.scope === 'ORGANIZATION' && p.type === 'ADMIN')
+})
+
+const showEditName = ref<boolean>(false)
+const editingAgent = ref<any>(null)
+const nameDraft = ref<string>('')
+const savingName = ref<boolean>(false)
+
+function openEditName (a: any) {
+    editingAgent.value = a
+    nameDraft.value = a.displayName ?? ''
+    showEditName.value = true
+}
+
+async function saveName () {
+    if (!editingAgent.value) return
+    savingName.value = true
+    try {
+        const updated = await store.dispatch('setAgentDisplayName', {
+            uuid: editingAgent.value.uuid,
+            displayName: nameDraft.value.trim() || null,
+        })
+        editingAgent.value.displayName = updated.displayName
+        showEditName.value = false
+        editingAgent.value = null
+        notification.success({ content: 'Display name saved' })
+    } catch (e: any) {
+        notification.error({ content: `Save failed: ${e?.message ?? e}` })
+    } finally {
+        savingName.value = false
+    }
+}
 const loading = ref<boolean>(false)
 const kpis = ref<any>(null)
 const agents = ref<any[]>([])
@@ -300,7 +359,9 @@ const sessionColumns: DataTableColumns<any> = [
 .acard__top { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 12px; }
 .acard__mark { width: 36px; height: 36px; border-radius: 8px; color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 18px; flex-shrink: 0; }
 .acard__head { flex: 1; min-width: 0; }
-.acard__name { font-weight: 600; }
+.acard__name { font-weight: 600; display: flex; align-items: center; gap: 6px; }
+.acard__edit-name { font-weight: 400; }
+.edit-name-hint { font-size: 12px; color: var(--n-text-color-3, #666); margin: 8px 0 0; }
 .acard__ids { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
 .acard__chip { font-family: monospace; font-size: 11px; padding: 1px 6px; border-radius: 4px; background: var(--n-color-embedded, #f5f5f5); color: var(--n-text-color-2, #555); border: 1px solid transparent; }
 .acard__chip-l { text-transform: uppercase; font-size: 9px; letter-spacing: 0.06em; color: var(--n-text-color-3, #888); margin-right: 4px; }

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1722,6 +1722,26 @@ const freeFormKeyFields: Ref<any> = ref([
         title: 'Notes'
     },
     {
+        key: 'boundAgents',
+        title: 'Bound Agent(s)',
+        render: (row: any) => {
+            const agents = row.boundAgents || []
+            if (!agents.length) {
+                return h('span', { class: 'text-muted' }, '—')
+            }
+            const links: any[] = []
+            agents.forEach((a: any, idx: number) => {
+                if (idx > 0) links.push(h('span', ', '))
+                links.push(h(
+                    RouterLink,
+                    { to: { name: 'AiAgentView', params: { uuid: a.uuid } } },
+                    { default: () => a.name || a.uuid }
+                ))
+            })
+            return h('div', links)
+        }
+    },
+    {
         key: 'controls',
         title: 'Manage',
         render: (row: any) => {
@@ -4283,6 +4303,10 @@ async function loadProgrammaticAccessKeys(useCache: boolean) {
                                     accessDate
                                     createdDate
                                     notes
+                                    boundAgents {
+                                        uuid
+                                        name
+                                    }
                                     permissions {
                                         permissions {
                                             org

--- a/ui/src/components/SigningKeyManager.vue
+++ b/ui/src/components/SigningKeyManager.vue
@@ -21,6 +21,28 @@
         <div v-if="!keys.length" class="empty">No keys enrolled.</div>
         <n-data-table v-else :columns="columns" :data="keys" :pagination="{ pageSize: 10 }" size="small"/>
 
+        <n-modal v-model:show="showEditIdentity" preset="card" title="Edit signing-key identity" style="width: 560px;">
+            <n-form label-placement="top">
+                <n-form-item label="Allowed-signers principal (identity)">
+                    <n-input v-model:value="identityDraft" placeholder="e.g. agent@your-org.example"/>
+                </n-form-item>
+                <p class="id-hint">
+                    The allowed-signers principal used to build the verification trust
+                    store. <strong>This is not</strong> what your commits are stamped with —
+                    the git author email comes from the agent's local git config. For SSH
+                    keys the verifier sweeps all enrolled principals, so this is primarily a
+                    display/label value today; it must stay non-blank for SSH.
+                </p>
+            </n-form>
+            <template #footer>
+                <n-space>
+                    <n-button @click="showEditIdentity = false">Cancel</n-button>
+                    <n-button type="primary" :loading="savingIdentity" :disabled="!canSaveIdentity"
+                              @click="saveIdentity">Save</n-button>
+                </n-space>
+            </template>
+        </n-modal>
+
         <n-modal v-model:show="showEnroll" preset="card" title="Enrol public key" style="width: 640px;">
             <n-form label-placement="top">
                 <n-form-item label="Format" required>
@@ -74,6 +96,38 @@ const draft = ref<{ format: 'SSH' | 'GPG', pubKey: string }>({
 })
 
 const canEnrol = computed(() => !!draft.value.pubKey.trim())
+
+const showEditIdentity = ref<boolean>(false)
+const editingKey = ref<any>(null)
+const identityDraft = ref<string>('')
+const savingIdentity = ref<boolean>(false)
+const canSaveIdentity = computed(() =>
+    editingKey.value?.format !== 'SSH' || !!identityDraft.value.trim())
+
+function openEditIdentity (row: any) {
+    editingKey.value = row
+    identityDraft.value = row.identity || ''
+    showEditIdentity.value = true
+}
+
+async function saveIdentity () {
+    if (!editingKey.value) return
+    savingIdentity.value = true
+    try {
+        await store.dispatch('updateSigningKeyIdentity', {
+            uuid: editingKey.value.uuid,
+            identity: identityDraft.value.trim() || null,
+        })
+        notification.success({ content: 'Identity updated' })
+        showEditIdentity.value = false
+        editingKey.value = null
+        await load()
+    } catch (e: any) {
+        notification.error({ content: `Update failed: ${e?.message ?? e}`, duration: 8000 })
+    } finally {
+        savingIdentity.value = false
+    }
+}
 
 onMounted(load)
 watch(() => props.ownerUuid, load)
@@ -143,7 +197,18 @@ const columns = computed<DataTableColumns<any>>(() => [
     {
         title: 'Identity',
         key: 'identity',
-        render: (row: any) => row.identity ? h('code', null, row.identity) : '—',
+        render: (row: any) => {
+            const label = row.identity ? h('code', null, row.identity) : h('span', { class: 'dim' }, '—')
+            if (row.revokedAt) return label
+            return h('span', { class: 'identity-cell' }, [
+                label,
+                h(NButton, {
+                    size: 'tiny', quaternary: true, class: 'edit-id-btn',
+                    title: 'Edit allowed-signers principal',
+                    onClick: () => openEditIdentity(row),
+                }, { default: () => 'Edit' }),
+            ])
+        },
     },
     {
         title: 'Status',
@@ -176,4 +241,7 @@ const columns = computed<DataTableColumns<any>>(() => [
 .info-icon { color: #888; cursor: help; }
 .empty { color: var(--n-text-color-3, #666); font-style: italic; padding: 8px 0; }
 :deep(.fp) { font-size: 11px; word-break: break-all; }
+.identity-cell { display: inline-flex; align-items: center; gap: 6px; }
+.identity-cell .dim { color: var(--n-text-color-3, #999); }
+.id-hint { font-size: 12px; color: var(--n-text-color-3, #666); margin: 4px 0 0; }
 </style>

--- a/ui/src/components/SigningKeyManager.vue
+++ b/ui/src/components/SigningKeyManager.vue
@@ -84,6 +84,7 @@ const props = defineProps<{
     org: string,
     ownerType: 'AGENT' | 'COMMITTER',
     ownerUuid: string,
+    canEditIdentity?: boolean,
 }>()
 
 const store = useStore()
@@ -200,7 +201,7 @@ const columns = computed<DataTableColumns<any>>(() => [
         key: 'identity',
         render: (row: any) => {
             const label = row.identity ? h('code', null, row.identity) : h('span', { class: 'dim' }, '—')
-            if (row.revokedAt) return label
+            if (row.revokedAt || !props.canEditIdentity) return label
             return h('span', { class: 'identity-cell' }, [
                 label,
                 h(NIcon, {

--- a/ui/src/components/SigningKeyManager.vue
+++ b/ui/src/components/SigningKeyManager.vue
@@ -78,6 +78,7 @@ import {
     DataTableColumns, useNotification,
 } from 'naive-ui'
 import { QuestionCircle20Regular } from '@vicons/fluent'
+import { Edit as EditIcon } from '@vicons/tabler'
 
 const props = defineProps<{
     org: string,
@@ -202,11 +203,11 @@ const columns = computed<DataTableColumns<any>>(() => [
             if (row.revokedAt) return label
             return h('span', { class: 'identity-cell' }, [
                 label,
-                h(NButton, {
-                    size: 'tiny', quaternary: true, class: 'edit-id-btn',
+                h(NIcon, {
+                    size: 15, class: 'edit-id-btn',
                     title: 'Edit allowed-signers principal',
                     onClick: () => openEditIdentity(row),
-                }, { default: () => 'Edit' }),
+                }, { default: () => h(EditIcon) }),
             ])
         },
     },
@@ -243,5 +244,7 @@ const columns = computed<DataTableColumns<any>>(() => [
 :deep(.fp) { font-size: 11px; word-break: break-all; }
 .identity-cell { display: inline-flex; align-items: center; gap: 6px; }
 .identity-cell .dim { color: var(--n-text-color-3, #999); }
+.edit-id-btn { cursor: pointer; color: var(--n-text-color-3, #888); }
+.edit-id-btn:hover { color: var(--n-primary-color, #18a058); }
 .id-hint { font-size: 12px; color: var(--n-text-color-3, #666); margin: 4px 0 0; }
 </style>

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -2143,6 +2143,13 @@ const storeObject : any = {
                                 publisher
                                 description
                             }
+                            boundApiKeys {
+                                uuid
+                                type
+                                object
+                                keyOrder
+                                notes
+                            }
                         }
                     }`,
                 variables: { uuid },
@@ -2470,6 +2477,18 @@ const storeObject : any = {
                 variables: { uuid }
             })
             return response.data.revokeSigningKey
+        },
+        async updateSigningKeyIdentity (context: any, { uuid, identity }: { uuid: string, identity: string | null }) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation updateSigningKeyIdentity($uuid: ID!, $identity: String) {
+                        updateSigningKeyIdentity(uuid: $uuid, identity: $identity) {
+                            uuid format ownerType ownerUuid fingerprint identity createdDate revokedAt
+                        }
+                    }`,
+                variables: { uuid, identity }
+            })
+            return response.data.updateSigningKeyIdentity
         },
     },
 }

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -2062,6 +2062,7 @@ const storeObject : any = {
                             uuid
                             org
                             name
+                            displayName
                             iconKind
                             color
                             notes
@@ -2098,6 +2099,7 @@ const storeObject : any = {
                             uuid
                             org
                             name
+                            displayName
                             iconKind
                             color
                             notes
@@ -2306,6 +2308,18 @@ const storeObject : any = {
                 variables: { input }
             })
             return response.data.updateAgent
+        },
+        async setAgentDisplayName (context: any, { uuid, displayName }: { uuid: string, displayName: string | null }) {
+            const response = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setAgentDisplayName($uuid: ID!, $displayName: String) {
+                        setAgentDisplayName(uuid: $uuid, displayName: $displayName) {
+                            uuid name displayName
+                        }
+                    }`,
+                variables: { uuid, displayName }
+            })
+            return response.data.setAgentDisplayName
         },
         async fetchAgentPoliciesOfOrg (context: any, orgUuid: string) {
             const response = await graphqlClient.query({


### PR DESCRIPTION
## Summary

UI for the FREEFORM-key ↔ agent binding + editable signing-key identity. Backend: relizaio/rearm-saas#141.

- **Org Settings › Free Form Keys**: new **Bound Agent(s)** column linking to each root agent the key drives (or — when unbound). Lazy binding — a freshly minted key shows unbound until an agent opens a session with it.
- **Agent view › Metadata**: new **Bound API key(s)** row listing the FREEFORM key id(s) backing the agent's identity, with a tooltip pointing to Org Settings.
- **SigningKeyManager**: identity (allowed-signers principal) is now editable per active key via a modal. The hint makes clear this is a verification/display label — **not** the git author email, which comes from the agent's local git config.

## Test plan

- [ ] Org Settings → Free Form Keys: a key used by an agent shows the agent name (links to agent view); an unused key shows —.
- [ ] Agent view → Metadata: Bound API key(s) lists the key id.
- [ ] SigningKeyManager: edit an SSH key's identity, save, reload — persists; blank rejected for SSH.
- [ ] Verified on psclaude.