### PR TITLE
PKCE for login-app + realm hardening (security)

### DIFF
--- a/keycloak/realms/2025-02-10-reliza-realm-rearmoss.json
+++ b/keycloak/realms/2025-02-10-reliza-realm-rearmoss.json
@@ -5,7 +5,7 @@
   "displayNameHtml": "",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": false,
+  "revokeRefreshToken": true,
   "refreshTokenMaxReuse": 0,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,
@@ -37,7 +37,7 @@
   "duplicateEmailsAllowed": false,
   "resetPasswordAllowed": false,
   "editUsernameAllowed": false,
-  "bruteForceProtected": false,
+  "bruteForceProtected": true,
   "permanentLockout": false,
   "maxTemporaryLockouts": 0,
   "maxFailureWaitSeconds": 900,
@@ -679,7 +679,7 @@
         "backchannel.logout.revoke.offline.tokens": "false"
       },
       "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
+      "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": -1,
       "protocolMappers": [
         {
@@ -706,7 +706,6 @@
       "optionalClientScopes": [
         "address",
         "phone",
-        "offline_access",
         "microprofile-jwt"
       ]
     },

--- a/keycloak/realms/2025-02-10-reliza-realm-rearmoss.json
+++ b/keycloak/realms/2025-02-10-reliza-realm-rearmoss.json
@@ -665,12 +665,13 @@
       "consentRequired": false,
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
+      "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "publicClient": true,
       "frontchannelLogout": true,
       "protocol": "openid-connect",
       "attributes": {
+        "pkce.code.challenge.method": "S256",
         "oidc.ciba.grant.enabled": "false",
         "backchannel.logout.session.required": "true",
         "post.logout.redirect.uris": "http://localhost:8092/*##http://localhost:8086/*##http://localhost:3000/*",
@@ -680,6 +681,20 @@
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "name": "rearm-backend-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "rearm-backend",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
+        }
+      ],
       "defaultClientScopes": [
         "web-origins",
         "acr",

--- a/ui/src/utils/keycloak.ts
+++ b/ui/src/utils/keycloak.ts
@@ -13,7 +13,10 @@ keycloak.onTokenExpired = async () => {
 
 await keycloak.init({
     onLoad: 'login-required',
-    checkLoginIframe: false
+    checkLoginIframe: false,
+    // Authorization Code Flow with PKCE (S256). login-app is a public client, so
+    // PKCE protects the code->token exchange against authorization-code interception.
+    pkceMethod: 'S256'
 })
 
 export default keycloak


### PR DESCRIPTION
## Summary
Companion to relizaio/rearm-saas "Bind JWTs to client (azp) + harden login-app". Branches off `main`.

- **`ui/src/utils/keycloak.ts`** — `pkceMethod: 'S256'` so the public `login-app` client uses Authorization Code Flow **with PKCE** (protects the code→token exchange against code interception).
- **Realm export (`login-app`)** — enforce `pkce.code.challenge.method=S256`, disable `directAccessGrantsEnabled` (ROPC), add `oidc-audience-mapper` (`aud=rearm-backend`).

## Test plan
- [ ] UI login still works (Authorization Code + PKCE) after deploy
- [ ] Backend azp validator (rearm-saas PR) accepts login-app tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)