### PR TITLE
feat(ui): actionable approval events (notifications Phase 4b)

### DIFF
--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -238,14 +238,20 @@ const deliveryColumns = computed(() => [
     },
     {
         title: 'Channel', key: 'channelUuid',
-        render: (row: DeliveryRow) => channelNameById.value[row.channelUuid]
-            || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'),
+        // Null channel = Phase 4a targeted delivery (personal inbox copy,
+        // no transmission channel) — not a deleted channel.
+        render: (row: DeliveryRow) => (row.channelUuid
+            ? (channelNameById.value[row.channelUuid]
+                || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
+            : h('span', { class: 'muted-12' }, 'Direct')),
     },
     {
         title: 'Subscription', key: 'subscriptionUuid',
         render: (row: DeliveryRow) => {
             if (!row.subscriptionUuid) {
-                return h('span', { class: 'muted-12' }, '(channel test)')
+                // Channel tests have a channel but no subscription; targeted
+                // approval deliveries have neither.
+                return h('span', { class: 'muted-12' }, row.channelUuid ? '(channel test)' : 'Direct')
             }
             return subscriptionNameById.value[row.subscriptionUuid]
                 || h('span', { class: 'muted-12', title: row.subscriptionUuid }, '(deleted subscription)')

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -173,10 +173,36 @@
                         {{ inboxDrawerRow.lastError }}
                     </n-alert>
 
-                    <!-- Structured payload view. Pretty-printed JSON for now;
-                         richer per-event-type rendering (deep-link buttons,
-                         affected-release table) lands with BD-3 actionable
-                         events in phase 4.
+                    <!-- Actionable approval events (Phase 4b): typed summary
+                         with a release deep link so the operator can act
+                         without digging the uuid out of the raw payload.
+                         Navigation closes both drawers — the target page
+                         renders underneath them otherwise. -->
+                    <n-descriptions v-if="approvalPayloadView" :column="1" size="small" label-placement="left">
+                        <n-descriptions-item label="Release">
+                            <router-link
+                                :to="`/release/show/${approvalPayloadView.releaseUuid}`"
+                                @click="inboxDrawerOpen = false; inboxListDrawerOpen = false"
+                            >
+                                {{ approvalPayloadView.releaseLabel }}
+                            </router-link>
+                        </n-descriptions-item>
+                        <n-descriptions-item v-if="approvalPayloadView.entryNames.length" label="Approval entries">
+                            {{ approvalPayloadView.entryNames.join(', ') }}
+                        </n-descriptions-item>
+                        <n-descriptions-item :label="approvalPayloadView.actorLabel">
+                            {{ approvalPayloadView.actor }}
+                        </n-descriptions-item>
+                        <n-descriptions-item v-if="approvalPayloadView.resolution" label="Resolution">
+                            <n-tag :type="approvalPayloadView.resolution === 'APPROVED' ? 'success' : 'error'" size="small">
+                                {{ approvalPayloadView.resolution }}
+                            </n-tag>
+                        </n-descriptions-item>
+                    </n-descriptions>
+
+                    <!-- Structured payload view. Pretty-printed JSON as the
+                         generic fallback; approval events additionally get
+                         the typed summary above.
                          v-if keys off the COMPUTED parsed payload, not the
                          raw string, so a malformed JSON falls through to
                          the alert below instead of rendering the literal
@@ -326,6 +352,51 @@ const inboxDrawerPayload = computed<Record<string, unknown> | null>(() => {
     } catch {
         return null
     }
+})
+
+interface ApprovalPayloadView {
+    releaseUuid: string
+    releaseLabel: string
+    entryNames: string[]
+    actorLabel: string
+    actor: string
+    resolution: string | null
+}
+
+function formatActor (name?: string, email?: string): string {
+    if (name && email) return `${name} <${email}>`
+    return name || email || '—'
+}
+
+// Normalized view over ApprovalRequestedPayload / ApprovalResolvedPayload;
+// null for every other event type (those keep the raw-payload collapse only).
+const approvalPayloadView = computed<ApprovalPayloadView | null>(() => {
+    const row = inboxDrawerRow.value
+    const p: any = inboxDrawerPayload.value
+    if (!row || !p?.release?.releaseUuid) return null
+    const releaseLabel = [p.release.componentName, p.release.version || p.release.releaseUuid]
+        .filter(Boolean).join(' ')
+    if (row.eventType === 'APPROVAL_REQUESTED') {
+        return {
+            releaseUuid: p.release.releaseUuid,
+            releaseLabel,
+            entryNames: (p.entries || []).map((e: any) => e.approvalEntryName || e.approvalEntryUuid),
+            actorLabel: 'Requested by',
+            actor: formatActor(p.requestedByName, p.requestedByEmail),
+            resolution: null,
+        }
+    }
+    if (row.eventType === 'APPROVAL_RESOLVED') {
+        return {
+            releaseUuid: p.release.releaseUuid,
+            releaseLabel,
+            entryNames: [p.approvalEntryName || p.approvalEntryUuid].filter(Boolean),
+            actorLabel: 'Resolved by',
+            actor: formatActor(p.resolvedByName, p.resolvedByEmail),
+            resolution: p.resolution || null,
+        }
+    }
+    return null
 })
 
 const INBOX_QUERY = gql`

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -380,7 +380,9 @@ const approvalPayloadView = computed<ApprovalPayloadView | null>(() => {
         return {
             releaseUuid: p.release.releaseUuid,
             releaseLabel,
-            entryNames: (p.entries || []).map((e: any) => e.approvalEntryName || e.approvalEntryUuid),
+            entryNames: (p.entries || [])
+                .map((e: any) => e?.approvalEntryName || e?.approvalEntryUuid)
+                .filter(Boolean),
             actorLabel: 'Requested by',
             actor: formatActor(p.requestedByName, p.requestedByEmail),
             resolution: null,

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -159,7 +159,8 @@
                             <n-tag :type="deliveryStatusTagType(inboxDrawerRow.status)" size="small">{{ inboxDrawerRow.status }}</n-tag>
                         </n-descriptions-item>
                         <n-descriptions-item label="Channel">
-                            <span>{{ channelNameById[inboxDrawerRow.channelUuid] || '(deleted)' }}</span>
+                            <span v-if="!inboxDrawerRow.channelUuid" class="muted-12">Direct</span>
+                            <span v-else>{{ channelNameById[inboxDrawerRow.channelUuid] || '(deleted)' }}</span>
                         </n-descriptions-item>
                         <n-descriptions-item label="Delivered">
                             {{ formatHistoryTimestamp(inboxDrawerRow.sentAt || inboxDrawerRow.createdDate) }}
@@ -825,8 +826,12 @@ const inboxColumns = computed(() => [
     },
     {
         title: 'Channel', key: 'channelUuid',
-        render: (row: InboxRow) => channelNameById.value[row.channelUuid]
-            || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'),
+        // Null channel = Phase 4a targeted delivery (personal inbox copy,
+        // no transmission channel) — not a deleted channel.
+        render: (row: InboxRow) => (row.channelUuid
+            ? (channelNameById.value[row.channelUuid]
+                || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
+            : h('span', { class: 'muted-12' }, 'Direct')),
     },
     {
         title: 'Read', key: 'readAt',

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1729,7 +1729,12 @@ async function fetchRelease () {
         }, [])
     }
 
+    // Reset before the conditional reload so prev/next navigation onto a
+    // release without an approval policy doesn't show the old release's
+    // requests.
+    approvalRequestsList.value = []
     if (updatedRelease.value.componentDetails.approvalPolicyDetails) {
+        loadApprovalRequests()
         givenApprovals.value = computeGivenApprovalsFromRelease()
         approvalEntries.value = updatedRelease.value.componentDetails.approvalPolicyDetails.approvalEntryDetails
         approvalEntries.value.forEach(ae => {
@@ -2165,11 +2170,31 @@ async function approve(approvals: ApprovalInput[]) {
 }
 
 const requestApprovalsPending: Ref<boolean> = ref(false)
+const approvalRequestsList: Ref<any[]> = ref([])
 
-const openApprovalRequests: ComputedRef<any[]> = computed((): any[] => {
-    const requests = updatedRelease.value?.approvalRequests || []
-    return requests.filter((r: any) => !r.resolvedAt)
-})
+const openApprovalRequests: ComputedRef<any[]> = computed((): any[] =>
+    approvalRequestsList.value.filter((r: any) => !r.resolvedAt))
+
+// Approval requests are a Pro-only schema surface (absent from the OSS
+// schema), so they ride a separate gated query instead of the shared
+// release fragments. Fire-and-forget from fetchRelease — the matrix
+// renders without it.
+async function loadApprovalRequests () {
+    if (!myUser?.installationType || myUser.installationType === 'OSS') return
+    const requestedFor = releaseUuid.value
+    try {
+        const response = await graphqlClient.query({
+            query: graphqlQueries.ReleaseApprovalRequestsGql,
+            variables: { releaseID: requestedFor, orgID: props.orgprop },
+            fetchPolicy: 'no-cache'
+        })
+        // Drop stale responses if the user prev/next-navigated mid-flight.
+        if (requestedFor !== releaseUuid.value) return
+        approvalRequestsList.value = response.data?.release?.approvalRequests || []
+    } catch (e) {
+        console.warn('Failed to load approval requests for release', e)
+    }
+}
 
 function approvalEntryNameById (entryUuid: string): string {
     const ae = approvalEntries.value?.find((e: any) => e.uuid === entryUuid)
@@ -2187,7 +2212,7 @@ async function requestApprovals () {
                 release: updatedRelease.value.uuid
             }
         })
-        await fetchRelease()
+        await loadApprovalRequests()
         notify('success', 'Requested', 'Approval request sent to eligible approvers.')
     } catch (error: any) {
         Swal.fire(

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1730,9 +1730,11 @@ async function fetchRelease () {
     }
 
     // Reset before the conditional reload so prev/next navigation onto a
-    // release without an approval policy doesn't show the old release's
-    // requests.
+    // release without an approval policy doesn't keep the old release's
+    // requests or matrix entries (a stale approvalEntries would keep the
+    // Request Approvals button visible and fire a doomed mutation).
     approvalRequestsList.value = []
+    approvalEntries.value = []
     if (updatedRelease.value.componentDetails.approvalPolicyDetails) {
         loadApprovalRequests()
         givenApprovals.value = computeGivenApprovalsFromRelease()
@@ -2179,18 +2181,23 @@ const openApprovalRequests: ComputedRef<any[]> = computed((): any[] =>
 // schema), so they ride a separate gated query instead of the shared
 // release fragments. Fire-and-forget from fetchRelease — the matrix
 // renders without it.
+let approvalRequestsLoadSeq = 0
 async function loadApprovalRequests () {
     if (!myUser?.installationType || myUser.installationType === 'OSS') return
-    const requestedFor = releaseUuid.value
+    const seq = ++approvalRequestsLoadSeq
     try {
         const response = await graphqlClient.query({
             query: graphqlQueries.ReleaseApprovalRequestsGql,
-            variables: { releaseID: requestedFor, orgID: props.orgprop },
+            variables: { releaseID: releaseUuid.value, orgID: props.orgprop },
             fetchPolicy: 'no-cache'
         })
-        // Drop stale responses if the user prev/next-navigated mid-flight.
-        if (requestedFor !== releaseUuid.value) return
+        // Drop out-of-order responses (prev/next navigation mid-flight, or a
+        // post-mutation refresh overtaking the fetchRelease-triggered load).
+        if (seq !== approvalRequestsLoadSeq) return
         approvalRequestsList.value = response.data?.release?.approvalRequests || []
+        // requestedBy renders through resolveUserById, which needs the org's
+        // users — normally only loaded on History-tab switch.
+        if (approvalRequestsList.value.length && !users.value.length) loadUsers()
     } catch (e) {
         console.warn('Failed to load approval requests for release', e)
     }

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -807,6 +807,23 @@
                                 </div>
                             </template>
                         </div>
+                        <n-space v-if="isWritable && approvalEntries.length" style="margin-bottom: 10px;">
+                            <n-button @click="requestApprovals" :loading="requestApprovalsPending" :disabled="requestApprovalsPending" title="Notify everyone who can still approve this release">
+                                <template #icon>
+                                    <n-icon><Bell /></n-icon>
+                                </template>
+                                Request Approvals
+                            </n-button>
+                        </n-space>
+                        <div v-if="openApprovalRequests.length" style="margin-bottom: 10px;">
+                            <strong>Open Approval Requests:</strong>
+                            <ul style="margin: 5px 0;">
+                                <li v-for="req in openApprovalRequests" :key="req.uuid">
+                                    {{ new Date(req.requestedAt).toLocaleString('en-CA') }} — requested by {{ resolveUserById(req.requestedBy) }}
+                                    <template v-if="req.approvalEntries && req.approvalEntries.length"> — {{ req.approvalEntries.map(approvalEntryNameById).join(', ') }}</template>
+                                </li>
+                            </ul>
+                        </div>
                         <n-data-table :data="releaseApprovalTableData" :columns="releaseApprovalTableFields" :row-key="approvalRowKey" />
                         <n-space v-if="hasApprovalChanges" style="margin-top: 5px;">
                             <n-spin :show="approvalPending" small>
@@ -1219,7 +1236,7 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { GlobeAdd24Regular, Info24Regular, Edit24Regular } from '@vicons/fluent'
-import { CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh } from '@vicons/tabler'
+import { Bell, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh } from '@vicons/tabler'
 import { Icon } from '@vicons/utils'
 import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regular, ChevronLeft20Regular, ChevronRight20Regular } from '@vicons/fluent'
 import { UpCircleOutlined } from '@vicons/antd'
@@ -2145,6 +2162,42 @@ async function approve(approvals: ApprovalInput[]) {
     }).finally(() => {
         approvalPending.value = false
     })
+}
+
+const requestApprovalsPending: Ref<boolean> = ref(false)
+
+const openApprovalRequests: ComputedRef<any[]> = computed((): any[] => {
+    const requests = updatedRelease.value?.approvalRequests || []
+    return requests.filter((r: any) => !r.resolvedAt)
+})
+
+function approvalEntryNameById (entryUuid: string): string {
+    const ae = approvalEntries.value?.find((e: any) => e.uuid === entryUuid)
+    return ae ? ae.approvalName : entryUuid
+}
+
+// Omitting approvalEntries asks the backend to target every entry that is
+// still actionable; it errors if nothing is pending, which we surface as is.
+async function requestApprovals () {
+    requestApprovalsPending.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: graphqlQueries.RequestReleaseApprovalsGqlMutate,
+            variables: {
+                release: updatedRelease.value.uuid
+            }
+        })
+        await fetchRelease()
+        notify('success', 'Requested', 'Approval request sent to eligible approvers.')
+    } catch (error: any) {
+        Swal.fire(
+            'Error!',
+            commonFunctions.parseGraphQLError(error.message),
+            'error'
+        )
+    } finally {
+        requestApprovalsPending.value = false
+    }
 }
 
 const activeApprovalTypes: Ref<any> = ref({})

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -661,6 +661,13 @@ const singleReleaseDataNoParent = `
             lastUpdatedBy
         }
     }
+    approvalRequests {
+        uuid
+        requestedBy
+        approvalEntries
+        requestedAt
+        resolvedAt
+    }
     updateEvents {
         rus
         rua
@@ -1139,6 +1146,13 @@ const singleReleaseProductNoParent = `
             lastUpdatedBy
         }
     }
+    approvalRequests {
+        uuid
+        requestedBy
+        approvalEntries
+        requestedAt
+        resolvedAt
+    }
     updateEvents {
         rus
         rua
@@ -1356,6 +1370,17 @@ mutation approveReleaseManual($release: ID!, $approvals: [ReleaseApprovalInput!]
     }
 }`
 
+const REQUEST_RELEASE_APPROVALS_GQL_MUTATE = gql`
+mutation requestReleaseApprovals($release: ID!, $approvalEntries: [ID!]) {
+    requestReleaseApprovals(release: $release, approvalEntries: $approvalEntries) {
+        uuid
+        requestedBy
+        approvalEntries
+        requestedAt
+        resolvedAt
+    }
+}`
+
 const COMPONENT_SHORT_DATA = `
     uuid
     name
@@ -1508,6 +1533,7 @@ export default {
     ReleaseTagsMetaGqlMutate: RELEASE_TAGS_META_GQL_MUTATE,
     UpdateArtifactTagsGqlMutate: UPDATE_ARTIFACT_TAGS_GQL_MUTATE,
     ApproveReleaseGqlMutate: APPROVE_RELEASE_GQL_MUTATE,
+    RequestReleaseApprovalsGqlMutate: REQUEST_RELEASE_APPROVALS_GQL_MUTATE,
     ComponentShortData: COMPONENT_SHORT_DATA,
     MarketingRelease: MARKETING_RELEASE_GQL_DATA,
     UserData: USER_GQL_DATA,

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -661,13 +661,6 @@ const singleReleaseDataNoParent = `
             lastUpdatedBy
         }
     }
-    approvalRequests {
-        uuid
-        requestedBy
-        approvalEntries
-        requestedAt
-        resolvedAt
-    }
     updateEvents {
         rus
         rua
@@ -1146,13 +1139,6 @@ const singleReleaseProductNoParent = `
             lastUpdatedBy
         }
     }
-    approvalRequests {
-        uuid
-        requestedBy
-        approvalEntries
-        requestedAt
-        resolvedAt
-    }
     updateEvents {
         rus
         rua
@@ -1370,6 +1356,10 @@ mutation approveReleaseManual($release: ID!, $approvals: [ReleaseApprovalInput!]
     }
 }`
 
+// Pro-only surface (like the notification inbox queries): the mutation and
+// the approvalRequests field are absent from the OSS schema, so callers must
+// gate on installationType !== 'OSS' — never fold approvalRequests into the
+// shared release fragments above.
 const REQUEST_RELEASE_APPROVALS_GQL_MUTATE = gql`
 mutation requestReleaseApprovals($release: ID!, $approvalEntries: [ID!]) {
     requestReleaseApprovals(release: $release, approvalEntries: $approvalEntries) {
@@ -1378,6 +1368,20 @@ mutation requestReleaseApprovals($release: ID!, $approvalEntries: [ID!]) {
         approvalEntries
         requestedAt
         resolvedAt
+    }
+}`
+
+const RELEASE_APPROVAL_REQUESTS_GQL = gql`
+query releaseApprovalRequests($releaseID: ID!, $orgID: ID) {
+    release(releaseUuid: $releaseID, orgUuid: $orgID) {
+        uuid
+        approvalRequests {
+            uuid
+            requestedBy
+            approvalEntries
+            requestedAt
+            resolvedAt
+        }
     }
 }`
 
@@ -1534,6 +1538,7 @@ export default {
     UpdateArtifactTagsGqlMutate: UPDATE_ARTIFACT_TAGS_GQL_MUTATE,
     ApproveReleaseGqlMutate: APPROVE_RELEASE_GQL_MUTATE,
     RequestReleaseApprovalsGqlMutate: REQUEST_RELEASE_APPROVALS_GQL_MUTATE,
+    ReleaseApprovalRequestsGql: RELEASE_APPROVAL_REQUESTS_GQL,
     ComponentShortData: COMPONENT_SHORT_DATA,
     MarketingRelease: MARKETING_RELEASE_GQL_DATA,
     UserData: USER_GQL_DATA,

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -123,6 +123,11 @@ export const eventTypeOptions = [
     { label: 'New vuln affects releases', value: 'NEW_VULN_AFFECTS_RELEASES' },
     { label: 'Vulnerability record updated', value: 'VULNERABILITY_RECORD_UPDATED' },
     { label: 'VEX state changed', value: 'VEX_STATE_CHANGED' },
+    { label: 'Release created', value: 'RELEASE_CREATED' },
+    { label: 'Release lifecycle changed', value: 'RELEASE_LIFECYCLE_CHANGED' },
+    { label: 'Release BOM diff', value: 'RELEASE_BOM_DIFF' },
+    { label: 'Approval requested', value: 'APPROVAL_REQUESTED' },
+    { label: 'Approval resolved', value: 'APPROVAL_RESOLVED' },
 ]
 
 export const severityOptions = [

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -56,7 +56,8 @@ export interface DeliveryRow {
     org: string
     outboxEventUuid: string
     subscriptionUuid: string | null
-    channelUuid: string
+    // Null for targeted (per-user) approval deliveries — no channel involved.
+    channelUuid: string | null
     status: string
     origin: string
     dedupKey: string | null
@@ -72,7 +73,8 @@ export interface InboxRow {
     org: string
     outboxEventUuid: string
     subscriptionUuid: string | null
-    channelUuid: string
+    // Null for targeted (per-user) approval deliveries — no channel involved.
+    channelUuid: string | null
     status: string
     origin: string
     dedupKey: string | null


### PR DESCRIPTION
## Summary

UI half of the actionable approval events feature (Phase 4 of the notifications roadmap; backend landed separately):

- **ReleaseView · Approvals tab**: a write-gated **Request Approvals** button calls the `requestReleaseApprovals` mutation with no entry filter — the backend targets every still-actionable approval entry and errors if nothing is pending (surfaced as-is). Open (unresolved) requests render above the approval matrix with requester, timestamp and entry names.
- **Pro-only schema isolation**: `approvalRequests` / `requestReleaseApprovals` are absent from the OSS schema, so the request list rides a dedicated query gated on `installationType !== 'OSS'` (same pattern as the notification inbox queries) instead of the shared release fragments — folding it into the fragments would break every release fetch on OSS. Fire-and-forget from `fetchRelease` with a stale-response guard for prev/next navigation.
- **NotificationInbox · detail drawer**: typed summary for `APPROVAL_REQUESTED` / `APPROVAL_RESOLVED` payloads — release deep link (closes both drawers on navigation), approval entry names, requester/resolver identity, and an APPROVED/DISAPPROVED tag. The raw-payload collapse remains the generic fallback for other event types.
- **Filter dropdowns**: `eventTypeOptions` gains the two approval event types, plus the three release event types (`RELEASE_CREATED` / `RELEASE_LIFECYCLE_CHANGED` / `RELEASE_BOM_DIFF`) that have been missing from the subscription and inbox filters since they shipped.

## Notes

- `npm run lint` is broken on main independently of this PR (deps bump moved to eslint 10; the script still passes the removed `--ignore-path` flag and the config is legacy `.eslintrc.js`) — left for a separate chore.

## Test plan

- [x] `npm run build` green
- [ ] Sandbox smoke: request approvals on a release with a pending policy → targeted inbox rows appear for eligible approvers; deep link lands on the release; casting the resolving vote emits APPROVAL_RESOLVED and marks the request resolved
- [ ] Verify OSS-safety: release page loads with no approval-requests query when installationType is OSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)