### PR TITLE
feat(ui): Pro-only hint on Slack/Teams catalog cards pointing at Notifications

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -126,12 +126,21 @@
                         <!-- Pro-only hint for messaging cards: the new
                              notifications framework is a separate, security-
                              focused destination surface. Gated on Pro so the
-                             OSS catalog stays the same. -->
+                             OSS catalog stays the same. RouterLink target
+                             (NotificationsOfOrg) only resolves once the
+                             notifications-impl branch lands — until then
+                             this PR's link 404s. See PR body for the
+                             merge-ordering note. -->
                         <div
                             v-if="showCiFeatures && (card.id === 'SLACK' || card.id === 'MSTEAMS')"
                             class="card-pro-hint"
                         >
-                            Security alerts use a separate destination — manage in Notifications →
+                            Security and vulnerability alerts use a separate destination —
+                            manage in
+                            <RouterLink :to="{ name: 'NotificationsOfOrg', params: { orguuid: props.orguuid } }">
+                                Notifications
+                            </RouterLink>
+                            →
                         </div>
                     </div>
                 </div>

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -122,6 +122,17 @@
                                 <span>Add another {{ card.name }}</span>
                             </button>
                         </template>
+
+                        <!-- Pro-only hint for messaging cards: the new
+                             notifications framework is a separate, security-
+                             focused destination surface. Gated on Pro so the
+                             OSS catalog stays the same. -->
+                        <div
+                            v-if="showCiFeatures && (card.id === 'SLACK' || card.id === 'MSTEAMS')"
+                            class="card-pro-hint"
+                        >
+                            Security alerts use a separate destination — manage in Notifications →
+                        </div>
                     </div>
                 </div>
             </template>
@@ -1132,6 +1143,13 @@ watch(() => props.orguuid, async () => {
     border-top: 1px dashed var(--line);
 }
 .muted-12 { font-size: 12px; color: var(--muted); }
+
+.card-pro-hint {
+    margin-top: 10px;
+    font-size: 11.5px;
+    color: var(--muted);
+    line-height: 1.4;
+}
 
 /* ---- instance rows ------------------------------------------------------ */
 .instance-list {


### PR DESCRIPTION
## Summary

Adds a small footer hint on the **Slack** and **MS Teams** cards in
`OrgIntegrations.vue` (Catalog tab) explaining that security and vulnerability
alerts live on a separate destination, manageable under Notifications. Gated on
`installationType !== 'OSS'` (reusing the `showCiFeatures` computed which
already encodes the Pro gate) so the OSS catalog stays unchanged.

Closes the discoverability gap created by Pro having two parallel
"Slack/Teams" surfaces:
- Legacy `IntegrationService` (CE + Pro): the existing catalog cards here
- New `NotificationChannel` framework (Pro-only): shipped in
  [rearm-saas #184](https://github.com/relizaio/rearm-saas/pull/184)

The destination is the *Slack incoming webhook URL*, not the workspace, so
per-concern channels with separate webhooks is the right model. The full
"coexist-don't-unify" design memo (Options A–E with rejection rationale) is
at `rearm-core/ai-plans/notifications-integration-unification.md` in PR #184.

## Merge ordering

The hint copy includes a `<RouterLink :to="{ name: 'NotificationsOfOrg', ... }">`
to give the user a one-click path to the new Notifications page. That route
name is only registered once the rearm sibling PR for the notifications-impl
branch lands; until then the link 404s. Suggested order:

1. Land rearm notifications-impl PR (registers the `NotificationsOfOrg` route)
2. Land this PR (turns the now-resolvable link live)

Shipping in the opposite order is harmless visually (the hint still renders
and reads correctly) but the link itself dead-ends.

## Visual

```
+-----------------------------------+
| [logo] Slack       [Available]    |
| Slack Technologies                |
|                                   |
| Push release notifications to a   |
| Slack channel.                    |
| - - - - - - - - - - - - - - - - - |
| Not configured        [+ Add]     |
|                                   |
| Security and vulnerability alerts |  ← new (Pro only)
| use a separate destination —      |
| manage in Notifications →         |
+-----------------------------------+
```

Same hint renders on the MS Teams card. CSS reuses muted-text styling
(`var(--muted)`, 11.5px) so it disappears into the card visually.

## Test plan
- [x] `npm run build` clean
- [ ] Roll the rearm UI image onto the sandbox alongside PR #184's backend and the notifications-impl PR; visually confirm:
  - Slack and MS Teams cards show the hint
  - "Notifications" in the hint navigates to the new framework page (not a 404)
  - DT / BEAR / CI cards do NOT show the hint
  - OSS edition shows neither hint nor the card-pro-hint CSS (gated on `showCiFeatures`)
- [ ] Confirm card layout doesn't look crowded in either Available or Configured state

🤖 Generated with [Claude Code](https://claude.com/claude-code)