### PR TITLE
feat(ui): single-row component icons; fold VCS into info tooltip

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -44,7 +44,7 @@
                             >{{ effectiveLifecycleLabel }}</n-tag>
                         </h5>
                         <div class="componentIconsAndSettings">
-                            <n-space v-cloak>
+                            <n-space v-cloak :size="0">
                                 <n-icon v-if="componentData && componentData.type === 'COMPONENT' && isWritable" @click="genApiKey('rlz')" class="clickable icons" title="Generate Component API Key" size="24"><LockOpen /></n-icon>
                                 <n-icon v-if="words.componentFirstUpper" class="clickable icons" :title="words.componentFirstUpper + ' Settings'" @click="openComponentSettings" size="24"><Tool /></n-icon>
                                 <n-icon v-if="words.componentFirstUpper" class="clickable icons" :title="words.componentFirstUpper + ' Changelog'" @click="showComponentChangelogModal = true" size="24"><List /></n-icon>
@@ -55,17 +55,16 @@
                                     <template #trigger>
                                         <n-icon class="icons" size="24"><InfoCircle /></n-icon>
                                     </template>
-                                    <strong>{{ words.componentFirstUpper }} UUID:</strong> {{ componentData.uuid }}
-                                    <n-icon class="clickable icons" @click="copyToClipboard(componentData.uuid)" size="24"><Clipboard /></n-icon>
-                                </n-tooltip>
-                                <n-tooltip trigger="hover" v-if="updatedComponent && updatedComponent.vcsRepositoryDetails && updatedComponent.vcsRepositoryDetails.uri">
-                                    <template #trigger>
-                                        <n-icon class="icons" size="24"><GitMerge /></n-icon>
-                                    </template>
-                                    <strong>VCS Repository:</strong>
-                                    {{ updatedComponent.vcsRepositoryDetails.uri }}
-                                    <a :href="'https://' + updatedComponent.vcsRepositoryDetails.uri" rel="noopener noreferrer"
-                                    target="_blank"><n-icon class="clickable icons" title="Open VCS Repository URI in New Window" size="24"><ExternalLink /></n-icon></a>
+                                    <div>
+                                        <strong>{{ words.componentFirstUpper }} UUID:</strong> {{ componentData.uuid }}
+                                        <n-icon class="clickable icons" title="Copy UUID" @click="copyToClipboard(componentData.uuid)" size="24"><Clipboard /></n-icon>
+                                    </div>
+                                    <div v-if="updatedComponent && updatedComponent.vcsRepositoryDetails && updatedComponent.vcsRepositoryDetails.uri">
+                                        <strong>VCS Repository:</strong> {{ updatedComponent.vcsRepositoryDetails.uri }}
+                                        <n-icon class="clickable icons" title="Copy VCS Repository URI" @click="copyToClipboard(updatedComponent.vcsRepositoryDetails.uri, 'VCS repository')" size="24"><Clipboard /></n-icon>
+                                        <a :href="'https://' + updatedComponent.vcsRepositoryDetails.uri" rel="noopener noreferrer"
+                                        target="_blank"><n-icon class="clickable icons" title="Open VCS Repository URI in New Window" size="24"><ExternalLink /></n-icon></a>
+                                    </div>
                                 </n-tooltip>
 
                                 <n-icon v-if="componentData" @click="navigateToVulnAnalysis" class="clickable icons" size="24" :title="'Open ' + words.componentFirstUpper + ' Finding Analysis'">
@@ -1023,7 +1022,7 @@ import FeatureSetParticipation from './FeatureSetParticipation.vue'
 import ReleasesPerDayChart from './ReleasesPerDayChart.vue'
 import Swal from 'sweetalert2'
 import { SwalData } from '@/utils/commonFunctions'
-import { Link as LinkIcon, Copy, CirclePlus, Trash, Edit, LockOpen, Tool, List, InfoCircle, Clipboard, GitMerge, ExternalLink, Check, X, AlertCircle, Star, Eye, QuestionMark, Calendar, Download } from '@vicons/tabler'
+import { Link as LinkIcon, Copy, CirclePlus, Trash, Edit, LockOpen, Tool, List, InfoCircle, Clipboard, ExternalLink, Check, X, AlertCircle, Star, Eye, QuestionMark, Calendar, Download } from '@vicons/tabler'
 import { Info20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import { BugOutlined } from '@vicons/antd'
@@ -1143,10 +1142,10 @@ const router = useRouter()
 const store = useStore()
 const notification = useNotification()
 
-async function copyToClipboard (text: string) {
+async function copyToClipboard (text: string, label = 'uuid') {
     try {
         navigator.clipboard.writeText(text);
-        notify('info', 'Copied', `${words.value.componentFirstUpper} uuid copied: ${text}`)
+        notify('info', 'Copied', `${words.value.componentFirstUpper} ${label} copied: ${text}`)
     } catch (error) {
         console.error(error)
     }
@@ -3328,7 +3327,7 @@ async function handleTabSwitch(tabName: string) {
 
 <style scoped lang="scss">
 .icons {
-    margin-left: 10px;
+    margin-left: 4px;
 }
 .apiKeyButtons {
     display: grid;


### PR DESCRIPTION
## Summary

The component-detail header icon row wrapped onto **two lines**. This makes it fit on one row:

- **Fold the VCS icon into the info (ⓘ) tooltip.** The standalone VCS/GitMerge icon is removed; the info tooltip now shows the component **UUID** and — when set — the **VCS Repository**, each with a **copy-to-clipboard** action (copy added for VCS) plus the existing **follow-link** (open in new tab) for VCS.
- **Tighter gaps, matching the branch view.** `n-space` gap set to `0` and `.icons` `margin-left` `10px → 4px` (BranchView uses `margin-left: 4px`). With one fewer icon and the smaller gap, the remaining icons fit on a single row on most screens (still wraps gracefully on very narrow widths).
- `copyToClipboard` takes an optional `label` so the toast reads "VCS repository copied" vs "uuid copied".

## Test plan

- [x] `vite build` passes.
- [ ] Visual check in browser: info tooltip shows UUID + VCS rows with working copy + follow-link; all header icons on one row. (Not browser-verified in the dev env — please confirm, or I can sideload the UI to scully.)

ReARM-Agentic-Session: ui-component-icons-1780259207
ReARM-Agent: 703fbe71-5a15-4bd3-b601-ce3f0d7d225b