### PR TITLE
feat(ui): notifications framework — Phase 7 (umbrella PR)

### DIFF
--- a/ui/src/components/AppWrapper.vue
+++ b/ui/src/components/AppWrapper.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="app-wrapper">
         <n-config-provider>
-            <n-loading-bar-provider><n-notification-provider placement="bottom-right"><n-message-provider>
+            <n-loading-bar-provider><n-notification-provider placement="bottom-right"><n-message-provider><n-dialog-provider>
                 <div class="main-content" v-if="!showSignUpFlow">
                     <div class="content-area">
                         <n-layout>
@@ -35,7 +35,7 @@
                 <sign-up-flow v-if="showSignUpFlow === 'signup'" />
                 <verify-email v-if="showSignUpFlow === 'verifyEmail'" />
                 <join-organization v-if="showSignUpFlow === 'joinOrganization'" />
-            </n-message-provider></n-notification-provider></n-loading-bar-provider>
+            </n-dialog-provider></n-message-provider></n-notification-provider></n-loading-bar-provider>
         </n-config-provider>
     </div>
 </template>
@@ -46,7 +46,7 @@ export default {
 </script>
 <script lang="ts" setup>
 import { Ref, ref, ComputedRef, computed } from 'vue'
-import { NConfigProvider, NLayout, NSpace, NLayoutContent, NNotificationProvider, NLoadingBarProvider, NMessageProvider, NDivider } from 'naive-ui'
+import { NConfigProvider, NLayout, NSpace, NLayoutContent, NNotificationProvider, NLoadingBarProvider, NMessageProvider, NDialogProvider, NDivider } from 'naive-ui'
 import TopNavBar from './TopNavBar.vue'
 import LeftNavBar from './LeftNavBar.vue'
 import { useStore } from 'vuex'

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -43,7 +43,7 @@ import type { MenuOption } from 'naive-ui'
 import { ref, h, Component, ComputedRef, computed, Ref, watch } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
 import { useStore } from 'vuex'
-import { HomeOutlined as HomeIcon, CloudServerOutlined, BugOutlined } from '@vicons/antd'
+import { HomeOutlined as HomeIcon, CloudServerOutlined, BugOutlined, BellOutlined } from '@vicons/antd'
 import { Adjustments, Folder, Stack2, BrandGit, Key, ChartBar, GitPullRequest, Robot } from '@vicons/tabler'
 
 
@@ -178,6 +178,21 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
             key: 'secrets',
             icon: renderIcon(Key)
         },
+        {
+            label: () =>
+                h(
+                    RouterLink,
+                    {
+                        to: {
+                            name: 'NotificationsOfOrg',
+                            params: {orguuid: org}
+                        }
+                    },
+                    { default: () => 'Notifications' }
+                ),
+            key: 'notifications',
+            icon: renderIcon(BellOutlined)
+        },
     ]
 
     const settingsOptions = [
@@ -266,6 +281,7 @@ const routeToMenuKey: Record<string, string> = {
     'InstancesOfOrg': 'instances',
     'Instance': 'instances',
     'SecretsOfOrg': 'secrets',
+    'NotificationsOfOrg': 'notifications',
     'AnalyticsOfOrg': 'analytics',
     'VulnerabilityAnalysis': 'vulnerabilityAnalysis',
     'VexProposalReview': 'vulnerabilityAnalysis',

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -369,6 +369,11 @@
 
                         <n-alert v-if="modalError" type="error" :show-icon="false">
                             {{ modalError }}
+                            <template v-if="isConflictError(modalError)" #action>
+                                <n-button size="small" type="primary" @click="reloadAfterConflict('channel')">
+                                    Reload from server
+                                </n-button>
+                            </template>
                         </n-alert>
 
                         <n-space>
@@ -532,6 +537,11 @@
 
                         <n-alert v-if="groupModalError" type="error" :show-icon="false">
                             {{ groupModalError }}
+                            <template v-if="isConflictError(groupModalError)" #action>
+                                <n-button size="small" type="primary" @click="reloadAfterConflict('group')">
+                                    Reload from server
+                                </n-button>
+                            </template>
                         </n-alert>
 
                         <n-space>
@@ -697,6 +707,11 @@
 
                         <n-alert v-if="subModalError" type="error" :show-icon="false">
                             {{ subModalError }}
+                            <template v-if="isConflictError(subModalError)" #action>
+                                <n-button size="small" type="primary" @click="reloadAfterConflict('subscription')">
+                                    Reload from server
+                                </n-button>
+                            </template>
                         </n-alert>
 
                         <n-space>
@@ -767,6 +782,10 @@ interface ChannelRow {
     name: string
     type: string
     status: string
+    // Hibernate @Version-managed revision captured on Edit-load; sent
+    // back as expectedRevision on save so a concurrent admin edit gets
+    // rejected with a "Conflict:" error instead of silently winning.
+    revision: number
 }
 
 interface SubscriptionRoute {
@@ -794,6 +813,7 @@ interface ChannelGroupRow {
 
 interface ChannelGroupForm {
     uuid: string | null
+    expectedRevision: number | null
     name: string
     channels: string[]
 }
@@ -844,6 +864,8 @@ interface SubscriptionRow {
     routes: string | null         // JSON-stringified server-side
     dedupWindowMinutes: number | null
     rateLimit: string | null      // JSON-stringified server-side
+    // See ChannelRow.revision — same optimistic-locking gate.
+    revision: number
 }
 
 const route = useRoute()
@@ -949,6 +971,9 @@ const modalError = ref<string>('')
 
 interface ChannelForm {
     uuid: string | null
+    // Captured at Edit-load; null on Create. Sent as expectedRevision
+    // on the upsert so a concurrent admin edit gets a Conflict error.
+    expectedRevision: number | null
     name: string
     type: string | null
     status: string
@@ -968,6 +993,7 @@ interface ChannelForm {
 function freshForm (): ChannelForm {
     return {
         uuid: null,
+        expectedRevision: null,
         name: '',
         type: null,
         status: 'ENABLED',
@@ -1013,6 +1039,7 @@ const showTestModal = ref<boolean>(false)
 // Subscription form state
 interface SubscriptionForm {
     uuid: string | null
+    expectedRevision: number | null
     name: string
     status: string
     eventTypes: string[]
@@ -1034,12 +1061,13 @@ function freshRoute (): SubscriptionRoute {
 }
 
 function freshGroupForm (): ChannelGroupForm {
-    return { uuid: null, name: '', channels: [] }
+    return { uuid: null, expectedRevision: null, name: '', channels: [] }
 }
 
 function freshSubscriptionForm (): SubscriptionForm {
     return {
         uuid: null,
+        expectedRevision: null,
         name: '',
         status: 'ACTIVE',
         eventTypes: [],
@@ -1211,7 +1239,7 @@ const historyFilters = ref<{ status: string | null, origin: string | null, chann
 const LIST_CHANNELS_QUERY = gql`
     query notificationChannels($orgUuid: ID!) {
         notificationChannels(orgUuid: $orgUuid) {
-            uuid org resourceGroup name type status
+            uuid org resourceGroup name type status revision
         }
     }
 `
@@ -1219,7 +1247,7 @@ const LIST_CHANNELS_QUERY = gql`
 const UPSERT_CHANNEL_MUTATION = gql`
     mutation upsertNotificationChannel($input: NotificationChannelInput!) {
         upsertNotificationChannel(input: $input) {
-            uuid org resourceGroup name type status
+            uuid org resourceGroup name type status revision
         }
     }
 `
@@ -1362,7 +1390,7 @@ const LIST_SUBSCRIPTIONS_QUERY = gql`
     query notificationSubscriptions($orgUuid: ID!) {
         notificationSubscriptions(orgUuid: $orgUuid) {
             uuid org resourceGroup name status eventTypes
-            filter routes dedupWindowMinutes rateLimit
+            filter routes dedupWindowMinutes rateLimit revision
         }
     }
 `
@@ -1371,7 +1399,7 @@ const UPSERT_SUBSCRIPTION_MUTATION = gql`
     mutation upsertNotificationSubscription($input: NotificationSubscriptionInput!) {
         upsertNotificationSubscription(input: $input) {
             uuid org resourceGroup name status eventTypes
-            filter routes dedupWindowMinutes rateLimit
+            filter routes dedupWindowMinutes rateLimit revision
         }
     }
 `
@@ -1664,6 +1692,7 @@ function openCreateGroup (): void {
 function openEditGroup (row: ChannelGroupRow): void {
     groupForm.value = {
         uuid: row.uuid,
+        expectedRevision: row.revision,
         name: row.name,
         channels: [...(row.channels || [])],
     }
@@ -1680,6 +1709,7 @@ async function saveGroup (): Promise<void> {
     }
     const input: any = {
         uuid: f.uuid || undefined,
+        expectedRevision: f.expectedRevision,
         org: orgUuid.value,
         name: f.name.trim(),
         channels: f.channels,
@@ -1938,6 +1968,7 @@ function openEditChannel (row: ChannelRow): void {
     // user to re-enter only if they want to update the credential.
     const f = freshForm()
     f.uuid = row.uuid
+    f.expectedRevision = row.revision
     f.name = row.name
     f.type = row.type
     f.status = row.status
@@ -1955,6 +1986,10 @@ async function saveChannel (): Promise<void> {
     }
     const input: any = {
         uuid: f.uuid || undefined,
+        // Round-trip the revision captured on Edit-load. Null on Create
+        // (no row yet); backend treats null as "opt out of the check"
+        // for backwards-compat.
+        expectedRevision: f.expectedRevision,
         org: orgUuid.value,
         name: f.name.trim(),
         type: f.type,
@@ -2126,6 +2161,7 @@ function openCreateSubscription (): void {
 function openEditSubscription (row: SubscriptionRow): void {
     const f = freshSubscriptionForm()
     f.uuid = row.uuid
+    f.expectedRevision = row.revision
     f.name = row.name
     f.status = row.status
     f.eventTypes = [...(row.eventTypes || [])]
@@ -2204,6 +2240,7 @@ async function saveSubscription (): Promise<void> {
     }
     const input: any = {
         uuid: f.uuid || undefined,
+        expectedRevision: f.expectedRevision,
         org: orgUuid.value,
         name: f.name.trim(),
         status: f.status,
@@ -2562,6 +2599,28 @@ const deliveryColumns = computed(() => [
 
 function extractError (e: any): string {
     return commonFunctions.parseGraphQLError(commonFunctions.extractGraphQLErrorMessage(e))
+}
+
+/**
+ * Detect the backend's optimistic-lock conflict marker. The three upsert
+ * services throw a RelizaException with the "Conflict:" prefix when the
+ * expectedRevision in the input doesn't match the row's current revision.
+ * The save's modalError shows the message; callers also surface a
+ * "reload" affordance so the operator can refresh the form with the
+ * latest server state before retrying.
+ */
+function isConflictError (msg: string): boolean {
+    return typeof msg === 'string' && msg.startsWith('Conflict:')
+}
+
+async function reloadAfterConflict (kind: 'channel' | 'subscription' | 'group'): Promise<void> {
+    // Refresh the underlying list so the next Edit picks up the
+    // current revision. The modal stays open with the modalError still
+    // visible so the operator can see why their save was rejected;
+    // closing + reopening is their explicit choice.
+    if (kind === 'channel') await loadChannels()
+    else if (kind === 'subscription') await loadSubscriptions()
+    else if (kind === 'group') await loadChannelGroups()
 }
 
 onMounted(async () => {

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -108,7 +108,7 @@
                     </n-space>
                 </div>
 
-                <n-grid :cols="2" :x-gap="12" class="history-filters">
+                <n-grid :cols="3" :x-gap="12" class="history-filters">
                     <n-gi>
                         <n-form-item label="Show" :show-feedback="false">
                             <n-radio-group v-model:value="inboxUnreadOnly" @update:value="applyInboxFilters">
@@ -122,6 +122,17 @@
                             <n-select
                                 v-model:value="inboxStatusFilter"
                                 :options="deliveryStatusOptions"
+                                placeholder="Any"
+                                clearable
+                                @update:value="applyInboxFilters"
+                            />
+                        </n-form-item>
+                    </n-gi>
+                    <n-gi>
+                        <n-form-item label="Event type" :show-feedback="false">
+                            <n-select
+                                v-model:value="inboxEventTypeFilter"
+                                :options="eventTypeOptions"
                                 placeholder="Any"
                                 clearable
                                 @update:value="applyInboxFilters"
@@ -1215,6 +1226,7 @@ const inboxPageCount = computed<number>(() =>
 )
 const inboxUnreadOnly = ref<boolean>(true)
 const inboxStatusFilter = ref<string | null>(null)
+const inboxEventTypeFilter = ref<string | null>(null)
 const selectedInboxRows = ref<string[]>([])
 const inboxBulkLoading = ref<boolean>(false)
 const inboxMarkAllLoading = ref<boolean>(false)
@@ -1293,6 +1305,7 @@ const INBOX_QUERY = gql`
         $orgUuid: ID!,
         $unreadOnly: Boolean,
         $status: NotificationDeliveryStatusEnum,
+        $eventType: NotificationEventTypeEnum,
         $limit: Int,
         $offset: Int
     ) {
@@ -1300,6 +1313,7 @@ const INBOX_QUERY = gql`
             orgUuid: $orgUuid,
             unreadOnly: $unreadOnly,
             status: $status,
+            eventType: $eventType,
             limit: $limit,
             offset: $offset
         ) {
@@ -1333,7 +1347,7 @@ const MARK_UNREAD_MUTATION = gql`
 
 const MARK_ALL_READ_MUTATION = gql`
     mutation markAllNotificationsRead($orgUuid: ID!) {
-        markAllNotificationsRead(orgUuid: $orgUuid)
+        markAllNotificationsRead(orgUuid: $orgUuid) { count hasMore }
     }
 `
 
@@ -1765,6 +1779,7 @@ async function loadInbox (): Promise<void> {
                 orgUuid: orgUuid.value,
                 unreadOnly: inboxUnreadOnly.value,
                 status: inboxStatusFilter.value,
+                eventType: inboxEventTypeFilter.value,
                 limit: inboxPageSize.value,
                 offset,
             },
@@ -1892,8 +1907,20 @@ function markAllReadConfirm (): void {
                     mutation: MARK_ALL_READ_MUTATION,
                     variables: { orgUuid: orgUuid.value },
                 })
-                const n = res.data?.markAllNotificationsRead || 0
-                message.success(`Marked ${n} read`)
+                const result = res.data?.markAllNotificationsRead
+                const marked = result?.count || 0
+                const hasMore = result?.hasMore === true
+                if (hasMore) {
+                    // Backend hit the per-sweep cap; some unread remain.
+                    // Use warning so the operator sees the "re-run" hint
+                    // rather than a green "done" toast that hides the
+                    // remaining tail.
+                    message.warning(
+                        `Marked ${marked} read — cap reached; re-run to clear the rest.`,
+                    )
+                } else {
+                    message.success(`Marked ${marked} read`)
+                }
                 await loadInbox()
             } catch (e: any) {
                 message.error(`Mark all failed: ${extractError(e)}`)

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -32,7 +32,28 @@
             </n-tab-pane>
 
             <n-tab-pane name="subscriptions" tab="Subscriptions">
-                <n-empty description="Subscriptions UI lands in the next Phase 7 slice." />
+                <div class="tab-toolbar">
+                    <div class="tab-toolbar-info">
+                        Rules that pick which events fire on which channels. One subscription matches a set of event types, optionally narrows via a filter, and fans out across one or more severity-gated routes.
+                    </div>
+                    <n-button
+                        v-if="canWrite"
+                        type="primary"
+                        size="small"
+                        @click="openCreateSubscription"
+                    >
+                        <template #icon><n-icon><CirclePlus /></n-icon></template>
+                        Add subscription
+                    </n-button>
+                </div>
+
+                <n-data-table
+                    :data="subscriptions"
+                    :columns="subscriptionColumns"
+                    :loading="subscriptionsLoading"
+                    :single-line="false"
+                    :bordered="false"
+                />
             </n-tab-pane>
 
             <n-tab-pane name="history" tab="History">
@@ -179,6 +200,160 @@
             </n-card>
         </n-modal>
 
+        <!-- Subscription create/edit modal -->
+        <n-modal v-model:show="showSubscriptionModal" preset="dialog" :show-icon="false">
+            <n-card
+                style="width: 760px"
+                size="huge"
+                :title="subForm.uuid ? `Edit subscription — ${subForm.name || ''}` : 'Add subscription'"
+                :bordered="false"
+                role="dialog"
+                aria-modal="true"
+            >
+                <n-form :model="subForm">
+                    <n-space vertical size="large">
+                        <n-grid :cols="2" :x-gap="12">
+                            <n-gi>
+                                <n-form-item label="Name">
+                                    <n-input v-model:value="subForm.name" placeholder="e.g. critical-vuln-oncall" />
+                                </n-form-item>
+                            </n-gi>
+                            <n-gi>
+                                <n-form-item label="Status">
+                                    <n-select v-model:value="subForm.status" :options="subscriptionStatusOptions" />
+                                </n-form-item>
+                            </n-gi>
+                        </n-grid>
+
+                        <n-form-item label="Event types">
+                            <n-select
+                                v-model:value="subForm.eventTypes"
+                                :options="eventTypeOptions"
+                                multiple
+                                placeholder="Pick one or more event types"
+                            />
+                        </n-form-item>
+
+                        <n-form-item label="Filter mode">
+                            <n-radio-group v-model:value="subForm.filterMode">
+                                <n-radio-button value="PRESET">Preset (match all selected event types)</n-radio-button>
+                                <n-radio-button value="ADVANCED">Advanced (CEL)</n-radio-button>
+                            </n-radio-group>
+                        </n-form-item>
+                        <n-form-item v-if="subForm.filterMode === 'ADVANCED'" label="CEL expression">
+                            <n-input
+                                v-model:value="subForm.celExpression"
+                                type="textarea"
+                                :autosize="{ minRows: 3, maxRows: 8 }"
+                                style="font-family: monospace; font-size: 12px;"
+                                placeholder='e.g. event.severity == "CRITICAL" && size(affectedReleases) > 0'
+                            />
+                        </n-form-item>
+
+                        <div class="routes-section">
+                            <div class="routes-header">
+                                <div class="routes-title">Routes</div>
+                                <n-button size="tiny" @click="addRoute">
+                                    <template #icon><n-icon><CirclePlus /></n-icon></template>
+                                    Add route
+                                </n-button>
+                            </div>
+                            <div v-for="(r, i) in subForm.routes" :key="i" class="route-row">
+                                <n-grid :cols="24" :x-gap="8" item-responsive>
+                                    <n-gi :span="8">
+                                        <n-form-item :label="i === 0 ? 'Minimum severity' : ''" :show-feedback="false">
+                                            <n-select
+                                                v-model:value="r.whenSeverityAtLeast"
+                                                :options="severityOptions"
+                                                placeholder="Any"
+                                                clearable
+                                            />
+                                        </n-form-item>
+                                    </n-gi>
+                                    <n-gi :span="14">
+                                        <n-form-item :label="i === 0 ? 'Channels' : ''" :show-feedback="false">
+                                            <n-select
+                                                v-model:value="r.channels"
+                                                :options="channelOptions"
+                                                multiple
+                                                placeholder="Pick one or more channels"
+                                            />
+                                        </n-form-item>
+                                    </n-gi>
+                                    <n-gi :span="2" class="route-remove-cell">
+                                        <n-form-item :label="i === 0 ? ' ' : ''" :show-feedback="false">
+                                            <n-button
+                                                size="small"
+                                                secondary
+                                                type="error"
+                                                :disabled="subForm.routes.length <= 1"
+                                                @click="removeRoute(i)"
+                                                :title="subForm.routes.length <= 1 ? 'Subscription must have at least one route' : 'Remove route'"
+                                            >
+                                                <template #icon><n-icon><Trash /></n-icon></template>
+                                            </n-button>
+                                        </n-form-item>
+                                    </n-gi>
+                                </n-grid>
+                            </div>
+                        </div>
+
+                        <n-grid :cols="2" :x-gap="12">
+                            <n-gi>
+                                <n-form-item label="Dedup window (minutes, optional)">
+                                    <n-input-number
+                                        v-model:value="subForm.dedupWindowMinutes"
+                                        :min="0"
+                                        clearable
+                                        placeholder="None"
+                                        style="width: 100%;"
+                                    />
+                                </n-form-item>
+                            </n-gi>
+                            <n-gi>
+                                <n-space>
+                                    <n-form-item label="Rate limit max">
+                                        <n-input-number
+                                            v-model:value="subForm.rateLimitMaxPerWindow"
+                                            :min="1"
+                                            clearable
+                                            placeholder="None"
+                                            style="width: 100px;"
+                                        />
+                                    </n-form-item>
+                                    <n-form-item label="per (min)">
+                                        <n-input-number
+                                            v-model:value="subForm.rateLimitWindowMinutes"
+                                            :min="1"
+                                            clearable
+                                            placeholder="None"
+                                            style="width: 100px;"
+                                        />
+                                    </n-form-item>
+                                </n-space>
+                            </n-gi>
+                        </n-grid>
+
+                        <n-alert v-if="subModalError" type="error" :show-icon="false">
+                            {{ subModalError }}
+                        </n-alert>
+
+                        <n-space>
+                            <n-button
+                                @click="saveSubscription"
+                                type="primary"
+                                :loading="savingSubscription"
+                                :disabled="!subForm.name.trim() || subForm.eventTypes.length === 0 || subForm.routes.length === 0"
+                            >
+                                Save
+                            </n-button>
+                            <n-button @click="showSubscriptionModal = false">Cancel</n-button>
+                        </n-space>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
         <!-- Test result modal -->
         <n-modal v-model:show="showTestModal" preset="dialog" :show-icon="false">
             <n-card style="width: 480px" size="huge" :title="`Test channel — ${testState.channelName}`" :bordered="false" role="dialog" aria-modal="true">
@@ -215,7 +390,8 @@ import { useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import {
     NTabs, NTabPane, NDataTable, NButton, NIcon, NEmpty, NModal, NCard, NForm,
-    NFormItem, NInput, NSelect, NSpace, NAlert, NGrid, NGi, NTag, useDialog, useMessage
+    NFormItem, NInput, NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag,
+    NRadioGroup, NRadioButton, useDialog, useMessage
 } from 'naive-ui'
 import { CirclePlus, Trash, Edit as EditIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
@@ -229,6 +405,24 @@ interface ChannelRow {
     name: string
     type: string
     status: string
+}
+
+interface SubscriptionRoute {
+    whenSeverityAtLeast: string | null
+    channels: string[]
+}
+
+interface SubscriptionRow {
+    uuid: string
+    org: string
+    resourceGroup: string | null
+    name: string
+    status: string
+    eventTypes: string[]
+    filter: string | null         // JSON-stringified server-side
+    routes: string | null         // JSON-stringified server-side
+    dedupWindowMinutes: number | null
+    rateLimit: string | null      // JSON-stringified server-side
 }
 
 const route = useRoute()
@@ -275,6 +469,32 @@ const webhookAuthOptions = [
     { label: 'Bearer token', value: 'BEARER' },
     { label: 'HMAC-SHA256', value: 'HMAC_SHA256' },
 ]
+
+const subscriptionStatusOptions = [
+    { label: 'Active (deliveries go out)', value: 'ACTIVE' },
+    { label: 'Disabled (no dispatch)', value: 'DISABLED' },
+    { label: 'Preview (rows land but no dispatch)', value: 'PREVIEW' },
+]
+
+const eventTypeOptions = [
+    { label: 'New vuln affects releases', value: 'NEW_VULN_AFFECTS_RELEASES' },
+    { label: 'Vulnerability record updated', value: 'VULNERABILITY_RECORD_UPDATED' },
+    { label: 'VEX state changed', value: 'VEX_STATE_CHANGED' },
+]
+
+const severityOptions = [
+    { label: 'CRITICAL', value: 'CRITICAL' },
+    { label: 'HIGH', value: 'HIGH' },
+    { label: 'MEDIUM', value: 'MEDIUM' },
+    { label: 'LOW', value: 'LOW' },
+    { label: 'INFO', value: 'INFO' },
+]
+
+const channelOptions = computed(() =>
+    channels.value
+        .filter(c => c.status === 'ENABLED')
+        .map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
+)
 
 const showChannelModal = ref<boolean>(false)
 const savingChannel = ref<boolean>(false)
@@ -333,6 +553,46 @@ const testState = ref<TestState>({
 })
 const showTestModal = ref<boolean>(false)
 
+// Subscription form state
+interface SubscriptionForm {
+    uuid: string | null
+    name: string
+    status: string
+    eventTypes: string[]
+    filterMode: string
+    celExpression: string
+    routes: SubscriptionRoute[]
+    dedupWindowMinutes: number | null
+    rateLimitMaxPerWindow: number | null
+    rateLimitWindowMinutes: number | null
+}
+
+function freshRoute (): SubscriptionRoute {
+    return { whenSeverityAtLeast: null, channels: [] }
+}
+
+function freshSubscriptionForm (): SubscriptionForm {
+    return {
+        uuid: null,
+        name: '',
+        status: 'ACTIVE',
+        eventTypes: [],
+        filterMode: 'PRESET',
+        celExpression: '',
+        routes: [freshRoute()],
+        dedupWindowMinutes: null,
+        rateLimitMaxPerWindow: null,
+        rateLimitWindowMinutes: null,
+    }
+}
+
+const subscriptions = ref<SubscriptionRow[]>([])
+const subscriptionsLoading = ref<boolean>(false)
+const showSubscriptionModal = ref<boolean>(false)
+const savingSubscription = ref<boolean>(false)
+const subModalError = ref<string>('')
+const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
+
 // ---- GraphQL queries / mutations -----------------------------------------
 
 const LIST_CHANNELS_QUERY = gql`
@@ -381,6 +641,38 @@ const LIST_DELIVERIES_QUERY = gql`
     }
 `
 
+const LIST_SUBSCRIPTIONS_QUERY = gql`
+    query notificationSubscriptions($orgUuid: ID!) {
+        notificationSubscriptions(orgUuid: $orgUuid) {
+            uuid org resourceGroup name status eventTypes
+            filter routes dedupWindowMinutes rateLimit
+        }
+    }
+`
+
+const UPSERT_SUBSCRIPTION_MUTATION = gql`
+    mutation upsertNotificationSubscription($input: NotificationSubscriptionInput!) {
+        upsertNotificationSubscription(input: $input) {
+            uuid org resourceGroup name status eventTypes
+            filter routes dedupWindowMinutes rateLimit
+        }
+    }
+`
+
+const SET_SUBSCRIPTION_STATUS_MUTATION = gql`
+    mutation setNotificationSubscriptionStatus($uuid: ID!, $status: NotificationSubscriptionStatusEnum!) {
+        setNotificationSubscriptionStatus(uuid: $uuid, status: $status) {
+            uuid status
+        }
+    }
+`
+
+const DELETE_SUBSCRIPTION_MUTATION = gql`
+    mutation deleteNotificationSubscription($uuid: ID!) {
+        deleteNotificationSubscription(uuid: $uuid)
+    }
+`
+
 // ---- Data loading --------------------------------------------------------
 
 async function loadChannels (): Promise<void> {
@@ -396,6 +688,22 @@ async function loadChannels (): Promise<void> {
         message.error(`Failed to load channels: ${extractError(e)}`)
     } finally {
         channelsLoading.value = false
+    }
+}
+
+async function loadSubscriptions (): Promise<void> {
+    subscriptionsLoading.value = true
+    try {
+        const res = await graphqlClient.query({
+            query: LIST_SUBSCRIPTIONS_QUERY,
+            variables: { orgUuid: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        subscriptions.value = res.data?.notificationSubscriptions || []
+    } catch (e: any) {
+        message.error(`Failed to load subscriptions: ${extractError(e)}`)
+    } finally {
+        subscriptionsLoading.value = false
     }
 }
 
@@ -590,6 +898,157 @@ async function pollForDelivery (eventUuid: string): Promise<void> {
     testState.value.status = 'TIMEOUT'
 }
 
+// ---- Subscription create / edit ------------------------------------------
+
+function openCreateSubscription (): void {
+    subForm.value = freshSubscriptionForm()
+    subModalError.value = ''
+    showSubscriptionModal.value = true
+}
+
+function openEditSubscription (row: SubscriptionRow): void {
+    const f = freshSubscriptionForm()
+    f.uuid = row.uuid
+    f.name = row.name
+    f.status = row.status
+    f.eventTypes = [...(row.eventTypes || [])]
+    f.dedupWindowMinutes = row.dedupWindowMinutes ?? null
+    // Filter / routes / rateLimit ride as JSON-stringified blobs over the
+    // wire (NotificationSubscriptionResult). Parse them back into the
+    // structured form shape.
+    try {
+        const filter = row.filter ? JSON.parse(row.filter) : null
+        if (filter) {
+            f.filterMode = filter.mode || 'PRESET'
+            f.celExpression = filter.celExpression || ''
+        }
+    } catch { /* fall back to PRESET defaults */ }
+    try {
+        const routes = row.routes ? JSON.parse(row.routes) : []
+        if (Array.isArray(routes) && routes.length > 0) {
+            f.routes = routes.map((r: any) => ({
+                whenSeverityAtLeast: r.whenSeverityAtLeast || null,
+                channels: Array.isArray(r.channels) ? [...r.channels] : [],
+            }))
+        }
+    } catch { /* fall back to one empty route */ }
+    try {
+        const rl = row.rateLimit ? JSON.parse(row.rateLimit) : null
+        if (rl) {
+            f.rateLimitMaxPerWindow = rl.maxPerWindow ?? null
+            f.rateLimitWindowMinutes = rl.windowMinutes ?? null
+        }
+    } catch { /* skip */ }
+    subForm.value = f
+    subModalError.value = ''
+    showSubscriptionModal.value = true
+}
+
+function addRoute (): void {
+    subForm.value.routes.push(freshRoute())
+}
+
+function removeRoute (i: number): void {
+    if (subForm.value.routes.length > 1) {
+        subForm.value.routes.splice(i, 1)
+    }
+}
+
+async function saveSubscription (): Promise<void> {
+    subModalError.value = ''
+    const f = subForm.value
+    if (!f.name.trim() || f.eventTypes.length === 0 || f.routes.length === 0) {
+        subModalError.value = 'Name, at least one event type, and at least one route are required.'
+        return
+    }
+    // Every route must have at least one channel; backend rejects empty
+    // {channels, channelGroups} anyway, but catch it client-side for a
+    // cleaner error path.
+    const emptyRouteIdx = f.routes.findIndex(r => (r.channels || []).length === 0)
+    if (emptyRouteIdx >= 0) {
+        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels — pick at least one.`
+        return
+    }
+    const input: any = {
+        uuid: f.uuid || undefined,
+        org: orgUuid.value,
+        name: f.name.trim(),
+        status: f.status,
+        eventTypes: f.eventTypes,
+        filter: {
+            mode: f.filterMode,
+            // presetConfigJson stays empty for slice 2 — future slices add
+            // preset-toggle UI on top.
+            celExpression: f.filterMode === 'ADVANCED' ? f.celExpression : null,
+        },
+        routes: f.routes.map(r => ({
+            whenSeverityAtLeast: r.whenSeverityAtLeast,
+            channels: r.channels,
+        })),
+        dedupWindowMinutes: f.dedupWindowMinutes,
+    }
+    if (f.rateLimitMaxPerWindow && f.rateLimitWindowMinutes) {
+        input.rateLimit = {
+            maxPerWindow: f.rateLimitMaxPerWindow,
+            windowMinutes: f.rateLimitWindowMinutes,
+        }
+    }
+    savingSubscription.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: UPSERT_SUBSCRIPTION_MUTATION,
+            variables: { input },
+        })
+        showSubscriptionModal.value = false
+        message.success(f.uuid ? 'Subscription updated' : 'Subscription created')
+        await loadSubscriptions()
+    } catch (e: any) {
+        subModalError.value = extractError(e)
+    } finally {
+        savingSubscription.value = false
+    }
+}
+
+async function toggleSubscriptionStatus (row: SubscriptionRow): Promise<void> {
+    const next = row.status === 'ACTIVE' ? 'DISABLED' : 'ACTIVE'
+    try {
+        await graphqlClient.mutate({
+            mutation: SET_SUBSCRIPTION_STATUS_MUTATION,
+            variables: { uuid: row.uuid, status: next },
+        })
+        message.success(`Subscription ${next.toLowerCase()}`)
+        await loadSubscriptions()
+    } catch (e: any) {
+        message.error(`Status change failed: ${extractError(e)}`)
+    }
+}
+
+function confirmDeleteSubscription (row: SubscriptionRow): void {
+    dialog.warning({
+        title: `Delete subscription "${row.name}"?`,
+        content: 'This is permanent. The matching events stop dispatching immediately; History rows for past deliveries are retained.',
+        positiveText: 'Delete',
+        negativeText: 'Cancel',
+        onPositiveClick: async () => {
+            try {
+                await graphqlClient.mutate({
+                    mutation: DELETE_SUBSCRIPTION_MUTATION,
+                    variables: { uuid: row.uuid },
+                })
+                message.success('Subscription deleted')
+                await loadSubscriptions()
+            } catch (e: any) {
+                message.error(`Delete failed: ${extractError(e)}`)
+            }
+        },
+    })
+}
+
+function subscriptionRouteCount (row: SubscriptionRow): number {
+    try { return row.routes ? (JSON.parse(row.routes) || []).length : 0 }
+    catch { return 0 }
+}
+
 // ---- Column defs ---------------------------------------------------------
 
 const channelColumns = computed(() => [
@@ -636,6 +1095,52 @@ const channelColumns = computed(() => [
     },
 ])
 
+const subscriptionColumns = computed(() => [
+    { title: 'Name', key: 'name' },
+    {
+        title: 'Status', key: 'status',
+        render: (row: SubscriptionRow) => h(
+            NTag,
+            {
+                type: row.status === 'ACTIVE' ? 'success' : (row.status === 'PREVIEW' ? 'info' : 'warning'),
+                size: 'small',
+            },
+            { default: () => row.status },
+        ),
+    },
+    {
+        title: 'Event types', key: 'eventTypes',
+        render: (row: SubscriptionRow) => `${(row.eventTypes || []).length} type(s)`,
+    },
+    {
+        title: 'Routes', key: 'routes',
+        render: (row: SubscriptionRow) => `${subscriptionRouteCount(row)} route(s)`,
+    },
+    {
+        title: 'Actions', key: 'actions',
+        render: (row: SubscriptionRow) => h(NSpace, { size: 'small' }, {
+            default: () => [
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => openEditSubscription(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => toggleSubscriptionStatus(row),
+                    disabled: !canWrite.value || row.status === 'PREVIEW',
+                    title: row.status === 'PREVIEW' ? 'Edit to leave Preview mode' : '',
+                }, { default: () => row.status === 'ACTIVE' ? 'Disable' : 'Enable' }),
+                h(NButton, {
+                    size: 'tiny', secondary: true, type: 'error',
+                    onClick: () => confirmDeleteSubscription(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
+            ],
+        }),
+    },
+])
+
 // ---- helpers -------------------------------------------------------------
 
 function extractError (e: any): string {
@@ -644,7 +1149,10 @@ function extractError (e: any): string {
 
 onMounted(async () => {
     userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
-    await loadChannels()
+    // Load channels first — the subscription form's channel picker depends
+    // on it. Load subscriptions in parallel since the row render doesn't
+    // depend on channels.
+    await Promise.all([loadChannels(), loadSubscriptions()])
 })
 </script>
 
@@ -663,4 +1171,20 @@ onMounted(async () => {
 }
 .tab-toolbar-info { font-size: 12.5px; color: var(--n-text-color-3, #888); }
 .muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
+
+.routes-section {
+    border: 1px solid var(--n-border-color, #eee);
+    border-radius: 6px;
+    padding: 12px 14px;
+    background: var(--n-color-embedded, transparent);
+}
+.routes-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+.routes-title { font-size: 13px; font-weight: 600; }
+.route-row + .route-row { margin-top: 6px; }
+.route-remove-cell { display: flex; align-items: flex-end; }
 </style>

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -410,6 +410,11 @@ interface ChannelRow {
 interface SubscriptionRoute {
     whenSeverityAtLeast: string | null
     channels: string[]
+    // Carries the as-loaded route object on edit so fields the slice-2
+    // UI doesn't model yet (channelGroups, andEnvIn, andLifecycleIn,
+    // perspectives) survive an Edit → Save round-trip instead of being
+    // silently stripped. Empty on Create.
+    _raw?: Record<string, any>
 }
 
 interface SubscriptionRow {
@@ -565,6 +570,11 @@ interface SubscriptionForm {
     dedupWindowMinutes: number | null
     rateLimitMaxPerWindow: number | null
     rateLimitWindowMinutes: number | null
+    // Carries the as-loaded filter object on edit so `presetConfigJson`
+    // (and any other field the slice-2 UI doesn't model yet) survives an
+    // Edit → Save round-trip. Empty on Create. Same pattern as
+    // SubscriptionRoute._raw.
+    _rawFilter?: Record<string, any>
 }
 
 function freshRoute (): SubscriptionRoute {
@@ -915,12 +925,15 @@ function openEditSubscription (row: SubscriptionRow): void {
     f.dedupWindowMinutes = row.dedupWindowMinutes ?? null
     // Filter / routes / rateLimit ride as JSON-stringified blobs over the
     // wire (NotificationSubscriptionResult). Parse them back into the
-    // structured form shape.
+    // structured form shape AND stash the original blob on _raw / _rawFilter
+    // so unmodelled fields (channelGroups, andEnvIn, andLifecycleIn on
+    // routes; presetConfigJson on filter) survive an Edit → Save round-trip.
     try {
         const filter = row.filter ? JSON.parse(row.filter) : null
         if (filter) {
             f.filterMode = filter.mode || 'PRESET'
             f.celExpression = filter.celExpression || ''
+            f._rawFilter = filter
         }
     } catch { /* fall back to PRESET defaults */ }
     try {
@@ -929,6 +942,7 @@ function openEditSubscription (row: SubscriptionRow): void {
             f.routes = routes.map((r: any) => ({
                 whenSeverityAtLeast: r.whenSeverityAtLeast || null,
                 channels: Array.isArray(r.channels) ? [...r.channels] : [],
+                _raw: r,
             }))
         }
     } catch { /* fall back to one empty route */ }
@@ -969,19 +983,28 @@ async function saveSubscription (): Promise<void> {
         subModalError.value = `Route ${emptyRouteIdx + 1} has no channels — pick at least one.`
         return
     }
+    // Build the filter input by overlaying the slice-2-modeled fields on
+    // top of the original blob. This preserves `presetConfigJson` (set via
+    // the future preset-toggle UI or directly via API) instead of nulling
+    // it on every edit.
+    const filterInput: any = {
+        ...(f._rawFilter || {}),
+        mode: f.filterMode,
+        celExpression: f.filterMode === 'ADVANCED' ? f.celExpression : null,
+    }
     const input: any = {
         uuid: f.uuid || undefined,
         org: orgUuid.value,
         name: f.name.trim(),
         status: f.status,
         eventTypes: f.eventTypes,
-        filter: {
-            mode: f.filterMode,
-            // presetConfigJson stays empty for slice 2 — future slices add
-            // preset-toggle UI on top.
-            celExpression: f.filterMode === 'ADVANCED' ? f.celExpression : null,
-        },
+        filter: filterInput,
+        // Spread the original route's unmodelled fields (channelGroups,
+        // andEnvIn, andLifecycleIn, perspectives) so an Edit → Save
+        // round-trip doesn't silently strip them. The slice-2-modeled
+        // fields overlay last and win.
         routes: f.routes.map(r => ({
+            ...(r._raw || {}),
             whenSeverityAtLeast: r.whenSeverityAtLeast,
             channels: r.channels,
         })),
@@ -1128,8 +1151,7 @@ const subscriptionColumns = computed(() => [
                 h(NButton, {
                     size: 'tiny', secondary: true,
                     onClick: () => toggleSubscriptionStatus(row),
-                    disabled: !canWrite.value || row.status === 'PREVIEW',
-                    title: row.status === 'PREVIEW' ? 'Edit to leave Preview mode' : '',
+                    disabled: !canWrite.value,
                 }, { default: () => row.status === 'ACTIVE' ? 'Disable' : 'Enable' }),
                 h(NButton, {
                     size: 'tiny', secondary: true, type: 'error',
@@ -1149,9 +1171,10 @@ function extractError (e: any): string {
 
 onMounted(async () => {
     userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
-    // Load channels first — the subscription form's channel picker depends
-    // on it. Load subscriptions in parallel since the row render doesn't
-    // depend on channels.
+    // Load both in parallel. The subscription form's channel picker
+    // degrades to an empty placeholder if the user opens the modal
+    // before channels resolve, which is acceptable given the typical
+    // few-hundred-ms load.
     await Promise.all([loadChannels(), loadSubscriptions()])
 })
 </script>

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -1015,16 +1015,6 @@ function freshForm (): ChannelForm {
     }
 }
 
-// Optimistic-locking note. The three upsert paths in this file
-// (upsertNotificationChannel, upsertNotificationSubscription,
-// upsertNotificationChannelGroup) do NOT forward the `revision` value
-// from the loaded row. The backend entities use @Version, but the
-// GraphQL Input shapes don't currently expose an `expectedRevision`
-// field, so the UI can't gate save on it. Accepted as-is across all
-// three surfaces for consistency; a stale concurrent edit on the same
-// row is last-writer-wins. If multi-admin races become a real customer
-// concern, the fix is a coordinated schema change (add expectedRevision
-// to all three Input shapes) + a UI guard that surfaces the conflict.
 const channelForm = ref<ChannelForm>(freshForm())
 
 const sentinelPlaceholder = computed<string>(() =>
@@ -1789,7 +1779,14 @@ async function loadInbox (): Promise<void> {
         const page = res.data?.notificationInbox
         inboxItems.value = page?.items || []
         inboxTotalCount.value = page?.totalCount || 0
-        inboxUnreadCount.value = page?.unreadCount || 0
+        // Don't write inboxUnreadCount from page.unreadCount: that
+        // value is the filtered count (matches the page's status /
+        // eventType / unreadOnly), but the tab badge needs the
+        // org-wide unread total. Otherwise a status=FAILED filter
+        // would silently shrink the badge to "FAILED-only unread"
+        // and an admin with 100 unread items would see a 5 next to
+        // "Inbox". loadInboxUnreadCount fires alongside (below) so
+        // any server-side change is still picked up on every page.
         // Drop checked rows that aren't on the new page.
         const visible = new Set(inboxItems.value.map(r => r.uuid))
         selectedInboxRows.value = selectedInboxRows.value.filter(uuid => visible.has(uuid))
@@ -1799,6 +1796,10 @@ async function loadInbox (): Promise<void> {
     } finally {
         if (myToken === inboxInflightToken) inboxLoading.value = false
     }
+    // Refresh the unfiltered badge alongside every inbox reload so
+    // markAll / bulk-mark paths that loadInbox() at the end also
+    // pull a fresh badge — no scattered explicit calls needed.
+    loadInboxUnreadCount()
 }
 
 function applyInboxFilters (): void {
@@ -2658,17 +2659,17 @@ onMounted(async () => {
     // before channels / groups resolve — acceptable given the typical
     // few-hundred-ms load. Inbox tab body loads lazily on tab open.
     const initialIsInbox = activeTab.value === 'inbox'
-    // Skip the badge-only round-trip when the initial tab is Inbox —
-    // the subsequent loadInbox() pulls unreadCount inside its own
-    // response so the separate notificationUnreadCount call would
-    // double-spend on landing.
+    // loadInboxUnreadCount runs unconditionally now: loadInbox no longer
+    // writes inboxUnreadCount (page.unreadCount is filtered, badge must
+    // not be), so the badge needs its own org-wide query whether or not
+    // the inbox tab is the initial view.
     const eagerLoads: Array<Promise<void>> = [
         loadChannels(),
         loadChannelGroups(),
         loadSubscriptions(),
         loadDeliveries(),
+        loadInboxUnreadCount(),
     ]
-    if (!initialIsInbox) eagerLoads.push(loadInboxUnreadCount())
     await Promise.all(eagerLoads)
     // If the initial route lands directly on the Inbox tab (e.g. a
     // bookmarked URL or a slash-style notification link), the lazy

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -15,14 +15,12 @@
             :show-icon="false"
         >
             <template #header>
-                <span class="quick-start-title">Welcome to Notifications</span>
+                <span class="quick-start-title">{{ quickStartBannerTitle }}</span>
             </template>
             <div class="quick-start-body">
-                <div>
-                    Get from zero to a working subscription in three steps — your first channel, your first rule, then we land it in <strong>Preview</strong> mode so deliveries record in History without firing your real destination. Flip it to Active once you've verified.
-                </div>
+                <div>{{ quickStartBannerBody }}</div>
                 <n-button type="primary" size="small" @click="openQuickStart">
-                    Start
+                    {{ quickStartBannerCta }}
                 </n-button>
             </div>
         </n-alert>
@@ -385,7 +383,7 @@
         </n-modal>
 
         <!-- Quick Start wizard modal -->
-        <n-modal v-model:show="showQuickStart" preset="dialog" :show-icon="false" :mask-closable="false">
+        <n-modal v-model:show="showQuickStart" preset="dialog" :show-icon="false" :mask-closable="false" :on-close="closeQuickStart">
             <n-card
                 style="width: 640px"
                 size="huge"
@@ -477,14 +475,27 @@
                     </n-form>
                 </div>
 
-                <!-- Step 3: done -->
+                <!-- Step 3: done — test event in flight + flip-to-Active guidance -->
                 <div v-if="quickStartStep === 3">
                     <n-space vertical size="large">
-                        <n-alert type="success" :show-icon="false">
-                            <strong>Done.</strong> Your subscription is in <strong>Preview</strong> mode. Matching deliveries land in History without firing the real destination.
+                        <n-alert v-if="quickStartTestState.status === 'PENDING'" type="info" :show-icon="false">
+                            Sending a real test message to <strong>{{ qsChannel.name }}</strong>… polling for delivery status.
                         </n-alert>
+                        <n-alert v-else-if="quickStartTestState.status === 'SENT'" type="success" :show-icon="false">
+                            <strong>Test message sent.</strong> Check the channel — you should see a card landing in <strong>{{ qsChannel.name }}</strong>.
+                        </n-alert>
+                        <n-alert v-else-if="quickStartTestState.status === 'FAILED'" type="error" :show-icon="false">
+                            <strong>Test delivery failed:</strong> {{ quickStartTestState.lastError || 'no error returned' }}. Edit the channel and re-verify the webhook URL.
+                        </n-alert>
+                        <n-alert v-else-if="quickStartTestState.status === 'ERROR'" type="error" :show-icon="false">
+                            <strong>Test could not start:</strong> {{ quickStartTestState.lastError }}
+                        </n-alert>
+                        <n-alert v-else-if="quickStartTestState.status === 'TIMEOUT'" type="warning" :show-icon="false">
+                            Delivery did not reach a terminal state within 30s. Check History for the latest status of the test event.
+                        </n-alert>
+
                         <div class="muted-12">
-                            Verify the right kinds of events show up in <strong>History</strong> (tagged <code>PREVIEW</code>). When you're confident, edit the subscription and flip the status to <strong>Active</strong> to start sending to your channel.
+                            Your subscription is in <strong>Preview</strong> mode — real vuln events that match will record in <strong>History</strong> (tagged <code>PREVIEW</code>) without firing your channel until you flip it to <strong>Active</strong>. Verify a few previews land first; promote when you're confident.
                         </div>
                         <n-space>
                             <n-button type="primary" @click="quickStartGoToHistory">View History</n-button>
@@ -1085,6 +1096,25 @@ function freshQsSubscription (): QuickStartSubscription {
 const qsChannel = ref<QuickStartChannel>(freshQsChannel())
 const qsSubscription = ref<QuickStartSubscription>(freshQsSubscription())
 
+// Step-3 test event state. The wizard fires a real synthetic event
+// to the just-created channel (design doc §6.7: "admin confirms the
+// test message arrived"). Uses testNotificationChannel which bypasses
+// the subscription's PREVIEW state — the channel is exercised
+// end-to-end, the subscription stays safely in PREVIEW until the
+// operator promotes it to ACTIVE.
+interface QuickStartTestState {
+    eventUuid: string | null
+    status: 'IDLE' | 'PENDING' | 'SENT' | 'FAILED' | 'ERROR' | 'TIMEOUT'
+    attempts: number
+    lastError: string
+}
+
+function freshQuickStartTestState (): QuickStartTestState {
+    return { eventUuid: null, status: 'IDLE', attempts: 0, lastError: '' }
+}
+
+const quickStartTestState = ref<QuickStartTestState>(freshQuickStartTestState())
+
 // Quick Start type picker is intentionally narrower than the full
 // channel form — Slack + Teams are the common starter destinations
 // (one URL, no other config). Sentinel (six fields) and Webhook
@@ -1094,14 +1124,41 @@ const qsChannelTypeOptions = [
     { label: 'Microsoft Teams', value: 'MS_TEAMS' },
 ]
 
+// Per the design-doc §6.7 anti-pattern: "a default subscription with no
+// channel = silent failures." The symmetric gap — a channel exists but no
+// subscription — also leaves the user with a half-finished setup and
+// nothing firing. So the banner now surfaces on EITHER side being empty,
+// with the message + CTA adapting to which gap exists.
+const quickStartGap = computed<'BOTH' | 'NO_SUB' | 'NONE'>(() => {
+    if (channels.value.length === 0) return 'BOTH'
+    if (subscriptions.value.length === 0) return 'NO_SUB'
+    return 'NONE'
+})
+
 const canShowQuickStart = computed<boolean>(() =>
     canWrite.value
     && !channelsLoading.value
     && !subscriptionsLoading.value
-    && channels.value.length === 0
-    && subscriptions.value.length === 0
+    && quickStartGap.value !== 'NONE'
     && !showQuickStart.value
 )
+
+const quickStartBannerTitle = computed<string>(() => {
+    if (quickStartGap.value === 'NO_SUB') return 'Finish setting up notifications'
+    return 'Welcome to Notifications'
+})
+
+const quickStartBannerBody = computed<string>(() => {
+    if (quickStartGap.value === 'NO_SUB') {
+        return "You've got a channel but no subscription. Add a rule that picks which events fire on it — we'll land it in Preview mode so you can verify before going live."
+    }
+    return 'Get from zero to a working subscription in three steps — your first channel, your first rule, then a real test message to the channel. The subscription itself lands in Preview mode so real vuln traffic records in History without firing your channel until you flip it to Active.'
+})
+
+const quickStartBannerCta = computed<string>(() => {
+    if (quickStartGap.value === 'NO_SUB') return 'Add subscription'
+    return 'Start'
+})
 
 // Channel groups state
 const channelGroups = ref<ChannelGroupRow[]>([])
@@ -1377,16 +1434,48 @@ let historyInflightToken = 0
 // ---- Quick Start wizard --------------------------------------------------
 
 function openQuickStart (): void {
-    quickStartStep.value = 1
     qsChannel.value = freshQsChannel()
     qsSubscription.value = freshQsSubscription()
-    quickStartChannelUuid.value = null
     quickStartError.value = ''
+    quickStartTestState.value = freshQuickStartTestState()
+    // Defensive reset — if a prior open hit an unhandled exception
+    // mid-save, the loading flag could be stuck true and disable
+    // every button on the form.
+    quickStartSaving.value = false
+    // If the user already has channels but no subscription, the
+    // channel step is moot — skip straight to step 2 with the first
+    // enabled channel pre-selected. Banner CTA text already adjusted
+    // ("Add subscription" instead of "Start").
+    if (quickStartGap.value === 'NO_SUB') {
+        const existing = channels.value.find(c => c.status === 'ENABLED')
+            || channels.value[0]
+        if (existing) {
+            quickStartChannelUuid.value = existing.uuid
+            qsChannel.value.name = existing.name
+            qsChannel.value.type = existing.type
+            qsSubscription.value.name = slugifySubName(existing.name)
+            quickStartStep.value = 2
+            showQuickStart.value = true
+            return
+        }
+    }
+    quickStartStep.value = 1
+    quickStartChannelUuid.value = null
     showQuickStart.value = true
 }
 
 function closeQuickStart (): void {
     showQuickStart.value = false
+}
+
+// Trim and sanitize a channel name into something likely to survive
+// future backend name validation. Today the backend just requires
+// non-blank, but a clean slug avoids "vulns-My Slack #sec!!!" showing
+// up in the form and making the user reach for backspace.
+function slugifySubName (channelName: string): string {
+    const slug = channelName.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '')
+    const trimmed = slug.length > 50 ? slug.slice(0, 50) : slug
+    return `vulns-${trimmed || 'channel'}`
 }
 
 async function quickStartCreateChannel (): Promise<void> {
@@ -1418,7 +1507,7 @@ async function quickStartCreateChannel (): Promise<void> {
         quickStartChannelUuid.value = created.uuid
         // Auto-suggest a subscription name based on the channel name so
         // step 2 doesn't start empty.
-        qsSubscription.value.name = `vulns-${c.name.trim()}`
+        qsSubscription.value.name = slugifySubName(c.name)
         await loadChannels()
         quickStartStep.value = 2
         quickStartError.value = ''
@@ -1464,11 +1553,81 @@ async function quickStartCreateSubscription (): Promise<void> {
         await loadSubscriptions()
         quickStartStep.value = 3
         quickStartError.value = ''
+        // Fire the §6.7 confirmation event: a real synthetic message
+        // to the channel itself (bypasses subscription evaluation, so
+        // the new sub's PREVIEW status doesn't block the test landing).
+        // Run async — step 3 UI polls the resulting delivery row.
+        quickStartFireTestEvent().catch(() => {/* state captured below */})
     } catch (e: any) {
         quickStartError.value = extractError(e)
     } finally {
         quickStartSaving.value = false
     }
+}
+
+async function quickStartFireTestEvent (): Promise<void> {
+    if (!quickStartChannelUuid.value) {
+        quickStartTestState.value.status = 'ERROR'
+        quickStartTestState.value.lastError = 'Internal: channel uuid lost'
+        return
+    }
+    quickStartTestState.value = { ...freshQuickStartTestState(), status: 'PENDING' }
+    try {
+        const res = await graphqlClient.mutate({
+            mutation: TEST_CHANNEL_MUTATION,
+            variables: { channelUuid: quickStartChannelUuid.value },
+        })
+        const eventUuid = res.data?.testNotificationChannel?.uuid
+        if (!eventUuid) {
+            quickStartTestState.value.status = 'ERROR'
+            quickStartTestState.value.lastError = 'No outbox event returned'
+            return
+        }
+        quickStartTestState.value.eventUuid = eventUuid
+        // Reuse the slice-1 pollForDelivery loop (30s budget, terminal-
+        // state aware: SENT/ACKED → success; FAILED/RATE_LIMITED/
+        // EVAL_TIMEOUT → failure with the lastError).
+        await pollQuickStartDelivery(eventUuid)
+    } catch (e: any) {
+        quickStartTestState.value.status = 'ERROR'
+        quickStartTestState.value.lastError = extractError(e)
+    }
+}
+
+async function pollQuickStartDelivery (eventUuid: string): Promise<void> {
+    const deadline = Date.now() + 30000
+    while (Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 1500))
+        try {
+            const res = await graphqlClient.query({
+                query: LIST_DELIVERIES_QUERY,
+                variables: { orgUuid: orgUuid.value, eventUuid, limit: 5 },
+                fetchPolicy: 'network-only',
+            })
+            const items = res.data?.notificationDeliveries?.items || []
+            if (items.length > 0) {
+                const d = items[0]
+                quickStartTestState.value.attempts = d.attemptCount || 0
+                quickStartTestState.value.lastError = d.lastError || ''
+                if (d.status === 'SENT' || d.status === 'ACKED') {
+                    quickStartTestState.value.status = 'SENT'
+                    return
+                }
+                if (d.status === 'FAILED'
+                    || d.status === 'RATE_LIMITED'
+                    || d.status === 'EVAL_TIMEOUT') {
+                    quickStartTestState.value.status = 'FAILED'
+                    if (!quickStartTestState.value.lastError) {
+                        quickStartTestState.value.lastError = `Delivery ${d.status.toLowerCase().replace(/_/g, ' ')}`
+                    }
+                    return
+                }
+            }
+        } catch {
+            // Transient — keep polling within budget.
+        }
+    }
+    quickStartTestState.value.status = 'TIMEOUT'
 }
 
 function quickStartGoToHistory (): void {
@@ -1618,6 +1777,11 @@ async function markRowRead (row: InboxRow): Promise<void> {
             inboxItems.value = inboxItems.value.filter(r => r.uuid !== row.uuid)
             if (inboxTotalCount.value > 0) inboxTotalCount.value -= 1
         }
+        // Invalidate any concurrent loadInbox so its late-landing
+        // response can't overwrite this optimistic patch with stale
+        // pre-mark data. Same idea as the inflight-token guard in
+        // loadInbox itself — just from the mutation side.
+        inboxInflightToken++
     } catch (e: any) {
         message.error(`Mark read failed: ${extractError(e)}`)
     }
@@ -1625,13 +1789,19 @@ async function markRowRead (row: InboxRow): Promise<void> {
 
 async function markRowUnread (row: InboxRow): Promise<void> {
     try {
-        await graphqlClient.mutate({
+        const wasUnmarked = await graphqlClient.mutate({
             mutation: MARK_UNREAD_MUTATION,
             variables: { deliveryUuid: row.uuid },
         })
+        const removed = wasUnmarked.data?.markNotificationUnread === true
         const idx = inboxItems.value.findIndex(r => r.uuid === row.uuid)
         if (idx >= 0) inboxItems.value[idx].readAt = null
-        inboxUnreadCount.value += 1
+        // Only bump the unread count when a row actually went from
+        // read → unread server-side. The button is gated by
+        // row.readAt != null so this is rarely false in practice, but
+        // a stale-cached row could otherwise double-count.
+        if (removed) inboxUnreadCount.value += 1
+        inboxInflightToken++
     } catch (e: any) {
         message.error(`Mark unread failed: ${extractError(e)}`)
     }
@@ -1640,30 +1810,49 @@ async function markRowUnread (row: InboxRow): Promise<void> {
 async function bulkMarkRead (): Promise<void> {
     if (selectedInboxRows.value.length === 0) return
     inboxBulkLoading.value = true
+    const uuids = [...selectedInboxRows.value]
     try {
-        // Fire one mutation per selected row in parallel. The backend
-        // guards each call with the visibility filter, so a malformed
-        // selection is rejected per-uuid, not silently.
-        await Promise.all(selectedInboxRows.value.map(uuid =>
+        // Fire one mutation per selected row in parallel. Use
+        // allSettled so a single failed uuid doesn't drop the success
+        // count from the surviving 24/25; the backend's per-uuid
+        // visibility guard is the per-row check, the UI surfaces the
+        // mixed outcome.
+        const results = await Promise.allSettled(uuids.map(uuid =>
             graphqlClient.mutate({
                 mutation: MARK_READ_MUTATION,
                 variables: { deliveryUuid: uuid },
             })
         ))
-        message.success(`Marked ${selectedInboxRows.value.length} read`)
+        const ok = results.filter(r => r.status === 'fulfilled').length
+        const failed = results.length - ok
+        if (failed === 0) {
+            message.success(`Marked ${ok} read`)
+        } else if (ok > 0) {
+            message.warning(`Marked ${ok} of ${results.length} read (${failed} failed)`)
+        } else {
+            message.error(`Mark read failed for all ${results.length} selected`)
+        }
         selectedInboxRows.value = []
-        await loadInbox()
-    } catch (e: any) {
-        message.error(`Bulk mark read failed: ${extractError(e)}`)
     } finally {
         inboxBulkLoading.value = false
+        // Always reload regardless of pass/fail mix so the table
+        // reconciles with server truth — the optimistic-patch
+        // approach we use for the single-row path doesn't fit here
+        // because partial failures could leave the table in an
+        // arbitrary state.
+        await loadInbox()
     }
 }
 
 function markAllReadConfirm (): void {
+    const n = Math.min(inboxUnreadCount.value, 500)
+    const remainder = Math.max(0, inboxUnreadCount.value - 500)
+    const tail = remainder > 0
+        ? ` Backend caps a single sweep at 500 — re-run to clear the remaining ${remainder}.`
+        : ''
     dialog.warning({
         title: 'Mark every visible unread notification as read?',
-        content: `This marks up to ${inboxUnreadCount.value} unread item(s) as read. Backend caps a single sweep at 500.`,
+        content: `This marks up to ${n} unread item(s) as read.${tail}`,
         positiveText: 'Mark all read',
         negativeText: 'Cancel',
         onPositiveClick: async () => {
@@ -2313,7 +2502,11 @@ const inboxColumns = computed(() => [
 function severityTagType (severity: string): 'success' | 'warning' | 'error' | 'info' | 'default' {
     if (severity === 'CRITICAL' || severity === 'HIGH') return 'error'
     if (severity === 'MEDIUM') return 'warning'
-    if (severity === 'LOW' || severity === 'INFO') return 'info'
+    if (severity === 'LOW') return 'info'
+    // INFO and NONE collapse to the neutral default — a triage queue
+    // shouldn't fight for the eye on informational events. Separating
+    // LOW (info-blue) from INFO (default-grey) preserves the backend
+    // enum distinction in the UI.
     return 'default'
 }
 
@@ -2378,18 +2571,24 @@ onMounted(async () => {
     // edit modal's pickers degrade to empty placeholders if opened
     // before channels / groups resolve — acceptable given the typical
     // few-hundred-ms load. Inbox tab body loads lazily on tab open.
-    await Promise.all([
+    const initialIsInbox = activeTab.value === 'inbox'
+    // Skip the badge-only round-trip when the initial tab is Inbox —
+    // the subsequent loadInbox() pulls unreadCount inside its own
+    // response so the separate notificationUnreadCount call would
+    // double-spend on landing.
+    const eagerLoads: Array<Promise<void>> = [
         loadChannels(),
         loadChannelGroups(),
         loadSubscriptions(),
         loadDeliveries(),
-        loadInboxUnreadCount(),
-    ])
+    ]
+    if (!initialIsInbox) eagerLoads.push(loadInboxUnreadCount())
+    await Promise.all(eagerLoads)
     // If the initial route lands directly on the Inbox tab (e.g. a
     // bookmarked URL or a slash-style notification link), the lazy
     // tab-activation hook on onTabChange doesn't fire — kick the load
     // explicitly here.
-    if (activeTab.value === 'inbox') {
+    if (initialIsInbox) {
         await loadInbox()
     }
 })

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -1,0 +1,651 @@
+<template>
+    <div class="notifications-page">
+        <div class="page-header">
+            <h2 class="page-title">Notifications</h2>
+            <div class="page-subtitle">Security and operational events routed to your destinations of choice.</div>
+        </div>
+
+        <n-tabs v-model:value="activeTab" type="segment" animated @update:value="onTabChange">
+            <n-tab-pane name="channels" tab="Channels">
+                <div class="tab-toolbar">
+                    <div class="tab-toolbar-info">
+                        Destinations that receive notification deliveries. One channel = one webhook / recipient list / Sentinel DCR.
+                    </div>
+                    <n-button
+                        v-if="canWrite"
+                        type="primary"
+                        size="small"
+                        @click="openCreateChannel"
+                    >
+                        <template #icon><n-icon><CirclePlus /></n-icon></template>
+                        Add channel
+                    </n-button>
+                </div>
+
+                <n-data-table
+                    :data="channels"
+                    :columns="channelColumns"
+                    :loading="channelsLoading"
+                    :single-line="false"
+                    :bordered="false"
+                />
+            </n-tab-pane>
+
+            <n-tab-pane name="subscriptions" tab="Subscriptions">
+                <n-empty description="Subscriptions UI lands in the next Phase 7 slice." />
+            </n-tab-pane>
+
+            <n-tab-pane name="history" tab="History">
+                <n-empty description="Delivery history UI lands in a later Phase 7 slice." />
+            </n-tab-pane>
+        </n-tabs>
+
+        <!-- Create / Edit channel modal -->
+        <n-modal v-model:show="showChannelModal" preset="dialog" :show-icon="false">
+            <n-card
+                style="width: 640px"
+                size="huge"
+                :title="channelForm.uuid ? `Edit channel — ${channelForm.name || ''}` : 'Add channel'"
+                :bordered="false"
+                role="dialog"
+                aria-modal="true"
+            >
+                <n-form :model="channelForm">
+                    <n-space vertical size="large">
+                        <n-form-item label="Name">
+                            <n-input v-model:value="channelForm.name" placeholder="e.g. sec-oncall-slack" />
+                        </n-form-item>
+
+                        <n-form-item label="Type">
+                            <n-select
+                                v-model:value="channelForm.type"
+                                :options="typeOptions"
+                                :disabled="!!channelForm.uuid"
+                                placeholder="Pick a channel type"
+                            />
+                            <template #feedback>
+                                <span v-if="channelForm.uuid" class="muted-12">
+                                    Type cannot be changed after creation.
+                                </span>
+                            </template>
+                        </n-form-item>
+
+                        <!-- Slack -->
+                        <template v-if="channelForm.type === 'SLACK'">
+                            <n-form-item label="Slack incoming webhook URL">
+                                <n-input
+                                    v-model:value="channelForm.slack.webhookUrl"
+                                    :placeholder="channelForm.uuid ? 'Re-enter to update; leave blank to keep existing' : 'https://hooks.slack.com/services/...'"
+                                />
+                            </n-form-item>
+                        </template>
+
+                        <!-- MS Teams -->
+                        <template v-if="channelForm.type === 'MS_TEAMS'">
+                            <n-form-item label="Teams Workflows webhook URL">
+                                <n-input
+                                    v-model:value="channelForm.teams.webhookUrl"
+                                    :placeholder="channelForm.uuid ? 'Re-enter to update; leave blank to keep existing' : 'https://...powerplatform.com/... or .../logic.azure.com/...'"
+                                />
+                            </n-form-item>
+                        </template>
+
+                        <!-- Generic webhook -->
+                        <template v-if="channelForm.type === 'WEBHOOK'">
+                            <n-form-item label="Webhook URL">
+                                <n-input
+                                    v-model:value="channelForm.webhook.url"
+                                    :placeholder="channelForm.uuid ? 'Re-enter to update; leave blank to keep existing' : 'https://your-receiver.example.com/path'"
+                                />
+                            </n-form-item>
+                            <n-form-item label="Auth">
+                                <n-select v-model:value="channelForm.webhook.authScheme" :options="webhookAuthOptions" />
+                            </n-form-item>
+                            <n-form-item
+                                v-if="channelForm.webhook.authScheme === 'BEARER'"
+                                label="Bearer token"
+                            >
+                                <n-input
+                                    v-model:value="channelForm.webhook.secret"
+                                    type="password"
+                                    show-password-on="click"
+                                    :placeholder="channelForm.uuid ? 'Re-enter to update; leave blank to keep existing' : 'Secret bearer token'"
+                                />
+                            </n-form-item>
+                            <n-form-item
+                                v-if="channelForm.webhook.authScheme === 'HMAC_SHA256'"
+                                label="HMAC shared secret"
+                            >
+                                <n-input
+                                    v-model:value="channelForm.webhook.secret"
+                                    type="password"
+                                    show-password-on="click"
+                                    :placeholder="channelForm.uuid ? 'Re-enter to update; leave blank to keep existing' : 'Shared HMAC secret'"
+                                />
+                            </n-form-item>
+                        </template>
+
+                        <!-- Sentinel -->
+                        <template v-if="channelForm.type === 'SENTINEL'">
+                            <n-grid :cols="2" :x-gap="12">
+                                <n-gi>
+                                    <n-form-item label="Tenant ID">
+                                        <n-input v-model:value="channelForm.sentinel.tenantId" :placeholder="sentinelPlaceholder" />
+                                    </n-form-item>
+                                </n-gi>
+                                <n-gi>
+                                    <n-form-item label="Client ID">
+                                        <n-input v-model:value="channelForm.sentinel.clientId" :placeholder="sentinelPlaceholder" />
+                                    </n-form-item>
+                                </n-gi>
+                            </n-grid>
+                            <n-form-item label="Client Secret">
+                                <n-input
+                                    v-model:value="channelForm.sentinel.clientSecret"
+                                    type="password"
+                                    show-password-on="click"
+                                    :placeholder="sentinelPlaceholder"
+                                />
+                            </n-form-item>
+                            <n-form-item label="DCR endpoint">
+                                <n-input v-model:value="channelForm.sentinel.dcrEndpoint" :placeholder="sentinelPlaceholder || 'https://dce-...ingest.monitor.azure.com'" />
+                            </n-form-item>
+                            <n-grid :cols="2" :x-gap="12">
+                                <n-gi>
+                                    <n-form-item label="DCR immutable ID">
+                                        <n-input v-model:value="channelForm.sentinel.dcrImmutableId" :placeholder="sentinelPlaceholder" />
+                                    </n-form-item>
+                                </n-gi>
+                                <n-gi>
+                                    <n-form-item label="Stream name">
+                                        <n-input v-model:value="channelForm.sentinel.streamName" :placeholder="sentinelPlaceholder || 'Custom-ReARMNotifications_CL'" />
+                                    </n-form-item>
+                                </n-gi>
+                            </n-grid>
+                        </template>
+
+                        <n-alert v-if="modalError" type="error" :show-icon="false">
+                            {{ modalError }}
+                        </n-alert>
+
+                        <n-space>
+                            <n-button @click="saveChannel" type="primary" :loading="savingChannel" :disabled="!channelForm.name || !channelForm.type">
+                                Save
+                            </n-button>
+                            <n-button @click="showChannelModal = false">Cancel</n-button>
+                        </n-space>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
+        <!-- Test result modal -->
+        <n-modal v-model:show="showTestModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 480px" size="huge" :title="`Test channel — ${testState.channelName}`" :bordered="false" role="dialog" aria-modal="true">
+                <n-space vertical>
+                    <n-alert v-if="testState.status === 'PENDING'" type="info" :show-icon="false">
+                        Sending a synthetic event… polling for delivery status.
+                    </n-alert>
+                    <n-alert v-else-if="testState.status === 'SENT'" type="success" :show-icon="false">
+                        Delivered successfully in {{ testState.attempts }} attempt(s).
+                        Now verify the message reached the destination tool.
+                    </n-alert>
+                    <n-alert v-else-if="testState.status === 'FAILED'" type="error" :show-icon="false">
+                        Delivery failed: {{ testState.lastError || 'no error message returned' }}
+                    </n-alert>
+                    <n-alert v-else-if="testState.status === 'ERROR'" type="error" :show-icon="false">
+                        Test could not be started: {{ testState.lastError }}
+                    </n-alert>
+                    <n-alert v-else-if="testState.status === 'TIMEOUT'" type="warning" :show-icon="false">
+                        Delivery did not reach a terminal state within the poll window. Check History for the latest state.
+                    </n-alert>
+                    <div v-if="testState.eventUuid" class="muted-12">
+                        Event UUID: <code>{{ testState.eventUuid }}</code>
+                    </div>
+                    <n-button @click="showTestModal = false">Close</n-button>
+                </n-space>
+            </n-card>
+        </n-modal>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, h, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useStore } from 'vuex'
+import {
+    NTabs, NTabPane, NDataTable, NButton, NIcon, NEmpty, NModal, NCard, NForm,
+    NFormItem, NInput, NSelect, NSpace, NAlert, NGrid, NGi, NTag, useDialog, useMessage
+} from 'naive-ui'
+import { CirclePlus, Trash } from '@vicons/tabler'
+import gql from 'graphql-tag'
+import graphqlClient from '@/utils/graphql'
+import { Edit as EditIcon } from '@vicons/tabler'
+import commonFunctions from '@/utils/commonFunctions'
+
+interface ChannelRow {
+    uuid: string
+    org: string
+    resourceGroup: string | null
+    name: string
+    type: string
+    status: string
+}
+
+const route = useRoute()
+const router = useRouter()
+const store = useStore()
+const dialog = useDialog()
+const message = useMessage()
+
+const orgUuid = computed<string>(() => route.params.orguuid as string)
+const myuser = computed<any>(() => store.getters.myuser)
+const userPermission = ref<string>('')
+
+const canWrite = computed<boolean>(() =>
+    userPermission.value === 'ADMIN' || userPermission.value === 'READ_WRITE'
+)
+
+const activeTab = ref<string>((route.query.tab as string) || 'channels')
+
+function onTabChange (tab: string): void {
+    router.replace({ query: { ...route.query, tab } })
+}
+
+const channels = ref<ChannelRow[]>([])
+const channelsLoading = ref<boolean>(false)
+
+const TYPE_LABELS: Record<string, string> = {
+    SLACK: 'Slack',
+    WEBHOOK: 'Webhook',
+    MS_TEAMS: 'MS Teams',
+    SENTINEL: 'Sentinel',
+    EMAIL: 'Email',
+}
+
+// Email omitted until the Phase 9 dispatcher lands in rearm-core.
+const typeOptions = [
+    { label: 'Slack', value: 'SLACK' },
+    { label: 'Microsoft Teams', value: 'MS_TEAMS' },
+    { label: 'Generic Webhook', value: 'WEBHOOK' },
+    { label: 'Azure Sentinel', value: 'SENTINEL' },
+]
+
+const webhookAuthOptions = [
+    { label: 'None (URL secrecy + TLS only)', value: 'NONE' },
+    { label: 'Bearer token', value: 'BEARER' },
+    { label: 'HMAC-SHA256', value: 'HMAC_SHA256' },
+]
+
+const showChannelModal = ref<boolean>(false)
+const savingChannel = ref<boolean>(false)
+const modalError = ref<string>('')
+
+interface ChannelForm {
+    uuid: string | null
+    name: string
+    type: string | null
+    status: string
+    slack: { webhookUrl: string }
+    teams: { webhookUrl: string }
+    webhook: { url: string; authScheme: string; secret: string }
+    sentinel: {
+        tenantId: string
+        clientId: string
+        clientSecret: string
+        dcrEndpoint: string
+        dcrImmutableId: string
+        streamName: string
+    }
+}
+
+function freshForm (): ChannelForm {
+    return {
+        uuid: null,
+        name: '',
+        type: null,
+        status: 'ENABLED',
+        slack: { webhookUrl: '' },
+        teams: { webhookUrl: '' },
+        webhook: { url: '', authScheme: 'NONE', secret: '' },
+        sentinel: { tenantId: '', clientId: '', clientSecret: '', dcrEndpoint: '', dcrImmutableId: '', streamName: '' },
+    }
+}
+
+const channelForm = ref<ChannelForm>(freshForm())
+
+const sentinelPlaceholder = computed<string>(() =>
+    channelForm.value.uuid ? 'Re-enter to update; leave blank to keep existing' : ''
+)
+
+// Test channel state
+interface TestState {
+    channelUuid: string | null
+    channelName: string
+    eventUuid: string | null
+    status: 'IDLE' | 'PENDING' | 'SENT' | 'FAILED' | 'ERROR' | 'TIMEOUT'
+    attempts: number
+    lastError: string
+}
+
+const testState = ref<TestState>({
+    channelUuid: null, channelName: '', eventUuid: null,
+    status: 'IDLE', attempts: 0, lastError: '',
+})
+const showTestModal = ref<boolean>(false)
+
+// ---- GraphQL queries / mutations -----------------------------------------
+
+const LIST_CHANNELS_QUERY = gql`
+    query notificationChannels($orgUuid: ID!) {
+        notificationChannels(orgUuid: $orgUuid) {
+            uuid org resourceGroup name type status
+        }
+    }
+`
+
+const UPSERT_CHANNEL_MUTATION = gql`
+    mutation upsertNotificationChannel($input: NotificationChannelInput!) {
+        upsertNotificationChannel(input: $input) {
+            uuid org resourceGroup name type status
+        }
+    }
+`
+
+const SET_STATUS_MUTATION = gql`
+    mutation setNotificationChannelStatus($uuid: ID!, $status: NotificationChannelStatusEnum!) {
+        setNotificationChannelStatus(uuid: $uuid, status: $status) {
+            uuid status
+        }
+    }
+`
+
+const DELETE_CHANNEL_MUTATION = gql`
+    mutation deleteNotificationChannel($uuid: ID!) {
+        deleteNotificationChannel(uuid: $uuid)
+    }
+`
+
+const TEST_CHANNEL_MUTATION = gql`
+    mutation testNotificationChannel($channelUuid: ID!) {
+        testNotificationChannel(channelUuid: $channelUuid) {
+            uuid status
+        }
+    }
+`
+
+const LIST_DELIVERIES_QUERY = gql`
+    query notificationDeliveries($orgUuid: ID!, $eventUuid: ID, $limit: Int) {
+        notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, limit: $limit) {
+            items { uuid status attemptCount lastError sentAt }
+        }
+    }
+`
+
+// ---- Data loading --------------------------------------------------------
+
+async function loadChannels (): Promise<void> {
+    channelsLoading.value = true
+    try {
+        const res = await graphqlClient.query({
+            query: LIST_CHANNELS_QUERY,
+            variables: { orgUuid: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        channels.value = res.data?.notificationChannels || []
+    } catch (e: any) {
+        message.error(`Failed to load channels: ${extractError(e)}`)
+    } finally {
+        channelsLoading.value = false
+    }
+}
+
+// ---- Create / Edit -------------------------------------------------------
+
+function openCreateChannel (): void {
+    channelForm.value = freshForm()
+    modalError.value = ''
+    showChannelModal.value = true
+}
+
+function openEditChannel (row: ChannelRow): void {
+    // Secrets aren't returned by the read surface — edit form is metadata
+    // only; per-type config fields stay blank as placeholders prompt the
+    // user to re-enter only if they want to update the credential.
+    const f = freshForm()
+    f.uuid = row.uuid
+    f.name = row.name
+    f.type = row.type
+    f.status = row.status
+    channelForm.value = f
+    modalError.value = ''
+    showChannelModal.value = true
+}
+
+async function saveChannel (): Promise<void> {
+    modalError.value = ''
+    const f = channelForm.value
+    if (!f.type || !f.name.trim()) {
+        modalError.value = 'Name and type are required.'
+        return
+    }
+    const input: any = {
+        uuid: f.uuid || undefined,
+        org: orgUuid.value,
+        name: f.name.trim(),
+        type: f.type,
+        status: f.status,
+    }
+    if (f.type === 'SLACK' && f.slack.webhookUrl) {
+        input.slackConfig = { webhookUrl: f.slack.webhookUrl }
+    }
+    if (f.type === 'MS_TEAMS' && f.teams.webhookUrl) {
+        input.teamsConfig = { webhookUrl: f.teams.webhookUrl }
+    }
+    if (f.type === 'WEBHOOK') {
+        const cfg: any = { authScheme: f.webhook.authScheme }
+        if (f.webhook.url) cfg.url = f.webhook.url
+        if (f.webhook.secret) cfg.authToken = f.webhook.secret
+        input.webhookConfig = cfg
+    }
+    if (f.type === 'SENTINEL') {
+        const s = f.sentinel
+        const cfg: any = {}
+        if (s.tenantId) cfg.tenantId = s.tenantId
+        if (s.clientId) cfg.clientId = s.clientId
+        if (s.clientSecret) cfg.clientSecret = s.clientSecret
+        if (s.dcrEndpoint) cfg.dcrEndpoint = s.dcrEndpoint
+        if (s.dcrImmutableId) cfg.dcrImmutableId = s.dcrImmutableId
+        if (s.streamName) cfg.streamName = s.streamName
+        input.sentinelConfig = cfg
+    }
+    savingChannel.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: UPSERT_CHANNEL_MUTATION,
+            variables: { input },
+        })
+        showChannelModal.value = false
+        message.success(f.uuid ? 'Channel updated' : 'Channel created')
+        await loadChannels()
+    } catch (e: any) {
+        modalError.value = extractError(e)
+    } finally {
+        savingChannel.value = false
+    }
+}
+
+// ---- Toggle / Delete -----------------------------------------------------
+
+async function toggleStatus (row: ChannelRow): Promise<void> {
+    const next = row.status === 'ENABLED' ? 'DISABLED' : 'ENABLED'
+    try {
+        await graphqlClient.mutate({
+            mutation: SET_STATUS_MUTATION,
+            variables: { uuid: row.uuid, status: next },
+        })
+        message.success(`Channel ${next.toLowerCase()}`)
+        await loadChannels()
+    } catch (e: any) {
+        message.error(`Status change failed: ${extractError(e)}`)
+    }
+}
+
+function confirmDelete (row: ChannelRow): void {
+    dialog.warning({
+        title: `Delete channel "${row.name}"?`,
+        content: 'This is permanent. Subscriptions that route only to this channel will silently stop dispatching.',
+        positiveText: 'Delete',
+        negativeText: 'Cancel',
+        onPositiveClick: async () => {
+            try {
+                await graphqlClient.mutate({
+                    mutation: DELETE_CHANNEL_MUTATION,
+                    variables: { uuid: row.uuid },
+                })
+                message.success('Channel deleted')
+                await loadChannels()
+            } catch (e: any) {
+                message.error(`Delete failed: ${extractError(e)}`)
+            }
+        },
+    })
+}
+
+// ---- Test channel --------------------------------------------------------
+
+async function testChannel (row: ChannelRow): Promise<void> {
+    testState.value = {
+        channelUuid: row.uuid, channelName: row.name, eventUuid: null,
+        status: 'PENDING', attempts: 0, lastError: '',
+    }
+    showTestModal.value = true
+    try {
+        const res = await graphqlClient.mutate({
+            mutation: TEST_CHANNEL_MUTATION,
+            variables: { channelUuid: row.uuid },
+        })
+        const eventUuid = res.data?.testNotificationChannel?.uuid
+        if (!eventUuid) {
+            testState.value.status = 'ERROR'
+            testState.value.lastError = 'No outbox event returned'
+            return
+        }
+        testState.value.eventUuid = eventUuid
+        await pollForDelivery(eventUuid)
+    } catch (e: any) {
+        testState.value.status = 'ERROR'
+        testState.value.lastError = extractError(e)
+    }
+}
+
+async function pollForDelivery (eventUuid: string): Promise<void> {
+    // Backend dispatcher loop ticks every few seconds; usually first poll
+    // (1.5s in) already finds the SENT row. Cap at ~30s to keep the modal
+    // honest under a backlogged worker.
+    const deadline = Date.now() + 30000
+    while (Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 1500))
+        try {
+            const res = await graphqlClient.query({
+                query: LIST_DELIVERIES_QUERY,
+                variables: { orgUuid: orgUuid.value, eventUuid, limit: 5 },
+                fetchPolicy: 'network-only',
+            })
+            const items = res.data?.notificationDeliveries?.items || []
+            if (items.length > 0) {
+                const d = items[0]
+                testState.value.attempts = d.attemptCount || 0
+                testState.value.lastError = d.lastError || ''
+                if (d.status === 'SENT') {
+                    testState.value.status = 'SENT'
+                    return
+                }
+                if (d.status === 'FAILED' || d.status === 'PERMANENT_FAILURE') {
+                    testState.value.status = 'FAILED'
+                    return
+                }
+            }
+        } catch {
+            // Transient — keep polling within budget.
+        }
+    }
+    testState.value.status = 'TIMEOUT'
+}
+
+// ---- Column defs ---------------------------------------------------------
+
+const channelColumns = computed(() => [
+    { title: 'Name', key: 'name' },
+    {
+        title: 'Type', key: 'type',
+        render: (row: ChannelRow) => h(NTag, { type: 'default', size: 'small' }, { default: () => TYPE_LABELS[row.type] || row.type }),
+    },
+    {
+        title: 'Status', key: 'status',
+        render: (row: ChannelRow) => h(
+            NTag,
+            { type: row.status === 'ENABLED' ? 'success' : 'warning', size: 'small' },
+            { default: () => row.status },
+        ),
+    },
+    {
+        title: 'Actions', key: 'actions',
+        render: (row: ChannelRow) => h(NSpace, { size: 'small' }, {
+            default: () => [
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => testChannel(row),
+                    disabled: row.status !== 'ENABLED',
+                    title: row.status === 'ENABLED' ? 'Send synthetic event to this channel' : 'Enable channel to test',
+                }, { default: () => 'Test' }),
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => openEditChannel(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => toggleStatus(row),
+                    disabled: !canWrite.value,
+                }, { default: () => row.status === 'ENABLED' ? 'Disable' : 'Enable' }),
+                h(NButton, {
+                    size: 'tiny', secondary: true, type: 'error',
+                    onClick: () => confirmDelete(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
+            ],
+        }),
+    },
+])
+
+// ---- helpers -------------------------------------------------------------
+
+function extractError (e: any): string {
+    const gql = e?.graphQLErrors?.[0]?.message
+    if (gql) return gql
+    return e?.message || 'Unknown error'
+}
+
+onMounted(async () => {
+    userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
+    await loadChannels()
+})
+</script>
+
+<style scoped>
+.notifications-page { padding: 24px; }
+.page-header { margin-bottom: 16px; }
+.page-title { margin: 0 0 4px; font-size: 18px; font-weight: 600; }
+.page-subtitle { font-size: 13px; color: var(--n-text-color-3, #888); }
+
+.tab-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 0 16px;
+}
+.tab-toolbar-info { font-size: 12.5px; color: var(--n-text-color-3, #888); }
+.muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
+</style>

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -2385,6 +2385,13 @@ onMounted(async () => {
         loadDeliveries(),
         loadInboxUnreadCount(),
     ])
+    // If the initial route lands directly on the Inbox tab (e.g. a
+    // bookmarked URL or a slash-style notification link), the lazy
+    // tab-activation hook on onTabChange doesn't fire — kick the load
+    // explicitly here.
+    if (activeTab.value === 'inbox') {
+        await loadInbox()
+    }
 })
 </script>
 

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -78,6 +78,81 @@
                 />
             </n-tab-pane>
 
+            <n-tab-pane name="inbox" :tab="inboxUnreadCount > 0 ? `Inbox (${inboxUnreadCount})` : 'Inbox'">
+                <div class="tab-toolbar">
+                    <div class="tab-toolbar-info">
+                        Your personal triage queue. Org-admins see every delivery; perspective-members see deliveries that touch a release in one of their perspectives.
+                    </div>
+                    <n-space size="small">
+                        <n-button
+                            v-if="canWrite && selectedInboxRows.length > 0"
+                            size="small"
+                            type="primary"
+                            @click="bulkMarkRead"
+                            :loading="inboxBulkLoading"
+                        >
+                            <template #icon><n-icon><Check /></n-icon></template>
+                            Mark {{ selectedInboxRows.length }} read
+                        </n-button>
+                        <n-button
+                            v-if="canWrite && inboxUnreadCount > 0"
+                            size="small"
+                            secondary
+                            @click="markAllReadConfirm"
+                            :loading="inboxMarkAllLoading"
+                        >
+                            Mark all read
+                        </n-button>
+                        <n-button size="small" @click="loadInbox">
+                            <template #icon><n-icon><Refresh /></n-icon></template>
+                            Refresh
+                        </n-button>
+                    </n-space>
+                </div>
+
+                <n-grid :cols="2" :x-gap="12" class="history-filters">
+                    <n-gi>
+                        <n-form-item label="Show" :show-feedback="false">
+                            <n-radio-group v-model:value="inboxUnreadOnly" @update:value="applyInboxFilters">
+                                <n-radio-button :value="true">Unread only</n-radio-button>
+                                <n-radio-button :value="false">All visible</n-radio-button>
+                            </n-radio-group>
+                        </n-form-item>
+                    </n-gi>
+                    <n-gi>
+                        <n-form-item label="Status" :show-feedback="false">
+                            <n-select
+                                v-model:value="inboxStatusFilter"
+                                :options="deliveryStatusOptions"
+                                placeholder="Any"
+                                clearable
+                                @update:value="applyInboxFilters"
+                            />
+                        </n-form-item>
+                    </n-gi>
+                </n-grid>
+
+                <n-data-table
+                    :data="inboxItems"
+                    :columns="inboxColumns"
+                    :loading="inboxLoading"
+                    :single-line="false"
+                    :bordered="false"
+                    :row-key="(row) => row.uuid"
+                    v-model:checked-row-keys="selectedInboxRows"
+                />
+
+                <div v-if="inboxTotalCount > inboxPageSize" class="history-pagination">
+                    <n-pagination
+                        v-model:page="inboxPage"
+                        :page-count="inboxPageCount"
+                        :page-size="inboxPageSize"
+                        :item-count="inboxTotalCount"
+                        @update:page="loadInbox"
+                    />
+                </div>
+            </n-tab-pane>
+
             <n-tab-pane name="groups" tab="Channel groups">
                 <div class="tab-toolbar">
                     <div class="tab-toolbar-info">
@@ -669,7 +744,7 @@ import {
     NRadioGroup, NRadioButton, NPagination, NSteps, NStep,
     useDialog, useMessage
 } from 'naive-ui'
-import { CirclePlus, Trash, Edit as EditIcon, Refresh } from '@vicons/tabler'
+import { CirclePlus, Trash, Edit as EditIcon, Refresh, Check } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -728,6 +803,25 @@ interface DeliveryRow {
     createdDate: string
 }
 
+interface InboxRow {
+    uuid: string
+    org: string
+    outboxEventUuid: string
+    subscriptionUuid: string | null
+    channelUuid: string
+    status: string
+    origin: string
+    dedupKey: string | null
+    attemptCount: number
+    nextAttemptAt: string | null
+    sentAt: string | null
+    lastError: string | null
+    createdDate: string
+    readAt: string | null
+    eventType: string | null
+    severity: string | null
+}
+
 interface SubscriptionRow {
     uuid: string
     org: string
@@ -759,6 +853,9 @@ const activeTab = ref<string>((route.query.tab as string) || 'channels')
 
 function onTabChange (tab: string): void {
     router.replace({ query: { ...route.query, tab } })
+    // Lazy-load the inbox body the first time the tab is opened so a
+    // user who never goes there doesn't pay the round-trip cost.
+    if (tab === 'inbox') loadInbox()
 }
 
 const channels = ref<ChannelRow[]>([])
@@ -1021,6 +1118,22 @@ const channelGroupOptions = computed(() =>
     }))
 )
 
+// Inbox MVP state (Phase 14)
+const inboxItems = ref<InboxRow[]>([])
+const inboxLoading = ref<boolean>(false)
+const inboxTotalCount = ref<number>(0)
+const inboxUnreadCount = ref<number>(0)
+const inboxPage = ref<number>(1)
+const inboxPageSize = ref<number>(25)
+const inboxPageCount = computed<number>(() =>
+    Math.max(1, Math.ceil(inboxTotalCount.value / inboxPageSize.value))
+)
+const inboxUnreadOnly = ref<boolean>(true)
+const inboxStatusFilter = ref<string | null>(null)
+const selectedInboxRows = ref<string[]>([])
+const inboxBulkLoading = ref<boolean>(false)
+const inboxMarkAllLoading = ref<boolean>(false)
+
 // Delivery history state
 const deliveries = ref<DeliveryRow[]>([])
 const deliveriesLoading = ref<boolean>(false)
@@ -1084,6 +1197,58 @@ const LIST_DELIVERIES_QUERY = gql`
         notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, limit: $limit) {
             items { uuid status attemptCount lastError sentAt }
         }
+    }
+`
+
+// Phase 14 Inbox MVP queries + mutations. Sibling to the History query
+// surface — the backend visibility filter is server-side; the UI just
+// supplies orgUuid + filters + pagination.
+const INBOX_QUERY = gql`
+    query notificationInbox(
+        $orgUuid: ID!,
+        $unreadOnly: Boolean,
+        $status: NotificationDeliveryStatusEnum,
+        $limit: Int,
+        $offset: Int
+    ) {
+        notificationInbox(
+            orgUuid: $orgUuid,
+            unreadOnly: $unreadOnly,
+            status: $status,
+            limit: $limit,
+            offset: $offset
+        ) {
+            items {
+                uuid org outboxEventUuid subscriptionUuid channelUuid
+                status origin dedupKey attemptCount nextAttemptAt sentAt
+                lastError createdDate readAt eventType severity
+            }
+            totalCount unreadCount limit offset
+        }
+    }
+`
+
+const INBOX_UNREAD_COUNT_QUERY = gql`
+    query notificationUnreadCount($orgUuid: ID!) {
+        notificationUnreadCount(orgUuid: $orgUuid)
+    }
+`
+
+const MARK_READ_MUTATION = gql`
+    mutation markNotificationRead($deliveryUuid: ID!) {
+        markNotificationRead(deliveryUuid: $deliveryUuid) { uuid readAt }
+    }
+`
+
+const MARK_UNREAD_MUTATION = gql`
+    mutation markNotificationUnread($deliveryUuid: ID!) {
+        markNotificationUnread(deliveryUuid: $deliveryUuid)
+    }
+`
+
+const MARK_ALL_READ_MUTATION = gql`
+    mutation markAllNotificationsRead($orgUuid: ID!) {
+        markAllNotificationsRead(orgUuid: $orgUuid)
     }
 `
 
@@ -1395,6 +1560,142 @@ function confirmDeleteGroup (row: ChannelGroupRow): void {
             }
         },
     })
+}
+
+// Inbox MVP — load + filters + mark-read flows.
+let inboxInflightToken = 0
+
+async function loadInbox (): Promise<void> {
+    const myToken = ++inboxInflightToken
+    inboxLoading.value = true
+    try {
+        const offset = (inboxPage.value - 1) * inboxPageSize.value
+        const res = await graphqlClient.query({
+            query: INBOX_QUERY,
+            variables: {
+                orgUuid: orgUuid.value,
+                unreadOnly: inboxUnreadOnly.value,
+                status: inboxStatusFilter.value,
+                limit: inboxPageSize.value,
+                offset,
+            },
+            fetchPolicy: 'network-only',
+        })
+        if (myToken !== inboxInflightToken) return
+        const page = res.data?.notificationInbox
+        inboxItems.value = page?.items || []
+        inboxTotalCount.value = page?.totalCount || 0
+        inboxUnreadCount.value = page?.unreadCount || 0
+        // Drop checked rows that aren't on the new page.
+        const visible = new Set(inboxItems.value.map(r => r.uuid))
+        selectedInboxRows.value = selectedInboxRows.value.filter(uuid => visible.has(uuid))
+    } catch (e: any) {
+        if (myToken !== inboxInflightToken) return
+        message.error(`Failed to load inbox: ${extractError(e)}`)
+    } finally {
+        if (myToken === inboxInflightToken) inboxLoading.value = false
+    }
+}
+
+function applyInboxFilters (): void {
+    inboxPage.value = 1
+    loadInbox()
+}
+
+async function markRowRead (row: InboxRow): Promise<void> {
+    try {
+        const res = await graphqlClient.mutate({
+            mutation: MARK_READ_MUTATION,
+            variables: { deliveryUuid: row.uuid },
+        })
+        const readAt = res.data?.markNotificationRead?.readAt || new Date().toISOString()
+        // Optimistic update — patch the row in place rather than reload.
+        const idx = inboxItems.value.findIndex(r => r.uuid === row.uuid)
+        if (idx >= 0) inboxItems.value[idx].readAt = readAt
+        if (inboxUnreadCount.value > 0) inboxUnreadCount.value -= 1
+        // If we're filtering unread-only, drop the row from the table.
+        if (inboxUnreadOnly.value) {
+            inboxItems.value = inboxItems.value.filter(r => r.uuid !== row.uuid)
+            if (inboxTotalCount.value > 0) inboxTotalCount.value -= 1
+        }
+    } catch (e: any) {
+        message.error(`Mark read failed: ${extractError(e)}`)
+    }
+}
+
+async function markRowUnread (row: InboxRow): Promise<void> {
+    try {
+        await graphqlClient.mutate({
+            mutation: MARK_UNREAD_MUTATION,
+            variables: { deliveryUuid: row.uuid },
+        })
+        const idx = inboxItems.value.findIndex(r => r.uuid === row.uuid)
+        if (idx >= 0) inboxItems.value[idx].readAt = null
+        inboxUnreadCount.value += 1
+    } catch (e: any) {
+        message.error(`Mark unread failed: ${extractError(e)}`)
+    }
+}
+
+async function bulkMarkRead (): Promise<void> {
+    if (selectedInboxRows.value.length === 0) return
+    inboxBulkLoading.value = true
+    try {
+        // Fire one mutation per selected row in parallel. The backend
+        // guards each call with the visibility filter, so a malformed
+        // selection is rejected per-uuid, not silently.
+        await Promise.all(selectedInboxRows.value.map(uuid =>
+            graphqlClient.mutate({
+                mutation: MARK_READ_MUTATION,
+                variables: { deliveryUuid: uuid },
+            })
+        ))
+        message.success(`Marked ${selectedInboxRows.value.length} read`)
+        selectedInboxRows.value = []
+        await loadInbox()
+    } catch (e: any) {
+        message.error(`Bulk mark read failed: ${extractError(e)}`)
+    } finally {
+        inboxBulkLoading.value = false
+    }
+}
+
+function markAllReadConfirm (): void {
+    dialog.warning({
+        title: 'Mark every visible unread notification as read?',
+        content: `This marks up to ${inboxUnreadCount.value} unread item(s) as read. Backend caps a single sweep at 500.`,
+        positiveText: 'Mark all read',
+        negativeText: 'Cancel',
+        onPositiveClick: async () => {
+            inboxMarkAllLoading.value = true
+            try {
+                const res = await graphqlClient.mutate({
+                    mutation: MARK_ALL_READ_MUTATION,
+                    variables: { orgUuid: orgUuid.value },
+                })
+                const n = res.data?.markAllNotificationsRead || 0
+                message.success(`Marked ${n} read`)
+                await loadInbox()
+            } catch (e: any) {
+                message.error(`Mark all failed: ${extractError(e)}`)
+            } finally {
+                inboxMarkAllLoading.value = false
+            }
+        },
+    })
+}
+
+async function loadInboxUnreadCount (): Promise<void> {
+    try {
+        const res = await graphqlClient.query({
+            query: INBOX_UNREAD_COUNT_QUERY,
+            variables: { orgUuid: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        inboxUnreadCount.value = res.data?.notificationUnreadCount || 0
+    } catch {
+        // Badge is decorative; failures are fine.
+    }
 }
 
 async function loadDeliveries (): Promise<void> {
@@ -1947,6 +2248,75 @@ function truncate (s: string | null, n: number): string {
     return s.length > n ? `${s.slice(0, n - 1)}…` : s
 }
 
+const inboxColumns = computed(() => [
+    {
+        type: 'selection' as const,
+        // Selection cell only meaningful for unread rows — read rows
+        // can't be re-marked-read.
+        disabled: (row: InboxRow) => !!row.readAt,
+    },
+    {
+        title: 'When', key: 'when',
+        render: (row: InboxRow) => formatHistoryTimestamp(row.sentAt || row.createdDate),
+    },
+    {
+        title: 'Status', key: 'status',
+        render: (row: InboxRow) => h(
+            NTag,
+            { type: deliveryStatusTagType(row.status), size: 'small' },
+            { default: () => row.status },
+        ),
+    },
+    {
+        title: 'Event', key: 'eventType',
+        render: (row: InboxRow) => row.eventType
+            ? truncate(row.eventType.replace(/_/g, ' ').toLowerCase(), 40)
+            : h('span', { class: 'muted-12' }, '—'),
+    },
+    {
+        title: 'Severity', key: 'severity',
+        render: (row: InboxRow) => row.severity
+            ? h(
+                NTag,
+                { type: severityTagType(row.severity), size: 'small' },
+                { default: () => row.severity },
+            )
+            : h('span', { class: 'muted-12' }, '—'),
+    },
+    {
+        title: 'Channel', key: 'channelUuid',
+        render: (row: InboxRow) => channelNameById.value[row.channelUuid]
+            || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'),
+    },
+    {
+        title: 'Read', key: 'readAt',
+        render: (row: InboxRow) => row.readAt
+            ? h(NSpace, { size: 'small', align: 'center' }, {
+                default: () => [
+                    h('span', { class: 'muted-12' }, formatHistoryTimestamp(row.readAt)),
+                    h(NButton, {
+                        size: 'tiny', secondary: true,
+                        onClick: () => markRowUnread(row),
+                        disabled: !canWrite.value,
+                        title: 'Mark unread',
+                    }, { default: () => 'Unread' }),
+                ],
+            })
+            : h(NButton, {
+                size: 'tiny', secondary: true, type: 'primary',
+                onClick: () => markRowRead(row),
+                disabled: !canWrite.value,
+            }, { icon: () => h(NIcon, null, { default: () => h(Check) }), default: () => 'Mark read' }),
+    },
+])
+
+function severityTagType (severity: string): 'success' | 'warning' | 'error' | 'info' | 'default' {
+    if (severity === 'CRITICAL' || severity === 'HIGH') return 'error'
+    if (severity === 'MEDIUM') return 'warning'
+    if (severity === 'LOW' || severity === 'INFO') return 'info'
+    return 'default'
+}
+
 const deliveryColumns = computed(() => [
     {
         title: 'When', key: 'createdDate',
@@ -2003,16 +2373,17 @@ function extractError (e: any): string {
 
 onMounted(async () => {
     userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
-    // Load channels, channel groups, subscriptions, and the first
-    // page of delivery history in parallel. Subscription edit modal's
-    // pickers degrade to empty placeholders if opened before channels
-    // / groups resolve — acceptable given the typical few-hundred-ms
-    // load.
+    // Load channels, channel groups, subscriptions, the first page of
+    // delivery history, and the inbox badge in parallel. Subscription
+    // edit modal's pickers degrade to empty placeholders if opened
+    // before channels / groups resolve — acceptable given the typical
+    // few-hundred-ms load. Inbox tab body loads lazily on tab open.
     await Promise.all([
         loadChannels(),
         loadChannelGroups(),
         loadSubscriptions(),
         loadDeliveries(),
+        loadInboxUnreadCount(),
     ])
 })
 </script>

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -217,10 +217,9 @@ import {
     NTabs, NTabPane, NDataTable, NButton, NIcon, NEmpty, NModal, NCard, NForm,
     NFormItem, NInput, NSelect, NSpace, NAlert, NGrid, NGi, NTag, useDialog, useMessage
 } from 'naive-ui'
-import { CirclePlus, Trash } from '@vicons/tabler'
+import { CirclePlus, Trash, Edit as EditIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
-import { Edit as EditIcon } from '@vicons/tabler'
 import commonFunctions from '@/utils/commonFunctions'
 
 interface ChannelRow {
@@ -442,7 +441,14 @@ async function saveChannel (): Promise<void> {
     if (f.type === 'MS_TEAMS' && f.teams.webhookUrl) {
         input.teamsConfig = { webhookUrl: f.teams.webhookUrl }
     }
-    if (f.type === 'WEBHOOK') {
+    if (f.type === 'WEBHOOK' && (f.webhook.url || f.webhook.secret)) {
+        // Mirror the Slack/Teams gating: only send webhookConfig when
+        // the user actually filled something in. Otherwise the backend
+        // preserves both URL + auth scheme + secret as a unit. This
+        // protects against a future backend change that trusts a
+        // non-null authScheme independent of the URL — without it,
+        // every metadata-only edit would silently flip the channel
+        // to NONE auth.
         const cfg: any = { authScheme: f.webhook.authScheme }
         if (f.webhook.url) cfg.url = f.webhook.url
         if (f.webhook.secret) cfg.authToken = f.webhook.secret
@@ -557,12 +563,23 @@ async function pollForDelivery (eventUuid: string): Promise<void> {
                 const d = items[0]
                 testState.value.attempts = d.attemptCount || 0
                 testState.value.lastError = d.lastError || ''
-                if (d.status === 'SENT') {
+                if (d.status === 'SENT' || d.status === 'ACKED') {
                     testState.value.status = 'SENT'
                     return
                 }
-                if (d.status === 'FAILED' || d.status === 'PERMANENT_FAILURE') {
+                // Terminal failure states per NotificationDeliveryStatusEnum.
+                // RATE_LIMITED + EVAL_TIMEOUT are terminal for the dispatch
+                // path even though they have different operator semantics;
+                // surface them with the failure alert and lastError will
+                // carry the disambiguation (the worker writes a descriptive
+                // lastError when it short-circuits on these).
+                if (d.status === 'FAILED'
+                    || d.status === 'RATE_LIMITED'
+                    || d.status === 'EVAL_TIMEOUT') {
                     testState.value.status = 'FAILED'
+                    if (!testState.value.lastError) {
+                        testState.value.lastError = `Delivery ${d.status.toLowerCase().replace(/_/g, ' ')}`
+                    }
                     return
                 }
             }
@@ -622,9 +639,7 @@ const channelColumns = computed(() => [
 // ---- helpers -------------------------------------------------------------
 
 function extractError (e: any): string {
-    const gql = e?.graphQLErrors?.[0]?.message
-    if (gql) return gql
-    return e?.message || 'Unknown error'
+    return commonFunctions.parseGraphQLError(commonFunctions.extractGraphQLErrorMessage(e))
 }
 
 onMounted(async () => {

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -736,6 +736,16 @@ function freshForm (): ChannelForm {
     }
 }
 
+// Optimistic-locking note. The three upsert paths in this file
+// (upsertNotificationChannel, upsertNotificationSubscription,
+// upsertNotificationChannelGroup) do NOT forward the `revision` value
+// from the loaded row. The backend entities use @Version, but the
+// GraphQL Input shapes don't currently expose an `expectedRevision`
+// field, so the UI can't gate save on it. Accepted as-is across all
+// three surfaces for consistency; a stale concurrent edit on the same
+// row is last-writer-wins. If multi-admin races become a real customer
+// concern, the fix is a coordinated schema change (add expectedRevision
+// to all three Input shapes) + a UI guard that surfaces the conflict.
 const channelForm = ref<ChannelForm>(freshForm())
 
 const sentinelPlaceholder = computed<string>(() =>
@@ -1416,10 +1426,11 @@ async function saveSubscription (): Promise<void> {
         status: f.status,
         eventTypes: f.eventTypes,
         filter: filterInput,
-        // Spread the original route's unmodelled fields (channelGroups,
-        // andEnvIn, andLifecycleIn, perspectives) so an Edit → Save
-        // round-trip doesn't silently strip them. The slice-2-modeled
-        // fields overlay last and win.
+        // Spread the original route's still-unmodelled fields
+        // (andEnvIn, andLifecycleIn, perspectives) so an Edit → Save
+        // round-trip doesn't silently strip them. The slice-2 +
+        // slice-4 modelled fields (severity, channels, channelGroups)
+        // overlay last and win.
         routes: f.routes.map(r => ({
             ...(r._raw || {}),
             whenSeverityAtLeast: r.whenSeverityAtLeast,

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -5,6 +5,28 @@
             <div class="page-subtitle">Security and operational events routed to your destinations of choice.</div>
         </div>
 
+        <!-- Quick Start banner. Surfaces only on an org with no channels
+             AND no subscriptions to avoid the "default subscription with
+             no channel = silent failure" anti-pattern (design doc §6.7). -->
+        <n-alert
+            v-if="canShowQuickStart"
+            class="quick-start-banner"
+            type="info"
+            :show-icon="false"
+        >
+            <template #header>
+                <span class="quick-start-title">Welcome to Notifications</span>
+            </template>
+            <div class="quick-start-body">
+                <div>
+                    Get from zero to a working subscription in three steps — your first channel, your first rule, then we land it in <strong>Preview</strong> mode so deliveries record in History without firing your real destination. Flip it to Active once you've verified.
+                </div>
+                <n-button type="primary" size="small" @click="openQuickStart">
+                    Start
+                </n-button>
+            </div>
+        </n-alert>
+
         <n-tabs v-model:value="activeTab" type="segment" animated @update:value="onTabChange">
             <n-tab-pane name="channels" tab="Channels">
                 <div class="tab-toolbar">
@@ -287,6 +309,117 @@
             </n-card>
         </n-modal>
 
+        <!-- Quick Start wizard modal -->
+        <n-modal v-model:show="showQuickStart" preset="dialog" :show-icon="false" :mask-closable="false">
+            <n-card
+                style="width: 640px"
+                size="huge"
+                :title="`Quick Start — step ${quickStartStep} of 3`"
+                :bordered="false"
+                role="dialog"
+                aria-modal="true"
+            >
+                <n-steps :current="quickStartStep" size="small" class="quick-start-steps">
+                    <n-step title="Channel" description="Where to send" />
+                    <n-step title="Subscription" description="What to send" />
+                    <n-step title="Done" description="Preview & verify" />
+                </n-steps>
+
+                <!-- Step 1: channel -->
+                <div v-if="quickStartStep === 1">
+                    <n-form :model="qsChannel">
+                        <n-space vertical size="large">
+                            <n-form-item label="Channel type">
+                                <n-select v-model:value="qsChannel.type" :options="qsChannelTypeOptions" />
+                            </n-form-item>
+                            <n-form-item label="Name">
+                                <n-input v-model:value="qsChannel.name" placeholder="e.g. sec-oncall-slack" />
+                            </n-form-item>
+                            <n-form-item v-if="qsChannel.type === 'SLACK'" label="Slack incoming webhook URL">
+                                <n-input v-model:value="qsChannel.url" placeholder="https://hooks.slack.com/services/..." />
+                            </n-form-item>
+                            <n-form-item v-if="qsChannel.type === 'MS_TEAMS'" label="Teams Workflows webhook URL">
+                                <n-input v-model:value="qsChannel.url" placeholder="https://...powerplatform.com/... or .../logic.azure.com/..." />
+                            </n-form-item>
+
+                            <n-alert v-if="quickStartError" type="error" :show-icon="false">{{ quickStartError }}</n-alert>
+
+                            <n-space>
+                                <n-button
+                                    type="primary"
+                                    :loading="quickStartSaving"
+                                    :disabled="!qsChannel.name.trim() || !qsChannel.url.trim()"
+                                    @click="quickStartCreateChannel"
+                                >
+                                    Save channel → next
+                                </n-button>
+                                <n-button @click="closeQuickStart">Cancel</n-button>
+                            </n-space>
+                        </n-space>
+                    </n-form>
+                </div>
+
+                <!-- Step 2: subscription -->
+                <div v-if="quickStartStep === 2">
+                    <n-form :model="qsSubscription">
+                        <n-space vertical size="large">
+                            <n-form-item label="Name">
+                                <n-input v-model:value="qsSubscription.name" placeholder="e.g. critical-vuln-oncall" />
+                            </n-form-item>
+                            <n-form-item label="Event types">
+                                <n-select
+                                    v-model:value="qsSubscription.eventTypes"
+                                    :options="eventTypeOptions"
+                                    multiple
+                                />
+                            </n-form-item>
+                            <n-form-item label="Minimum severity">
+                                <n-select
+                                    v-model:value="qsSubscription.severity"
+                                    :options="severityOptions"
+                                    placeholder="Any"
+                                    clearable
+                                />
+                            </n-form-item>
+                            <div class="muted-12">
+                                Routes to the channel you just created. The subscription will land in <strong>Preview</strong> mode — deliveries record in History but don't fire your real destination.
+                            </div>
+
+                            <n-alert v-if="quickStartError" type="error" :show-icon="false">{{ quickStartError }}</n-alert>
+
+                            <n-space>
+                                <n-button
+                                    type="primary"
+                                    :loading="quickStartSaving"
+                                    :disabled="!qsSubscription.name.trim() || qsSubscription.eventTypes.length === 0"
+                                    @click="quickStartCreateSubscription"
+                                >
+                                    Save subscription → next
+                                </n-button>
+                                <n-button @click="closeQuickStart">Cancel</n-button>
+                            </n-space>
+                        </n-space>
+                    </n-form>
+                </div>
+
+                <!-- Step 3: done -->
+                <div v-if="quickStartStep === 3">
+                    <n-space vertical size="large">
+                        <n-alert type="success" :show-icon="false">
+                            <strong>Done.</strong> Your subscription is in <strong>Preview</strong> mode. Matching deliveries land in History without firing the real destination.
+                        </n-alert>
+                        <div class="muted-12">
+                            Verify the right kinds of events show up in <strong>History</strong> (tagged <code>PREVIEW</code>). When you're confident, edit the subscription and flip the status to <strong>Active</strong> to start sending to your channel.
+                        </div>
+                        <n-space>
+                            <n-button type="primary" @click="quickStartGoToHistory">View History</n-button>
+                            <n-button @click="closeQuickStart">Close</n-button>
+                        </n-space>
+                    </n-space>
+                </div>
+            </n-card>
+        </n-modal>
+
         <!-- Channel group create/edit modal -->
         <n-modal v-model:show="showGroupModal" preset="dialog" :show-icon="false">
             <n-card
@@ -533,7 +666,8 @@ import { useStore } from 'vuex'
 import {
     NTabs, NTabPane, NDataTable, NButton, NIcon, NEmpty, NModal, NCard, NForm,
     NFormItem, NInput, NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag,
-    NRadioGroup, NRadioButton, NPagination, useDialog, useMessage
+    NRadioGroup, NRadioButton, NPagination, NSteps, NStep,
+    useDialog, useMessage
 } from 'naive-ui'
 import { CirclePlus, Trash, Edit as EditIcon, Refresh } from '@vicons/tabler'
 import gql from 'graphql-tag'
@@ -817,6 +951,61 @@ const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
 
+// Quick Start wizard state — see design doc §6.7. Lands a fresh org's
+// first channel + first subscription as a guided flow; the resulting
+// subscription is PREVIEW status so the operator can verify in History
+// before flipping to ACTIVE.
+const showQuickStart = ref<boolean>(false)
+const quickStartStep = ref<number>(1)
+const quickStartSaving = ref<boolean>(false)
+const quickStartError = ref<string>('')
+const quickStartChannelUuid = ref<string | null>(null)
+
+interface QuickStartChannel {
+    type: string
+    name: string
+    url: string
+}
+
+interface QuickStartSubscription {
+    name: string
+    eventTypes: string[]
+    severity: string | null
+}
+
+function freshQsChannel (): QuickStartChannel {
+    return { type: 'SLACK', name: '', url: '' }
+}
+
+function freshQsSubscription (): QuickStartSubscription {
+    return {
+        name: '',
+        eventTypes: ['NEW_VULN_AFFECTS_RELEASES'],
+        severity: 'HIGH',
+    }
+}
+
+const qsChannel = ref<QuickStartChannel>(freshQsChannel())
+const qsSubscription = ref<QuickStartSubscription>(freshQsSubscription())
+
+// Quick Start type picker is intentionally narrower than the full
+// channel form — Slack + Teams are the common starter destinations
+// (one URL, no other config). Sentinel (six fields) and Webhook
+// (auth-scheme decision) belong in the full Add Channel flow.
+const qsChannelTypeOptions = [
+    { label: 'Slack', value: 'SLACK' },
+    { label: 'Microsoft Teams', value: 'MS_TEAMS' },
+]
+
+const canShowQuickStart = computed<boolean>(() =>
+    canWrite.value
+    && !channelsLoading.value
+    && !subscriptionsLoading.value
+    && channels.value.length === 0
+    && subscriptions.value.length === 0
+    && !showQuickStart.value
+)
+
 // Channel groups state
 const channelGroups = ref<ChannelGroupRow[]>([])
 const channelGroupsLoading = ref<boolean>(false)
@@ -1019,6 +1208,110 @@ async function loadSubscriptions (): Promise<void> {
 // the newer state. The token guards apply-time so a stale response is
 // dropped silently.
 let historyInflightToken = 0
+
+// ---- Quick Start wizard --------------------------------------------------
+
+function openQuickStart (): void {
+    quickStartStep.value = 1
+    qsChannel.value = freshQsChannel()
+    qsSubscription.value = freshQsSubscription()
+    quickStartChannelUuid.value = null
+    quickStartError.value = ''
+    showQuickStart.value = true
+}
+
+function closeQuickStart (): void {
+    showQuickStart.value = false
+}
+
+async function quickStartCreateChannel (): Promise<void> {
+    quickStartError.value = ''
+    const c = qsChannel.value
+    if (!c.name.trim() || !c.url.trim()) {
+        quickStartError.value = 'Name and webhook URL are required.'
+        return
+    }
+    const input: any = {
+        org: orgUuid.value,
+        name: c.name.trim(),
+        type: c.type,
+        status: 'ENABLED',
+    }
+    if (c.type === 'SLACK') input.slackConfig = { webhookUrl: c.url }
+    if (c.type === 'MS_TEAMS') input.teamsConfig = { webhookUrl: c.url }
+    quickStartSaving.value = true
+    try {
+        const res = await graphqlClient.mutate({
+            mutation: UPSERT_CHANNEL_MUTATION,
+            variables: { input },
+        })
+        const created = res.data?.upsertNotificationChannel
+        if (!created?.uuid) {
+            quickStartError.value = 'Channel save returned no uuid.'
+            return
+        }
+        quickStartChannelUuid.value = created.uuid
+        // Auto-suggest a subscription name based on the channel name so
+        // step 2 doesn't start empty.
+        qsSubscription.value.name = `vulns-${c.name.trim()}`
+        await loadChannels()
+        quickStartStep.value = 2
+        quickStartError.value = ''
+    } catch (e: any) {
+        quickStartError.value = extractError(e)
+    } finally {
+        quickStartSaving.value = false
+    }
+}
+
+async function quickStartCreateSubscription (): Promise<void> {
+    quickStartError.value = ''
+    const s = qsSubscription.value
+    if (!s.name.trim() || s.eventTypes.length === 0) {
+        quickStartError.value = 'Name and at least one event type are required.'
+        return
+    }
+    if (!quickStartChannelUuid.value) {
+        quickStartError.value = 'Internal error: channel uuid lost between steps. Cancel and try again.'
+        return
+    }
+    const input: any = {
+        org: orgUuid.value,
+        name: s.name.trim(),
+        // Wizard subscriptions ALWAYS land in PREVIEW per design doc §6.7
+        // so the operator verifies via History before going live.
+        status: 'PREVIEW',
+        eventTypes: s.eventTypes,
+        filter: { mode: 'PRESET', celExpression: null },
+        routes: [{
+            whenSeverityAtLeast: s.severity,
+            channels: [quickStartChannelUuid.value],
+            channelGroups: [],
+        }],
+        dedupWindowMinutes: null,
+    }
+    quickStartSaving.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: UPSERT_SUBSCRIPTION_MUTATION,
+            variables: { input },
+        })
+        await loadSubscriptions()
+        quickStartStep.value = 3
+        quickStartError.value = ''
+    } catch (e: any) {
+        quickStartError.value = extractError(e)
+    } finally {
+        quickStartSaving.value = false
+    }
+}
+
+function quickStartGoToHistory (): void {
+    showQuickStart.value = false
+    activeTab.value = 'history'
+    onTabChange('history')
+    loadDeliveries()
+}
 
 async function loadChannelGroups (): Promise<void> {
     channelGroupsLoading.value = true
@@ -1739,6 +2032,16 @@ onMounted(async () => {
 }
 .tab-toolbar-info { font-size: 12.5px; color: var(--n-text-color-3, #888); }
 .muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
+
+.quick-start-banner { margin-bottom: 16px; }
+.quick-start-title { font-weight: 600; }
+.quick-start-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+}
+.quick-start-steps { margin-bottom: 16px; }
 
 .history-filters { margin-bottom: 12px; }
 .history-pagination { margin-top: 12px; display: flex; justify-content: flex-end; }

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -57,7 +57,69 @@
             </n-tab-pane>
 
             <n-tab-pane name="history" tab="History">
-                <n-empty description="Delivery history UI lands in a later Phase 7 slice." />
+                <div class="tab-toolbar">
+                    <div class="tab-toolbar-info">
+                        Audit log of every delivery row: when, to whom, status, attempts. Test rows (channel-test button) and PREVIEW rows (subscriptions in preview mode) are included.
+                    </div>
+                    <n-button size="small" @click="loadDeliveries">
+                        <template #icon><n-icon><Refresh /></n-icon></template>
+                        Refresh
+                    </n-button>
+                </div>
+
+                <n-grid :cols="3" :x-gap="12" class="history-filters">
+                    <n-gi>
+                        <n-form-item label="Status" :show-feedback="false">
+                            <n-select
+                                v-model:value="historyFilters.status"
+                                :options="deliveryStatusOptions"
+                                placeholder="Any"
+                                clearable
+                                @update:value="loadDeliveries"
+                            />
+                        </n-form-item>
+                    </n-gi>
+                    <n-gi>
+                        <n-form-item label="Origin" :show-feedback="false">
+                            <n-select
+                                v-model:value="historyFilters.origin"
+                                :options="deliveryOriginOptions"
+                                placeholder="Any"
+                                clearable
+                                @update:value="loadDeliveries"
+                            />
+                        </n-form-item>
+                    </n-gi>
+                    <n-gi>
+                        <n-form-item label="Channel" :show-feedback="false">
+                            <n-select
+                                v-model:value="historyFilters.channelUuid"
+                                :options="channelFilterOptions"
+                                placeholder="Any"
+                                clearable
+                                @update:value="loadDeliveries"
+                            />
+                        </n-form-item>
+                    </n-gi>
+                </n-grid>
+
+                <n-data-table
+                    :data="deliveries"
+                    :columns="deliveryColumns"
+                    :loading="deliveriesLoading"
+                    :single-line="false"
+                    :bordered="false"
+                />
+
+                <div class="history-pagination">
+                    <n-pagination
+                        v-model:page="historyPage"
+                        :page-count="historyPageCount"
+                        :page-size="historyPageSize"
+                        :item-count="historyTotalCount"
+                        @update:page="loadDeliveries"
+                    />
+                </div>
             </n-tab-pane>
         </n-tabs>
 
@@ -391,9 +453,9 @@ import { useStore } from 'vuex'
 import {
     NTabs, NTabPane, NDataTable, NButton, NIcon, NEmpty, NModal, NCard, NForm,
     NFormItem, NInput, NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag,
-    NRadioGroup, NRadioButton, useDialog, useMessage
+    NRadioGroup, NRadioButton, NPagination, useDialog, useMessage
 } from 'naive-ui'
-import { CirclePlus, Trash, Edit as EditIcon } from '@vicons/tabler'
+import { CirclePlus, Trash, Edit as EditIcon, Refresh } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -415,6 +477,22 @@ interface SubscriptionRoute {
     // perspectives) survive an Edit → Save round-trip instead of being
     // silently stripped. Empty on Create.
     _raw?: Record<string, any>
+}
+
+interface DeliveryRow {
+    uuid: string
+    org: string
+    outboxEventUuid: string
+    subscriptionUuid: string | null
+    channelUuid: string
+    status: string
+    origin: string
+    dedupKey: string | null
+    attemptCount: number
+    nextAttemptAt: string | null
+    sentAt: string | null
+    lastError: string | null
+    createdDate: string
 }
 
 interface SubscriptionRow {
@@ -500,6 +578,29 @@ const channelOptions = computed(() =>
         .filter(c => c.status === 'ENABLED')
         .map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
 )
+
+// History tab — channel filter spans ALL channels (incl. disabled) so a
+// user investigating why nothing landed on a disabled channel can still
+// see past deliveries.
+const channelFilterOptions = computed(() =>
+    channels.value.map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
+)
+
+const deliveryStatusOptions = [
+    { label: 'PENDING', value: 'PENDING' },
+    { label: 'SENT', value: 'SENT' },
+    { label: 'ACKED', value: 'ACKED' },
+    { label: 'FAILED', value: 'FAILED' },
+    { label: 'RATE_LIMITED', value: 'RATE_LIMITED' },
+    { label: 'EVAL_TIMEOUT', value: 'EVAL_TIMEOUT' },
+    { label: 'TEST', value: 'TEST' },
+    { label: 'PREVIEW', value: 'PREVIEW' },
+]
+
+const deliveryOriginOptions = [
+    { label: 'REAL', value: 'REAL' },
+    { label: 'SYNTHETIC (test / Quick Start)', value: 'SYNTHETIC' },
+]
 
 const showChannelModal = ref<boolean>(false)
 const savingChannel = ref<boolean>(false)
@@ -603,6 +704,21 @@ const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
 
+// Delivery history state
+const deliveries = ref<DeliveryRow[]>([])
+const deliveriesLoading = ref<boolean>(false)
+const historyPage = ref<number>(1)
+const historyPageSize = ref<number>(25)
+const historyTotalCount = ref<number>(0)
+const historyPageCount = computed<number>(() =>
+    Math.max(1, Math.ceil(historyTotalCount.value / historyPageSize.value))
+)
+const historyFilters = ref<{ status: string | null, origin: string | null, channelUuid: string | null }>({
+    status: null,
+    origin: null,
+    channelUuid: null,
+})
+
 // ---- GraphQL queries / mutations -----------------------------------------
 
 const LIST_CHANNELS_QUERY = gql`
@@ -643,10 +759,40 @@ const TEST_CHANNEL_MUTATION = gql`
     }
 `
 
+// Narrow projection used by the test-channel poll loop. Keeps the SLA
+// path independent of the wider history projection (which fetches more
+// fields).
 const LIST_DELIVERIES_QUERY = gql`
     query notificationDeliveries($orgUuid: ID!, $eventUuid: ID, $limit: Int) {
         notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, limit: $limit) {
             items { uuid status attemptCount lastError sentAt }
+        }
+    }
+`
+
+const HISTORY_DELIVERIES_QUERY = gql`
+    query notificationDeliveriesPage(
+        $orgUuid: ID!,
+        $channelUuid: ID,
+        $status: NotificationDeliveryStatusEnum,
+        $origin: NotificationDeliveryOriginEnum,
+        $limit: Int,
+        $offset: Int
+    ) {
+        notificationDeliveries(
+            orgUuid: $orgUuid,
+            channelUuid: $channelUuid,
+            status: $status,
+            origin: $origin,
+            limit: $limit,
+            offset: $offset
+        ) {
+            items {
+                uuid org outboxEventUuid subscriptionUuid channelUuid
+                status origin dedupKey attemptCount nextAttemptAt sentAt
+                lastError createdDate
+            }
+            totalCount limit offset
         }
     }
 `
@@ -714,6 +860,32 @@ async function loadSubscriptions (): Promise<void> {
         message.error(`Failed to load subscriptions: ${extractError(e)}`)
     } finally {
         subscriptionsLoading.value = false
+    }
+}
+
+async function loadDeliveries (): Promise<void> {
+    deliveriesLoading.value = true
+    try {
+        const offset = (historyPage.value - 1) * historyPageSize.value
+        const res = await graphqlClient.query({
+            query: HISTORY_DELIVERIES_QUERY,
+            variables: {
+                orgUuid: orgUuid.value,
+                channelUuid: historyFilters.value.channelUuid,
+                status: historyFilters.value.status,
+                origin: historyFilters.value.origin,
+                limit: historyPageSize.value,
+                offset,
+            },
+            fetchPolicy: 'network-only',
+        })
+        const page = res.data?.notificationDeliveries
+        deliveries.value = page?.items || []
+        historyTotalCount.value = page?.totalCount || 0
+    } catch (e: any) {
+        message.error(`Failed to load history: ${extractError(e)}`)
+    } finally {
+        deliveriesLoading.value = false
     }
 }
 
@@ -1163,6 +1335,82 @@ const subscriptionColumns = computed(() => [
     },
 ])
 
+// Cross-ref helpers — history rows carry uuids; resolve to names from
+// the already-loaded channels + subscriptions lists.
+const channelNameById = computed<Record<string, string>>(() => {
+    const m: Record<string, string> = {}
+    for (const c of channels.value) m[c.uuid] = c.name
+    return m
+})
+const subscriptionNameById = computed<Record<string, string>>(() => {
+    const m: Record<string, string> = {}
+    for (const s of subscriptions.value) m[s.uuid] = s.name
+    return m
+})
+
+function deliveryStatusTagType (status: string): 'success' | 'warning' | 'error' | 'info' | 'default' {
+    if (status === 'SENT' || status === 'ACKED') return 'success'
+    if (status === 'FAILED' || status === 'EVAL_TIMEOUT' || status === 'RATE_LIMITED') return 'error'
+    if (status === 'PREVIEW' || status === 'TEST') return 'info'
+    return 'default'
+}
+
+function formatHistoryTimestamp (s: string | null): string {
+    if (!s) return '—'
+    // Avoid pulling in a date library for one column; rely on the
+    // browser's locale-aware string formatter. createdDate from the
+    // backend is ISO-8601 UTC.
+    try { return new Date(s).toLocaleString() } catch { return s }
+}
+
+function truncate (s: string | null, n: number): string {
+    if (!s) return ''
+    return s.length > n ? `${s.slice(0, n - 1)}…` : s
+}
+
+const deliveryColumns = computed(() => [
+    {
+        title: 'When', key: 'createdDate',
+        render: (row: DeliveryRow) => formatHistoryTimestamp(row.sentAt || row.createdDate),
+    },
+    {
+        title: 'Status', key: 'status',
+        render: (row: DeliveryRow) => h(
+            NTag,
+            { type: deliveryStatusTagType(row.status), size: 'small' },
+            { default: () => row.status },
+        ),
+    },
+    {
+        title: 'Origin', key: 'origin',
+        render: (row: DeliveryRow) => h(
+            NTag,
+            { type: row.origin === 'SYNTHETIC' ? 'info' : 'default', size: 'small' },
+            { default: () => row.origin },
+        ),
+    },
+    {
+        title: 'Channel', key: 'channelUuid',
+        render: (row: DeliveryRow) => channelNameById.value[row.channelUuid] || truncate(row.channelUuid, 12),
+    },
+    {
+        title: 'Subscription', key: 'subscriptionUuid',
+        render: (row: DeliveryRow) => row.subscriptionUuid
+            ? (subscriptionNameById.value[row.subscriptionUuid] || truncate(row.subscriptionUuid, 12))
+            : h('span', { class: 'muted-12' }, '(channel test)'),
+    },
+    {
+        title: 'Attempts', key: 'attemptCount',
+        render: (row: DeliveryRow) => `${row.attemptCount}`,
+    },
+    {
+        title: 'Last error', key: 'lastError',
+        render: (row: DeliveryRow) => row.lastError
+            ? h('span', { title: row.lastError, class: 'muted-12' }, truncate(row.lastError, 60))
+            : '',
+    },
+])
+
 // ---- helpers -------------------------------------------------------------
 
 function extractError (e: any): string {
@@ -1171,11 +1419,11 @@ function extractError (e: any): string {
 
 onMounted(async () => {
     userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
-    // Load both in parallel. The subscription form's channel picker
-    // degrades to an empty placeholder if the user opens the modal
-    // before channels resolve, which is acceptable given the typical
-    // few-hundred-ms load.
-    await Promise.all([loadChannels(), loadSubscriptions()])
+    // Load channels, subscriptions, and the first page of delivery
+    // history in parallel. Subscription edit modal's channel picker
+    // degrades to an empty placeholder if opened before channels
+    // resolve — acceptable given the typical few-hundred-ms load.
+    await Promise.all([loadChannels(), loadSubscriptions(), loadDeliveries()])
 })
 </script>
 
@@ -1194,6 +1442,9 @@ onMounted(async () => {
 }
 .tab-toolbar-info { font-size: 12.5px; color: var(--n-text-color-3, #888); }
 .muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
+
+.history-filters { margin-bottom: 12px; }
+.history-pagination { margin-top: 12px; display: flex; justify-content: flex-end; }
 
 .routes-section {
     border: 1px solid var(--n-border-color, #eee);

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -75,7 +75,7 @@
                                 :options="deliveryStatusOptions"
                                 placeholder="Any"
                                 clearable
-                                @update:value="loadDeliveries"
+                                @update:value="applyHistoryFilters"
                             />
                         </n-form-item>
                     </n-gi>
@@ -86,7 +86,7 @@
                                 :options="deliveryOriginOptions"
                                 placeholder="Any"
                                 clearable
-                                @update:value="loadDeliveries"
+                                @update:value="applyHistoryFilters"
                             />
                         </n-form-item>
                     </n-gi>
@@ -97,7 +97,7 @@
                                 :options="channelFilterOptions"
                                 placeholder="Any"
                                 clearable
-                                @update:value="loadDeliveries"
+                                @update:value="applyHistoryFilters"
                             />
                         </n-form-item>
                     </n-gi>
@@ -111,7 +111,7 @@
                     :bordered="false"
                 />
 
-                <div class="history-pagination">
+                <div v-if="historyTotalCount > historyPageSize" class="history-pagination">
                     <n-pagination
                         v-model:page="historyPage"
                         :page-count="historyPageCount"
@@ -863,7 +863,15 @@ async function loadSubscriptions (): Promise<void> {
     }
 }
 
+// Monotonic in-flight token. ApolloClient with `fetchPolicy: network-only`
+// does NOT dedup or cancel concurrent identical queries, so rapidly
+// toggling a filter can race the older response in last and overwrite
+// the newer state. The token guards apply-time so a stale response is
+// dropped silently.
+let historyInflightToken = 0
+
 async function loadDeliveries (): Promise<void> {
+    const myToken = ++historyInflightToken
     deliveriesLoading.value = true
     try {
         const offset = (historyPage.value - 1) * historyPageSize.value
@@ -879,14 +887,24 @@ async function loadDeliveries (): Promise<void> {
             },
             fetchPolicy: 'network-only',
         })
+        if (myToken !== historyInflightToken) return  // stale response
         const page = res.data?.notificationDeliveries
         deliveries.value = page?.items || []
         historyTotalCount.value = page?.totalCount || 0
     } catch (e: any) {
+        if (myToken !== historyInflightToken) return  // stale failure
         message.error(`Failed to load history: ${extractError(e)}`)
     } finally {
-        deliveriesLoading.value = false
+        if (myToken === historyInflightToken) deliveriesLoading.value = false
     }
+}
+
+// Filter change must reset to page 1 — otherwise a user on page 3 of
+// an unfiltered list who applies a narrowing filter would request an
+// out-of-range offset and land on a phantom empty page.
+function applyHistoryFilters (): void {
+    historyPage.value = 1
+    loadDeliveries()
 }
 
 // ---- Create / Edit -------------------------------------------------------
@@ -1355,12 +1373,12 @@ function deliveryStatusTagType (status: string): 'success' | 'warning' | 'error'
     return 'default'
 }
 
+// Route through commonFunctions.dateDisplay so the History timestamps
+// stay in the en-CA locale convention used elsewhere in the UI
+// (ReleaseView etc.). The helper doesn't itself guard null, so we do.
 function formatHistoryTimestamp (s: string | null): string {
     if (!s) return '—'
-    // Avoid pulling in a date library for one column; rely on the
-    // browser's locale-aware string formatter. createdDate from the
-    // backend is ISO-8601 UTC.
-    try { return new Date(s).toLocaleString() } catch { return s }
+    try { return commonFunctions.dateDisplay(s) } catch { return s }
 }
 
 function truncate (s: string | null, n: number): string {
@@ -1391,13 +1409,18 @@ const deliveryColumns = computed(() => [
     },
     {
         title: 'Channel', key: 'channelUuid',
-        render: (row: DeliveryRow) => channelNameById.value[row.channelUuid] || truncate(row.channelUuid, 12),
+        render: (row: DeliveryRow) => channelNameById.value[row.channelUuid]
+            || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'),
     },
     {
         title: 'Subscription', key: 'subscriptionUuid',
-        render: (row: DeliveryRow) => row.subscriptionUuid
-            ? (subscriptionNameById.value[row.subscriptionUuid] || truncate(row.subscriptionUuid, 12))
-            : h('span', { class: 'muted-12' }, '(channel test)'),
+        render: (row: DeliveryRow) => {
+            if (!row.subscriptionUuid) {
+                return h('span', { class: 'muted-12' }, '(channel test)')
+            }
+            return subscriptionNameById.value[row.subscriptionUuid]
+                || h('span', { class: 'muted-12', title: row.subscriptionUuid }, '(deleted subscription)')
+        },
     },
     {
         title: 'Attempts', key: 'attemptCount',

--- a/ui/src/components/NotificationsOfOrg.vue
+++ b/ui/src/components/NotificationsOfOrg.vue
@@ -56,6 +56,31 @@
                 />
             </n-tab-pane>
 
+            <n-tab-pane name="groups" tab="Channel groups">
+                <div class="tab-toolbar">
+                    <div class="tab-toolbar-info">
+                        Named, cross-type collections of channels. Reference one group instead of repeating a channel list across multiple subscription routes — e.g. "Security oncall" = Slack #sec + Teams #leadership + Email security@.
+                    </div>
+                    <n-button
+                        v-if="canWrite"
+                        type="primary"
+                        size="small"
+                        @click="openCreateGroup"
+                    >
+                        <template #icon><n-icon><CirclePlus /></n-icon></template>
+                        Add group
+                    </n-button>
+                </div>
+
+                <n-data-table
+                    :data="channelGroups"
+                    :columns="channelGroupColumns"
+                    :loading="channelGroupsLoading"
+                    :single-line="false"
+                    :bordered="false"
+                />
+            </n-tab-pane>
+
             <n-tab-pane name="history" tab="History">
                 <div class="tab-toolbar">
                     <div class="tab-toolbar-info">
@@ -262,6 +287,50 @@
             </n-card>
         </n-modal>
 
+        <!-- Channel group create/edit modal -->
+        <n-modal v-model:show="showGroupModal" preset="dialog" :show-icon="false">
+            <n-card
+                style="width: 600px"
+                size="huge"
+                :title="groupForm.uuid ? `Edit group — ${groupForm.name || ''}` : 'Add channel group'"
+                :bordered="false"
+                role="dialog"
+                aria-modal="true"
+            >
+                <n-form :model="groupForm">
+                    <n-space vertical size="large">
+                        <n-form-item label="Name">
+                            <n-input v-model:value="groupForm.name" placeholder="e.g. security-oncall" />
+                        </n-form-item>
+                        <n-form-item label="Channels">
+                            <n-select
+                                v-model:value="groupForm.channels"
+                                :options="channelOptions"
+                                multiple
+                                placeholder="Pick the channels in this group"
+                            />
+                        </n-form-item>
+
+                        <n-alert v-if="groupModalError" type="error" :show-icon="false">
+                            {{ groupModalError }}
+                        </n-alert>
+
+                        <n-space>
+                            <n-button
+                                @click="saveGroup"
+                                type="primary"
+                                :loading="savingGroup"
+                                :disabled="!groupForm.name.trim() || groupForm.channels.length === 0"
+                            >
+                                Save
+                            </n-button>
+                            <n-button @click="showGroupModal = false">Cancel</n-button>
+                        </n-space>
+                    </n-space>
+                </n-form>
+            </n-card>
+        </n-modal>
+
         <!-- Subscription create/edit modal -->
         <n-modal v-model:show="showSubscriptionModal" preset="dialog" :show-icon="false">
             <n-card
@@ -338,7 +407,7 @@
                                                 v-model:value="r.channels"
                                                 :options="channelOptions"
                                                 multiple
-                                                placeholder="Pick one or more channels"
+                                                placeholder="Pick channels (and/or groups below)"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -354,6 +423,17 @@
                                             >
                                                 <template #icon><n-icon><Trash /></n-icon></template>
                                             </n-button>
+                                        </n-form-item>
+                                    </n-gi>
+                                    <n-gi :span="22" :offset="0">
+                                        <n-form-item :label="i === 0 ? 'Channel groups (optional)' : ''" :show-feedback="false">
+                                            <n-select
+                                                v-model:value="r.channelGroups"
+                                                :options="channelGroupOptions"
+                                                multiple
+                                                placeholder="(none)"
+                                                clearable
+                                            />
                                         </n-form-item>
                                     </n-gi>
                                 </n-grid>
@@ -472,11 +552,30 @@ interface ChannelRow {
 interface SubscriptionRoute {
     whenSeverityAtLeast: string | null
     channels: string[]
-    // Carries the as-loaded route object on edit so fields the slice-2
-    // UI doesn't model yet (channelGroups, andEnvIn, andLifecycleIn,
-    // perspectives) survive an Edit → Save round-trip instead of being
-    // silently stripped. Empty on Create.
+    channelGroups: string[]
+    // Carries the as-loaded route object on edit so fields the slice-4
+    // UI still doesn't model (andEnvIn, andLifecycleIn, perspectives)
+    // survive an Edit → Save round-trip instead of being silently
+    // stripped. channels + channelGroups overlay this last and win.
+    // Empty on Create.
     _raw?: Record<string, any>
+}
+
+interface ChannelGroupRow {
+    uuid: string
+    org: string
+    resourceGroup: string | null
+    name: string
+    channels: string[]
+    revision: number
+    createdDate: string | null
+    lastUpdatedDate: string | null
+}
+
+interface ChannelGroupForm {
+    uuid: string | null
+    name: string
+    channels: string[]
 }
 
 interface DeliveryRow {
@@ -679,7 +778,11 @@ interface SubscriptionForm {
 }
 
 function freshRoute (): SubscriptionRoute {
-    return { whenSeverityAtLeast: null, channels: [] }
+    return { whenSeverityAtLeast: null, channels: [], channelGroups: [] }
+}
+
+function freshGroupForm (): ChannelGroupForm {
+    return { uuid: null, name: '', channels: [] }
 }
 
 function freshSubscriptionForm (): SubscriptionForm {
@@ -703,6 +806,21 @@ const showSubscriptionModal = ref<boolean>(false)
 const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
+
+// Channel groups state
+const channelGroups = ref<ChannelGroupRow[]>([])
+const channelGroupsLoading = ref<boolean>(false)
+const showGroupModal = ref<boolean>(false)
+const savingGroup = ref<boolean>(false)
+const groupModalError = ref<string>('')
+const groupForm = ref<ChannelGroupForm>(freshGroupForm())
+
+const channelGroupOptions = computed(() =>
+    channelGroups.value.map(g => ({
+        label: `${g.name} (${g.channels.length} ch)`,
+        value: g.uuid,
+    }))
+)
 
 // Delivery history state
 const deliveries = ref<DeliveryRow[]>([])
@@ -797,6 +915,28 @@ const HISTORY_DELIVERIES_QUERY = gql`
     }
 `
 
+const LIST_GROUPS_QUERY = gql`
+    query notificationChannelGroups($orgUuid: ID!) {
+        notificationChannelGroups(orgUuid: $orgUuid) {
+            uuid org resourceGroup name channels revision createdDate lastUpdatedDate
+        }
+    }
+`
+
+const UPSERT_GROUP_MUTATION = gql`
+    mutation upsertNotificationChannelGroup($input: NotificationChannelGroupInput!) {
+        upsertNotificationChannelGroup(input: $input) {
+            uuid org resourceGroup name channels revision createdDate lastUpdatedDate
+        }
+    }
+`
+
+const DELETE_GROUP_MUTATION = gql`
+    mutation deleteNotificationChannelGroup($uuid: ID!) {
+        deleteNotificationChannelGroup(uuid: $uuid)
+    }
+`
+
 const LIST_SUBSCRIPTIONS_QUERY = gql`
     query notificationSubscriptions($orgUuid: ID!) {
         notificationSubscriptions(orgUuid: $orgUuid) {
@@ -869,6 +1009,90 @@ async function loadSubscriptions (): Promise<void> {
 // the newer state. The token guards apply-time so a stale response is
 // dropped silently.
 let historyInflightToken = 0
+
+async function loadChannelGroups (): Promise<void> {
+    channelGroupsLoading.value = true
+    try {
+        const res = await graphqlClient.query({
+            query: LIST_GROUPS_QUERY,
+            variables: { orgUuid: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        channelGroups.value = res.data?.notificationChannelGroups || []
+    } catch (e: any) {
+        message.error(`Failed to load channel groups: ${extractError(e)}`)
+    } finally {
+        channelGroupsLoading.value = false
+    }
+}
+
+// ---- Channel group create / edit -----------------------------------------
+
+function openCreateGroup (): void {
+    groupForm.value = freshGroupForm()
+    groupModalError.value = ''
+    showGroupModal.value = true
+}
+
+function openEditGroup (row: ChannelGroupRow): void {
+    groupForm.value = {
+        uuid: row.uuid,
+        name: row.name,
+        channels: [...(row.channels || [])],
+    }
+    groupModalError.value = ''
+    showGroupModal.value = true
+}
+
+async function saveGroup (): Promise<void> {
+    groupModalError.value = ''
+    const f = groupForm.value
+    if (!f.name.trim() || f.channels.length === 0) {
+        groupModalError.value = 'Name and at least one channel are required.'
+        return
+    }
+    const input: any = {
+        uuid: f.uuid || undefined,
+        org: orgUuid.value,
+        name: f.name.trim(),
+        channels: f.channels,
+    }
+    savingGroup.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: UPSERT_GROUP_MUTATION,
+            variables: { input },
+        })
+        showGroupModal.value = false
+        message.success(f.uuid ? 'Group updated' : 'Group created')
+        await loadChannelGroups()
+    } catch (e: any) {
+        groupModalError.value = extractError(e)
+    } finally {
+        savingGroup.value = false
+    }
+}
+
+function confirmDeleteGroup (row: ChannelGroupRow): void {
+    dialog.warning({
+        title: `Delete channel group "${row.name}"?`,
+        content: 'Subscriptions that reference this group will silently lose this hop. Channels in the group are not affected.',
+        positiveText: 'Delete',
+        negativeText: 'Cancel',
+        onPositiveClick: async () => {
+            try {
+                await graphqlClient.mutate({
+                    mutation: DELETE_GROUP_MUTATION,
+                    variables: { uuid: row.uuid },
+                })
+                message.success('Group deleted')
+                await loadChannelGroups()
+            } catch (e: any) {
+                message.error(`Delete failed: ${extractError(e)}`)
+            }
+        },
+    })
+}
 
 async function loadDeliveries (): Promise<void> {
     const myToken = ++historyInflightToken
@@ -1132,6 +1356,7 @@ function openEditSubscription (row: SubscriptionRow): void {
             f.routes = routes.map((r: any) => ({
                 whenSeverityAtLeast: r.whenSeverityAtLeast || null,
                 channels: Array.isArray(r.channels) ? [...r.channels] : [],
+                channelGroups: Array.isArray(r.channelGroups) ? [...r.channelGroups] : [],
                 _raw: r,
             }))
         }
@@ -1165,12 +1390,14 @@ async function saveSubscription (): Promise<void> {
         subModalError.value = 'Name, at least one event type, and at least one route are required.'
         return
     }
-    // Every route must have at least one channel; backend rejects empty
-    // {channels, channelGroups} anyway, but catch it client-side for a
-    // cleaner error path.
-    const emptyRouteIdx = f.routes.findIndex(r => (r.channels || []).length === 0)
+    // Every route must have at least one channel or one group; backend
+    // rejects empty {channels, channelGroups} anyway, but catch it
+    // client-side for a cleaner error path.
+    const emptyRouteIdx = f.routes.findIndex(r =>
+        (r.channels || []).length === 0 && (r.channelGroups || []).length === 0
+    )
     if (emptyRouteIdx >= 0) {
-        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels — pick at least one.`
+        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels or groups — pick at least one.`
         return
     }
     // Build the filter input by overlaying the slice-2-modeled fields on
@@ -1197,6 +1424,7 @@ async function saveSubscription (): Promise<void> {
             ...(r._raw || {}),
             whenSeverityAtLeast: r.whenSeverityAtLeast,
             channels: r.channels,
+            channelGroups: r.channelGroups,
         })),
         dedupWindowMinutes: f.dedupWindowMinutes,
     }
@@ -1301,6 +1529,35 @@ const channelColumns = computed(() => [
                 h(NButton, {
                     size: 'tiny', secondary: true, type: 'error',
                     onClick: () => confirmDelete(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
+            ],
+        }),
+    },
+])
+
+const channelGroupColumns = computed(() => [
+    { title: 'Name', key: 'name' },
+    {
+        title: 'Channels', key: 'channels',
+        render: (row: ChannelGroupRow) => `${(row.channels || []).length} channel(s)`,
+    },
+    {
+        title: 'Last updated', key: 'lastUpdatedDate',
+        render: (row: ChannelGroupRow) => formatHistoryTimestamp(row.lastUpdatedDate),
+    },
+    {
+        title: 'Actions', key: 'actions',
+        render: (row: ChannelGroupRow) => h(NSpace, { size: 'small' }, {
+            default: () => [
+                h(NButton, {
+                    size: 'tiny', secondary: true,
+                    onClick: () => openEditGroup(row),
+                    disabled: !canWrite.value,
+                }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
+                h(NButton, {
+                    size: 'tiny', secondary: true, type: 'error',
+                    onClick: () => confirmDeleteGroup(row),
                     disabled: !canWrite.value,
                 }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
             ],
@@ -1442,11 +1699,17 @@ function extractError (e: any): string {
 
 onMounted(async () => {
     userPermission.value = commonFunctions.getUserPermission(orgUuid.value, myuser.value)?.org || ''
-    // Load channels, subscriptions, and the first page of delivery
-    // history in parallel. Subscription edit modal's channel picker
-    // degrades to an empty placeholder if opened before channels
-    // resolve — acceptable given the typical few-hundred-ms load.
-    await Promise.all([loadChannels(), loadSubscriptions(), loadDeliveries()])
+    // Load channels, channel groups, subscriptions, and the first
+    // page of delivery history in parallel. Subscription edit modal's
+    // pickers degrade to empty placeholders if opened before channels
+    // / groups resolve — acceptable given the typical few-hundred-ms
+    // load.
+    await Promise.all([
+        loadChannels(),
+        loadChannelGroups(),
+        loadSubscriptions(),
+        loadDeliveries(),
+    ])
 })
 </script>
 

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -140,6 +140,11 @@ const routes : any[] = [
         component: () => import('@/components/OrgSettings.vue')
     },
     {
+        path: '/notificationsOfOrg/:orguuid',
+        name: 'NotificationsOfOrg',
+        component: () => import('@/components/NotificationsOfOrg.vue')
+    },
+    {
         path: '/instancesOfOrg/:orguuid',
         name: 'InstancesOfOrg',
         component: () => import('@/components/InstancesOfOrg.vue')


### PR DESCRIPTION
## Umbrella PR for the notifications-framework frontend

Long-lived branch per the umbrella-branch convention established by the rearm-core notifications work ([PR #184](https://github.com/relizaio/rearm-saas/pull/184)). Each slice is a logical group of commits, not a separate branch.

Backend GraphQL surface is fully shipped in PR #184; this PR builds the UI for it slice by slice.

## Slice 1 — Channels CRUD + Test (this push)

**What lands:** a new Pro-gated "Notifications" entry under the org with a Channels tab fully wired against the backend.

- `NotificationsOfOrg.vue` — new page; three tabs (Channels / Subscriptions / History), only Channels populated; Subscriptions + History are placeholders for later slices
- Channels tab: list + Add + per-row Test / Edit / Disable / Enable / Delete actions
- Type-switched add/edit form: Slack, MS Teams, generic Webhook (NONE / BEARER / HMAC_SHA256), Azure Sentinel
- Email omitted until the Phase 9 dispatcher lands in rearm-core
- "Test channel" calls `testNotificationChannel` and polls `notificationDeliveries(eventUuid)` until SENT / FAILED / 30s budget
- Edit form respects the design-doc §7.1 secret model: secrets are never read back, blank fields on update preserve the encrypted value
- Route: `/notificationsOfOrg/:orguuid`
- LeftNavBar entry in `nonOssOptions` so OSS deployments don't see it

## Future slices (same branch, more commits)

- **Slice 2:** Subscriptions CRUD with preset filters + advanced CEL editor
- **Slice 3:** Delivery history (paginated, filterable by status/channel/origin)
- **Slice 4:** Channel groups
- **Slice 5:** Inbox MVP (read-state per delivery)
- **Slice 6:** Quick Start wizard

## Test plan
- [x] `npm run build` clean
- [ ] Roll UI image on the sandbox alongside backend `2026-06-notifications-impl.1`; visually verify:
  - Navigation entry visible under Pro (not under OSS)
  - Channels list loads
  - Add / Edit / Test / Disable / Enable / Delete all round-trip cleanly
  - Test polls and reports a terminal state (SENT, FAILED, TIMEOUT)
- [ ] `/review` skill + senior-rearm-engineer convention check before declaring slice 1 done (per `[[notifications-phase-review-workflow]]`)

Related: [rearm-saas #184](https://github.com/relizaio/rearm-saas/pull/184) (backend), [rearm #121](https://github.com/relizaio/rearm/pull/121) (Pro-only hint on the legacy Catalog cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)