### PR TITLE
feat(instance-ui): not-matching icon + tooltip on Actual column

### DIFF
--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -467,7 +467,7 @@ import * as prism from 'prismjs';
 import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-json';
 import 'prismjs/themes/prism-tomorrow.css';
-import { AlertOff24Regular, AlertOn24Regular, Edit24Regular, Target20Regular} from '@vicons/fluent'
+import { AlertOff24Regular, AlertOn24Regular, Edit24Regular, Target20Regular, DismissCircle20Regular} from '@vicons/fluent'
 import { Box, Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, Clipboard, X, Check, Server, History } from '@vicons/tabler'
 import { Commit } from '@vicons/carbon'
 import constants from '@/utils/constants'
@@ -604,9 +604,15 @@ const filteredUnmatchedReleases: ComputedRef<any[]> = computed((): any[] => {
 // already; the per-row breakdown explains why.
 function buildMatchTooltipBody(row: any) {
     const lines: any[] = []
-    const headerText = row.notMatchingSince
-        ? `Not matching since ${(new Date(row.notMatchingSince)).toLocaleString('en-CA')}`
-        : 'Matching'
+    const isMatching = !!row.matchedRelease && !row.notMatchingSince
+    let headerText: string
+    if (isMatching) {
+        headerText = 'Matching'
+    } else if (row.notMatchingSince) {
+        headerText = `Not matching since ${(new Date(row.notMatchingSince)).toLocaleString('en-CA')}`
+    } else {
+        headerText = 'Not matching'
+    }
     lines.push(h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, headerText))
 
     const deps = (row.featureSetDetails && row.featureSetDetails.dependencies) || []
@@ -1503,9 +1509,23 @@ const matchedProductFields: any[] = [
                     
                 ]))
             }else {
-                els.push(h('span', 'Not Matched'))
+                els.push(h(NTooltip, {
+                    trigger: 'hover',
+                    placement: 'top',
+                    width: 720,
+                    style: { maxWidth: '720px' }
+                }, {
+                    trigger: () => h(NIcon, {
+                        size: 16,
+                        color: 'red'
+                    }, {
+                        default: () => h(DismissCircle20Regular)
+                    }),
+                    default: () => buildMatchTooltipBody(row)
+                }))
+                els.push(h('span', { style: 'margin-left: 4px;' }, 'Not Matched'))
             }
-            
+
             return els
         }
     },

--- a/ui/trigger_build
+++ b/ui/trigger_build
@@ -1,1 +1,2 @@
 64
+retrigger: control-plane 502 on addrelease for .0 build


### PR DESCRIPTION
## Summary

On the instance page's product plan table, a matched plan shows a green bulls-eye (`Target`) icon with a per-component match-breakdown tooltip. When a plan was **not** matched, the Actual column showed bare "Not Matched" text — no icon, no explanation.

This adds a red `DismissCircle` icon for the not-matched case carrying the **same-style tooltip** (`buildMatchTooltipBody`), so operators can see *why* it isn't matching (target vs actual version per dependency, with the same JOB/TRANSIENT/REQUIRED verdicts).

Also fixes the tooltip header to resolve all three states correctly: **Matching** / **Not matching since `<date>`** / **Not matching**.

UI-only (rearm CE).

## Test plan

- [ ] Instance with an unmatched product plan: red DismissCircle icon shows next to "Not Matched"; hover shows the per-component breakdown with a "Not matching" header.
- [ ] Matched plan still shows the green bulls-eye + "Matching".
- [ ] Matched-but-drifted (notMatchingSince set) still shows red bulls-eye + "Not matching since …".
- [ ] Verified on psclaude.