### PR TITLE
fix(ui): release severity circles open vulnerabilities + weaknesses, not vuln-only

### DIFF
--- a/ui/src/components/AppHome.vue
+++ b/ui/src/components/AppHome.vue
@@ -496,11 +496,11 @@
                                 <div style="display: flex; align-items: center; justify-content: space-between; gap: 12px;">
                                     <router-link :to="{ name: item.routeName, params: { orguuid: myorg?.uuid, compuuid: item.uuid } }">{{ item.name }}</router-link>
                                     <n-space :size="1">
-                                        <span title="Criticial Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'CRITICAL', 'Vulnerability')">{{ item.metrics.critical }}</span>
-                                        <span title="High Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.HIGH, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'HIGH', 'Vulnerability')">{{ item.metrics.high }}</span>
-                                        <span title="Medium Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.MEDIUM, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'MEDIUM', 'Vulnerability')">{{ item.metrics.medium }}</span>
-                                        <span title="Low Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.LOW, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'LOW', 'Vulnerability')">{{ item.metrics.low }}</span>
-                                        <span title="Vulnerabilities with Unassigned Severity" class="circle" :style="{background: constants.VulnerabilityColors.UNASSIGNED, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'UNASSIGNED', 'Vulnerability')">{{ item.metrics.unassigned }}</span>
+                                        <span title="Criticial Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ item.metrics.critical }}</span>
+                                        <span title="High Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.HIGH, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'HIGH', ['Vulnerability', 'Weakness'])">{{ item.metrics.high }}</span>
+                                        <span title="Medium Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.MEDIUM, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'MEDIUM', ['Vulnerability', 'Weakness'])">{{ item.metrics.medium }}</span>
+                                        <span title="Low Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.LOW, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'LOW', ['Vulnerability', 'Weakness'])">{{ item.metrics.low }}</span>
+                                        <span title="Vulnerabilities with Unassigned Severity" class="circle" :style="{background: constants.VulnerabilityColors.UNASSIGNED, cursor: 'pointer'}" @click="openVulnModalForComponent(item, 'UNASSIGNED', ['Vulnerability', 'Weakness'])">{{ item.metrics.unassigned }}</span>
                                         <div style="width: 12px;"></div>
                                         <span title="Licensing Policy Violations" class="circle" :style="{background: constants.ViolationColors.LICENSE, cursor: 'pointer'}" @click="openVulnModalForComponent(item, '', 'Violation')">{{ item.metrics.policyViolationsLicenseTotal }}</span>
                                         <span title="Security Policy Violations" class="circle" :style="{background: constants.ViolationColors.SECURITY, cursor: 'pointer'}" @click="openVulnModalForComponent(item, '', 'Violation')">{{ item.metrics.policyViolationsSecurityTotal }}</span>
@@ -1359,11 +1359,11 @@ const vulnModalComponentName = ref('')
 const vulnModalData: Ref<any[]> = ref([])
 const vulnModalLoading = ref(false)
 const vulnModalSeverityFilter = ref('')
-const vulnModalTypeFilter = ref('')
+const vulnModalTypeFilter: Ref<string | string[]> = ref('')
 const vulnModalComponentUuid = ref('')
 const vulnModalComponentType = ref('')
 
-function openVulnModalForComponent (item: any, severityFilter: string = '', typeFilter: string = '') {
+function openVulnModalForComponent (item: any, severityFilter: string = '', typeFilter: string | string[] = '') {
     const typeLabel = vulnerableComponentsInput.value.componentType === 'PRODUCT' ? 'product' : 'component'
     vulnModalComponentName.value = `Findings for ${typeLabel}: ${item.name}`
     vulnModalComponentUuid.value = item.uuid

--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -2085,11 +2085,11 @@ const releaseFields: ComputedRef<any[]>  = computed((): any[] => {
             if (status.kind !== 'ready') return [renderPendingBadge(status)]
             let els: any[] = []
             if (row.metrics && row.metrics.lastScanned) {
-                const criticalEl = h('div', {title: 'Criticial Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.CRITICAL}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'CRITICAL', 'Vulnerability')}, row.metrics.critical)
-                const highEl = h('div', {title: 'High Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.HIGH}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'HIGH', 'Vulnerability')}, row.metrics.high)
-                const medEl = h('div', {title: 'Medium Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.MEDIUM}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'MEDIUM', 'Vulnerability')}, row.metrics.medium)
-                const lowEl = h('div', {title: 'Low Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.LOW}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'LOW', 'Vulnerability')}, row.metrics.low)
-                const unassignedEl = h('div', {title: 'Vulnerabilities with Unassigned Severity', class: 'circle', style: `background: ${constants.VulnerabilityColors.UNASSIGNED}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'UNASSIGNED', 'Vulnerability')}, row.metrics.unassigned)
+                const criticalEl = h('div', {title: 'Criticial Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.CRITICAL}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'CRITICAL', ['Vulnerability', 'Weakness'])}, row.metrics.critical)
+                const highEl = h('div', {title: 'High Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.HIGH}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'HIGH', ['Vulnerability', 'Weakness'])}, row.metrics.high)
+                const medEl = h('div', {title: 'Medium Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.MEDIUM}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'MEDIUM', ['Vulnerability', 'Weakness'])}, row.metrics.medium)
+                const lowEl = h('div', {title: 'Low Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.LOW}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'LOW', ['Vulnerability', 'Weakness'])}, row.metrics.low)
+                const unassignedEl = h('div', {title: 'Vulnerabilities with Unassigned Severity', class: 'circle', style: `background: ${constants.VulnerabilityColors.UNASSIGNED}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'UNASSIGNED', ['Vulnerability', 'Weakness'])}, row.metrics.unassigned)
                 els = [h(NSpace, {size: 1}, () => [criticalEl, highEl, medEl, lowEl, unassignedEl])]
             }
             if (!els.length) els = [h('div'), 'N/A']
@@ -2128,9 +2128,9 @@ const currentReleaseArtifacts: Ref<any[]> = ref([])
 const currentReleaseOrgUuid: Ref<string> = ref('')
 const currentDtrackProjectUuids: Ref<string[]> = ref([])
 const currentSeverityFilter: Ref<string> = ref('')
-const currentTypeFilter: Ref<string> = ref('')
+const currentTypeFilter: Ref<string | string[]> = ref('')
 
-async function viewDetailedVulnerabilitiesForRelease(releaseRow: any, severityFilter: string = '', typeFilter: string = '') {
+async function viewDetailedVulnerabilitiesForRelease(releaseRow: any, severityFilter: string = '', typeFilter: string | string[] = '') {
     loadingVulnerabilities.value = true
     showDetailedVulnerabilitiesModal.value = true
     selectedReleaseForModal.value = releaseRow

--- a/ui/src/components/MostRecentReleasesWidget.vue
+++ b/ui/src/components/MostRecentReleasesWidget.vue
@@ -69,11 +69,11 @@
                             :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', flexShrink: 0, background: getPendingStatus(rel).kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
                         >{{ getPendingStatus(rel).label }}</span>
                         <n-space :size="1" v-else-if="rel.metrics?.lastScanned" style="flex-shrink: 0;">
-                            <span title="Critical Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer' }" @click="openVulnModal(rel, 'CRITICAL', 'Vulnerability')">{{ rel.metrics.critical }}</span>
-                            <span title="High Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.HIGH, cursor: 'pointer' }" @click="openVulnModal(rel, 'HIGH', 'Vulnerability')">{{ rel.metrics.high }}</span>
-                            <span title="Medium Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.MEDIUM, cursor: 'pointer' }" @click="openVulnModal(rel, 'MEDIUM', 'Vulnerability')">{{ rel.metrics.medium }}</span>
-                            <span title="Low Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.LOW, cursor: 'pointer' }" @click="openVulnModal(rel, 'LOW', 'Vulnerability')">{{ rel.metrics.low }}</span>
-                            <span title="Vulnerabilities with Unassigned Severity" class="circle" :style="{ background: constants.VulnerabilityColors.UNASSIGNED, cursor: 'pointer' }" @click="openVulnModal(rel, 'UNASSIGNED', 'Vulnerability')">{{ rel.metrics.unassigned }}</span>
+                            <span title="Critical Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer' }" @click="openVulnModal(rel, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ rel.metrics.critical }}</span>
+                            <span title="High Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.HIGH, cursor: 'pointer' }" @click="openVulnModal(rel, 'HIGH', ['Vulnerability', 'Weakness'])">{{ rel.metrics.high }}</span>
+                            <span title="Medium Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.MEDIUM, cursor: 'pointer' }" @click="openVulnModal(rel, 'MEDIUM', ['Vulnerability', 'Weakness'])">{{ rel.metrics.medium }}</span>
+                            <span title="Low Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.LOW, cursor: 'pointer' }" @click="openVulnModal(rel, 'LOW', ['Vulnerability', 'Weakness'])">{{ rel.metrics.low }}</span>
+                            <span title="Vulnerabilities with Unassigned Severity" class="circle" :style="{ background: constants.VulnerabilityColors.UNASSIGNED, cursor: 'pointer' }" @click="openVulnModal(rel, 'UNASSIGNED', ['Vulnerability', 'Weakness'])">{{ rel.metrics.unassigned }}</span>
                             <div style="width: 12px;"></div>
                             <span title="Licensing Policy Violations" class="circle" :style="{ background: constants.ViolationColors.LICENSE, cursor: 'pointer' }" @click="openVulnModal(rel, '', 'Violation')">{{ rel.metrics.policyViolationsLicenseTotal }}</span>
                             <span title="Security Policy Violations" class="circle" :style="{ background: constants.ViolationColors.SECURITY, cursor: 'pointer' }" @click="openVulnModal(rel, '', 'Violation')">{{ rel.metrics.policyViolationsSecurityTotal }}</span>
@@ -182,7 +182,7 @@ const vulnModalArtifacts: Ref<any[]> = ref([])
 const vulnModalOrgUuid = ref('')
 const vulnModalDtrackProjectUuids: Ref<string[]> = ref([])
 const vulnModalSeverity = ref('')
-const vulnModalType = ref('')
+const vulnModalType: Ref<string | string[]> = ref('')
 
 function getDateRange(): { startDate: Date, endDate: Date } {
     if (props.startDate && props.endDate) {
@@ -241,7 +241,7 @@ async function fetchReleases() {
     }
 }
 
-async function openVulnModal(rel: any, severityFilter: string, typeFilter: string) {
+async function openVulnModal(rel: any, severityFilter: string, typeFilter: string | string[]) {
     vulnModalRelease.value = rel
     vulnModalSeverity.value = severityFilter
     vulnModalType.value = typeFilter


### PR DESCRIPTION
## Summary

On the release finding-count widgets, the 5 severity circles (critical/high/medium/low/unassigned) opened the findings modal pre-filtered to **type = Vulnerability**. But those severity counts include **vulnerabilities and weaknesses combined** — so a release whose only finding is a *weakness* shows a non-zero circle that opens an **empty** modal (the weakness is filtered out). Reported on the *Most Recent Releases* dashboard widget.

## Fix

The 5 severity circles now pass `['Vulnerability', 'Weakness']` as the modal's initial type filter, so both finding types show. The 3 violation circles keep their `'Violation'`-only filter (unchanged).

`ReleaseView.vue` already does exactly this — this brings the three components that still passed `'Vulnerability'`-only into line:

| Component | Notes |
|---|---|
| `MostRecentReleasesWidget.vue` | the reported case |
| `AppHome.vue` | vulnerable-components table |
| `BranchView.vue` | release rows |

Each widened its type-filter ref + handler param to `string \| string[]`. `VulnerabilityModal`'s `initialTypeFilter` prop and `buildVulnerabilityColumns` (utils/metrics.ts) already accept arrays and seed the type column's default filter from them, so no other plumbing changed.

## Test plan

- [ ] On a release whose only finding is a **weakness**, click each of the 5 severity circles → modal opens showing the weakness (type filter = Vulnerability + Weakness)
- [ ] On a release with vulnerabilities, the circles still show them
- [ ] The 3 violation circles still open Violation-only
- [ ] Verified across Most Recent Releases widget, AppHome vulnerable-components, and BranchView release rows
- `npm run build` passes

## Known related (out of scope)

`MarketingReleaseView.vue` renders the same severity circles but its `@click` calls a `viewDetailedVulnerabilitiesForRelease` handler that **isn't defined in that file** and there's no findings modal there — those circles are already non-functional (a separate pre-existing bug). Left untouched; flagged for a follow-up if wanted.

## Provenance

Authored under ReARM session `ui-finding-circles-weaknesses-1780140724` (agent `703fbe71-…`). SSH-signed; trailers verified with `git interpret-trailers --parse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)