### PR TITLE
Clarify Sentinel channel label: Microsoft Sentinel (Azure Log Analytics)

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -236,7 +236,7 @@
                 <div>
                     <div class="info-banner-title">Notification subscriptions</div>
                     <div class="info-banner-body">
-                        Rules that route security and operational events to your messaging channels. Channels themselves are configured as Slack / Teams / Webhook / Sentinel integrations in the Catalog.
+                        Rules that route security and operational events to your messaging channels. Channels themselves are configured as Slack / Teams / Webhook / Microsoft Sentinel integrations in the Catalog.
                     </div>
                 </div>
             </div>

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -97,7 +97,7 @@ export const TYPE_LABELS: Record<string, string> = {
     SLACK: 'Slack',
     WEBHOOK: 'Webhook',
     MS_TEAMS: 'MS Teams',
-    SENTINEL: 'Sentinel',
+    SENTINEL: 'Microsoft Sentinel',
     EMAIL: 'Email',
 }
 
@@ -106,7 +106,9 @@ export const typeOptions = [
     { label: 'Slack', value: 'SLACK' },
     { label: 'Microsoft Teams', value: 'MS_TEAMS' },
     { label: 'Generic Webhook', value: 'WEBHOOK' },
-    { label: 'Azure Sentinel', value: 'SENTINEL' },
+    // Ships to an Azure Log Analytics workspace — Sentinel is the usual
+    // consumer but any Log Analytics workspace works.
+    { label: 'Microsoft Sentinel (Azure Log Analytics)', value: 'SENTINEL' },
 ]
 
 export const webhookAuthOptions = [


### PR DESCRIPTION
## Summary
- Resolves the deferred Sentinel-channel naming decision: keep the `SENTINEL` enum value (zero migration), clarify the user-facing labels instead.
- Channel-type dropdown option: "Azure Sentinel" → "Microsoft Sentinel (Azure Log Analytics)".
- Type chip label: "Sentinel" → "Microsoft Sentinel".

The channel ships events to an Azure Log Analytics workspace; Sentinel is the SIEM layered on top, but any Log Analytics workspace works. The label now says both, while keeping the brand name security teams look for.

## Test plan
- [x] `npm run build` green (label-only change in `notificationsCommon.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)