### PR TITLE
fix(rebom): scheduler retries stale PENDING enrichment (+ enrich timeout 60m->30m)

### DIFF
--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -23,7 +23,7 @@ import { createHash } from 'crypto';
 import * as fs from 'fs';
 
 // Enrichment timeout constant - used by both enrichCycloneDxBom and triggerEnrichment
-const ENRICHMENT_TIMEOUT_MS = 3600000; // 60 minutes timeout
+const ENRICHMENT_TIMEOUT_MS = 1800000; // 30 minutes timeout
 const ENRICHMENT_GRACE_PERIOD_MS = 300000; // 5 minutes grace period for stale PENDING status
 
 export function extractTldFromBom(bom: any): any {

--- a/rebom-backend/src/services/enrichmentScheduler.ts
+++ b/rebom-backend/src/services/enrichmentScheduler.ts
@@ -1,5 +1,5 @@
 import { logger } from '../logger';
-import { EnrichmentStatus } from '../types';
+import { EnrichmentStatus, IntegrationType } from '../types';
 import * as BomRepository from '../bomRepository';
 import { fetchFromOci, extractRepositoryNameFromBom } from './oci';
 import { enrichBomAsync } from './bom/bomProcessingService';
@@ -10,33 +10,65 @@ import { AdvisoryLockKey, tryAdvisoryLock, releaseAdvisoryLock } from './advisor
 const SCHEDULER_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 const ENRICHMENT_BATCH_LIMIT = 50;
 
+// A BOM stuck in PENDING past this window is treated as abandoned: the
+// fire-and-forget enrich kicked off at ingest never reached a terminal status
+// — the pod rolled mid-enrichment, or BEAR was configured after the BOM was
+// uploaded so the ingest-time attempt early-returned with no credentials.
+// Matches triggerEnrichment's timeout(30m)+grace(5m) so the scheduler never
+// races an enrich that is genuinely still in flight.
+const STALE_PENDING_THRESHOLD_MS = 35 * 60 * 1000;
+
 let schedulerInterval: NodeJS.Timeout | null = null;
 let isRunning = false;
 
 // TODO: implement retry counter and permanently failed status on bom enrichment 
 
 /**
- * Finds BOMs that need enrichment (status is null, FAILED, or SKIPPED).
+ * Finds BOMs that need enrichment. Picks up:
+ *  - never-attempted / retryable rows: enrichmentStatus null, FAILED, or SKIPPED;
+ *  - abandoned PENDING rows: stuck in PENDING past STALE_PENDING_THRESHOLD_MS,
+ *    but ONLY for orgs that actually have a BEAR integration configured.
+ *    Without this branch a BOM whose ingest-time enrich never reached a
+ *    terminal status (pod rolled mid-run, or BEAR was configured after the
+ *    upload) stays PENDING forever — the manual triggerEnrichment mutation was
+ *    the only way to recover it. The org-has-BEAR guard keeps un-enrichable
+ *    PENDING rows (no integration → getBearCredentials returns null) out of the
+ *    batch so they can't starve enrichable ones under the LIMIT.
  * Returns up to ENRICHMENT_BATCH_LIMIT records.
  * IMPORTANT: Must include 'bom' field so extractRepositoryNameFromBom can find repository name.
  */
 async function findBomsNeedingEnrichment(): Promise<Array<{ uuid: string; organization: string; serialNumber: string; meta: any; bom: any }>> {
   const queryText = `
-    SELECT uuid, organization, meta->>'serialNumber' as "serialNumber", bom
-    FROM rebom.boms 
-    WHERE meta->>'enrichmentStatus' IS NULL 
-       OR meta->>'enrichmentStatus' = $1
-       OR meta->>'enrichmentStatus' = $2
-    ORDER BY created_date ASC
-    LIMIT $3
+    SELECT b.uuid, b.organization, b.meta->>'serialNumber' as "serialNumber", b.bom
+    FROM rebom.boms b
+    WHERE b.meta->>'enrichmentStatus' IS NULL
+       OR b.meta->>'enrichmentStatus' = $1
+       OR b.meta->>'enrichmentStatus' = $2
+       OR (
+            b.meta->>'enrichmentStatus' = $3
+            AND b.created_date < $4
+            AND EXISTS (
+              SELECT 1 FROM rebom.integrations i
+              WHERE i.organization = b.organization
+                AND i.config->>'type' = $5
+                AND i.config->>'uri' IS NOT NULL
+                AND i.config->>'secretUuid' IS NOT NULL
+            )
+          )
+    ORDER BY b.created_date ASC
+    LIMIT $6
   `;
-  
+
+  const stalePendingCutoff = new Date(Date.now() - STALE_PENDING_THRESHOLD_MS).toISOString();
   const result = await runQuery(queryText, [
     EnrichmentStatus.FAILED,
     EnrichmentStatus.SKIPPED,
+    EnrichmentStatus.PENDING,
+    stalePendingCutoff,
+    IntegrationType.BEAR,
     ENRICHMENT_BATCH_LIMIT
   ]);
-  
+
   return result.rows;
 }
 


### PR DESCRIPTION
## Summary

The rebom enrichment **scheduler never retries `PENDING` BOMs** — `findBomsNeedingEnrichment()` only selects rows with status `NULL`, `FAILED`, or `SKIPPED`. The only things that move a BOM out of `PENDING` are the fire-and-forget enrich kicked off at ingest and the manual `triggerEnrichment` mutation (which already has stale-PENDING recovery).

So when the ingest-time enrich never reaches a terminal status — e.g. **the rebom pod rolls mid-enrichment**, or **BEAR is configured after the BOM was uploaded** (creds absent at ingest → it early-returns leaving `PENDING`) — the BOM is stranded in `PENDING` forever. Clicking "Enrich" in the UI was the only recovery.

Observed on the scully sandbox: **377/377 BOMs were `PENDING`** and not one had ever reached a terminal status via the scheduler since May 9 — the scheduler had been ticking for 13+ hours enriching nothing.

This is **not** related to the recent backend release-light/artifact-light optimization — scully runs that exact commit and ingest-time enrichment auto-triggered and completed there.

## Changes

- `enrichmentScheduler.ts` — `findBomsNeedingEnrichment` now also picks up `PENDING` rows older than the timeout+grace window, **gated to orgs that have a BEAR integration** (via `EXISTS` on `rebom.integrations`) so un-enrichable PENDING rows can't starve the batch under the `LIMIT`.
- `bomProcessingService.ts` — per-enrich timeout `60m -> 30m` (grace stays 5m). This also moves `triggerEnrichment`'s stale threshold to 30m+5m; the scheduler's `STALE_PENDING_THRESHOLD_MS` mirrors it.

## Test plan

- [x] Typecheck passes (`tsc --noEmit`).
- [x] New query validated against the live scully rebom DB: a manufactured stale-PENDING BEAR-org row is selected by the new query and **not** by the old one; the 376 no-BEAR PENDING rows are correctly excluded.
- [ ] Sideload debug image to scully and confirm the scheduler picks up a stale-PENDING BOM and re-enriches it to COMPLETED.

ReARM-Agentic-Session: rebom-enrich-pending-1780192483
ReARM-Agent: 703fbe71-5a15-4bd3-b601-ce3f0d7d225b