### PR TITLE
fix(ui): invalidate in-flight approval-requests load on release switch

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1733,6 +1733,10 @@ async function fetchRelease () {
     // release without an approval policy doesn't keep the old release's
     // requests or matrix entries (a stale approvalEntries would keep the
     // Request Approvals button visible and fire a doomed mutation).
+    // Bump the seq too: if the new release has no policy, no fresh
+    // loadApprovalRequests() supersedes an in-flight one, whose late
+    // response would otherwise repopulate the old release's requests.
+    approvalRequestsLoadSeq++
     approvalRequestsList.value = []
     approvalEntries.value = []
     if (updatedRelease.value.componentDetails.approvalPolicyDetails) {


### PR DESCRIPTION
## Summary
- One-line follow-up to #133 from its post-merge senior review: `fetchRelease` resets `approvalRequestsList`/`approvalEntries` when the new release has no approval policy, but did not bump `approvalRequestsLoadSeq` — so an in-flight `loadApprovalRequests()` response from the previous release could pass the `seq === approvalRequestsLoadSeq` guard and repopulate the old release's open requests onto the policy-less release (display-only: the Request Approvals button stays hidden since `approvalEntries` stays reset).
- Fix: increment the seq in the reset block so any late response fails the guard.

## Test plan
- [x] `npm run build` green
- [ ] Manual: open a release with open approval requests, prev/next quickly onto a release without a policy — Open Approval Requests block must not flash the previous release's requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)