### PR TITLE
style(ui): unify tab styling to segment (Org Settings style)

### DIFF
--- a/ui/src/components/AiAgentSessionView.vue
+++ b/ui/src/components/AiAgentSessionView.vue
@@ -20,7 +20,7 @@
         </div>
         <h3>{{ session.title || '(untitled)' }}</h3>
 
-        <n-tabs type="line" v-model:value="tab">
+        <n-tabs type="segment" v-model:value="tab" animated>
             <n-tab-pane name="overview" tab="Overview">
                 <n-descriptions :column="1" bordered label-placement="left" label-align="left" :label-style="metaLabelStyle">
                     <n-descriptions-item label="Status">

--- a/ui/src/components/AiAgentView.vue
+++ b/ui/src/components/AiAgentView.vue
@@ -64,7 +64,7 @@
             </div>
         </div>
 
-        <n-tabs type="line" v-model:value="tab">
+        <n-tabs type="segment" v-model:value="tab" animated>
             <n-tab-pane name="open" :tab="`Open sessions · ${openSessions.length}`">
                 <SessionTable :rows="openSessions" :on-open="openSession"/>
             </n-tab-pane>

--- a/ui/src/components/AppHome.vue
+++ b/ui/src/components/AppHome.vue
@@ -49,9 +49,9 @@
                         <h3>Search Releases</h3>
                         <div class="searchUnit artifactSearch">
                             <n-tabs
-                            class="card-tabs"
+                            type="segment"
                             default-value="searchreleasesbytext"
-                            size="large"
+                            size="medium"
                             animated
                             style="margin: 0 -4px"
                             pane-style="padding-left: 4px; padding-right: 4px; box-sizing: border-box;"

--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -80,7 +80,7 @@
             </n-button>
         </div>
         
-        <n-tabs v-if="changelog" v-model:value="activeTab" type="line" animated style="margin-top: 4px;">
+        <n-tabs v-if="changelog" v-model:value="activeTab" type="segment" animated style="margin-top: 4px;">
             <!-- Code / Component Changes tab -->
             <n-tab-pane name="code" :tab="codeTabLabel">
                 <SeverityFilter v-model:selectedSeverity="selectedSeverity" />

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -184,8 +184,8 @@
                             >
                                 <h3>{{ words.componentFirstUpper }} Settings for {{ componentData?.name }}</h3>
                                 <n-tabs
-                                    class="card-tabs"
-                                    size="large"
+                                    type="segment"
+                                    size="medium"
                                     animated
                                     style="margin: 0 -4px"
                                     pane-style="padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
@@ -975,7 +975,7 @@
                     </div>
                 </div>
                 <div class="componentDetails">
-                    <n-tabs v-if="componentData && componentData.type === 'COMPONENT'" v-model:value="selectedTab" type="line" @update:value="handleTabChange">
+                    <n-tabs v-if="componentData && componentData.type === 'COMPONENT'" v-model:value="selectedTab" type="segment" @update:value="handleTabChange" animated>
                         <n-tab-pane name="branches" tab="Branches">
                             <n-data-table :data="branches" :columns="branchFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                         </n-tab-pane>

--- a/ui/src/components/CreateComponent.vue
+++ b/ui/src/components/CreateComponent.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="createComponentGlobal">
         <div v-if="!props.isHideTitle">Create {{ componentProductWords.componentFirstUpper }}</div>
-        <n-tabs v-if="!isProduct" type="line" animated>
+        <n-tabs v-if="!isProduct" type="segment" animated>
             <n-tab-pane name="create" :tab="'Create ' + componentProductWords.componentFirstUpper">
         <n-form
             ref="createComponentForm"

--- a/ui/src/components/CreateInstance.vue
+++ b/ui/src/components/CreateInstance.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="createInstanceGlobal">
         <n-tabs
-            class="card-tabs"
+            type="segment"
             :default-value="isWritableGeneral ? 'createmanual' : 'createauto'"
-            size="large"
+            size="medium"
             animated
             style="margin: 0 -4px"
             pane-style="padding-left: 4px; padding-right: 4px; box-sizing: border-box;"

--- a/ui/src/components/FindingAnalysisPage.vue
+++ b/ui/src/components/FindingAnalysisPage.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="finding-analysis-page">
-        <n-tabs v-model:value="activeTab" type="line" animated @update:value="onTabChange">
+        <n-tabs v-model:value="activeTab" type="segment" animated @update:value="onTabChange">
             <n-tab-pane name="findings" tab="Finding Analysis">
                 <vulnerability-analysis />
             </n-tab-pane>

--- a/ui/src/components/MarketingReleaseView.vue
+++ b/ui/src/components/MarketingReleaseView.vue
@@ -60,7 +60,7 @@
         </div>
        
         <div class="row" v-if="marketingRelease && marketingRelease.orgDetails && updatedMarketingRelease && updatedMarketingRelease.orgDetails">
-            <n-tabs style="padding-left:2%;" type="line" @update:value="handleTabChange">
+            <n-tabs style="padding-left:2%;" type="segment" @update:value="handleTabChange" animated>
                 <n-tab-pane name="integration" tab="Integration">
                     <div class="container" v-if="updatedMarketingRelease.type !== 'PLACEHOLDER'">
                         <div class="versionSchemaBlock">

--- a/ui/src/components/MitigationAttestationsInbox.vue
+++ b/ui/src/components/MitigationAttestationsInbox.vue
@@ -1,6 +1,6 @@
 <template>
     <n-card title="Mitigation Attestations">
-        <n-tabs v-model:value="statusFilter" type="line">
+        <n-tabs v-model:value="statusFilter" type="segment" animated>
             <n-tab-pane name="PENDING" tab="Pending" />
             <n-tab-pane name="ATTESTED" tab="Attested" />
             <n-tab-pane name="WAIVED" tab="Waived" />

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -665,7 +665,7 @@
                     >
                         <template #header>Edit key {{ selectedFreeFormKey.uuid }}</template>
                         <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
-                            <n-tabs v-model:value="freeFormKeyEditTab" type="line" animated>
+                            <n-tabs v-model:value="freeFormKeyEditTab" type="segment" animated>
                                 <n-tab-pane name="permissions" tab="Permissions">
                                     <ScopedPermissions
                                         v-model="freeFormKeyScopedPermissions"

--- a/ui/src/components/OrganizationChangelogView.vue
+++ b/ui/src/components/OrganizationChangelogView.vue
@@ -17,7 +17,7 @@
                     </n-button>
                 </div>
                 
-                <n-tabs v-model:value="activeTab" type="line" animated style="margin-top: 4px;">
+                <n-tabs v-model:value="activeTab" type="segment" animated style="margin-top: 4px;">
                     <n-tab-pane name="sbom" tab="📦 SBOM Changes">
                         <div v-if="aggregationType === 'NONE' && changelog.__typename === 'NoneOrganizationChangelog'">
                             <div v-for="component in changelog.components" :key="component.componentUuid">
@@ -77,7 +77,7 @@
             </div>
             
             <div v-else-if="!loading">
-                <n-tabs type="line" animated style="margin-top: 20px;">
+                <n-tabs type="segment" animated style="margin-top: 20px;">
                     <n-tab-pane name="sbom" tab="📦 SBOM Changes">
                         <p class="no-data-hint">No changelog data available for the selected date range</p>
                     </n-tab-pane>

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -685,7 +685,7 @@
         </div>
 
         <div class="row" v-if="release && release.orgDetails && updatedRelease && updatedRelease.orgDetails">
-            <n-tabs style="padding-left:0.2%;" type="line" @update:value="handleTabSwitch">
+            <n-tabs style="padding-left:0.2%;" type="segment" @update:value="handleTabSwitch" animated>
                 <n-tab-pane name="components" tab="Components">
                     <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
                         <h3>Components

--- a/ui/src/components/VexProposalsInbox.vue
+++ b/ui/src/components/VexProposalsInbox.vue
@@ -1,6 +1,6 @@
 <template>
     <n-card title="VEX Statement Proposals">
-        <n-tabs v-model:value="statusFilter" type="line">
+        <n-tabs v-model:value="statusFilter" type="segment" animated>
             <n-tab-pane name="PENDING" tab="Pending" />
             <n-tab-pane name="ACCEPTED" tab="Accepted" />
             <n-tab-pane name="REJECTED" tab="Rejected" />


### PR DESCRIPTION
## Summary

Applies the Org Settings **segment** tab style to every `n-tabs` strip across the UI for a consistent look. Converts `type="line"` (and the default/`card-tabs` pickers) to `type="segment"` with `animated`; the large card pickers (create-mode toggles, home search) are normalized to `size="medium"`.

14 components touched; bindings, handlers, `v-if`, and pane content are unchanged (19 insertions / 19 deletions — attribute-only).

## Visual review
This is a broad, purely visual change. A preview is being deployed to the scully sandbox for review — worth checking the wider tab strips (ReleaseView ~11 tabs, ComponentView, the AI Agent views) for spacing.

ReARM-Agentic-Session: ui-segment-tabs-1780425877
ReARM-Agent: 703fbe71-5a15-4bd3-b601-ce3f0d7d225b