### PR TITLE
feat(rebom): emit licenses in exact CycloneDX shape

### DIFF
--- a/rebom-backend/src/schema.graphql.ts
+++ b/rebom-backend/src/schema.graphql.ts
@@ -147,7 +147,7 @@ const typeDefs = gql`
     version: String
     isRoot: Boolean!
     cpe: String
-    licenses: [String!]!
+    licenses: [Object!]!
   }
 
   type BomDependency {

--- a/rebom-backend/src/services/bom/bomComponentExtractor.ts
+++ b/rebom-backend/src/services/bom/bomComponentExtractor.ts
@@ -39,9 +39,12 @@ export interface ParsedBomComponent {
 	// either coordinate (NVD/CPE-keyed advisories vs purl-keyed ones). null when
 	// the BOM declared no cpe for the component.
 	cpe: string | null;
-	// Declared license identifiers (SPDX id, free-text name, or SPDX expression),
-	// deduped. Always an array (possibly empty) so the field is never null.
-	licenses: string[];
+	// Declared licenses in EXACT CycloneDX shape: each item is
+	// { license: { id | name, text?, url?, ... } } or { expression }. Passed
+	// through structurally (not flattened to strings) so the precise id/name/
+	// expression distinction is preserved and can be re-emitted to / matched by
+	// Dependency-Track. Always an array (possibly empty).
+	licenses: any[];
 }
 
 export interface ParsedBomDependency {
@@ -82,37 +85,15 @@ export function canonicalizePurl(rawPurl: string | undefined | null): string | n
 }
 
 /**
- * Normalize a CycloneDX component.licenses array into a deduped list of
- * identifier strings. Each entry is either { license: { id | name } } or
- * { expression }; prefer SPDX id, then free-text name, then expression.
+ * Pass a CycloneDX component.licenses array through structurally, preserving the
+ * exact shape (each item is { license: { id | name, ... } } or { expression }).
+ * Only well-formed object entries are kept; the array is returned verbatim
+ * otherwise so it can be re-emitted to Dependency-Track unchanged.
  */
-function extractLicenses(raw: { licenses?: any } | undefined): string[] {
+function extractLicenses(raw: { licenses?: any } | undefined): any[] {
 	const arr = raw?.licenses;
 	if (!Array.isArray(arr)) return [];
-	const out: string[] = [];
-	const seen = new Set<string>();
-	for (const entry of arr) {
-		if (!entry || typeof entry !== 'object') continue;
-		let val: string | undefined;
-		if (entry.license && typeof entry.license === 'object') {
-			val =
-				typeof entry.license.id === 'string'
-					? entry.license.id
-					: typeof entry.license.name === 'string'
-						? entry.license.name
-						: undefined;
-		} else if (typeof entry.expression === 'string') {
-			val = entry.expression;
-		}
-		if (typeof val === 'string') {
-			const v = val.trim();
-			if (v && !seen.has(v)) {
-				seen.add(v);
-				out.push(v);
-			}
-		}
-	}
-	return out;
+	return arr.filter((entry) => entry && typeof entry === 'object');
 }
 
 function toParsedComponent(

--- a/rebom-backend/test/unit/bomComponentExtractor.test.ts
+++ b/rebom-backend/test/unit/bomComponentExtractor.test.ts
@@ -58,7 +58,7 @@ describe('bomComponentExtractor.parseBom', () => {
 		});
 	});
 
-	it('captures cpe and normalized/deduped licenses when present, defaults otherwise', () => {
+	it('captures cpe and passes licenses through in exact CycloneDX shape', () => {
 		const bom = {
 			components: [
 				{
@@ -68,22 +68,30 @@ describe('bomComponentExtractor.parseBom', () => {
 						{ license: { id: 'MIT' } },
 						{ license: { name: 'Custom License' } },
 						{ expression: '(Apache-2.0 OR MIT)' },
-						{ license: { id: 'MIT' } }, // duplicate -> deduped
 					],
 				},
 				{ purl: 'pkg:npm/bare@1.0' },
+				{ purl: 'pkg:npm/garbage@1.0', licenses: ['not-an-object', null] },
 			],
 		};
 		const got = parseBom(bom);
 		const withMeta = got.components.find((c) => c.canonicalPurl === 'pkg:npm/withmeta@1.0');
 		expect(withMeta?.cpe).toBe('cpe:2.3:a:vendor:withmeta:1.0:*:*:*:*:*:*:*');
-		expect(withMeta?.licenses).toEqual(['MIT', 'Custom License', '(Apache-2.0 OR MIT)']);
+		// structural passthrough — id/name/expression distinction preserved
+		expect(withMeta?.licenses).toEqual([
+			{ license: { id: 'MIT' } },
+			{ license: { name: 'Custom License' } },
+			{ expression: '(Apache-2.0 OR MIT)' },
+		]);
 		const bare = got.components.find((c) => c.canonicalPurl === 'pkg:npm/bare@1.0');
 		expect(bare?.cpe).toBeNull();
 		expect(bare?.licenses).toEqual([]);
+		// non-object entries are dropped
+		const garbage = got.components.find((c) => c.canonicalPurl === 'pkg:npm/garbage@1.0');
+		expect(garbage?.licenses).toEqual([]);
 	});
 
-	it('carries cpe/licenses onto the synthesised root node', () => {
+	it('carries cpe/licenses (structural) onto the synthesised root node', () => {
 		const bom = {
 			metadata: {
 				component: {
@@ -95,7 +103,7 @@ describe('bomComponentExtractor.parseBom', () => {
 		};
 		const root = parseBom(bom).components.find((c) => c.isRoot);
 		expect(root?.cpe).toBe('cpe:2.3:a:acme:myapp:1.0.0:*:*:*:*:*:*:*');
-		expect(root?.licenses).toEqual(['Apache-2.0']);
+		expect(root?.licenses).toEqual([{ license: { id: 'Apache-2.0' } }]);
 	});
 
 	it('drops components without a purl but keeps the rest', () => {


### PR DESCRIPTION
Part of the structured-licenses fix. `extractLicenses` now passes `component.licenses` through **structurally** (each item `{ license: { id|name, ... } }` or `{ expression }`) instead of flattening to strings — preserving the id/name/expression distinction so DTrack sees the exact shape. `BomComponent.licenses` GraphQL → `[Object!]!`. Pairs with the rearm-saas consumer PR. tsc + vitest 19/19.