### PR TITLE
fix(rebom): sanitize non-SPDX license ids at capture (mirror of saas #191)

### DIFF
--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -451,10 +451,29 @@ export function normalizeLicenses(licenses: any): any[] | undefined {
   if (!Array.isArray(licenses) || licenses.length === 0) return licenses;
 
   const converted = licenses.map((entry: any) => {
-    if (entry && typeof entry === 'object' && typeof entry.expression === 'string') {
-      const expr = entry.expression;
-      const fixedId = CDXSpdx.fixupSpdxId(expr) ?? CDXSpdx.fixupSpdxId(expr.replace(/\s+/g, '-'));
-      if (fixedId) return { license: { id: fixedId } };
+    if (entry && typeof entry === 'object') {
+      // A bare license expression that resolves to a single SPDX id -> {license:{id}}.
+      if (typeof entry.expression === 'string') {
+        const expr = entry.expression;
+        const fixedId = CDXSpdx.fixupSpdxId(expr) ?? CDXSpdx.fixupSpdxId(expr.replace(/\s+/g, '-'));
+        if (fixedId) return { license: { id: fixedId } };
+        return entry;
+      }
+      // license.id must be a recognized SPDX id — Dependency-Track strict-validates
+      // it against the SPDX enum, so a non-SPDX value (e.g. "LGPL", "Apache 2.0", a
+      // proprietary string) fails the whole BOM upload. Canonicalize the casing of a
+      // valid id; otherwise move the value to the freeform name field (unconstrained,
+      // always valid). Mirrors the backend CdxLicenseUtil emit-time guard.
+      const lic = entry.license;
+      if (lic && typeof lic === 'object' && typeof lic.id === 'string') {
+        const fixedId = CDXSpdx.fixupSpdxId(lic.id);
+        if (fixedId) {
+          const { name, ...rest } = lic;   // drop a conflicting name; a valid id wins
+          return { license: { ...rest, id: fixedId } };
+        }
+        const { id, ...rest } = lic;
+        return { license: { ...rest, name: typeof lic.name === 'string' && lic.name ? lic.name : lic.id } };
+      }
     }
     return entry;
   });

--- a/rebom-backend/test/unit/bomProcessingService.test.ts
+++ b/rebom-backend/test/unit/bomProcessingService.test.ts
@@ -572,6 +572,27 @@ describe('BOM Processing Service - Unit Tests', () => {
             ]);
         });
 
+        it('keeps a valid SPDX id (incl. deprecated) and canonicalizes its case', () => {
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'Apache-2.0' } }]))
+                .toEqual([{ license: { id: 'Apache-2.0' } }]);
+            // deprecated but still in the SPDX/DTrack enum -> kept, not demoted
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'GPL-3.0' } }]))
+                .toEqual([{ license: { id: 'GPL-3.0' } }]);
+            // mis-cased valid id -> canonical casing
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'apache-2.0' } }]))
+                .toEqual([{ license: { id: 'Apache-2.0' } }]);
+        });
+
+        it('demotes a non-SPDX license id to a freeform name (DTrack enum guard)', () => {
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'LGPL' } }]))
+                .toEqual([{ license: { name: 'LGPL' } }]);
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'Apache 2.0' } }]))
+                .toEqual([{ license: { name: 'Apache 2.0' } }]);
+            // preserves other fields (e.g. url) when demoting
+            expect(BomProcessingService.normalizeLicenses([{ license: { id: 'MyCo-1.0', url: 'https://x/y' } }]))
+                .toEqual([{ license: { url: 'https://x/y', name: 'MyCo-1.0' } }]);
+        });
+
         it('walks components, services, and metadata.component recursively', () => {
             const bom: any = {
                 metadata: {


### PR DESCRIPTION
## Summary
Capture-side mirror of the backend emit-time guard (rearm-saas #191). `normalizeLicenses` (run via `normalizeLicensesInBom` in the add/merge augmentation path) already converted a bare `expression` to `{license:{id}}`, but passed `license.id` through unchanged — so a source SBOM with a non-SPDX id (`LGPL`, `Apache 2.0`, a proprietary string) flowed into `sbom_components` and the synthetic BOM, which Dependency-Track rejects (`license.id` is enum-constrained).

Now `license.id` is validated via the cyclonedx-library `SPDX.fixupSpdxId`:
- recognized SPDX id → kept and **case-canonicalized** (`apache-2.0` → `Apache-2.0`); deprecated-but-valid ids like `GPL-3.0` are retained; **no fuzzy remap** (`BSD` → `undefined`, not `BSD-4-Clause`);
- anything else → moved to the freeform `name` field (schema-unconstrained), preserving other fields (e.g. `url`).

## Relationship to saas #191
- saas #191 sanitizes at the **emit** boundary (`CdxLicenseUtil.buildBom`) and fixes the DTrack 400 for **all** data, including already-stored rows.
- This PR cleans data **at capture**, so newly ingested BOMs store clean licenses (better `sbom_components`/UI inventory). It does **not** retroactively clean already-stored BOMs/rows on dev — that path stays covered by #191 at submit time.

## Tests
`bomProcessingService.test.ts`: +2 cases (valid/deprecated/mis-cased ids kept-and-canonicalized; non-SPDX ids → name preserving url). `tsc` clean; 37 processing tests green.

## Test plan
- [ ] Merge after saas #191; confirm newly uploaded BOMs with odd license ids land in `sbom_components` with `name` (not a bad `id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)