### PR TITLE
Fix CE backend tests: invalid-UTF-8 bytes in application.yaml

### DIFF
--- a/backend/application.yaml
+++ b/backend/application.yaml
@@ -24,7 +24,7 @@ spring:
     username: ${PG_USER:postgres}
     password: ${PG_PASS:relizaPass}
     # NB: test-on-borrow / validationQuery (Tomcat-JDBC / dbcp2 keys) were
-    # removed here — Spring Boot uses HikariCP, which ignores them. Hikari
+    # removed here - Spring Boot uses HikariCP, which ignores them. Hikari
     # validates borrowed connections via JDBC isValid() automatically; no
     # connection-test-query is needed for pgjdbc.
     hikari:
@@ -39,7 +39,7 @@ spring:
       # back when idle (ZGC reclaims the burst heap).
       minimum-idle: ${DB_POOL_MIN:5}
       # keepalive-time: probe idle pooled connections so infra/LB/Postgres
-      # idle-kill can't silently leave a dead connection in the pool —
+      # idle-kill can't silently leave a dead connection in the pool -
       # this is the direct fix for the observed staleness.
       keepalive-time: ${DB_KEEPALIVE_MS:120000}
       # max-lifetime: recycle connections well before any infra-side idle


### PR DESCRIPTION
## Summary
After the compile fix, the backend build still failed — now in the test phase. Every `@SpringBootTest` (UserTest, ReleaseMetricsFinderQueryTest, AutoIntegrateProductsTest, …) failed to load the `ApplicationContext` with:

```
org.yaml.snakeyaml.error.YAMLException:
  java.nio.charset.MalformedInputException: Input length = 1
  at ...ScannerImpl.scanComment(...)
  at ...OriginTrackedYamlLoader...
```

## Root cause
`backend/application.yaml` had two comments containing **Windows-1252 em-dash bytes** (invalid UTF-8) — introduced in `a0d718da`. Spring's `OriginTrackedYamlLoader`/SnakeYAML reads the file with the JVM default charset, which in the container build is **not** UTF-8, so scanning those comment bytes threw `MalformedInputException` and aborted context startup. (It compiled fine, which is why it only surfaced once the compile error was cleared and tests began to run.)

## Fix
Replace the two invalid bytes with ASCII hyphens, making the config charset-independent. Verified: file is now pure ASCII (`iconv -f UTF-8` clean) and parses as valid YAML.

Scope kept to `rearm/backend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)