### PR TITLE
feat(ui): CISA KEV badges + KEV details modal (Phase 6b)

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -2127,7 +2127,8 @@ async function viewDetailedVulnerabilitiesForRelease(releaseRow: any, severityFi
     try {
         const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(
             releaseRow.uuid,
-            branchData.value.org
+            branchData.value.org,
+            myUser?.installationType
         )
         
         // Update reactive values with the processed data

--- a/ui/src/components/KevDetailsModal.vue
+++ b/ui/src/components/KevDetailsModal.vue
@@ -1,0 +1,134 @@
+<template>
+    <n-modal
+        v-model:show="isVisible"
+        preset="dialog"
+        :show-icon="false"
+        style="width: 640px;"
+    >
+        <template #header>
+            <n-space align="center" :size="8">
+                <n-tag type="error" size="small" :bordered="false">KEV</n-tag>
+                <span>CISA Known Exploited Vulnerability: {{ cveId }}</span>
+            </n-space>
+        </template>
+        <n-spin :show="loading">
+            <div v-if="record">
+                <n-descriptions label-placement="left" :column="1" bordered size="small">
+                    <n-descriptions-item v-if="record.vulnerabilityName" label="Name">
+                        {{ record.vulnerabilityName }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.vendorProject" label="Vendor / Project">
+                        {{ record.vendorProject }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.product" label="Product">
+                        {{ record.product }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.dateAdded" label="Added to KEV">
+                        {{ record.dateAdded }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.dueDate" label="Remediation due (FCEB)">
+                        {{ record.dueDate }}
+                    </n-descriptions-item>
+                    <n-descriptions-item label="Ransomware campaign use">
+                        <n-tag :type="record.knownRansomwareCampaignUse ? 'error' : 'default'" size="small" :bordered="false">
+                            {{ record.knownRansomwareCampaignUse ? 'Known' : 'Unknown' }}
+                        </n-tag>
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.cwes && record.cwes.length > 0" label="CWEs">
+                        <n-space :size="4">
+                            <template v-for="cwe in record.cwes" :key="cwe">
+                                <a
+                                    v-if="getFindingUrl(cwe)"
+                                    :href="getFindingUrl(cwe)!"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    @click.prevent="openExternalLink(getFindingUrl(cwe)!)"
+                                >{{ cwe }}</a>
+                                <span v-else>{{ cwe }}</span>
+                            </template>
+                        </n-space>
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.shortDescription" label="Description">
+                        {{ record.shortDescription }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.requiredAction" label="Required action">
+                        {{ record.requiredAction }}
+                    </n-descriptions-item>
+                    <n-descriptions-item v-if="record.notes" label="Notes">
+                        {{ record.notes }}
+                    </n-descriptions-item>
+                </n-descriptions>
+                <n-space style="margin-top: 12px;" :size="16">
+                    <a
+                        :href="cisaCatalogUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        @click.prevent="openExternalLink(cisaCatalogUrl)"
+                    >View in CISA KEV catalog</a>
+                    <a
+                        v-if="osvUrl"
+                        :href="osvUrl"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        @click.prevent="openExternalLink(osvUrl!)"
+                    >View on osv.dev</a>
+                </n-space>
+            </div>
+            <n-empty
+                v-else-if="!loading"
+                description="This vulnerability is not currently listed in the CISA KEV catalog."
+                style="padding: 24px 0;"
+            />
+        </n-spin>
+    </n-modal>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'KevDetailsModal'
+}
+</script>
+
+<script lang="ts" setup>
+import { computed, ref, watch } from 'vue'
+import { NModal, NSpin, NSpace, NTag, NDescriptions, NDescriptionsItem, NEmpty } from 'naive-ui'
+import { fetchKevRecordDetails, KevRecordDetails } from '@/utils/kevService'
+import { getFindingUrl, openExternalLink } from '@/utils/findingUtils'
+
+interface Props {
+    show: boolean
+    orgUuid: string
+    cveId: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+    'update:show': [value: boolean]
+}>()
+
+const isVisible = computed({
+    get: () => props.show,
+    set: (value: boolean) => emit('update:show', value)
+})
+
+const loading = ref(false)
+const record = ref<KevRecordDetails | null>(null)
+
+const cisaCatalogUrl = computed(() =>
+    `https://www.cisa.gov/known-exploited-vulnerabilities-catalog?search_api_fulltext=${encodeURIComponent(props.cveId)}`)
+
+const osvUrl = computed(() => getFindingUrl(props.cveId))
+
+watch(() => props.show, async (shown) => {
+    if (!shown) return
+    record.value = null
+    if (!props.orgUuid || !props.cveId) return
+    loading.value = true
+    try {
+        record.value = await fetchKevRecordDetails(props.orgUuid, props.cveId)
+    } finally {
+        loading.value = false
+    }
+})
+</script>

--- a/ui/src/components/KevDetailsModal.vue
+++ b/ui/src/components/KevDetailsModal.vue
@@ -75,6 +75,11 @@
                 </n-space>
             </div>
             <n-empty
+                v-else-if="loadError && !loading"
+                description="Failed to load CISA KEV catalog details. Please try again."
+                style="padding: 24px 0;"
+            />
+            <n-empty
                 v-else-if="!loading"
                 description="This vulnerability is not currently listed in the CISA KEV catalog."
                 style="padding: 24px 0;"
@@ -113,6 +118,7 @@ const isVisible = computed({
 })
 
 const loading = ref(false)
+const loadError = ref(false)
 const record = ref<KevRecordDetails | null>(null)
 
 const cisaCatalogUrl = computed(() =>
@@ -120,15 +126,25 @@ const cisaCatalogUrl = computed(() =>
 
 const osvUrl = computed(() => getFindingUrl(props.cveId))
 
-watch(() => props.show, async (shown) => {
+// Token guards against a stale in-flight response landing after the
+// modal was closed and reopened for a different CVE.
+let fetchToken = 0
+
+watch([() => props.show, () => props.cveId], async ([shown]) => {
     if (!shown) return
     record.value = null
+    loadError.value = false
     if (!props.orgUuid || !props.cveId) return
+    const token = ++fetchToken
     loading.value = true
     try {
-        record.value = await fetchKevRecordDetails(props.orgUuid, props.cveId)
+        const result = await fetchKevRecordDetails(props.orgUuid, props.cveId)
+        if (token === fetchToken) record.value = result
+    } catch (err) {
+        console.error('Error fetching KEV record details:', err)
+        if (token === fetchToken) loadError.value = true
     } finally {
-        loading.value = false
+        if (token === fetchToken) loading.value = false
     }
 })
 </script>

--- a/ui/src/components/MarketingReleaseView.vue
+++ b/ui/src/components/MarketingReleaseView.vue
@@ -240,7 +240,8 @@ async function viewDetailedVulnerabilitiesForRelease(releaseUuid: string, severi
     try {
         const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(
             releaseUuid,
-            marketingRelease.value.org
+            marketingRelease.value.org,
+            myUser?.installationType
         )
         vulnModalArtifacts.value = releaseData.artifacts
         vulnModalOrgUuid.value = releaseData.orgUuid

--- a/ui/src/components/MostRecentReleasesWidget.vue
+++ b/ui/src/components/MostRecentReleasesWidget.vue
@@ -114,6 +114,7 @@ export default {
 
 <script lang="ts" setup>
 import { ref, Ref, computed, watch, onMounted } from 'vue'
+import { useStore } from 'vuex'
 import { NIcon, NSpin, NSpace, NInputNumber, NSelect, NTooltip, useNotification } from 'naive-ui'
 import { ArrowExpand20Regular } from '@vicons/fluent'
 import { Refresh, CalendarTime } from '@vicons/tabler'
@@ -145,6 +146,7 @@ const props = withDefaults(defineProps<{
     componentType: null
 })
 
+const store = useStore()
 const notification = useNotification()
 const loading = ref(false)
 const releases: Ref<any[]> = ref([])
@@ -250,7 +252,8 @@ async function openVulnModal(rel: any, severityFilter: string, typeFilter: strin
     try {
         const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(
             rel.uuid,
-            rel.org
+            rel.org,
+            store.getters.myuser?.installationType
         )
         vulnModalArtifacts.value = releaseData.artifacts
         vulnModalOrgUuid.value = releaseData.orgUuid

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1251,6 +1251,7 @@ import { DownloadLink} from '@/utils/commonTypes'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
 import { getReleaseScanStatus, isDtrackConfiguredForOrg } from '@/utils/releaseScanStatus'
 import { processMetricsData } from '@/utils/metrics'
+import { annotateKnownExploited, fetchArtifactKevVulnIds, isProInstallation } from '@/utils/kevService'
 import { exportFindingsToPdf } from '@/utils/pdfExport'
 import { PackageURL } from 'packageurl-js'
 
@@ -3132,9 +3133,10 @@ async function viewDetailedVulnerabilitiesForRelease(releaseUuid: string, severi
     try {
         const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(
             releaseUuid,
-            release.value.org
+            release.value.org,
+            myUser?.installationType
         )
-        
+
         // Update reactive values with the processed data (same as BranchView)
         currentReleaseArtifacts.value = releaseData.artifacts
         currentReleaseOrgUuid.value = releaseData.orgUuid
@@ -3157,8 +3159,11 @@ async function viewDetailedVulnerabilities(artifactUuid: string, dependencyTrack
     currentSeverityFilter.value = severityFilter
     currentTypeFilter.value = typeFilter
     loadingVulnerabilities.value = true
-    
+
     try {
+        const kevVulnIdsPromise = isProInstallation(myUser?.installationType)
+            ? fetchArtifactKevVulnIds(artifactUuid)
+            : Promise.resolve(new Set<string>())
         const response = await graphqlClient.query({
             query: gql`
                 query getArtifactDetails($artifactUuid: ID!) {
@@ -3252,7 +3257,9 @@ async function viewDetailedVulnerabilities(artifactUuid: string, dependencyTrack
         
         const artifact = response.data.artifact
         if (artifact && artifact.metrics) {
-            detailedVulnerabilitiesData.value = processMetricsData(artifact.metrics)
+            const processedMetrics = processMetricsData(artifact.metrics)
+            annotateKnownExploited(processedMetrics, await kevVulnIdsPromise)
+            detailedVulnerabilitiesData.value = processedMetrics
             currentArtifactDisplayId.value = artifact.displayIdentifier || ''
         }
     } catch (error) {

--- a/ui/src/components/VulnerabilityModal.vue
+++ b/ui/src/components/VulnerabilityModal.vue
@@ -42,6 +42,12 @@
         </n-space>
     </n-modal>
     
+    <kev-details-modal
+        v-model:show="showKevModal"
+        :org-uuid="orgUuid"
+        :cve-id="kevModalCveId"
+    />
+
     <create-vuln-analysis-modal
         v-model:show="showCreateAnalysisModal"
         :finding-row="selectedFinding"
@@ -163,6 +169,7 @@ import { buildBovJson, downloadBovJson } from '@/utils/bovExport'
 import { isSuppressedAnalysisState } from '@/constants/vulnAnalysis'
 import CreateVulnAnalysisModal from './CreateVulnAnalysisModal.vue'
 import ViewVulnAnalysisModal from './ViewVulnAnalysisModal.vue'
+import KevDetailsModal from './KevDetailsModal.vue'
 
 interface Props {
     show: boolean
@@ -341,6 +348,14 @@ const unsuppressedCount = computed(() => {
     return props.data.filter(row => !isSuppressed(row)).length
 })
 
+const showKevModal = ref(false)
+const kevModalCveId = ref('')
+
+const handleKevClick = (cveId: string) => {
+    kevModalCveId.value = cveId
+    showKevModal.value = true
+}
+
 const handleEditFinding = (row: any) => {
     selectedFinding.value = row
     showCreateAnalysisModal.value = true
@@ -372,6 +387,7 @@ const vulnerabilityColumns = computed(() => buildVulnerabilityColumns(h, NTag, N
     onPurlClick: props.releaseUuid ? handlePurlClick : undefined,
     onEditFinding: handleEditFinding,
     onViewAnalysis: handleViewAnalysis,
+    onKevClick: handleKevClick,
     initialSeverityFilter: props.initialSeverityFilter,
     initialTypeFilter: props.initialTypeFilter,
     data: props.data

--- a/ui/src/utils/kevService.ts
+++ b/ui/src/utils/kevService.ts
@@ -114,19 +114,32 @@ export async function fetchArtifactKevVulnIds(artifactUuid: string): Promise<Set
     }
 }
 
-/** Full catalog entry for one CVE; null when not KEV-listed or on error. */
+/**
+ * Full catalog entry for one CVE; null means authoritatively not KEV-listed.
+ * Unlike the badge fetches this rethrows on transport/backend errors, so the
+ * modal can show an error state instead of a false "not listed" claim.
+ */
 export async function fetchKevRecordDetails(orgUuid: string, cveId: string): Promise<KevRecordDetails | null> {
-    try {
-        const response = await graphqlClient.query({
-            query: KEV_RECORD_DETAILS_GQL,
-            variables: { orgUuid, cveId },
-            fetchPolicy: 'no-cache'
-        })
-        return (response.data as any).kevRecordDetails || null
-    } catch (err) {
-        console.error('Error fetching KEV record details:', err)
-        return null
-    }
+    const response = await graphqlClient.query({
+        query: KEV_RECORD_DETAILS_GQL,
+        variables: { orgUuid, cveId },
+        fetchPolicy: 'no-cache'
+    })
+    return (response.data as any).kevRecordDetails || null
+}
+
+/**
+ * The catalog keys records by CVE id, but a finding's primary id may be a
+ * GHSA/other alias with the KEV CVE in its aliases. Prefer the row id when
+ * it is already a CVE, else the first CVE-prefixed alias.
+ */
+export function resolveKevCveId(row: any): string {
+    const id = String(row?.id || '')
+    if (id.startsWith('CVE-')) return id
+    const aliasCve = (Array.isArray(row?.aliases) ? row.aliases : [])
+        .map((a: any) => (typeof a === 'string' ? a : a?.aliasId))
+        .find((a: any) => typeof a === 'string' && a.startsWith('CVE-'))
+    return aliasCve || id
 }
 
 /** Stamps knownExploited on processed vulnerability rows (matched by id). */

--- a/ui/src/utils/kevService.ts
+++ b/ui/src/utils/kevService.ts
@@ -1,0 +1,140 @@
+/**
+ * CISA KEV (Known Exploited Vulnerabilities) read surface.
+ *
+ * Pro-only (like approvalRequests): the knownExploited field and the
+ * kevRecordDetails query are absent from the OSS schema, so callers must
+ * gate on installationType !== 'OSS' — never fold these fields into the
+ * shared release/metrics fragments.
+ */
+
+import gql from 'graphql-tag'
+import graphqlClient from './graphql'
+
+export interface KevRecordDetails {
+    cveId: string
+    vendorProject?: string
+    product?: string
+    vulnerabilityName?: string
+    dateAdded?: string
+    shortDescription?: string
+    requiredAction?: string
+    dueDate?: string
+    knownRansomwareCampaignUse?: boolean
+    notes?: string
+    cwes?: string[]
+}
+
+export function isProInstallation(installationType?: string): boolean {
+    return !!installationType && installationType !== 'OSS'
+}
+
+const RELEASE_KEV_FLAGS_GQL = gql`
+query releaseKevFlags($releaseUuid: ID!, $orgUuid: ID) {
+    release(releaseUuid: $releaseUuid, orgUuid: $orgUuid) {
+        uuid
+        metrics {
+            vulnerabilityDetails {
+                vulnId
+                knownExploited
+            }
+        }
+    }
+}`
+
+const ARTIFACT_KEV_FLAGS_GQL = gql`
+query artifactKevFlags($artifactUuid: ID!) {
+    artifact(artifactUuid: $artifactUuid) {
+        uuid
+        metrics {
+            vulnerabilityDetails {
+                vulnId
+                knownExploited
+            }
+        }
+    }
+}`
+
+const KEV_RECORD_DETAILS_GQL = gql`
+query kevRecordDetails($orgUuid: ID!, $cveId: String!) {
+    kevRecordDetails(orgUuid: $orgUuid, cveId: $cveId) {
+        cveId
+        vendorProject
+        product
+        vulnerabilityName
+        dateAdded
+        shortDescription
+        requiredAction
+        dueDate
+        knownRansomwareCampaignUse
+        notes
+        cwes
+    }
+}`
+
+function toKevIdSet(vulnerabilityDetails: any[] | null | undefined): Set<string> {
+    const kevIds = new Set<string>()
+    if (Array.isArray(vulnerabilityDetails)) {
+        vulnerabilityDetails.forEach((v: any) => {
+            if (v?.knownExploited && v.vulnId) kevIds.add(v.vulnId)
+        })
+    }
+    return kevIds
+}
+
+/**
+ * KEV-listed vulnIds among a release's findings. Fail-soft: any error
+ * returns an empty set so the findings view never breaks over the badge.
+ */
+export async function fetchReleaseKevVulnIds(releaseUuid: string, orgUuid: string): Promise<Set<string>> {
+    try {
+        const response = await graphqlClient.query({
+            query: RELEASE_KEV_FLAGS_GQL,
+            variables: { releaseUuid, orgUuid },
+            fetchPolicy: 'no-cache'
+        })
+        return toKevIdSet((response.data as any).release?.metrics?.vulnerabilityDetails)
+    } catch (err) {
+        console.error('Error fetching KEV flags for release:', err)
+        return new Set<string>()
+    }
+}
+
+/** Artifact-level variant of fetchReleaseKevVulnIds, same fail-soft contract. */
+export async function fetchArtifactKevVulnIds(artifactUuid: string): Promise<Set<string>> {
+    try {
+        const response = await graphqlClient.query({
+            query: ARTIFACT_KEV_FLAGS_GQL,
+            variables: { artifactUuid },
+            fetchPolicy: 'no-cache'
+        })
+        return toKevIdSet((response.data as any).artifact?.metrics?.vulnerabilityDetails)
+    } catch (err) {
+        console.error('Error fetching KEV flags for artifact:', err)
+        return new Set<string>()
+    }
+}
+
+/** Full catalog entry for one CVE; null when not KEV-listed or on error. */
+export async function fetchKevRecordDetails(orgUuid: string, cveId: string): Promise<KevRecordDetails | null> {
+    try {
+        const response = await graphqlClient.query({
+            query: KEV_RECORD_DETAILS_GQL,
+            variables: { orgUuid, cveId },
+            fetchPolicy: 'no-cache'
+        })
+        return (response.data as any).kevRecordDetails || null
+    } catch (err) {
+        console.error('Error fetching KEV record details:', err)
+        return null
+    }
+}
+
+/** Stamps knownExploited on processed vulnerability rows (matched by id). */
+export function annotateKnownExploited(rows: any[] | null | undefined, kevVulnIds: Set<string>): void {
+    if (!Array.isArray(rows) || kevVulnIds.size === 0) return
+    rows.forEach((row: any) => {
+        if (row?.type === 'Vulnerability' && row.id && kevVulnIds.has(row.id)) {
+            row.knownExploited = true
+        }
+    })
+}

--- a/ui/src/utils/metrics.ts
+++ b/ui/src/utils/metrics.ts
@@ -4,6 +4,7 @@ import { searchDtrackComponentByPurl } from '@/utils/dtrack'
 import { Info20Regular } from '@vicons/fluent'
 import { Edit, Eye } from '@vicons/tabler'
 import { isSuppressedAnalysisState } from '@/constants/vulnAnalysis'
+import { resolveKevCveId } from '@/utils/kevService'
 
 export type DetailedMetric = {
   type: 'Vulnerability' | 'Violation' | 'Weakness'
@@ -317,7 +318,7 @@ export function buildVulnerabilityColumns(
           bordered: false,
           title: 'CISA Known Exploited Vulnerability — click for details',
           style: options?.onKevClick ? 'cursor: pointer;' : '',
-          onClick: () => options?.onKevClick?.(id)
+          onClick: () => options?.onKevClick?.(resolveKevCveId(row))
         }, { default: () => 'KEV' })
         return h('div', { style: 'display: flex; align-items: center; gap: 6px; flex-wrap: wrap;' }, [idLink, kevTag])
       }

--- a/ui/src/utils/metrics.ts
+++ b/ui/src/utils/metrics.ts
@@ -19,6 +19,8 @@ export type DetailedMetric = {
   analysisState?: string
   analysisDate?: string
   attributedAt?: string
+  // Pro-only CISA KEV flag, stamped post-fetch by kevService.annotateKnownExploited
+  knownExploited?: boolean
 }
 
 // Helper function to create vulnerability links with confirmation dialog
@@ -164,6 +166,9 @@ export function buildVulnerabilityColumns(
     onPurlClick?: (purl: string) => void
     onEditFinding?: (row: any) => void
     onViewAnalysis?: (row: any) => void
+    // Opens the CISA KEV details modal for a KEV-flagged CVE (Pro only —
+    // rows only carry knownExploited when the caller annotated them)
+    onKevClick?: (cveId: string) => void
     initialSeverityFilter?: string
     initialTypeFilter?: string | string[]
     data?: any[]
@@ -304,7 +309,17 @@ export function buildVulnerabilityColumns(
       render: (row: any) => {
         const id = String(row.id || '')
         if (!id) return ''
-        return createVulnerabilityLink(h, id)
+        const idLink = createVulnerabilityLink(h, id)
+        if (!row.knownExploited) return idLink
+        const kevTag = h(NTag, {
+          type: 'error',
+          size: 'small',
+          bordered: false,
+          title: 'CISA Known Exploited Vulnerability — click for details',
+          style: options?.onKevClick ? 'cursor: pointer;' : '',
+          onClick: () => options?.onKevClick?.(id)
+        }, { default: () => 'KEV' })
+        return h('div', { style: 'display: flex; align-items: center; gap: 6px; flex-wrap: wrap;' }, [idLink, kevTag])
       }
     },
     { title: 'PURL or Location', key: 'purl', width: 400, ellipsis: { tooltip: true }, render: makePurlRenderer() },

--- a/ui/src/utils/releaseVulnerabilityService.ts
+++ b/ui/src/utils/releaseVulnerabilityService.ts
@@ -1,6 +1,7 @@
 import gql from 'graphql-tag'
 import graphqlClient from './graphql'
 import { processMetricsData } from './metrics'
+import { annotateKnownExploited, fetchReleaseKevVulnIds, isProInstallation } from './kevService'
 
 export interface ReleaseVulnerabilityData {
     artifacts: any[]
@@ -161,12 +162,19 @@ export class ReleaseVulnerabilityService {
      * Fetches release vulnerability data and processes it into a structured format
      * @param releaseUuid - The UUID of the release to fetch data for
      * @param orgUuid - The organization UUID
+     * @param installationType - Caller's installationType; when Pro (not 'OSS'/absent),
+     *                           vulnerability rows are annotated with CISA KEV flags
+     *                           via a separate Pro-only query (kevService)
      * @returns Promise containing processed release vulnerability data
      */
     static async fetchReleaseVulnerabilityData(
-        releaseUuid: string, 
-        orgUuid: string
+        releaseUuid: string,
+        orgUuid: string,
+        installationType?: string
     ): Promise<ReleaseVulnerabilityData> {
+        const kevVulnIdsPromise = isProInstallation(installationType)
+            ? fetchReleaseKevVulnIds(releaseUuid, orgUuid)
+            : Promise.resolve(new Set<string>())
         const response = await graphqlClient.query({
             query: this.RELEASE_DETAILS_QUERY,
             variables: {
@@ -188,9 +196,11 @@ export class ReleaseVulnerabilityService {
         const dtrackProjectUuids = this.extractDtrackProjectUuids(artifacts)
 
         // Process metrics data (only from current release, not parent releases)
-        const vulnerabilityData = releaseData.metrics 
+        const vulnerabilityData = releaseData.metrics
             ? processMetricsData(releaseData.metrics)
             : null
+
+        annotateKnownExploited(vulnerabilityData, await kevVulnIdsPromise)
 
         return {
             artifacts,


### PR DESCRIPTION
## Summary

- **KEV badge in the findings table**: vulnerabilities listed in the CISA Known Exploited Vulnerabilities catalog get a clickable red `KEV` tag next to their Issue ID in `VulnerabilityModal` — covering ReleaseView (release- and artifact-level), BranchView, MostRecentReleasesWidget, and MarketingReleaseView.
- **New `KevDetailsModal`**: clicking the badge shows the full KEV catalog entry — vendor/project, product, date added, FCEB remediation due date, ransomware-campaign use, CWEs (linked to MITRE), description, required action, notes — plus consent-gated external links to the CISA catalog and osv.dev.
- **New `kevService`**: Pro-only read surface. The `knownExploited` flag and `kevRecordDetails` query are absent from the OSS schema, so (like `approvalRequests`) they live in separate queries gated on `installationType !== 'OSS'` and are never folded into the shared release/metrics fragments. All KEV fetches fail soft (empty set / null) so a findings view never breaks over the badge.

Annotation happens once in the `ReleaseVulnerabilityService.fetchReleaseVulnerabilityData` chokepoint; callers just pass their `installationType`. Changelog finding lists and the analytics/history surfaces (AppHome, FindingsOverTimeChart, VulnerabilityAnalysis) keep their current rendering — KEV badges there are a follow-up.

Depends on the Pro backend KEV read surface (Phase 6a); on OSS or older backends the UI sends no KEV queries and renders exactly as before.

## Test plan

- [x] `npm run build` green (`npm run lint` is broken at main: eslint v10 vs eslint-8 flags in the script — pre-existing, untouched here)
- [x] Two-layer review (`/review` + convention check) — done; layer-2 MUST-FIX (alias-primary rows) + SHOULD-FIXes fixed in 85f82af4, summary in PR comment
- [x] Sandbox verification (2026-06-12): KEV badges on the Log4Shell pair only, badge → details modal with populated CISA fields, clean GraphQL trace — evidence in PR comment (OSS path covered by review; sandbox is a Pro install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

