### PR TITLE
feat(rebom): capture cpe and licenses in component extraction

### DIFF
--- a/rebom-backend/src/schema.graphql.ts
+++ b/rebom-backend/src/schema.graphql.ts
@@ -146,6 +146,8 @@ const typeDefs = gql`
     name: String
     version: String
     isRoot: Boolean!
+    cpe: String
+    licenses: [String!]!
   }
 
   type BomDependency {

--- a/rebom-backend/src/services/bom/bomComponentExtractor.ts
+++ b/rebom-backend/src/services/bom/bomComponentExtractor.ts
@@ -35,6 +35,13 @@ export interface ParsedBomComponent {
 	name: string | null;
 	version: string | null;
 	isRoot: boolean;
+	// cpe carried alongside the purl so downstream vuln matching can match on
+	// either coordinate (NVD/CPE-keyed advisories vs purl-keyed ones). null when
+	// the BOM declared no cpe for the component.
+	cpe: string | null;
+	// Declared license identifiers (SPDX id, free-text name, or SPDX expression),
+	// deduped. Always an array (possibly empty) so the field is never null.
+	licenses: string[];
 }
 
 export interface ParsedBomDependency {
@@ -74,9 +81,43 @@ export function canonicalizePurl(rawPurl: string | undefined | null): string | n
 	}
 }
 
+/**
+ * Normalize a CycloneDX component.licenses array into a deduped list of
+ * identifier strings. Each entry is either { license: { id | name } } or
+ * { expression }; prefer SPDX id, then free-text name, then expression.
+ */
+function extractLicenses(raw: { licenses?: any } | undefined): string[] {
+	const arr = raw?.licenses;
+	if (!Array.isArray(arr)) return [];
+	const out: string[] = [];
+	const seen = new Set<string>();
+	for (const entry of arr) {
+		if (!entry || typeof entry !== 'object') continue;
+		let val: string | undefined;
+		if (entry.license && typeof entry.license === 'object') {
+			val =
+				typeof entry.license.id === 'string'
+					? entry.license.id
+					: typeof entry.license.name === 'string'
+						? entry.license.name
+						: undefined;
+		} else if (typeof entry.expression === 'string') {
+			val = entry.expression;
+		}
+		if (typeof val === 'string') {
+			const v = val.trim();
+			if (v && !seen.has(v)) {
+				seen.add(v);
+				out.push(v);
+			}
+		}
+	}
+	return out;
+}
+
 function toParsedComponent(
 	rawPurl: string,
-	fallback: { group?: any; name?: any; version?: any } | undefined,
+	fallback: { group?: any; name?: any; version?: any; cpe?: any; licenses?: any } | undefined,
 	isRoot: boolean
 ): ParsedBomComponent | null {
 	const canonicalPurl = canonicalizePurl(rawPurl);
@@ -100,6 +141,8 @@ function toParsedComponent(
 			parsed?.version ??
 			(typeof fallback?.version === 'string' ? fallback.version : null),
 		isRoot,
+		cpe: typeof fallback?.cpe === 'string' && fallback.cpe.length > 0 ? fallback.cpe : null,
+		licenses: extractLicenses(fallback),
 	};
 }
 

--- a/rebom-backend/test/unit/bomComponentExtractor.test.ts
+++ b/rebom-backend/test/unit/bomComponentExtractor.test.ts
@@ -58,6 +58,46 @@ describe('bomComponentExtractor.parseBom', () => {
 		});
 	});
 
+	it('captures cpe and normalized/deduped licenses when present, defaults otherwise', () => {
+		const bom = {
+			components: [
+				{
+					purl: 'pkg:npm/withmeta@1.0',
+					cpe: 'cpe:2.3:a:vendor:withmeta:1.0:*:*:*:*:*:*:*',
+					licenses: [
+						{ license: { id: 'MIT' } },
+						{ license: { name: 'Custom License' } },
+						{ expression: '(Apache-2.0 OR MIT)' },
+						{ license: { id: 'MIT' } }, // duplicate -> deduped
+					],
+				},
+				{ purl: 'pkg:npm/bare@1.0' },
+			],
+		};
+		const got = parseBom(bom);
+		const withMeta = got.components.find((c) => c.canonicalPurl === 'pkg:npm/withmeta@1.0');
+		expect(withMeta?.cpe).toBe('cpe:2.3:a:vendor:withmeta:1.0:*:*:*:*:*:*:*');
+		expect(withMeta?.licenses).toEqual(['MIT', 'Custom License', '(Apache-2.0 OR MIT)']);
+		const bare = got.components.find((c) => c.canonicalPurl === 'pkg:npm/bare@1.0');
+		expect(bare?.cpe).toBeNull();
+		expect(bare?.licenses).toEqual([]);
+	});
+
+	it('carries cpe/licenses onto the synthesised root node', () => {
+		const bom = {
+			metadata: {
+				component: {
+					purl: 'pkg:oci/myapp@1.0.0',
+					cpe: 'cpe:2.3:a:acme:myapp:1.0.0:*:*:*:*:*:*:*',
+					licenses: [{ license: { id: 'Apache-2.0' } }],
+				},
+			},
+		};
+		const root = parseBom(bom).components.find((c) => c.isRoot);
+		expect(root?.cpe).toBe('cpe:2.3:a:acme:myapp:1.0.0:*:*:*:*:*:*:*');
+		expect(root?.licenses).toEqual(['Apache-2.0']);
+	});
+
 	it('drops components without a purl but keeps the rest', () => {
 		const bom = {
 			components: [


### PR DESCRIPTION
**PR 1 of the synthetic-DTrack-registry feature** (targets the `2026-06-synthetic-dtrack-registry` integration branch, not main).

## Why
The feature dedupes SBOM components org-wide into a matchable registry and submits *synthetic* SBOMs to Dependency-Track instead of one project per real SBOM. `rearm-core` sources parsed components **solely** from rebom's `parseBomById` GraphQL — which today drops CPE and license data. This PR is the additive foundation that makes them available.

## What
- `ParsedBomComponent` gains `cpe: string | null` and `licenses: string[]`.
- `extractLicenses` normalizes CycloneDX `component.licenses` (`license.id` → `license.name` → `expression`), deduped; always returns an array.
- `component.cpe` carried through (null when absent).
- `BomComponent` GraphQL type exposes `cpe` and `licenses`.

## Deliberately additive / non-breaking
Still only **purl-bearing** components are emitted. Emitting CPE-only/no-purl components is deferred to a later PR, once `rearm-core`'s `canonicalPurl`-keyed consumer is made null-safe — otherwise it would break the existing pipeline cross-repo.

## Test plan
- [x] `npm run build` (tsc) clean
- [x] `vitest` extractor suite 19/19 (+2 new: cpe/license normalization+dedup, root-node carry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)