### PR TITLE
docs: set up GitHub web-flow as a committer

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -24,7 +24,8 @@ function sidebar() {
           {text: 'Importing VEX', link: '/workflows/importing-vex'},
           {text: 'Supply Chain Forensics', link: '/workflows/supply-chain-forensics'},
           {text: 'Exporting Compliance Artifacts', link: '/workflows/exporting-compliance-artifacts'},
-          {text: 'Pull Requests', link: '/workflows/pull-requests'}
+          {text: 'Pull Requests', link: '/workflows/pull-requests'},
+          {text: 'Verifying GitHub Web-Flow Commits', link: '/workflows/github-web-flow-committer'}
         ]},
         {text: 'Configure', link: '/configure/', items: [
           {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'}

--- a/documentation_site/docs/workflows/github-web-flow-committer.md
+++ b/documentation_site/docs/workflows/github-web-flow-committer.md
@@ -41,9 +41,9 @@ In the ReARM UI go to **Organization Settings → Committers → New committer**
 | Linked ReARM user | *None — standalone* (GitHub is not a ReARM user) |
 | **Name**         | `GitHub`                               |
 | **Email**        | `noreply@github.com`                   |
-| Aliases          | *(leave empty)*                        |
+| Aliases          | `web-flow@github.com`                  |
 
-The name/email are for clean attribution on the commit and in the UI — verification itself matches on the enrolled key, not the email.
+The name/email are for clean attribution on the commit and in the UI — verification itself matches on the enrolled key, not the email. Add `web-flow@github.com` as an alias because GitHub stamps some web-UI commits with that committer address instead of `noreply@github.com`; the alias lets ReARM resolve both back to this one committer.
 
 ### 3. Enrol the web-flow key
 

--- a/documentation_site/docs/workflows/github-web-flow-committer.md
+++ b/documentation_site/docs/workflows/github-web-flow-committer.md
@@ -1,0 +1,69 @@
+# Verifying GitHub Web-Flow Commits
+
+::: tip Available in ReARM CE and ReARM Pro
+Commit signature verification — committers, enrolled signing keys, and the resulting `VERIFIED` verdict — is part of the shared ReARM codebase and works on **both ReARM CE and ReARM Pro**.
+:::
+
+## What is GitHub web-flow?
+
+Commits you make through GitHub's **web UI** are signed by GitHub itself, not by you:
+
+- editing a file in the browser and committing,
+- the **Merge pull request** / **Squash and merge** / **Rebase and merge** buttons,
+- web-based reverts, and committing a suggested change in a review.
+
+GitHub signs each of these with its own GPG key — *"GitHub (web-flow commit signing)"* — and records the committer as:
+
+```
+GitHub <noreply@github.com>
+```
+
+These commits show a green **Verified** badge on GitHub, but ReARM will leave them `UNKNOWN_KEY` until you tell ReARM to trust GitHub's web-flow key. ReARM never trusts the key embedded in a signature — it only matches against keys you have **enrolled** on a [Committer](../concepts/). For non-agent commits the verifier checks the org's enrolled **committer** GPG keys, so the fix is to enroll GitHub's public web-flow key under a committer.
+
+## Set up a GitHub web-flow committer
+
+### 1. Fetch GitHub's web-flow public key
+
+GitHub publishes the web-flow public key. Download the ASCII-armoured block:
+
+```bash
+curl https://github.com/web-flow.gpg
+```
+
+This key is global to `github.com` — one key signs the web-UI commits of every repository. (On GitHub Enterprise Server, fetch it from your instance instead: `curl https://<your-ghes-host>/web-flow.gpg`.)
+
+### 2. Create the committer
+
+In the ReARM UI go to **Organization Settings → Committers → New committer** and fill in:
+
+| Field            | Value                                  |
+| ---------------- | -------------------------------------- |
+| Linked ReARM user | *None — standalone* (GitHub is not a ReARM user) |
+| **Name**         | `GitHub`                               |
+| **Email**        | `noreply@github.com`                   |
+| Aliases          | *(leave empty)*                        |
+
+The name/email are for clean attribution on the commit and in the UI — verification itself matches on the enrolled key, not the email.
+
+### 3. Enrol the web-flow key
+
+Open the committer you just created. Under **Signing keys** click **+ Enrol key**:
+
+- **Format:** `GPG`
+- **Public key:** paste the full ASCII-armoured block from step 1 (the `-----BEGIN PGP PUBLIC KEY BLOCK-----` … `-----END PGP PUBLIC KEY BLOCK-----` text).
+
+Click **Enrol**. The key is now active for the organization.
+
+## Result
+
+From now on, commits authored through the GitHub web UI verify as **`VERIFIED`** in ReARM and attribute to the `GitHub` committer — visible on the Source Code Entry signature badge, the [Pull Request](./pull-requests) view, and anywhere CEL policies read `commit.signature.state`. For example, a component or global rule can now require:
+
+```
+release.commits.exists(c, c.signature.state != "VERIFIED")
+```
+
+and merge commits created with the GitHub **Merge** button will satisfy it.
+
+::: tip
+The web-flow key is just one committer. Enrol your developers' own GPG/SSH public keys on their committers the same way so their locally-signed commits verify too.
+:::

--- a/documentation_site/docs/workflows/index.md
+++ b/documentation_site/docs/workflows/index.md
@@ -12,4 +12,5 @@ sidebarDepth: 2
 - [Supply Chain Forensics](./supply-chain-forensics)
 - [Exporting Compliance Artifacts](./exporting-compliance-artifacts)
 - [Pull Requests](./pull-requests)
+- [Verifying GitHub Web-Flow Commits](./github-web-flow-committer)
 


### PR DESCRIPTION
## Summary

New docsite page (`workflows/github-web-flow-committer.md`) documenting how to make GitHub **web-flow**-signed commits verify in ReARM.

Covers:
- **What web-flow is** — commits made through the GitHub web UI (edit-in-browser, Merge/Squash/Rebase buttons, web reverts, suggested-change commits) are GPG-signed by GitHub's own key as `GitHub <noreply@github.com>`. They show "Verified" on GitHub but land `UNKNOWN_KEY` in ReARM until the key is enrolled.
- **Setup steps** — fetch `https://github.com/web-flow.gpg`, create a `GitHub` / `noreply@github.com` committer (standalone), and enrol the ASCII-armoured GPG public key under it (GHES note included).
- **Result** — those commits verify as `VERIFIED`, attribute to the GitHub committer, and satisfy CEL gates like `release.commits.exists(c, c.signature.state != "VERIFIED")`.

Modelled on the committer configured at the reference instance. Wired into the workflows sidebar (`config.mjs`) and `workflows/index.md`.

## Validation
- `npm run docs:build` succeeds (the `cel` highlight warnings are pre-existing on other pages).

## Note
Docsite change — no psclaude app deploy applies. Happy to share a local `vitepress dev` preview if useful.