### PR TITLE
fix(ui): widen CEL helper popover so field paths don't wrap

### DIFF
--- a/ui/src/components/CelExpressionBuilder.vue
+++ b/ui/src/components/CelExpressionBuilder.vue
@@ -185,7 +185,7 @@
                 <n-popover
                     trigger="click"
                     placement="bottom-end"
-                    :width="640"
+                    :width="880"
                     style="max-height: 70vh; overflow: auto;"
                 >
                     <template #trigger>
@@ -208,7 +208,7 @@
                                             @click="insertSnippet(v.snippet)"
                                         ><ClipboardPaste20Regular /></n-icon>
                                     </td>
-                                    <td style="padding: 2px 8px 2px 0;"><code v-html="v.display"></code></td>
+                                    <td style="padding: 2px 8px 2px 0; white-space: nowrap;"><code v-html="v.display"></code></td>
                                     <td v-html="v.desc"></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
## Summary

The CEL help popover wrapped long field paths like `release.agentSessions[].uuid` onto two lines. Widened it from 640px → 880px and added `white-space: nowrap` to the variable-name column so paths stay on one line (descriptions still wrap). The popover is `placement="bottom-end"`, so the extra width extends **leftward** as requested.

Lives in the shared `CelExpressionBuilder.vue`, so this covers **both** the global rule editor and the local component editor.

UI-only (rearm CE).

## Test plan

- [ ] Global rule editor → CEL help (?) popover: `release.agentSessions[].uuid` and similar paths render on one line; panel is wider and grows to the left.
- [ ] Local component editor: same.
- [ ] Verified on psclaude.