### PR TITLE
fix(ui): hide unsupported ephemeral-instance controls

### DIFF
--- a/ui/src/components/CreateInstance.vue
+++ b/ui/src/components/CreateInstance.vue
@@ -50,7 +50,8 @@
                     <n-button type="warning" @click="onResetManual">Reset</n-button>
                 </n-form>
             </n-tab-pane>
-            <n-tab-pane name="createauto" tab="Auto Ephemeral" v-if="instanceTypeProp === InstanceType.STANDALONE_INSTANCE">
+            <!-- Auto Ephemeral hidden: not supported in ReARM yet. -->
+            <n-tab-pane name="createauto" tab="Auto Ephemeral" v-if="false && instanceTypeProp === InstanceType.STANDALONE_INSTANCE">
                 <create-release
                                 v-if="!autoInstance.productReleaseUuid"     
                                 :orgProp="props.orgProp"

--- a/ui/src/components/InstancesOfOrg.vue
+++ b/ui/src/components/InstancesOfOrg.vue
@@ -14,7 +14,8 @@
                                 v-on:update:value="onFilterChange"
                                 :options="environmentTypes" />
                     </div>
-                    <div>Type:
+                    <!-- Type filter hidden: ephemeral/persistent instance types are not supported in ReARM yet. -->
+                    <div v-if="false">Type:
                         <n-select
                                 v-model:value="filterValue.type"
                                 v-on:update:value="onFilterChange"


### PR DESCRIPTION
Ephemeral / auto-ephemeral instances aren't supported in ReARM yet, so hide the two UI entry points that expose them. Both are hidden via `v-if="false"` (kept, not deleted, so they can be re-enabled when the feature lands).

- **CreateInstance.vue** — the **Auto Ephemeral** tab in *Add New Instance*.
- **InstancesOfOrg.vue** — the **Type** filter (Persistent / Ephemeral) selector in the instances filter.

## Test plan
- [x] `vite build` passes
- [ ] Browser: *Add New Instance* shows no "Auto Ephemeral" tab; the instances Filter popover has no Type selector