### PR TITLE
docs(landing): add 26.06.5 release news post

### DIFF
--- a/landing_site/src/content/news/2026-06-01-rearm-26-06-5-release.md
+++ b/landing_site/src/content/news/2026-06-01-rearm-26-06-5-release.md
@@ -1,0 +1,41 @@
+---
+title: "ReARM 26.06.5: Agentic Coding Guardrails and DevOps"
+date: "2026-06-01"
+---
+
+We're announcing a major release of ReARM [v26.06.5](https://github.com/relizaio/rearm/releases/tag/26.06.5). Detailed information is available on its [release view](https://demo.rearmhq.com/release/show/886401ca-5e93-404c-aa16-70a3ac7083b1) on the ReARM Demo instance. ReARM Pro installations have already been upgraded; ReARM CE users are encouraged to upgrade to benefit from the changes described below.
+
+
+**Agentic Coding Guardrails**
+
+The headline of this release is an end-to-end platform for governing AI coding agents, spanning the ReARM backend and UI. ReARM now models Agents, Sessions, and a Model Ontology as first-class entities, with a dedicated AI Agents dashboard, an interactive session view, and a Live Sessions table. Every commit produced in a session is tied back to the agent and session that authored it through commit-trailer attribution. ReARM also adds full commit signature verification — both SSH and GPG — with signing-key enrolment for agents (including FREEFORM keys, with server-side fingerprint and SSH-identity derivation) alongside human committer keys, so ReARM can now clearly tell which commits come from human developers and which from AI agents. Agents bootstrap against a published orientation contract served at `/api/agents/orientation.md`, and a new `AGENT` permission function governs agentic operations. On ReARM Pro, configurable policies can block agentic operations at the session, pull-request, and release level — requiring, for example, a final session report, signed commits, or a minimum security posture such as no critical vulnerabilities before an operation is allowed to proceed.
+
+
+**DevOps**
+
+The DevOps surface graduates from Preview to Beta. With ReARM DevOps you assign product releases to instances, and ReARM CD automatically routes each release to the right instances based on its approval status and each instance's environment — so a release progresses from staging toward production as it clears the required gates. Just as importantly, ReARM reports back what is *actually* running on each instance, not only what was intended to deploy: the Instance view is split into Instance, Plan History, and Actual History tabs, and watcher-reported ("actual") deployed images are surfaced against the planned feature set so drift is visible at a glance. Feature sets attached to instances require exactly one Helm dependency, target releases can be scoped to a namespace, and per-scope `DEVOPS_READ` / `DEVOPS_WRITE` permissions are plumbed end-to-end. See the new [DevOps workflow documentation](https://docs.rearmhq.com/workflows/devops.html) for details. DevOps functionality is ReARM Pro only.
+
+
+**Full Agentic Feedback Loop**
+
+Taken together, agentic guardrails and the DevOps surface let an AI agent close the entire loop — not just write code and open a pull request, but deploy what it built and observe the result. An agent can be assigned to a specific instance and, once its work is released, drive the rollout end to end: it assembles a new feature set pinning the build it produced and switches the target instance over to it, then reads back the instance's actual state to confirm the deployment landed and to detect drift from what was planned. Because every step runs under the same attribution, signing, and policy guardrails described above, organizations get an autonomous code-to-deployment loop that stays observable and governed throughout.
+
+
+**Reliability and Performance**
+
+This release includes a large round of backend performance and reliability work: totals-only metrics reads backed by generated columns and read-only Lite entities, tuned JVM/GC settings with exit-on-OOM for clean Kubernetes restarts, Dependency-Track cleanup and paging improvements, and an explicit connection pool with shorter query timeouts. The Rebom BOM-enrichment scheduler now retries stale enrichments and scopes its work to enrichment-configured organizations, and reconcile-driven BOM-diff notifications are emitted once per release. The net effect is lower memory pressure and more predictable behavior on large component portfolios.
+
+
+**Platform Upgrade**
+
+The backend moves to Java 25, Spring Boot 4, Jackson 3, and the ZGC garbage collector, and gains readiness/startup probes and graceful shutdown across the backend and Helm chart.
+
+
+**Dependency Updates**
+
+This release contains a number of dependency updates, including those fixing underlying CVEs in dependencies. ReARM users are encouraged to upgrade to this release to benefit from these fixes.
+
+
+**Release Identification**
+
+We are continuing to publish TEIs for all ReARM releases. TEI for this release: *urn:tei:purl:demo.rearmhq.com:pkg:github/relizaio/rearm@26.06.5*.


### PR DESCRIPTION
## Summary

Adds the release news article **"ReARM 26.06.5: Agentic Coding Guardrails and DevOps"** to the landing site (`landing_site/src/content/news/2026-06-01-rearm-26-06-5-release.md`), following the existing release-post format.

Sections: Agentic Coding Guardrails · DevOps (now Beta) · Full Agentic Feedback Loop · Reliability and Performance · Platform Upgrade · Dependency Updates · Release Identification.

## Notes
- Links to the GitHub release, the ReARM Demo release view, and the new DevOps workflow docs (`docs.rearmhq.com/workflows/devops.html`).

ReARM-Agentic-Session: news-26-06-5-1780337604
ReARM-Agent: 703fbe71-5a15-4bd3-b601-ce3f0d7d225b