### PR TITLE
docs: agentic CE/Pro distinction, agent concepts, DevOps workflow

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -19,6 +19,7 @@ function sidebar() {
         {text: 'Workflows', link: '/workflows/', items: [
           {text: 'Bootstrap an AI Agent', link: '/workflows/agentic'},
           {text: 'Bundling & Auto-Integrate', link: '/workflows/bundling'},
+          {text: 'DevOps: Instances & Delivery', link: '/workflows/devops'},
           {text: 'License Compliance', link: '/workflows/license-compliance'},
           {text: 'Auditing Findings', link: '/workflows/auditing-findings'},
           {text: 'Importing VEX', link: '/workflows/importing-vex'},

--- a/documentation_site/docs/concepts/index.md
+++ b/documentation_site/docs/concepts/index.md
@@ -97,8 +97,19 @@ In the case of a Product Release, Release would only have components (other Rele
 ## Instance
 Instance is a medium which runs software built by organization (Components or Products). This could be a VM, a set of VMs, a Kubernetes cluster, a PaaS solution - literally anything that is configured to run software. Instance is defined by its URI.
 
+In ReARM Pro, an Instance is also the unit ReARM tracks deployments against: it records which [Feature Set](#feature-set) and releases are targeted per namespace, and the in-cluster `rearm-cd` agent can reconcile the running deployment to match. See the [DevOps workflow](../workflows/devops).
+
 ## Cluster
-Cluster is a set of instances. In example, Kubernetes may be considered a cluster with Instances running inside its namespaces.
+Cluster is a set of instances. In example, Kubernetes may be considered a cluster with Instances running inside its namespaces. A Cluster lets ReARM Pro manage feature-set deploys and secrets across the instances it contains.
+
+## Agent
+An Agent is an autonomous worker — typically an AI coding agent such as Claude Code, Cursor, Aider, or a custom runtime — that acts against ReARM under its own identity, distinct from human users. An Agent is described by its name, model, and vendor, and authenticates with a FREEFORM API key carrying the `AGENT` permission function. Work an Agent performs is attributed back to it: commits it authors carry a `ReARM-Agent` trailer, and ReARM records every [Session](#session) the Agent runs — giving a full audit trail of which agent (and model) did what. Agents are available in **both ReARM Community Edition and ReARM Pro**; policy-based gating of agent behaviour is a ReARM Pro addition. See the [agentic workflow](../workflows/agentic).
+
+## Session
+A Session (Agent Session) is a bounded unit of work an [Agent](#agent) opens when it starts a task and closes when the work is done. It carries a client-supplied session id, the agent identity and model, any artifacts the agent attaches (for example orientation and final reports), and — in ReARM Pro — the verdicts of any agent policies evaluated against it. Commits made during the Session carry a `ReARM-Agentic-Session` trailer that links them back to it, so a release can be traced to the exact session — and agent — that produced it. The Session's whole lifecycle (open, blocked, artifacts, policy verdicts, close) is captured in the audit trail.
+
+## Sub-agent
+A Sub-agent is an [Agent](#agent) spawned by a root Agent to handle part of a task — for example a coding agent that delegates focused subtasks to specialized helper agents. A Sub-agent is registered under its root: it inherits the root's API key and is appended to the root's sub-agents list, and it **does not own its own [Session](#session)**. Instead, its work contributes to the root Agent's Session, so attribution rolls up to the root. This mirrors how agentic runtimes spawn child agents within a single task while keeping one coherent, auditable session.
 
 ## Evidence Store
 A Supply-Chain Evidence Store is a system of record that collects, stores, versions, verifies, and traces all digital artefacts required to prove the integrity, safety, and compliance of software, firmware, and hardware throughout their lifecycle.

--- a/documentation_site/docs/workflows/agentic.md
+++ b/documentation_site/docs/workflows/agentic.md
@@ -1,10 +1,18 @@
 # Bootstrap an AI Agent
 
-::: tip Available in ReARM Pro
-Agent sessions, attribution, and the inbox poll endpoint are ReARM Pro features.
+::: tip Available in both ReARM Community Edition and ReARM Pro
+The **agentic core** works in **both editions**: agent identities, agent sessions, commit attribution (`ReARM-Agent` / `ReARM-Agentic-Session` trailers), signing-key enrolment, and the inbox poll endpoint are all present in ReARM CE and ReARM Pro.
+
+What is **ReARM Pro only**:
+
+- **Agent policies** — the CEL verdicts and `BLOCK`-severity session gating in [Agent policies](#agent-policies) below. On CE the policy machinery isn't loaded, so a session's `policyEvents[]` is always empty (it means "no checks exist", *not* "everything passed") and nothing auto-gates a release on agent behaviour.
+- **Approval policies** — the human approve/disapprove gating that the closed-loop demo below relies on.
+- **The DevOps surface** — instances and feature-set deploys (see the [DevOps workflow](./devops)), including granting an agent permission to deploy.
+
+So on CE you get full agent attribution and a signed, auditable session trail; the policy-driven gating and deploy steps are Pro additions.
 :::
 
-This page walks an **operator** through the steps to point an AI coding agent (Claude Code, Cursor, Aider, your own runtime) at a ReARM Pro instance. ReARM treats the agent as a worker that needs guardrails: the operator stays the principal, the agent stays the worker, and every step is captured in the audit trail.
+This page walks an **operator** through the steps to point an AI coding agent (Claude Code, Cursor, Aider, your own runtime) at a ReARM instance (Community Edition or Pro). ReARM treats the agent as a worker that needs guardrails: the operator stays the principal, the agent stays the worker, and every step is captured in the audit trail.
 
 The agent itself **does not need to read this page** — its contract lives at `$REARM_URL/api/agents/orientation.md`, which the operator points the agent at in its first prompt. That document is served by the running ReARM instance and is pinned to the same version as the backend; an agent fetching it always sees the contract for the instance it's actually talking to.
 
@@ -13,7 +21,7 @@ The agent itself **does not need to read this page** — its contract lives at `
 The operator's setup is intentionally minimal — two things, both
 one-time per agent identity:
 
-1. **A ReARM Pro org** the agent will work under.
+1. **A ReARM org** (Community Edition or Pro) the agent will work under.
 2. **A FREEFORM API key** scoped to that org with `PermissionFunction.AGENT` at `ORGANIZATION` scope. `ESSENTIAL_READ` is the minimum permission type — the agent surface intentionally accepts the floor so an agent-flow key doesn't have to carry broader rights. Mint the key from **Org Settings → API Keys → Add FREEFORM key** in the ReARM UI, then attach the `AGENT` function on the org scope from the permissions panel. The plaintext secret is shown **only once** on creation — capture it immediately into your secret store.
 
 That's it. **You do not provision a signing key for the agent.** The
@@ -70,6 +78,10 @@ Once pointed at the orientation doc:
 
 ## Agent policies
 
+::: warning ReARM Pro only
+Agent policies are not present in ReARM Community Edition — the policy engine lives in the Pro-only packages. On CE, `policyEvents[]` is always empty and none of the gating below applies; sessions, attribution, and signing still work fully. The rest of this section applies to ReARM Pro.
+:::
+
 Operators configure CEL-based **agent policies** (Org Settings →
 Policies → AI Agent Policies tab) that ReARM evaluates against each
 session. Three kinds, distinguished by *when* their verdict locks:
@@ -119,6 +131,19 @@ The canonical demo:
 6. Agent attaches a FINAL report and closes the session.
 
 Every step is in the audit trail: session row, commits with their attribution, releases with `updateEvents[].message` carrying the rejection reason, approval events with comments. The orientation artifact at step 1 and the final report at step 6 bracket the session's audit story.
+
+## Letting an agent deploy (ReARM Pro)
+
+::: warning ReARM Pro only
+Relies on the DevOps surface, which is not present in ReARM Community Edition.
+:::
+
+By default an agent's FREEFORM key carries only the `AGENT` function — enough to run sessions, attribute commits, and read releases, but **not** to change what is deployed. In ReARM Pro you can additionally grant that key the **`DEVOPS` permission function scoped to a specific instance** (or its parent cluster). That unlocks the `rearm devops` commands against that instance, so the agent can deploy what it just built:
+
+- **`rearm devops versionfeatureset`** — create a new [Feature Set](../concepts/#feature-set) for a product that re-pins one or more component branches to specific releases. This is "assemble the exact set of component versions I want to ship together."
+- **`rearm devops switchfeatureset`** — point a running [Instance](../concepts/#instance) at that feature set. The in-cluster [`rearm-cd`](./devops) reconciler picks up the change and rolls the instance to match.
+
+So an agent with DevOps permission on its instance can close the loop end to end: build and attribute a release, then **promote and deploy it** by versioning a feature set and switching its instance onto it — every step landing in the same session audit trail. Grant this deliberately and scope it narrowly (a single instance, never org-wide): it is the difference between an agent that *proposes* changes and one that *ships* them. The orientation doc (`§10`) tells the agent to never run a `rearm devops` command unless the operator's task explicitly names the target instance. See the [DevOps workflow](./devops) for the full surface.
 
 ## When the agent will stop
 

--- a/documentation_site/docs/workflows/devops.md
+++ b/documentation_site/docs/workflows/devops.md
@@ -1,0 +1,45 @@
+# DevOps: Instances, Secrets & Continuous Delivery
+
+::: warning ReARM Pro only
+The DevOps surface — Instances, Secrets, feature-set deploys, and the `rearm devops` CLI commands — is part of **ReARM Pro**. It is not present in ReARM Community Edition (the implementation lives in the Pro-only packages, so the corresponding GraphQL fields and CLI commands simply aren't there on CE).
+:::
+
+Beyond tracking what you *built*, ReARM Pro tracks what you have *deployed* and can drive deployments. The pieces:
+
+- **[Instances](../concepts/#instance)** — a record of a running deployment target (a VM, a Kubernetes namespace, a PaaS, …), identified by URI. ReARM tracks, per namespace on the instance, which [Feature Set](../concepts/#feature-set) and releases are *targeted* (the plan) and which are *actually running* (the actual state, reported by the in-cluster agent).
+- **[Clusters](../concepts/#cluster)** — a set of instances managed together (e.g. a Kubernetes cluster with one instance per namespace).
+- **Secrets** — values ReARM stores and resolves per instance/namespace so a deployment can be configured without those values living in the repo. On Kubernetes, secret material is delivered through [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets).
+- **`rearm-cd`** — the in-cluster reconciler that connects an instance to ReARM (see below).
+
+## ReARM CD
+
+[`rearm-cd`](https://github.com/relizaio/rearm-cd) is a small agent you install **inside your Kubernetes cluster**. It connects the cluster to ReARM so that deployments to the instance can be controlled *from* ReARM: `rearm-cd` watches the instance's target plan in ReARM and reconciles the running workloads to match it, in a GitOps/continuous-delivery style. It uses [Bitnami Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) for secret material and is installed via its Helm chart with a ReARM API key (`REARM_APIKEYID` / `REARM_APIKEY` / `REARM_URI`). RBAC can be cluster-wide or scoped to specific namespaces.
+
+In short: you change the *target* in ReARM, `rearm-cd` makes the cluster match it.
+
+## Deploying with feature sets
+
+A deploy in ReARM Pro is expressed by pointing an instance at a [Feature Set](../concepts/#feature-set) — a versioned bundle that pins each component (and product) release that should ship together. Two CLI commands drive this (`rearm devops …`):
+
+| Command | What it does |
+| --- | --- |
+| `rearm devops listfeaturesets --instanceuri <uri> --namespace <ns>` | Discovery: the product, the feature set currently deployed, and the feature sets you could switch to. Record the current feature set as your rollback target. |
+| `rearm devops versionfeatureset --product <uuid> --overrides '[{"vcsUri":"…","repoPath":"…","branch":"…"}]'` | Create a new feature set that re-pins the listed component branches to specific releases — "assemble the exact set of versions I want to ship together." |
+| `rearm devops switchfeatureset --instanceuri <uri> --product <uuid> --featureset <uuid> --namespace <ns>` | Point the running instance's product at that feature set. `rearm-cd` then reconciles the cluster to it. |
+
+::: tip
+`rearm devops` commands change what a running instance serves and are visible to anyone using that instance — switching a shared or production instance to the wrong build is a real incident. Always run `listfeaturesets` first, record the current feature set as the rollback target, and confirm you are naming the intended instance by URI.
+:::
+
+## Letting an AI agent deploy
+
+The DevOps surface composes with the [agentic workflow](./agentic). An [Agent](../concepts/#agent)'s API key normally carries only the `AGENT` permission function — enough to run sessions, attribute commits, and read releases, but not to change a deployment. Grant that key the **`DEVOPS` permission function scoped to a single instance** (or its parent cluster) and the agent can also run `versionfeatureset` / `switchfeatureset` against that instance.
+
+That lets an agent close the loop end to end — build and attribute a release, then promote and deploy it by versioning a feature set and switching its instance onto it — with `rearm-cd` reconciling the cluster and every step recorded in the agent's session audit trail. Grant it deliberately and scope it narrowly (one instance, never org-wide): it is the difference between an agent that *proposes* changes and one that *ships* them.
+
+## Reference
+
+- [`rearm-cd`](https://github.com/relizaio/rearm-cd) — the in-cluster reconciler (Helm-installed).
+- [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) — secret delivery prerequisite for `rearm-cd`.
+- [Agentic workflow](./agentic) — granting an agent DevOps permission to deploy.
+- Concepts: [Instance](../concepts/#instance), [Cluster](../concepts/#cluster), [Feature Set](../concepts/#feature-set).

--- a/documentation_site/docs/workflows/index.md
+++ b/documentation_site/docs/workflows/index.md
@@ -6,6 +6,7 @@ sidebarDepth: 2
 
 - [Bootstrap an AI Agent](./agentic)
 - [Bundling & Auto-Integrate](./bundling)
+- [DevOps: Instances, Secrets & Delivery](./devops)
 - [License Compliance](./license-compliance)
 - [Auditing Findings](./auditing-findings)
 - [Importing VEX](./importing-vex)


### PR DESCRIPTION
Documentation updates grounded in the current control-plane `orientation.md` contract.

## 1. Agentic CE vs Pro (the reported fix)
`workflows/agentic` claimed agent sessions/attribution/inbox are "ReARM Pro" features — they're **not**. The agentic core (agent identities, sessions, commit attribution via `ReARM-Agent`/`ReARM-Agentic-Session` trailers, signing-key enrolment, inbox poll) works in **both CE and Pro**. Only **agent policies**, **approval policies**, and the **DevOps surface** are Pro-only.
- Rewrote the top banner to state this cleanly.
- Added a "ReARM Pro only" callout on the **Agent policies** section (on CE `policyEvents[]` is always empty — "no checks exist", not "passed").
- Newer-update check: the sub-agent "not in v1" note is still accurate (no `rearm agent spawn` CLI yet); sub-agents are now a first-class concept (see below).

## 2. New Concepts
Added **Agent**, **Session**, **Sub-agent** to `concepts/`, and fleshed out the existing **Instance** / **Cluster** with the Pro deployment-tracking + feature-set context (these two already existed).

## 3. New DevOps workflow (Pro only)
New `workflows/devops` page covering **Instances**, **Secrets**, and **[rearm-cd](https://github.com/relizaio/rearm-cd)** (the in-cluster reconciler that lets deployments be controlled from ReARM), plus `listfeaturesets` / `versionfeatureset` / `switchfeatureset`. Includes a **"Letting an AI agent deploy"** section: grant the agent's key the `DEVOPS` function scoped to one instance so it can `versionfeatureset` + `switchfeatureset` — i.e. an agent that not only builds/attributes but promotes and ships, with `rearm-cd` reconciling. Cross-linked from `workflows/agentic`. Wired into the workflows sidebar + index.

## Test plan
- [x] `vitepress build` (`npm run docs:build`) passes