### PR TITLE
feat(ui): clock icon with precise created-time tooltip in recent releases

### DIFF
--- a/ui/src/components/MostRecentReleasesWidget.vue
+++ b/ui/src/components/MostRecentReleasesWidget.vue
@@ -51,7 +51,16 @@
                                 </template>
                                 {{ rel.version }}
                             </n-tooltip>
-                            <span v-if="!props.showFullPageIcon" style="flex-shrink: 0;">&nbsp;·&nbsp;{{ formatDate(rel.createdDate) }}</span>
+                            <span style="flex-shrink: 0; display: inline-flex; align-items: center;">
+                                <template v-if="!props.showFullPageIcon">&nbsp;·&nbsp;{{ formatDate(rel.createdDate) }}</template>
+                                <span v-else>&nbsp;·&nbsp;</span>
+                                <n-tooltip trigger="hover" :delay="200">
+                                    <template #trigger>
+                                        <n-icon size="14" style="margin-left: 4px; cursor: help; vertical-align: middle;"><Clock /></n-icon>
+                                    </template>
+                                    Release created: {{ formatDateTime(rel.createdDate) }}
+                                </n-tooltip>
+                            </span>
                             <span style="flex-shrink: 0;">&nbsp;·&nbsp;{{ rel.lifecycle }}</span>
                         </span>
                         <span
@@ -107,7 +116,7 @@ export default {
 import { ref, Ref, computed, watch, onMounted } from 'vue'
 import { NIcon, NSpin, NSpace, NInputNumber, NSelect, NTooltip, useNotification } from 'naive-ui'
 import { ArrowExpand20Regular } from '@vicons/fluent'
-import { Refresh } from '@vicons/tabler'
+import { Refresh, Clock } from '@vicons/tabler'
 import graphqlClient from '@/utils/graphql'
 import GqlQueries from '@/utils/graphqlQueries'
 import constants from '@/utils/constants'
@@ -258,6 +267,12 @@ async function openVulnModal(rel: any, severityFilter: string, typeFilter: strin
 function formatDate(dateStr: string): string {
     if (!dateStr) return ''
     return new Date(dateStr).toLocaleDateString('en-CA')
+}
+
+// Full timestamp down to the second, e.g. "2026-05-28, 9:09:36 p.m."
+function formatDateTime(dateStr: string): string {
+    if (!dateStr) return ''
+    return new Date(dateStr).toLocaleString('en-CA')
 }
 
 watch(() => props.perspectiveUuid, () => fetchReleases())


### PR DESCRIPTION
## Summary

Adds a clock icon to each row of the most-recent-releases widget. Hovering it shows the full creation timestamp down to the second:

> Release created: 2026-05-28, 9:09:36 p.m.

- **Full page** (`MostRecentReleasesPage`, `showFullPageIcon=false`): icon sits **right after** the existing date.
- **Compact dashboard widget** (`showFullPageIcon=true`): the icon stands in for the date (which is hidden there for space), so you still get the exact time on hover.

Both render paths are the same widget component, so one change covers the widget and the page. Timestamp uses `toLocaleString('en-CA')` (matches the requested `yyyy-mm-dd, h:mm:ss a.m./p.m.` format).

UI-only (rearm CE).

## Test plan

- [ ] Dashboard recent-releases widget: clock icon present; hover → "Release created: <full timestamp to seconds>".
- [ ] Most-recent-releases full page: date still shown, clock icon right after it, same tooltip.
- [ ] Verified on psclaude.