### PR TITLE
Security headers + CSP (Report-Only) on the UI nginx

### DIFF
--- a/ui/nginx/default.conf.template
+++ b/ui/nginx/default.conf.template
@@ -17,6 +17,21 @@ server {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
+
+        # Security headers for the SPA shell + static assets. HSTS is intentionally
+        # NOT set here — TLS terminates at the Traefik ingress / upstream LB, which
+        # owns Strict-Transport-Security. The backend (/api, /graphql) and Keycloak
+        # (/kauth) emit their own headers, so these live only on the static app.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        # CSP ships in Report-Only first so it can be validated in a browser before
+        # enforcing — switch the directive name to Content-Security-Policy to enforce.
+        # 'unsafe-eval' is required by Vega (vega/vega-lite compile expressions via
+        # Function); 'unsafe-inline' in style-src covers Vue's runtime-injected
+        # <style> blocks and inline style attributes; img-src allows data:/blob: for
+        # generated charts and client-side downloads.
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self'" always;
     }
 
     location /v1 {


### PR DESCRIPTION
## Summary
- Adds non-TLS security headers to the UI nginx SPA location (`ui/nginx/default.conf.template`): `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`.
- Adds a `Content-Security-Policy-Report-Only` so the policy can be validated in a browser before it is enforced (flip the directive name to `Content-Security-Policy` to enforce).
- HSTS is **not** set here — TLS terminates at the Traefik ingress / upstream LB, which owns `Strict-Transport-Security` (handled in the saas helm chart, separately).

## CSP rationale
- `script-src 'self' 'unsafe-eval'` — Vega/vega-lite compile expressions via `Function()`; without `unsafe-eval` charts break. (Can later be dropped by switching Vega to its interpreter mode — an app code change, out of scope here.)
- `style-src 'self' 'unsafe-inline'` — Vue injects runtime `<style>` blocks and inline style attributes.
- `img-src 'self' data: blob:` — generated charts and client-side download blobs.
- `connect-src 'self'` — API, GraphQL and Keycloak are all same-origin behind this nginx.
- `object-src 'none'`, `frame-ancestors 'self'`, `base-uri 'self'`, `form-action 'self'`.

Scoped to the `location / {}` (SPA) block so it doesn't duplicate the backend's Spring Security headers or Keycloak's own headers on `/api`, `/graphql`, `/kauth`.

## Test plan
- [ ] Deploy and load the app; confirm `Content-Security-Policy-Report-Only` + the three headers are present on the SPA, and **absent/unchanged** on `/api`, `/graphql`, `/kauth`.
- [ ] Exercise Vega charts, SBOM/artifact downloads, and login; check the browser console for CSP violation reports.
- [ ] Once clean, flip `Content-Security-Policy-Report-Only` → `Content-Security-Policy` to enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)