### PR TITLE
fix(rearm-helm): replace bare CP-1252 em-dash with UTF-8 in chart comments

### DIFF
--- a/deploy/helm/rearm-helm/templates/backend-deployment.yaml
+++ b/deploy/helm/rearm-helm/templates/backend-deployment.yaml
@@ -112,7 +112,7 @@ spec:
               protocol: TCP
           # /api/healthCheck runs a real DB query (fetches the external-proj
           # org), so it returns OK only once Spring is up AND the DB is
-          # reachable — exactly what startup/readiness should mean.
+          # reachable â€” exactly what startup/readiness should mean.
           # startupProbe covers slow boot (Flyway etc.); while it runs both
           # readiness and liveness are suppressed.
           startupProbe:

--- a/deploy/helm/rearm-helm/templates/ingress.yaml
+++ b/deploy/helm/rearm-helm/templates/ingress.yaml
@@ -70,7 +70,7 @@ spec:
 {{- end}}
 {{- if .Values.hsts.enabled }}
 ---
-# HSTS is emitted at the TLS edge (Traefik), not the UI nginx — nginx only sees
+# HSTS is emitted at the TLS edge (Traefik), not the UI nginx â€” nginx only sees
 # HTTP because TLS terminates here (certResolver le) or at an upstream LB
 # (traefikBehindLb). forceSTSHeader makes Traefik send the header even when it
 # sees the request as HTTP (the behind-LB case).


### PR DESCRIPTION
## Summary

- `backend-deployment.yaml:115` and `ingress.yaml:73` each contain a stray `0x97` byte (CP-1252 em-dash) inside a comment, introduced in commit e2cf22a7 (`fix(rearm-helm): hardening settings and graceful updates`).
- Helm template rendering aborts on strict-UTF-8 stacks (the rearm-cd reconciler is one) with:

  ```
  Error: UPGRADE FAILED: YAML parse error on rearm/templates/backend-deployment.yaml:
  error converting YAML to JSON: yaml: invalid leading UTF-8 octet
  ```

  This is currently blocking the rearm-cd controller on `rearmce.rearmhq.com` from rolling forward to any post-e2cf22a7 chart — observed today on a CE bump attempt.
- Replace `0x97` with the canonical UTF-8 em-dash (`0xe2 0x80 0x94`) in both files. Preserves the author's intended punctuation; just makes the byte sequence valid UTF-8.

Diff is 2 lines (one per file). Both files round-trip clean now:

```bash
python3 -c "open('deploy/helm/rearm-helm/templates/backend-deployment.yaml','rb').read().decode('utf-8')"
python3 -c "open('deploy/helm/rearm-helm/templates/ingress.yaml','rb').read().decode('utf-8')"
```

## Test plan

- [x] Both modified files decode cleanly as UTF-8
- [ ] After merge: re-trigger the failed CE chart bump on `rearmce.rearmhq.com` (controlling ReARM → switchfeatureset → confirm `rearm-cd-rearm-cd-0` advances past "Replacing tags" without the YAML parse error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)