### PR TITLE
feat(ui): KEV badges on analysis, changelog, home and trend surfaces

### DIFF
--- a/ui/src/components/AppHome.vue
+++ b/ui/src/components/AppHome.vue
@@ -567,6 +567,7 @@ import ComponentBranchesTable from './ComponentBranchesTable.vue'
 import VulnerabilityModal from './VulnerabilityModal.vue'
 import MostRecentReleasesWidget from './MostRecentReleasesWidget.vue'
 import { processMetricsData } from '@/utils/metrics'
+import { kevFieldSelection } from '@/utils/kevService'
 
 const store = useStore()
 const router = useRouter()
@@ -1264,6 +1265,7 @@ async function fetchMostVulnerableComponents () {
                                 analysisState
                                 analysisDate
                                 attributedAt
+                                ${kevFieldSelection(installationType.value)}
                                 aliases { type aliasId }
                                 sources {
                                     artifact

--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -250,7 +250,7 @@
                             :branch-uuid="entry.branch.branchUuid"
                             :branch-name="entry.branch.branchName"
                         />
-                        <FindingChangesDisplay :finding-changes="entry.release.findingChanges" />
+                        <FindingChangesDisplay :finding-changes="entry.release.findingChanges" :org-uuid="changelog.orgUuid" />
                     </div>
                 </div>
 
@@ -274,7 +274,7 @@
                                     :branch-uuid="branch.branchUuid"
                                     :branch-name="branch.branchName"
                                 />
-                                <FindingChangesDisplay :finding-changes="release.findingChanges" />
+                                <FindingChangesDisplay :finding-changes="release.findingChanges" :org-uuid="changelog.orgUuid" />
                             </div>
                         </template>
                     </div>
@@ -283,7 +283,7 @@
                 <!-- AGGREGATED mode: Show top-level aggregated changes -->
                 <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog'">
                     <p style="margin-bottom: 10px; font-style: italic;">{{ aggregatedDescription }}</p>
-                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" />
+                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" />
                 </div>
             </n-tab-pane>
         </n-tabs>
@@ -329,7 +329,8 @@ async function getComponentChangelog (org: string, aggregationType: string, comp
             org: org,
             aggregated: aggregationType as 'NONE' | 'AGGREGATED',
             dateFrom: dateFrom,
-            dateTo: dateTo
+            dateTo: dateTo,
+            installationType: store.getters.myuser?.installationType
         })
     }
     return null
@@ -341,7 +342,8 @@ async function getChangelog (org: string, aggregationType: string, release1?: st
             release1: release1,
             release2: release2,
             org: org,
-            aggregated: aggregationType as 'NONE' | 'AGGREGATED'
+            aggregated: aggregationType as 'NONE' | 'AGGREGATED',
+            installationType: store.getters.myuser?.installationType
         })
     }
     return null

--- a/ui/src/components/FindingsOverTimeChart.vue
+++ b/ui/src/components/FindingsOverTimeChart.vue
@@ -69,6 +69,7 @@ import { NSkeleton, NEmpty, NModal, useNotification, NotificationType } from 'na
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import { processMetricsData } from '@/utils/metrics'
+import { kevFieldSelection } from '@/utils/kevService'
 import constants from '@/utils/constants'
 import * as vegaEmbed from 'vega-embed'
 import VulnerabilityModal from './VulnerabilityModal.vue'
@@ -196,8 +197,9 @@ const refreshAnalyticsForCurrentDate = () => {
     }
 }
 
-// Common GraphQL fields for findings queries
-const FINDINGS_FIELDS = `
+// Common GraphQL fields for findings queries; kevField is the Pro-only
+// knownExploited selection from kevFieldSelection ('' on OSS)
+const findingsFields = (kevField: string) => `
     vulnerabilityDetails {
         purl
         vulnId
@@ -205,6 +207,7 @@ const FINDINGS_FIELDS = `
         analysisState
         analysisDate
         attributedAt
+        ${kevField}
         aliases {
             type
             aliasId
@@ -383,6 +386,7 @@ async function fetchFindingsPerDay(dateOverride?: string) {
     if (!dateToUse) return
     
     findingsPerDayLoading.value = true
+    const FINDINGS_FIELDS = findingsFields(kevFieldSelection(myUser.value?.installationType))
     try {
         let response
         if (props.type === 'ORGANIZATION') {

--- a/ui/src/components/OrganizationChangelogView.vue
+++ b/ui/src/components/OrganizationChangelogView.vue
@@ -62,7 +62,7 @@
                                             :version="release.version"
                                             :lifecycle="release.lifecycle"
                                         />
-                                        <FindingChangesDisplay :finding-changes="release.findingChanges" />
+                                        <FindingChangesDisplay :finding-changes="release.findingChanges" :org-uuid="orgUuid" />
                                     </div>
                                 </div>
                             </div>
@@ -70,7 +70,7 @@
                         
                         <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedOrganizationChangelog'">
                             <p class="aggregation-note">Aggregated across all components</p>
-                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" />
+                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" />
                         </div>
                     </n-tab-pane>
                 </n-tabs>
@@ -141,7 +141,8 @@ const fetchChangelog = async () => {
             dateFrom,
             dateTo,
             aggregated: aggregationType.value as 'NONE' | 'AGGREGATED',
-            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+            timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            installationType: store.getters.myuser?.installationType
         }
                 
         const result = await fetchOrganizationChangelogByDate(params)

--- a/ui/src/components/VulnerabilityAnalysis.vue
+++ b/ui/src/components/VulnerabilityAnalysis.vue
@@ -30,6 +30,11 @@
             :perspective-name="currentPerspectiveName"
             :show-is-latest-column="true"
         />
+        <kev-details-modal
+            v-model:show="showKevModal"
+            :cve-id="kevModalCveId"
+            :org-uuid="myorg?.uuid || ''"
+        />
         <div id="vulnAnalysisMain">
             <h4>Finding Analysis</h4>
             <n-spin :show="loading">
@@ -137,18 +142,21 @@ import { useNotification, NotificationType } from 'naive-ui'
 import CreateVulnAnalysisModal from './CreateVulnAnalysisModal.vue'
 import UpdateVulnAnalysisModal from './UpdateVulnAnalysisModal.vue'
 import ReleasesByCve from './ReleasesByCve.vue'
+import KevDetailsModal from './KevDetailsModal.vue'
 import Swal from 'sweetalert2'
 import commonFunctions from '@/utils/commonFunctions'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
 import { isSuppressedAnalysisState } from '@/constants/vulnAnalysis'
+import { kevFieldSelection, resolveKevCveId } from '@/utils/kevService'
 
 // GraphQL fragment for findings details (DRY)
-const FINDINGS_DETAILS_FRAGMENT = `
+const findingsDetailsFragment = (kevField: string) => `
     vulnerabilityDetails {
         purl
         vulnId
         severity
         analysisState
+        ${kevField}
         aliases {
             type
             aliasId
@@ -562,6 +570,14 @@ const handleAddScope = (row: any) => {
     showCreateAnalysisModal.value = true
 }
 
+const showKevModal = ref(false)
+const kevModalCveId = ref('')
+
+function openKevModal(row: any) {
+    kevModalCveId.value = resolveKevCveId({ id: row.findingId, aliases: row.findingAliases })
+    showKevModal.value = true
+}
+
 const columns: DataTableColumns<any> = [
     {
         title: 'Finding ID',
@@ -569,10 +585,22 @@ const columns: DataTableColumns<any> = [
         width: 180,
         render: (row: any) => {
             const findingId = createVulnerabilityLink(row.findingId)
-            
+            const parts: any[] = [findingId]
+
+            if (row.knownExploited) {
+                parts.push(h(NTag, {
+                    type: 'error',
+                    size: 'small',
+                    bordered: false,
+                    title: 'CISA Known Exploited Vulnerability — click for details',
+                    style: 'cursor: pointer; margin-left: 6px;',
+                    onClick: () => openKevModal(row)
+                }, { default: () => 'KEV' }))
+            }
+
             if (row.findingAliases && row.findingAliases.length > 0) {
                 const aliasesText = 'Aliases: ' + row.findingAliases.join(', ')
-                const infoIcon = h(NTooltip, {
+                parts.push(h(NTooltip, {
                     trigger: 'hover'
                 }, {
                     trigger: () => h(NIcon, {
@@ -580,11 +608,13 @@ const columns: DataTableColumns<any> = [
                         size: 16
                     }, () => h(Info20Regular)),
                     default: () => aliasesText
-                })
-                
-                return h('div', { style: 'display: flex; align-items: center;' }, [findingId, infoIcon])
+                }))
             }
-            
+
+            if (parts.length > 1) {
+                return h('div', { style: 'display: flex; align-items: center;' }, parts)
+            }
+
             return findingId
         }
     },
@@ -916,6 +946,8 @@ const fetchAnalysisRecords = async () => {
     }
     
     loading.value = true
+    const installationType = myuser.value?.installationType
+    const FINDINGS_DETAILS_FRAGMENT = findingsDetailsFragment(kevFieldSelection(installationType))
     try {
         // Get today's date in UTC format YYYY-MM-DD
         const today = new Date()
@@ -1051,7 +1083,8 @@ const fetchAnalysisRecords = async () => {
             // Fetch release data using ReleaseVulnerabilityService
             const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(
                 selectedRelease.value,
-                myorg.value.uuid
+                myorg.value.uuid,
+                installationType
             )
             // ReleaseVulnerabilityService returns processed DetailedMetric[] array
             processedMetrics = releaseData.vulnerabilityData || []
@@ -1066,7 +1099,8 @@ const fetchAnalysisRecords = async () => {
                         severity: m.severity,
                         analysisState: m.analysisState,
                         aliases: m.aliases || [],
-                        sources: m.sources || []
+                        sources: m.sources || [],
+                        knownExploited: m.knownExploited
                     })),
                 violationDetails: processedMetrics
                     .filter((m: any) => m.type === 'Violation')
@@ -1108,7 +1142,10 @@ const fetchAnalysisRecords = async () => {
         // Build a set of finding IDs and location pairs that exist in current scope's metrics
         const scopeFindingIds = new Set<string>()
         const scopeFindingLocations = new Map<string, Set<string>>() // findingId -> Set of locations
-        
+        // KEV-listed ids (vulnId + aliases) in scope; only populated on Pro,
+        // where the queries above selected knownExploited
+        const kevFindingIds = new Set<string>()
+
         if (metrics) {
             // Process vulnerabilities from metrics
             if (metrics.vulnerabilityDetails && Array.isArray(metrics.vulnerabilityDetails)) {
@@ -1117,6 +1154,10 @@ const fetchAnalysisRecords = async () => {
                     // Add aliases
                     const vulnAliases = vuln.aliases?.map((a: any) => a.aliasId) || []
                     vulnAliases.forEach((alias: string) => scopeFindingIds.add(alias))
+                    if (vuln.knownExploited) {
+                        kevFindingIds.add(vuln.vulnId)
+                        vulnAliases.forEach((alias: string) => kevFindingIds.add(alias))
+                    }
                     
                     // Track locations for this finding
                     if (!scopeFindingLocations.has(vuln.vulnId)) {
@@ -1282,8 +1323,16 @@ const fetchAnalysisRecords = async () => {
             }
         }
         
-        // Combine filtered existing analysis and new findings
-        analysisRecords.value = [...filteredExistingAnalysis, ...newFindings]
+        // Combine filtered existing analysis and new findings, stamping the
+        // KEV flag by findingId/alias match (copies — Apollo results may be frozen)
+        const markKev = (record: any) => {
+            if (kevFindingIds.size === 0 || record.findingType !== 'VULNERABILITY') return record
+            const ids = [record.findingId, ...(record.findingAliases || [])]
+            return ids.some((id: string) => id && kevFindingIds.has(id))
+                ? { ...record, knownExploited: true }
+                : record
+        }
+        analysisRecords.value = [...filteredExistingAnalysis, ...newFindings].map(markKev)
     } catch (error: any) {
         console.error('Error fetching vulnerability analysis records:', error)
         const errorMessage = commonFunctions.extractGraphQLErrorMessage(error)

--- a/ui/src/components/changelog/FindingChangesDisplay.vue
+++ b/ui/src/components/changelog/FindingChangesDisplay.vue
@@ -9,8 +9,9 @@
                 </n-tag>
             </div>
             
-            <FindingListSection title="New Findings" title-class="finding-new" key-prefix="appeared" :findings="appearedFindings" />
-            <FindingListSection title="Resolved Findings" title-class="finding-resolved" key-prefix="resolved" :findings="resolvedFindings" />
+            <FindingListSection title="New Findings" title-class="finding-new" key-prefix="appeared" :findings="appearedFindings" @kev-click="openKevModal" />
+            <FindingListSection title="Resolved Findings" title-class="finding-resolved" key-prefix="resolved" :findings="resolvedFindings" @kev-click="openKevModal" />
+            <kev-details-modal v-model:show="showKevModal" :cve-id="kevModalCveId" :org-uuid="orgUuid || ''" />
         </div>
         <div v-else class="empty-state">
             <div class="summary-tags">
@@ -23,17 +24,28 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { NTag } from 'naive-ui'
 import FindingListSection from './FindingListSection.vue'
+import KevDetailsModal from '../KevDetailsModal.vue'
 import { getSeverityIndex } from '../../utils/findingUtils'
+import { resolveKevCveId } from '../../utils/kevService'
 import type { ReleaseFindingChanges } from '../../types/changelog-sealed'
 
 interface Props {
     findingChanges?: ReleaseFindingChanges
+    orgUuid?: string
 }
 
 const props = defineProps<Props>()
+
+const showKevModal = ref(false)
+const kevModalCveId = ref('')
+
+function openKevModal(finding: any) {
+    kevModalCveId.value = resolveKevCveId({ id: finding.findingId, aliases: finding.aliases })
+    showKevModal.value = true
+}
 
 const summary = computed(() => {
     if (!props.findingChanges) return null
@@ -61,7 +73,8 @@ const normalizeVuln = (v: any) => ({
     aliases: Array.isArray(v.aliases) ? v.aliases.map((a: any) => typeof a === 'string' ? a : a.aliasId) : [],
     type: 'VULN',
     typeLabel: 'VULNERABILITY',
-    analysisState: v.analysisState || null
+    analysisState: v.analysisState || null,
+    knownExploited: !!v.knownExploited
 })
 
 const normalizeViolation = (v: any) => ({

--- a/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
+++ b/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
@@ -46,7 +46,8 @@
             </div>
             
             <FindingListSection title="New Findings" title-class="finding-new" key-prefix="new" :findings="newFindings" :rich-aliases="true"
-                :description="isOrgLevelView ? 'Findings that appear for the first time across the entire organization in this period.' : 'Findings introduced in this component for the first time in this period.'">
+                :description="isOrgLevelView ? 'Findings that appear for the first time across the entire organization in this period.' : 'Findings introduced in this component for the first time in this period.'"
+                @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getAppearedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
@@ -55,7 +56,8 @@
             </FindingListSection>
 
             <FindingListSection v-if="isOrgLevelView" title="Partially Resolved" title-class="finding-partial" key-prefix="partial" :findings="partiallyResolvedFindings" :rich-aliases="true"
-                description="Findings resolved in some components but still present in others within this period.">
+                description="Findings resolved in some components but still present in others within this period."
+                @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
@@ -64,7 +66,8 @@
             </FindingListSection>
 
             <FindingListSection v-if="isOrgLevelView" title="Inherited Technical Debt" title-class="finding-inherited" key-prefix="inherited" :findings="inheritedTechnicalDebtFindings" :rich-aliases="true"
-                description="Findings that existed before this period and remain unresolved — pre-existing technical debt carried across the entire date range.">
+                description="Findings that existed before this period and remain unresolved — pre-existing technical debt carried across the entire date range."
+                @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getInheritedDebtContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
@@ -73,7 +76,8 @@
             </FindingListSection>
 
             <FindingListSection v-if="!isOrgLevelView" title="Still Present" title-class="finding-present" key-prefix="present" :findings="stillPresentFindings" :rich-aliases="true"
-                description="Findings that existed before this period and remain unresolved in this component.">
+                description="Findings that existed before this period and remain unresolved in this component."
+                @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getStillPresentContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
@@ -82,13 +86,16 @@
             </FindingListSection>
 
             <FindingListSection :title="isOrgLevelView ? 'Fully Resolved' : 'Resolved'" title-class="finding-resolved" key-prefix="resolved" :findings="fullyResolvedFindings" :rich-aliases="true"
-                :description="isOrgLevelView ? 'Findings resolved across all affected components and no longer present anywhere in this period.' : 'Findings that were present before and are no longer detected in this component.'">
+                :description="isOrgLevelView ? 'Findings resolved across all affected components and no longer present anywhere in this period.' : 'Findings that were present before and are no longer detected in this component.'"
+                @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
                     </div>
                 </template>
             </FindingListSection>
+
+            <kev-details-modal v-model:show="showKevModal" :cve-id="kevModalCveId" :org-uuid="orgUuid || ''" />
         </div>
         <div v-else class="empty-state">
             <div class="summary-tags">
@@ -101,10 +108,12 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { NTag, NTooltip } from 'naive-ui'
 import FindingListSection from './FindingListSection.vue'
+import KevDetailsModal from '../KevDetailsModal.vue'
 import { getSeverityIndex } from '../../utils/findingUtils'
+import { resolveKevCveId } from '../../utils/kevService'
 import type { 
     FindingChangesWithAttribution,
     VulnerabilityWithAttribution,
@@ -116,11 +125,20 @@ import type {
 interface Props {
     findingChanges?: FindingChangesWithAttribution
     showAttribution?: boolean
+    orgUuid?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
     showAttribution: true
 })
+
+const showKevModal = ref(false)
+const kevModalCveId = ref('')
+
+function openKevModal(finding: any) {
+    kevModalCveId.value = resolveKevCveId({ id: finding.findingId, aliases: finding.aliases })
+    showKevModal.value = true
+}
 
 type AttributionSegment = {
     text: string
@@ -132,6 +150,7 @@ type NormalizedFinding = {
     affectedComponent: string
     severity?: string
     aliases?: Array<{ aliasId: string }>
+    knownExploited?: boolean
     type: 'VULN' | 'VIOLATION' | 'WEAKNESS'
     typeLabel: string
     appearedIn: any[]
@@ -157,6 +176,7 @@ const normalizeVulnerability = (vuln: VulnerabilityWithAttribution): NormalizedF
     affectedComponent: vuln.purl,
     severity: vuln.severity,
     aliases: vuln.aliases,
+    knownExploited: !!vuln.knownExploited,
     type: 'VULN',
     typeLabel: 'VULNERABILITY',
     appearedIn: vuln.appearedIn,

--- a/ui/src/components/changelog/FindingListSection.vue
+++ b/ui/src/components/changelog/FindingListSection.vue
@@ -18,6 +18,7 @@
                         </n-tag>
                         <n-tag :type="getFindingTypeTagType(finding.type)" size="small">{{ finding.typeLabel }}</n-tag>
                         <strong><a v-if="getFindingUrl(finding.findingId)" :href="getFindingUrl(finding.findingId)!" target="_blank" rel="noopener noreferrer" class="finding-link" @click.prevent="openExternalLink(getFindingUrl(finding.findingId)!)">{{ finding.findingId }}</a><span v-else>{{ finding.findingId }}</span></strong>
+                        <n-tag v-if="finding.knownExploited" type="error" size="small" :bordered="false" class="kev-tag" title="CISA Known Exploited Vulnerability — click for details" @click="emit('kev-click', finding)">KEV</n-tag>
                         <n-tooltip v-if="finding.aliases && finding.aliases.length > 0" trigger="hover">
                             <template #trigger>
                                 <n-icon class="alias-icon" :size="16"><Info20Regular /></n-icon>
@@ -60,6 +61,7 @@
                             </n-tag>
                             <n-tag :type="getFindingTypeTagType(finding.type)" size="small">{{ finding.typeLabel }}</n-tag>
                             <strong><a v-if="getFindingUrl(finding.findingId)" :href="getFindingUrl(finding.findingId)!" target="_blank" rel="noopener noreferrer" class="finding-link" @click.prevent="openExternalLink(getFindingUrl(finding.findingId)!)">{{ finding.findingId }}</a><span v-else>{{ finding.findingId }}</span></strong>
+                            <n-tag v-if="finding.knownExploited" type="error" size="small" :bordered="false" class="kev-tag" title="CISA Known Exploited Vulnerability — click for details" @click="emit('kev-click', finding)">KEV</n-tag>
                             <n-tooltip v-if="finding.aliases && finding.aliases.length > 0" trigger="hover">
                                 <template #trigger>
                                     <n-icon class="alias-icon" :size="16"><Info20Regular /></n-icon>
@@ -108,6 +110,10 @@ const props = withDefaults(defineProps<Props>(), {
     description: undefined
 })
 
+const emit = defineEmits<{
+    (e: 'kev-click', finding: any): void
+}>()
+
 const showSuppressed = ref(false)
 
 const isSuppressed = (finding: any): boolean => {
@@ -154,6 +160,10 @@ const getAnalysisStateLabel = (state: string | null | undefined): string => {
     &:hover {
         opacity: 0.9;
     }
+}
+
+.kev-tag {
+    cursor: pointer;
 }
 
 .suppressed-section {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1784,7 +1784,8 @@ const storeObject : any = {
                 release2: params.release2,
                 org: params.org,
                 aggregated: params.aggregated || 'AGGREGATED',
-                timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone
+                timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+                installationType: context.getters.myuser?.installationType
             })
         },
         async updateRelease (context: any, release: any) {

--- a/ui/src/types/changelog-attribution.ts
+++ b/ui/src/types/changelog-attribution.ts
@@ -59,6 +59,7 @@ export interface VulnerabilityWithAttribution {
     purl: string
     severity: string
     aliases: Array<{ aliasId: string }>
+    knownExploited?: boolean
     resolvedIn: ComponentAttribution[]
     appearedIn: ComponentAttribution[]
     presentIn: ComponentAttribution[]

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -51,6 +51,7 @@ export interface ReleaseVulnerabilityInfo {
     purl?: string
     severity?: string
     aliases?: { aliasId: string }[]
+    knownExploited?: boolean
 }
 
 /**

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -5,6 +5,13 @@
 import { gql } from '@apollo/client/core'
 import graphqlClient from './graphql'
 import { ComponentChangelog, OrganizationChangelog } from '../types/changelog-sealed'
+import { kevFieldSelection } from './kevService'
+
+// Fragments selecting vulnerability findings are functions of the Pro-only
+// knownExploited selection (kevFieldSelection: '' on OSS), so the flag rides
+// the main changelog query on Pro instead of re-running the expensive
+// changelog computation through a mirror query. This file stays store-free:
+// callers pass installationType in.
 
 // ========== GraphQL Field Fragments ==========
 
@@ -37,7 +44,7 @@ const RELEASE_SBOM_CHANGES_FRAGMENT = `
     }
 `
 
-const RELEASE_FINDING_CHANGES_FRAGMENT = `
+const releaseFindingChangesFragment = (kevField: string) => `
     appearedCount
     resolvedCount
     appearedVulnerabilities {
@@ -48,6 +55,7 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
             aliasId
         }
         analysisState
+        ${kevField}
     }
     resolvedVulnerabilities {
         vulnId
@@ -57,6 +65,7 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
             aliasId
         }
         analysisState
+        ${kevField}
     }
     appearedViolations {
         type
@@ -84,7 +93,7 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
     }
 `
 
-const NONE_RELEASE_CHANGES_FRAGMENT = `
+const noneReleaseChangesFragment = (kevField: string) => `
     releaseUuid
     version
     lifecycle
@@ -96,7 +105,7 @@ const NONE_RELEASE_CHANGES_FRAGMENT = `
         ${RELEASE_SBOM_CHANGES_FRAGMENT}
     }
     findingChanges {
-        ${RELEASE_FINDING_CHANGES_FRAGMENT}
+        ${releaseFindingChangesFragment(kevField)}
     }
 `
 
@@ -144,7 +153,7 @@ const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
     }
 `
 
-const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
+const findingChangesWithAttributionFragment = (kevField: string) => `
     totalAppeared
     totalResolved
     vulnerabilities {
@@ -154,6 +163,7 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         aliases {
             aliasId
         }
+        ${kevField}
         isNetAppeared
         isNetResolved
         isStillPresent
@@ -217,18 +227,18 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
 
 // ========== Shared Component Changelog Fragments ==========
 
-const NONE_BRANCH_CHANGES_FRAGMENT = `
+const noneBranchChangesFragment = (kevField: string) => `
     branchUuid
     branchName
     componentUuid
     componentName
     changeType
     releases {
-        ${NONE_RELEASE_CHANGES_FRAGMENT}
+        ${noneReleaseChangesFragment(kevField)}
     }
 `
 
-const NONE_CHANGELOG_FIELDS = `
+const noneChangelogFields = (kevField: string) => `
     componentUuid
     componentName
     orgUuid
@@ -239,11 +249,11 @@ const NONE_CHANGELOG_FIELDS = `
         ${RELEASE_INFO_FRAGMENT}
     }
     branches {
-        ${NONE_BRANCH_CHANGES_FRAGMENT}
+        ${noneBranchChangesFragment(kevField)}
     }
 `
 
-const NONE_PRODUCT_CHANGELOG_FIELDS = `
+const noneProductChangelogFields = (kevField: string) => `
     componentUuid
     componentName
     orgUuid
@@ -259,12 +269,12 @@ const NONE_PRODUCT_CHANGELOG_FIELDS = `
         lifecycle
         createdDate
         branches {
-            ${NONE_BRANCH_CHANGES_FRAGMENT}
+            ${noneBranchChangesFragment(kevField)}
         }
     }
 `
 
-const AGGREGATED_CHANGELOG_FIELDS = `
+const aggregatedChangelogFields = (kevField: string) => `
     componentUuid
     componentName
     orgUuid
@@ -292,7 +302,7 @@ const AGGREGATED_CHANGELOG_FIELDS = `
         ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
     }
     findingChanges {
-        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+        ${findingChangesWithAttributionFragment(kevField)}
     }
 `
 
@@ -307,7 +317,9 @@ export async function fetchComponentChangelog(params: {
     org: string
     aggregated: 'NONE' | 'AGGREGATED'
     timeZone?: string
+    installationType?: string
 }): Promise<ComponentChangelog> {
+    const kevField = kevFieldSelection(params.installationType)
     const response = await graphqlClient.query({
         query: gql`
             query FetchComponentChangelog(
@@ -326,13 +338,13 @@ export async function fetchComponentChangelog(params: {
                 ) {
                     __typename
                     ... on NoneChangelog {
-                        ${NONE_CHANGELOG_FIELDS}
+                        ${noneChangelogFields(kevField)}
                     }
                     ... on NoneProductChangelog {
-                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
+                        ${noneProductChangelogFields(kevField)}
                     }
                     ... on AggregatedChangelog {
-                        ${AGGREGATED_CHANGELOG_FIELDS}
+                        ${aggregatedChangelogFields(kevField)}
                     }
                 }
             }
@@ -361,7 +373,9 @@ export async function fetchComponentChangelogByDate(params: {
     timeZone?: string
     dateFrom: string
     dateTo: string
+    installationType?: string
 }): Promise<ComponentChangelog> {
+    const kevField = kevFieldSelection(params.installationType)
     const response = await graphqlClient.query({
         query: gql`
             query FetchComponentChangelogByDate(
@@ -384,13 +398,13 @@ export async function fetchComponentChangelogByDate(params: {
                 ) {
                     __typename
                     ... on NoneChangelog {
-                        ${NONE_CHANGELOG_FIELDS}
+                        ${noneChangelogFields(kevField)}
                     }
                     ... on NoneProductChangelog {
-                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
+                        ${noneProductChangelogFields(kevField)}
                     }
                     ... on AggregatedChangelog {
-                        ${AGGREGATED_CHANGELOG_FIELDS}
+                        ${aggregatedChangelogFields(kevField)}
                     }
                 }
             }
@@ -420,7 +434,9 @@ export async function fetchOrganizationChangelogByDate(params: {
     dateTo: string
     aggregated: 'NONE' | 'AGGREGATED'
     timeZone?: string
+    installationType?: string
 }): Promise<OrganizationChangelog> {
+    const kevField = kevFieldSelection(params.installationType)
     const response = await graphqlClient.query({
         query: gql`
             query FetchOrganizationChangelogByDate(
@@ -447,7 +463,7 @@ export async function fetchOrganizationChangelogByDate(params: {
                         components {
                             __typename
                             ... on NoneChangelog {
-                                ${NONE_CHANGELOG_FIELDS}
+                                ${noneChangelogFields(kevField)}
                             }
                         }
                     }
@@ -458,14 +474,14 @@ export async function fetchOrganizationChangelogByDate(params: {
                         components {
                             __typename
                             ... on AggregatedChangelog {
-                                ${AGGREGATED_CHANGELOG_FIELDS}
+                                ${aggregatedChangelogFields(kevField)}
                             }
                         }
                         sbomChanges {
                             ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
                         }
                         findingChanges {
-                            ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+                            ${findingChangesWithAttributionFragment(kevField)}
                         }
                     }
                 }

--- a/ui/src/utils/kevService.ts
+++ b/ui/src/utils/kevService.ts
@@ -3,8 +3,13 @@
  *
  * Pro-only (like approvalRequests): the knownExploited field and the
  * kevRecordDetails query are absent from the OSS schema, so callers must
- * gate on installationType !== 'OSS' — never fold these fields into the
- * shared release/metrics fragments.
+ * gate on installationType !== 'OSS' — never fold these fields into
+ * shared static fragments. Two sanctioned patterns:
+ *  - a separate Pro-only mirror query (releaseKevFlags/artifactKevFlags
+ *    below) when the primary fetch is cheap or its fragments are shared;
+ *  - conditional inclusion via kevFieldSelection() when the selection set
+ *    is built per call and the underlying query is expensive to re-run
+ *    (changelog diffs, findingsPerDay, mostVulnerableComponentsPerOrg).
  */
 
 import gql from 'graphql-tag'
@@ -26,6 +31,16 @@ export interface KevRecordDetails {
 
 export function isProInstallation(installationType?: string): boolean {
     return !!installationType && installationType !== 'OSS'
+}
+
+/**
+ * GraphQL selection snippet for the Pro-only knownExploited field: the
+ * field name on Pro, empty string on OSS (or while installationType is
+ * still unknown), so OSS queries never reference a field their schema
+ * lacks. For interpolation into selection sets built per call.
+ */
+export function kevFieldSelection(installationType?: string): string {
+    return isProInstallation(installationType) ? 'knownExploited' : ''
 }
 
 const RELEASE_KEV_FLAGS_GQL = gql`

--- a/ui/src/utils/metrics.ts
+++ b/ui/src/utils/metrics.ts
@@ -20,7 +20,8 @@ export type DetailedMetric = {
   analysisState?: string
   analysisDate?: string
   attributedAt?: string
-  // Pro-only CISA KEV flag, stamped post-fetch by kevService.annotateKnownExploited
+  // Pro-only CISA KEV flag: stamped post-fetch by kevService.annotateKnownExploited,
+  // or carried straight from a Pro query via kevFieldSelection
   knownExploited?: boolean
 }
 
@@ -105,7 +106,8 @@ export function processMetricsData(metrics: any): DetailedMetric[] {
         fingerprint: '-',
         analysisState: vuln.analysisState,
         analysisDate: vuln.analysisDate,
-        attributedAt: vuln.attributedAt
+        attributedAt: vuln.attributedAt,
+        knownExploited: !!vuln.knownExploited
       })
     })
   }


### PR DESCRIPTION
## Summary

Follow-up to #136: extends CISA KEV visibility to the four remaining UI surfaces:

- **Vulnerability Analysis** (`VulnerabilityAnalysis.vue`) — KEV tag next to the finding id, click opens the KEV details modal.
- **Component & Organization changelogs** — KEV tag on vulnerability findings in all changelog sections (new / partially resolved / inherited debt / still present / resolved), both NONE and AGGREGATED modes.
- **AppHome** most-vulnerable-components widget — vulnerabilities in the drill-in modal carry the KEV badge.
- **Findings-over-time chart** drilldown — same.

## Design: conditional field inclusion instead of a mirror query

#136 used a small mirror query (`fetchReleaseKevVulnIds`) to keep OSS schemas untouched. That pattern is wrong for these surfaces: they sit on expensive backend computations (changelog diffing, `findingsPerDay`, `mostVulnerableComponentsPerOrg`), and a mirror query would re-run each computation in full.

Instead, a new `kevFieldSelection(installationType)` helper returns `'knownExploited'` on Pro and `''` on OSS (or while installationType is unknown), so the flag rides the main query at zero extra cost and OSS queries never reference a field their schema lacks. This is safe because `installationType` comes from the same backend that serves the schema. Both sanctioned patterns are now documented in `kevService.ts`.

Notes:

- `changelogQueries.ts` fragments became functions of the kev field; the file stays store-free — callers pass `installationType` in.
- The vuln-analysis DTO has no `knownExploited`, so analysis rows are stamped by matching `findingId`/aliases against KEV ids collected from the scope's `vulnerabilityDetails` (Pro-only by construction — the set is empty on OSS).
- Rows are annotated via copies, not mutation (Apollo result freezing).

## Test plan

- [x] `npm run build` passes (lint is broken at main, pre-existing)
- [ ] Sandbox verify: KEV tag + modal on Vulnerability Analysis, component changelog, org changelog, AppHome widget, findings-over-time drilldown
- [ ] Confirm no `knownExploited` field errors on OSS (field omitted when installationType ≠ Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)