### PR TITLE
Fix CE backend build break: missing brace in createRelease

### DIFF
--- a/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
@@ -1491,6 +1491,7 @@ public class OssReleaseService {
 				try { autoIntegrateProducts(postSaveRd); }
 				catch (Exception e) { log.error("autoIntegrateProducts failed for release {}", postSaveRd.getUuid(), e); }
 			}
+		}
 		// Queue SBOM-component reconciliation for any release that came in with
 		// artifacts attached (e.g. addReleaseProgrammatic / addReleaseManual
 		// passing them on the create payload). The post-creation addArtifact


### PR DESCRIPTION
## Summary
`rearm/backend` fails to compile on `main`:

```
OssReleaseService.java:[1519,9] illegal start of expression
```

The `deferAutoIntegrate` guard ported into the CE `OssReleaseService.createRelease` dropped the closing brace of the `ASSEMBLED` lifecycle block. With that brace missing the method never closed, so `javac` ran past `return r;` into the next method declaration (`hasArtifactsRequiringReconcile`) and reported "illegal start of expression". Brace count in the method was 4 opens / 3 closes.

## Fix
Re-add the single `}` so the `ASSEMBLED` block ends right after the auto-integrate call, leaving the SBOM-reconcile gate and `return r` in the method body — the same structure used elsewhere.

## Verification
- `mvn compile` (JDK 25) on `rearm/backend` now succeeds (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)