### PR TITLE
feat(kev): per-org KEV backend on CE (catch-up for rearm-core #221)

### DIFF
--- a/backend/src/main/java/io/reliza/model/IntegrationData.java
+++ b/backend/src/main/java/io/reliza/model/IntegrationData.java
@@ -49,7 +49,16 @@ public class IntegrationData extends RelizaDataParent implements RelizaObject {
 		// non-destination types (DEPENDENCYTRACK/GITHUB/…) at its gate.
 		EMAIL,
 		WEBHOOK,
-		SENTINEL;
+		SENTINEL,
+		// KEV catalog sources (V54 per-org refactor). CISA_KEV has no
+		// credentials (public feed) and is auto-created enabled per org;
+		// VULNCHECK_KEV stores the per-org VulnCheck API token in
+		// {@link IntegrationData#secret} (encrypted via EncryptionService,
+		// same path as DEPENDENCYTRACK). Sync orchestration in
+		// KevCatalogSyncService iterates enabled integrations of these
+		// two types per org.
+		CISA_KEV,
+		VULNCHECK_KEV;
 
 		private IntegrationType () {}
 	}

--- a/backend/src/main/java/io/reliza/model/KevAssertion.java
+++ b/backend/src/main/java/io/reliza/model/KevAssertion.java
@@ -22,18 +22,21 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 
 /**
  * One assertion that a {@link KevSource} reports {@code cveId} as known to
- * be exploited. GLOBAL — no org column; the catalogs are public,
- * instance-wide data, and org-scoped surfaces join by {@code cve_id} at
- * read time.
+ * be exploited, scoped to a single org (V54 per-org refactor). The token
+ * to fetch the catalog (where applicable, e.g. VulnCheck) lives on the
+ * matching per-org {@code Integration} row.
  *
- * <p>Unique on {@code (source, cve_id)}: each source asserts a CVE at most
- * once, and multiple sources asserting the same CVE produce multiple rows.
+ * <p>Unique on {@code (org_id, source, cve_id)}: each (org, source) pair
+ * asserts a CVE at most once; one org's CISA + VulnCheck assertions for the
+ * same CVE produce two rows; two orgs that both source from CISA produce
+ * two rows (deliberate duplication for clean isolation — the user accepted
+ * the trade for SaaS multi-tenant correctness).
  *
  * <p>{@code revokedDate} is the soft-delete marker — set when a source
- * stops reporting the CVE, never deleted. A CVE with any assertion (even
- * revoked) still reads as known-exploited; the revocation is surfaced as a
- * note. The full per-source entry lives in {@code recordData} as
- * {@link KevAssertionData}.
+ * stops reporting the CVE within an org, never deleted. A CVE with any
+ * assertion (even revoked) in this org still reads as known-exploited; the
+ * revocation is surfaced as a note. The full per-source entry lives in
+ * {@code recordData} as {@link KevAssertionData}.
  *
  * <p>{@link Version} on {@code revision}: Hibernate owns the increment.
  */
@@ -57,6 +60,9 @@ public class KevAssertion implements Serializable, RelizaEntity {
 
 	@Column(nullable = false)
 	private ZonedDateTime lastUpdatedDate = ZonedDateTime.now();
+
+	@Column(nullable = false, name = "org_id")
+	private UUID orgId;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -112,6 +118,14 @@ public class KevAssertion implements Serializable, RelizaEntity {
 
 	public void setLastUpdatedDate(ZonedDateTime lastUpdatedDate) {
 		this.lastUpdatedDate = lastUpdatedDate;
+	}
+
+	public UUID getOrgId() {
+		return orgId;
+	}
+
+	public void setOrgId(UUID orgId) {
+		this.orgId = orgId;
 	}
 
 	public KevSource getSource() {

--- a/backend/src/main/java/io/reliza/model/SystemInfoData.java
+++ b/backend/src/main/java/io/reliza/model/SystemInfoData.java
@@ -54,7 +54,8 @@ public class SystemInfoData extends RelizaDataParent{
 	private UUID defaultOrg;
 	private ZonedDateTime lastDtrackSync;
 	private AzureCreds azureCredentials;
-	private String vulncheckKevToken;
+	// vulncheckKevToken (instance-global) removed in V54 KEV per-org refactor;
+	// per-org VulnCheck tokens now live on VULNCHECK_KEV Integration rows.
 	private String license;
 	private ZonedDateTime licenseStartDate;
 	private ZonedDateTime licenseEndDate;

--- a/backend/src/main/java/io/reliza/repositories/IntegrationRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/IntegrationRepository.java
@@ -35,4 +35,9 @@ public interface IntegrationRepository extends CrudRepository<Integration, UUID>
 			nativeQuery = true)
 	List<String> listOrgsWithDtrackIntegration();
 
+	@Query(
+			value = VariableQueries.LIST_ENABLED_INTEGRATIONS_BY_TYPE,
+			nativeQuery = true)
+	List<Integration> listEnabledIntegrationsByType(String typeAsString);
+
 }

--- a/backend/src/main/java/io/reliza/repositories/KevAssertionRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/KevAssertionRepository.java
@@ -16,32 +16,40 @@ import io.reliza.model.KevSource;
 
 public interface KevAssertionRepository extends CrudRepository<KevAssertion, UUID> {
 
-	/** Every assertion for a CVE, across all sources (active and revoked) —
-	 *  drives the per-source detail surface. */
-	List<KevAssertion> findByCveIdOrderBySourceAsc(String cveId);
+	/** Every assertion for a CVE within one org, across all sources (active
+	 *  and revoked) — drives the per-source detail surface. */
+	List<KevAssertion> findByOrgIdAndCveIdOrderBySourceAsc(UUID orgId, String cveId);
 
-	/** This source's current assertions, for the reconcile diff. */
-	List<KevAssertion> findBySource(KevSource source);
+	/** This org+source's current assertions, for the reconcile diff. */
+	List<KevAssertion> findByOrgIdAndSource(UUID orgId, KevSource source);
 
 	/**
 	 * Bulk membership probe for the {@code knownExploited} data loader — one
-	 * round trip for all CVE ids on a findings page. Distinct cve_id, and
-	 * deliberately NOT filtered on {@code revoked_date}: a CVE that was ever
-	 * asserted stays KEV-listed, so a withdrawn/poisoned feed can't flip the
-	 * answer to false.
+	 * round trip for all CVE ids on a findings page, scoped to one org.
+	 * Distinct cve_id, and deliberately NOT filtered on {@code revoked_date}:
+	 * a CVE that was ever asserted (in this org) stays KEV-listed, so a
+	 * withdrawn/poisoned feed can't flip the answer to false.
 	 */
 	@Query(
-		value = "SELECT DISTINCT cve_id FROM rearm.kev_assertions WHERE cve_id IN (:cveIds)",
+		value = "SELECT DISTINCT cve_id FROM rearm.kev_assertions WHERE org_id = :orgId AND cve_id IN (:cveIds)",
 		nativeQuery = true)
-	List<String> findExistingCveIds(@Param("cveIds") Collection<String> cveIds);
+	List<String> findExistingCveIdsForOrg(@Param("orgId") UUID orgId, @Param("cveIds") Collection<String> cveIds);
 
 	/**
-	 * Every CVE asserted by any source (active or revoked). Read once per
-	 * sync to tell a genuinely new KEV (no prior assertion anywhere → emit a
-	 * KEV_ADDED event) from one a different source already listed.
+	 * Every CVE asserted by any source within one org (active or revoked).
+	 * Read once per per-org sync to tell a genuinely new KEV (no prior
+	 * assertion in this org → emit a KEV_ADDED event) from one a different
+	 * source in the same org already listed.
 	 */
 	@Query(
-		value = "SELECT DISTINCT cve_id FROM rearm.kev_assertions",
+		value = "SELECT DISTINCT cve_id FROM rearm.kev_assertions WHERE org_id = :orgId",
 		nativeQuery = true)
-	List<String> findAllDistinctCveIds();
+	List<String> findAllDistinctCveIdsForOrg(@Param("orgId") UUID orgId);
+
+	/**
+	 * Count of assertion rows in one org. Used by the bootstrap-silent check
+	 * in KevCatalogSyncService — first sync for an org skips the KEV_ADDED
+	 * event pass to avoid storming over years of old listings.
+	 */
+	long countByOrgId(UUID orgId);
 }

--- a/backend/src/main/java/io/reliza/repositories/VariableQueries.java
+++ b/backend/src/main/java/io/reliza/repositories/VariableQueries.java
@@ -1098,8 +1098,22 @@ class VariableQueries {
 	protected static final String LIST_INTEGRATIONS_BY_ORG = "select * from rearm.integrations a where a.record_data->>'org' = :orgUuidAsString";
 
 	protected static final String LIST_ORGS_WITH_DTRACK_INTEGRATION = """
-			select distinct a.record_data->>'org' as org_uuid from rearm.integrations a 
+			select distinct a.record_data->>'org' as org_uuid from rearm.integrations a
 			where a.record_data->>'type' = 'DEPENDENCYTRACK'
+			and a.record_data->>'identifier' = 'base'
+		""";
+
+	/**
+	 * Per-org KEV sync orchestration (V54): list enabled integrations of one
+	 * type across all orgs. KevCatalogSyncService iterates the result and
+	 * dispatches one fetch + reconcile per row (per-org credential resolved
+	 * from the integration's encrypted secret for VULNCHECK_KEV; ignored for
+	 * CISA_KEV's public feed).
+	 */
+	protected static final String LIST_ENABLED_INTEGRATIONS_BY_TYPE = """
+			select * from rearm.integrations a
+			where a.record_data->>'type' = :typeAsString
+			and coalesce(a.record_data->>'isEnabled', 'true') = 'true'
 			and a.record_data->>'identifier' = 'base'
 		""";
 

--- a/backend/src/main/java/io/reliza/service/IntegrationService.java
+++ b/backend/src/main/java/io/reliza/service/IntegrationService.java
@@ -285,6 +285,44 @@ public class IntegrationService {
 			.collect(Collectors.toList());
 	}
 	
+	/**
+	 * KEV per-org integration upsert (V54). Creates the {@code (org, type,
+	 * "base")} integration row if missing, otherwise patches the existing
+	 * row. {@code isEnabled} replaces the flag; {@code rawToken} (PLAINTEXT
+	 * — encrypted here) replaces the secret when non-null, leaves it
+	 * untouched when null. Pass {@code rawToken = ""} to explicitly clear
+	 * the secret. {@code type} must be {@code CISA_KEV} or
+	 * {@code VULNCHECK_KEV}.
+	 */
+	@Transactional
+	public IntegrationData upsertKevIntegration(UUID orgUuid, IntegrationType type,
+			boolean isEnabled, String rawToken, WhoUpdated wu) {
+		if (type != IntegrationType.CISA_KEV && type != IntegrationType.VULNCHECK_KEV) {
+			throw new IllegalArgumentException("upsertKevIntegration: type must be CISA_KEV or VULNCHECK_KEV, was " + type);
+		}
+		String identifier = CommonVariables.BASE_INTEGRATION_IDENTIFIER;
+		Optional<Integration> existing = repository.findIntegrationByOrgTypeIdentifier(
+				orgUuid.toString(), type.name(), identifier);
+		Integration i = existing.orElseGet(Integration::new);
+		IntegrationData id = existing.isPresent()
+				? IntegrationData.dataFromRecord(existing.get())
+				: new IntegrationData();
+		if (!existing.isPresent()) {
+			id.setOrg(orgUuid);
+			id.setType(type);
+			id.setIdentifier(identifier);
+		}
+		id.setIsEnabled(isEnabled);
+		if (rawToken != null) {
+			id.setSecret(rawToken.isEmpty() ? null : encryptionService.encrypt(rawToken));
+		}
+		saveIntegration(i, Utils.dataToRecord(id), wu);
+		// Re-read so the returned object has the uuid stamped by saveIntegration
+		// (existing case kept it; new case generated one).
+		IntegrationData out = IntegrationData.dataFromRecord(i);
+		return out;
+	}
+
 	@Transactional
 	public Integration createIntegration (String identifier, UUID organization, IntegrationType type,
 			URI uri, String secret, String schedule, URI frontendUri, WhoUpdated wu) {

--- a/backend/src/main/java/io/reliza/service/KevAssertionService.java
+++ b/backend/src/main/java/io/reliza/service/KevAssertionService.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -28,17 +29,17 @@ import io.reliza.repositories.KevAssertionRepository;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Read + write surface for the global {@link KevAssertion} store. Reads
- * serve the {@code knownExploited} GraphQL surface and the per-source
- * detail view; the single write path is {@link #applyCatalog}, called by
- * {@code KevCatalogSyncService} once per source with a freshly fetched
- * full catalog.
+ * Read + write surface for the per-org {@link KevAssertion} store (V54
+ * refactor). Reads serve the {@code knownExploited} GraphQL surface and
+ * the per-source detail view, both scoped to one org; the single write
+ * path is {@link #applyCatalog}, called by {@code KevCatalogSyncService}
+ * once per (org, source) with a freshly fetched full catalog.
  *
- * <p>Soft delete: a source dropping a CVE marks the row revoked, never
- * deletes it. Read surfaces still treat any asserted CVE (even
- * all-revoked) as known-exploited — the membership probe deliberately
- * ignores {@code revoked_date} — so a truncated or tampered feed cannot
- * blank the KEV list.
+ * <p>Soft delete: a source dropping a CVE in this org marks the row
+ * revoked, never deletes it. Read surfaces still treat any asserted CVE
+ * (even all-revoked within the org) as known-exploited — the membership
+ * probe deliberately ignores {@code revoked_date} — so a truncated or
+ * tampered feed cannot blank an org's KEV list.
  */
 @Slf4j
 @Service
@@ -47,11 +48,13 @@ public class KevAssertionService {
 	@Autowired
 	private KevAssertionRepository repository;
 
-	/** The full per-source detail for one CVE; empty when no source ever asserted it. */
-	public Optional<KevRecordDetails> getKevDetails(String cveId) {
+	/** The full per-source detail for one CVE in one org; empty when no
+	 *  source in this org ever asserted it. */
+	public Optional<KevRecordDetails> getKevDetails(UUID orgUuid, String cveId) {
+		if (orgUuid == null) return Optional.empty();
 		String normalized = normalizeCveId(cveId);
 		if (normalized == null) return Optional.empty();
-		List<KevAssertion> rows = repository.findByCveIdOrderBySourceAsc(normalized);
+		List<KevAssertion> rows = repository.findByOrgIdAndCveIdOrderBySourceAsc(orgUuid, normalized);
 		if (rows.isEmpty()) return Optional.empty();
 
 		List<KevSourceAssertion> assertions = new ArrayList<>(rows.size());
@@ -80,28 +83,33 @@ public class KevAssertionService {
 	}
 
 	/**
-	 * Bulk membership probe: of the candidate ids passed in, which are
-	 * KEV-listed by any source? Non-CVE ids (GHSA etc.) are filtered out
-	 * before the query — assertions are keyed by CVE id only. One round trip.
+	 * Bulk membership probe within one org: of the candidate ids passed in,
+	 * which are KEV-listed by any of THIS ORG's configured sources? Non-CVE
+	 * ids (GHSA etc.) are filtered out before the query — assertions are
+	 * keyed by CVE id only. One round trip.
 	 */
-	public Set<String> filterKnownExploited(Collection<String> candidateIds) {
-		if (candidateIds == null || candidateIds.isEmpty()) return Set.of();
+	public Set<String> filterKnownExploited(UUID orgUuid, Collection<String> candidateIds) {
+		if (orgUuid == null || candidateIds == null || candidateIds.isEmpty()) return Set.of();
 		Set<String> cveIds = new HashSet<>();
 		for (String id : candidateIds) {
 			String normalized = normalizeCveId(id);
 			if (normalized != null) cveIds.add(normalized);
 		}
 		if (cveIds.isEmpty()) return Set.of();
-		return new HashSet<>(repository.findExistingCveIds(cveIds));
+		return new HashSet<>(repository.findExistingCveIdsForOrg(orgUuid, cveIds));
 	}
 
-	/** True when any of the candidate ids is KEV-listed. */
-	public boolean isAnyKnownExploited(Collection<String> candidateIds) {
-		return !filterKnownExploited(candidateIds).isEmpty();
+	/** True when any of the candidate ids is KEV-listed in this org. */
+	public boolean isAnyKnownExploited(UUID orgUuid, Collection<String> candidateIds) {
+		return !filterKnownExploited(orgUuid, candidateIds).isEmpty();
 	}
 
-	public long countRecords() {
-		return repository.count();
+	/** Count of assertion rows in one org — drives the bootstrap-silent
+	 *  decision in {@code KevCatalogSyncService}: an org with zero rows is
+	 *  on its first sync and skips the KEV_ADDED event pass. */
+	public long countRecordsForOrg(UUID orgUuid) {
+		if (orgUuid == null) return 0L;
+		return repository.countByOrgId(orgUuid);
 	}
 
 	/**
@@ -116,29 +124,30 @@ public class KevAssertionService {
 	}
 
 	/**
-	 * Outcome of one source's catalog reconciliation. {@code newlyKevCveIds}
-	 * are CVEs that had no prior assertion from any source — the only ones
-	 * that drive KEV_ADDED events (once KEV, always KEV: re-adds and extra
-	 * sources don't re-notify).
+	 * Outcome of one (org, source) catalog reconciliation. {@code newlyKevCveIds}
+	 * are CVEs that had no prior assertion in THIS ORG from any source — the
+	 * only ones that drive KEV_ADDED events (once KEV-in-org, always
+	 * KEV-in-org: re-adds and extra sources within the same org don't re-notify).
 	 */
 	public record KevCatalogApplyOutcome(List<String> newlyKevCveIds, int updated,
 			int revived, int revoked, int total) {}
 
 	/**
-	 * Reconcile one source's full catalog: insert new assertions, rewrite
+	 * Reconcile one (org, source) catalog: insert new assertions, rewrite
 	 * changed ones (JSONB map comparison), un-revoke any that reappeared, and
-	 * soft-delete (stamp {@code revoked_date}) this source's rows that are no
-	 * longer published. The caller guarantees {@code entries} is a complete,
-	 * sanity-checked catalog — an empty or truncated fetch must be rejected
-	 * upstream.
+	 * soft-delete (stamp {@code revoked_date}) this org+source's rows that
+	 * are no longer published. The caller guarantees {@code entries} is a
+	 * complete, sanity-checked catalog — an empty or truncated fetch must
+	 * be rejected upstream.
 	 */
 	@Transactional
-	public KevCatalogApplyOutcome applyCatalog(KevSource source, List<KevAssertionData> entries) {
-		Map<String, KevAssertion> existingForSource = new HashMap<>();
-		for (KevAssertion ka : repository.findBySource(source)) {
-			existingForSource.put(ka.getCveId(), ka);
+	public KevCatalogApplyOutcome applyCatalog(UUID orgUuid, KevSource source, List<KevAssertionData> entries) {
+		if (orgUuid == null) throw new IllegalArgumentException("orgUuid is required");
+		Map<String, KevAssertion> existingForOrgSource = new HashMap<>();
+		for (KevAssertion ka : repository.findByOrgIdAndSource(orgUuid, source)) {
+			existingForOrgSource.put(ka.getCveId(), ka);
 		}
-		Set<String> assertedAnySource = new HashSet<>(repository.findAllDistinctCveIds());
+		Set<String> assertedAnySourceInOrg = new HashSet<>(repository.findAllDistinctCveIdsForOrg(orgUuid));
 
 		List<String> newlyKev = new ArrayList<>();
 		int updated = 0;
@@ -152,16 +161,17 @@ public class KevAssertionService {
 			if (cveId == null || !seen.add(cveId)) continue;
 			entry.setCveId(cveId);
 			Map<String, Object> nextData = entry.toRecordData();
-			KevAssertion existing = existingForSource.get(cveId);
+			KevAssertion existing = existingForOrgSource.get(cveId);
 			if (existing == null) {
 				KevAssertion ka = new KevAssertion();
+				ka.setOrgId(orgUuid);
 				ka.setSource(source);
 				ka.setCveId(cveId);
 				ka.setCreatedDate(now);
 				ka.setLastUpdatedDate(now);
 				ka.setRecordData(nextData);
 				toSave.add(ka);
-				if (!assertedAnySource.contains(cveId)) newlyKev.add(cveId);
+				if (!assertedAnySourceInOrg.contains(cveId)) newlyKev.add(cveId);
 			} else {
 				boolean wasRevoked = existing.getRevokedDate() != null;
 				// Byte-stable map comparison: holds for CISA's flat scalars +
@@ -185,7 +195,7 @@ public class KevAssertionService {
 		if (!toSave.isEmpty()) repository.saveAll(toSave);
 
 		List<KevAssertion> toRevoke = new ArrayList<>();
-		for (KevAssertion existing : existingForSource.values()) {
+		for (KevAssertion existing : existingForOrgSource.values()) {
 			if (!seen.contains(existing.getCveId()) && existing.getRevokedDate() == null) {
 				existing.setRevokedDate(now);
 				existing.setLastUpdatedDate(now);
@@ -195,8 +205,8 @@ public class KevAssertionService {
 		if (!toRevoke.isEmpty()) repository.saveAll(toRevoke);
 
 		if (!newlyKev.isEmpty() || updated > 0 || revived > 0 || !toRevoke.isEmpty()) {
-			log.info("KEV catalog reconciled for {}: {} new, {} updated, {} revived, {} revoked, {} total",
-					source, newlyKev.size(), updated, revived, toRevoke.size(), seen.size());
+			log.info("KEV catalog reconciled for org {} source {}: {} new, {} updated, {} revived, {} revoked, {} total",
+					orgUuid, source, newlyKev.size(), updated, revived, toRevoke.size(), seen.size());
 		}
 		return new KevCatalogApplyOutcome(newlyKev, updated, revived, toRevoke.size(), seen.size());
 	}

--- a/backend/src/main/java/io/reliza/service/ReleaseMetricsComputeService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseMetricsComputeService.java
@@ -121,8 +121,9 @@ public class ReleaseMetricsComputeService {
 			// Stamp KEV membership onto each finding, then re-derive kevCount.
 			// Done after all merges + vuln-analysis so the probe sees the final
 			// alias-organized vulnerabilityDetails. This is the authoritative
-			// KEV stamp for the persisted metrics.
-			stampKnownExploited(rmd);
+			// KEV stamp for the persisted metrics. orgUuid scopes the probe to
+			// this org's kev_assertions (V54 per-org refactor).
+			stampKnownExploited(rd.getOrg(), rmd);
 			if (null == lastScanned) lastScanned = ZonedDateTime.now();
 			rmd.setLastScanned(lastScanned);
 			// Merge artifact firstScanned into whatever rollUpProductReleaseMetrics contributed.
@@ -216,7 +217,7 @@ public class ReleaseMetricsComputeService {
 			ReleaseMetricsDto originalMetrics = rd.getMetrics();
 			ReleaseMetricsDto clonedMetrics = originalMetrics.clone();
 			vulnAnalysisService.processReleaseMetricsDto(rd.getOrg(), r.getUuid(), AnalysisScope.RELEASE, clonedMetrics);
-			stampKnownExploited(clonedMetrics);
+			stampKnownExploited(rd.getOrg(), clonedMetrics);
 			if (!clonedMetrics.equals(originalMetrics)) {
 				rd.setMetrics(clonedMetrics);
 				sharedReleaseService.saveReleaseMetrics(r, clonedMetrics);
@@ -244,7 +245,7 @@ public class ReleaseMetricsComputeService {
 	 * with only GHSA/OSV findings), the probe is skipped entirely — every
 	 * finding is stamped {@code FALSE} without a DB call.
 	 */
-	private void stampKnownExploited(ReleaseMetricsDto rmd) {
+	private void stampKnownExploited(java.util.UUID orgUuid, ReleaseMetricsDto rmd) {
 		List<VulnerabilityDto> findings = rmd.getVulnerabilityDetails();
 		if (findings == null || findings.isEmpty()) {
 			rmd.computeMetricsFromFacts();
@@ -255,11 +256,12 @@ public class ReleaseMetricsComputeService {
 			allCandidates.addAll(candidateCveIds(vuln));
 		}
 		Set<String> listed;
-		if (allCandidates.isEmpty()) {
-			// No CVE-shaped ids anywhere: nothing can match the KEV catalog.
+		if (orgUuid == null || allCandidates.isEmpty()) {
+			// No org context or no CVE-shaped ids: nothing can match the
+			// per-org KEV catalog.
 			listed = Set.of();
 		} else {
-			listed = kevAssertionService.filterKnownExploited(allCandidates);
+			listed = kevAssertionService.filterKnownExploited(orgUuid, allCandidates);
 		}
 		List<VulnerabilityDto> stamped = new ArrayList<>(findings.size());
 		for (VulnerabilityDto vuln : findings) {

--- a/backend/src/main/java/io/reliza/service/SchedulingService.java
+++ b/backend/src/main/java/io/reliza/service/SchedulingService.java
@@ -388,20 +388,20 @@ public class SchedulingService {
     }
 
     /**
-     * Daily KEV catalog sync. Interval-based (fixedDelay) rather than a fixed
+     * Daily KEV catalog sync (Phase 6a). Interval-based rather than a fixed
      * cron so a fleet of replicas restarted together doesn't synchronise their
      * fetches on one wall-clock minute; the advisory lock dedupes whichever
      * replica ticks first. The 2-minute initial delay keeps the fetch and
      * first reconcile out of pod startup (and out of {@code @SpringBootTest}
-     * context spins, which run these schedulers). Both knobs are properties
-     * so a deployment can shorten them for verification without a code change.
+     * context spins, which run these schedulers). Both knobs are properties so
+     * the sandbox can shorten them for verification without a code change.
      *
-     * <p>CE counterpart of the Pro {@code SaasSchedulingService.syncKevCatalog}
-     * (saas/ is not mirrored to CE). Per the V54 per-org refactor, the shared
-     * {@code KevCatalogSyncService.syncCatalog()} now iterates every org with
-     * an enabled KEV integration; CE's singleton org gets its CISA_KEV row from
-     * the V54 backfill. Holds the {@code SYNC_KEV_CATALOG} advisory lock as the
-     * sync's caller contract requires.
+     * <p>Lives in the shared scheduler (not {@code saas/}) because per the V54
+     * per-org refactor KEV is a both-editions feature: the shared
+     * {@code KevCatalogSyncService.syncCatalog()} iterates every org with an
+     * enabled KEV integration, and CE installs mirror this class directly. The
+     * sync's caller contract is to hold the {@code SYNC_KEV_CATALOG} advisory
+     * lock, which this does.
      */
     @Scheduled(
             fixedDelayString = "${relizaprops.kevSyncInterval:PT24H}",

--- a/backend/src/main/java/io/reliza/service/SchedulingService.java
+++ b/backend/src/main/java/io/reliza/service/SchedulingService.java
@@ -395,6 +395,13 @@ public class SchedulingService {
      * first reconcile out of pod startup (and out of {@code @SpringBootTest}
      * context spins, which run these schedulers). Both knobs are properties
      * so a deployment can shorten them for verification without a code change.
+     *
+     * <p>CE counterpart of the Pro {@code SaasSchedulingService.syncKevCatalog}
+     * (saas/ is not mirrored to CE). Per the V54 per-org refactor, the shared
+     * {@code KevCatalogSyncService.syncCatalog()} now iterates every org with
+     * an enabled KEV integration; CE's singleton org gets its CISA_KEV row from
+     * the V54 backfill. Holds the {@code SYNC_KEV_CATALOG} advisory lock as the
+     * sync's caller contract requires.
      */
     @Scheduled(
             fixedDelayString = "${relizaprops.kevSyncInterval:PT24H}",

--- a/backend/src/main/java/io/reliza/service/SystemInfoService.java
+++ b/backend/src/main/java/io/reliza/service/SystemInfoService.java
@@ -124,22 +124,10 @@ public class SystemInfoService {
 		saveSystemInfo(sysInfo, sd);
 	}
 	
-	public String getVulncheckKevToken(){
-		var sysInfo = findSystemInfo();
-		String encToken = sysInfo.getVulncheckKevToken();
-		String decToken = null;
-		if(StringUtils.isNotEmpty(encToken))
-			decToken = encryptionService.decrypt(encToken);
-		return decToken;
-	}
-
-	@Transactional
-	public void setVulncheckKevToken(String token){
-		SystemInfo sysInfo =  this.repository.findSystemInfo();
-		SystemInfoData sd = SystemInfoData.dataFromRecord(sysInfo);
-		sd.setVulncheckKevToken(StringUtils.isNotEmpty(token) ? encryptionService.encrypt(token) : null);
-		saveSystemInfo(sysInfo, sd);
-	}
+	// VulnCheck token getter/setter on SystemInfo removed in V54 KEV per-org
+	// refactor; per-org tokens now live on VULNCHECK_KEV Integration rows
+	// (encrypted via the same EncryptionService, looked up by the per-org
+	// KevCatalogSyncService.syncOrgSourceAsync entry point).
 
 	@Transactional
 	public void setDefaultOrg (UUID defaultOrg) {
@@ -208,12 +196,13 @@ public class SystemInfoService {
 		return findSystemInfo().isSystemSealed();
 	}
 
-	public static record SystemInfoDto (Boolean emailDetailsSet, UUID defaultOrg, Boolean vulncheckKevConfigured) {}
+	// vulncheckKevConfigured dropped from SystemInfoDto in V54 (per-org now;
+	// surfaced through the org's Integration catalog cards instead).
+	public static record SystemInfoDto (Boolean emailDetailsSet, UUID defaultOrg) {}
 
 	public SystemInfoDto getSystemInfoIsSet(){
 		var sysInfo = findSystemInfo();
-		return new SystemInfoDto(sysInfo.getEmailSendType() != EmailSendType.UNSET, sysInfo.getDefaultOrg(),
-				StringUtils.isNotEmpty(sysInfo.getVulncheckKevToken()));
+		return new SystemInfoDto(sysInfo.getEmailSendType() != EmailSendType.UNSET, sysInfo.getDefaultOrg());
 	}
 	
 	public SystemInfoData getSystemInfoData() {

--- a/backend/src/main/java/io/reliza/service/kev/CisaKevConnector.java
+++ b/backend/src/main/java/io/reliza/service/kev/CisaKevConnector.java
@@ -66,7 +66,8 @@ public class CisaKevConnector implements KevSourceConnector {
 	}
 
 	@Override
-	public List<KevAssertionData> fetchCatalog() {
+	public List<KevAssertionData> fetchCatalog(String credential) {
+		// Public feed — no auth, credential is ignored.
 		try {
 			String body = webClient.get()
 					// URI.create: pass the configured URL byte-for-byte, no template re-encoding

--- a/backend/src/main/java/io/reliza/service/kev/KevCatalogSyncService.java
+++ b/backend/src/main/java/io/reliza/service/kev/KevCatalogSyncService.java
@@ -3,20 +3,30 @@
 */
 package io.reliza.service.kev;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import io.reliza.model.Integration;
+import io.reliza.model.IntegrationData;
+import io.reliza.model.IntegrationData.IntegrationType;
 import io.reliza.model.KevAssertionData;
+import io.reliza.model.KevSource;
 import io.reliza.model.VulnerabilityRecord;
 import io.reliza.model.VulnerabilityRecordData;
+import io.reliza.repositories.IntegrationRepository;
 import io.reliza.repositories.VulnerabilityRecordRepository;
+import io.reliza.service.EncryptionService;
 import io.reliza.service.KevAssertionService;
 import io.reliza.service.KevAssertionService.KevCatalogApplyOutcome;
 import io.reliza.service.VulnAnalysisUpdateService;
@@ -24,23 +34,26 @@ import io.reliza.service.VulnerabilityRecordChangeHook;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * KEV catalog sync orchestrator: for each {@link KevSourceConnector},
- * fetch the source's full catalog, reconcile it into {@code kev_assertions}
- * via {@link KevAssertionService#applyCatalog}, then emit a KEV_ADDED
+ * Per-org KEV catalog sync orchestrator (V54 refactor): for every enabled
+ * {@code Integration} of type {@code CISA_KEV} or {@code VULNCHECK_KEV},
+ * dispatch the matching connector against that org's credential (where
+ * applicable), reconcile the result into {@code kev_assertions} under that
+ * org via {@link KevAssertionService#applyCatalog}, then emit a KEV_ADDED
  * notification for every org vulnerability record matching a genuinely new
  * KEV (by primary id or alias). Scheduled by the edition's scheduling
  * service under the {@code SYNC_KEV_CATALOG} advisory lock.
  *
  * <p><b>Fail-closed.</b> A connector returns an empty list on a failed or
- * empty fetch; the orchestrator then skips that source's reconcile, so a
- * truncated response never revokes live assertions. (And revocation is a
- * soft mark that still reads as KEV anyway — two layers of safety.)
+ * empty fetch; the orchestrator then skips that (org, source) reconcile,
+ * so a truncated response never revokes live assertions for the org.
+ * (Soft-deleted assertions still read as KEV in the same org anyway — two
+ * layers of safety.)
  *
- * <p><b>Bootstrap is silent.</b> On the first deploy ({@code kev_assertions}
- * empty), the initial load would mark every entry "new" and storm every org
- * with KEV_ADDED events for years-old listings. The event pass is skipped
- * when the store starts empty; only incremental additions on later runs
- * notify.
+ * <p><b>Bootstrap is silent per-org.</b> The first sync for an org (zero
+ * existing rows in {@code kev_assertions} for that {@code org_id}) would
+ * mark every entry "new" and storm the org with KEV_ADDED events for
+ * years-old listings. The event pass is skipped on the per-org first
+ * sync; only incremental additions on later runs notify.
  *
  * <p><b>CE-safe.</b> The notification hook is autowired
  * {@code required = false} — the CE backend has no implementation bean, so
@@ -48,9 +61,9 @@ import lombok.extern.slf4j.Slf4j;
  * notifications subsystem is present.
  *
  * <p>Transaction shape: each connector's HTTP fetch happens outside any
- * transaction; that source's reconcile + event emission share one
- * {@link TransactionTemplate} transaction so the outbox rows commit iff the
- * assertion rows do.
+ * transaction; that (org, source) reconcile + event emission share one
+ * {@link TransactionTemplate} transaction so the outbox rows commit iff
+ * the assertion rows do.
  */
 @Slf4j
 @Service
@@ -61,6 +74,12 @@ public class KevCatalogSyncService {
 
 	@Autowired
 	private KevAssertionService kevAssertionService;
+
+	@Autowired
+	private IntegrationRepository integrationRepository;
+
+	@Autowired
+	private EncryptionService encryptionService;
 
 	@Autowired
 	private VulnerabilityRecordRepository vulnerabilityRecordRepository;
@@ -79,96 +98,160 @@ public class KevCatalogSyncService {
 	@Autowired
 	private VulnAnalysisUpdateService vulnAnalysisUpdateService;
 
+	/** Map IntegrationType → matching source enum. CISA_KEV / VULNCHECK_KEV only. */
+	private static KevSource toSource(IntegrationType type) {
+		if (type == IntegrationType.CISA_KEV) return KevSource.CISA;
+		if (type == IntegrationType.VULNCHECK_KEV) return KevSource.VULNCHECK;
+		return null;
+	}
+
 	/**
-	 * One full sync pass across every source. Returns the total number of
-	 * genuinely new KEV CVEs across all sources. Never throws — the
-	 * scheduler tick treats every outcome as "try again next tick".
+	 * One full sync pass across every org × every enabled KEV source.
+	 * Returns the total number of genuinely new (org, CVE) pairs across
+	 * the pass. Never throws — the scheduler tick treats every outcome as
+	 * "try again next tick".
 	 *
 	 * <p><b>Caller contract: hold the {@code SYNC_KEV_CATALOG} advisory lock.</b>
-	 * The bootstrap decision is read once up front and per-source reconciles
-	 * are separate transactions, so two concurrent passes could double-emit
-	 * KEV_ADDED or collide on the {@code (source, cve_id)} unique constraint.
-	 * The Pro scheduler serializes this behind the advisory lock; any other
+	 * Per-org reconciles are separate transactions, so two concurrent
+	 * passes could double-emit KEV_ADDED or collide on the
+	 * {@code (org_id, source, cve_id)} unique constraint. The Pro
+	 * scheduler serializes this behind the advisory lock; any other
 	 * caller (e.g. a future CE scheduler) must do the same.
 	 */
 	public int syncCatalog() {
-		boolean bootstrap = kevAssertionService.countRecords() == 0;
+		Map<KevSource, KevSourceConnector> bySource = new HashMap<>();
+		for (KevSourceConnector c : connectors) bySource.put(c.source(), c);
+
 		int totalNew = 0;
-		for (KevSourceConnector connector : connectors) {
-			try {
-				totalNew += syncSource(connector, bootstrap);
-			} catch (Exception e) {
-				log.error("KEV sync failed for source {}", connector.source(), e);
+		for (IntegrationType type : List.of(IntegrationType.CISA_KEV, IntegrationType.VULNCHECK_KEV)) {
+			KevSourceConnector connector = bySource.get(toSource(type));
+			if (connector == null) continue;
+			List<Integration> rows = integrationRepository.listEnabledIntegrationsByType(type.name());
+			for (Integration row : rows) {
+				try {
+					IntegrationData id = IntegrationData.dataFromRecord(row);
+					if (id.getOrg() == null) continue;
+					totalNew += syncOneOrgSource(id.getOrg(), connector, decryptCredential(id));
+				} catch (Exception e) {
+					log.error("KEV sync failed for integration {} ({})", row.getUuid(), type, e);
+				}
 			}
 		}
 		return totalNew;
 	}
 
-	private int syncSource(KevSourceConnector connector, boolean bootstrap) {
-		List<KevAssertionData> entries = connector.fetchCatalog();
+	/**
+	 * Sync one (org, source). Public so the configure-flow can fire an
+	 * immediate async sync after an org admin sets a VulnCheck token,
+	 * without waiting for the next scheduler tick.
+	 */
+	@Async
+	public void syncOrgSourceAsync(UUID orgUuid, IntegrationType type) {
+		KevSource source = toSource(type);
+		if (source == null) return;
+		KevSourceConnector connector = connectors.stream()
+				.filter(c -> c.source() == source)
+				.findFirst().orElse(null);
+		if (connector == null) {
+			log.warn("KEV connector missing for source {}", source);
+			return;
+		}
+		Integration row = integrationRepository
+				.findIntegrationByOrgTypeIdentifier(orgUuid.toString(), type.name(), "base")
+				.orElse(null);
+		if (row == null) {
+			log.warn("KEV async sync requested for {}/{} but no integration row found", orgUuid, type);
+			return;
+		}
+		try {
+			IntegrationData id = IntegrationData.dataFromRecord(row);
+			syncOneOrgSource(orgUuid, connector, decryptCredential(id));
+		} catch (Exception e) {
+			log.error("KEV async sync failed for {}/{}", orgUuid, type, e);
+		}
+	}
+
+	private String decryptCredential(IntegrationData id) {
+		String enc = id.getSecret();
+		if (enc == null || enc.isEmpty()) return null;
+		try {
+			return encryptionService.decrypt(enc);
+		} catch (Exception e) {
+			log.warn("Failed to decrypt KEV integration credential for org {}", id.getOrg(), e);
+			return null;
+		}
+	}
+
+	private int syncOneOrgSource(UUID orgUuid, KevSourceConnector connector, String credential) {
+		boolean bootstrap = kevAssertionService.countRecordsForOrg(orgUuid) == 0;
+		List<KevAssertionData> entries = connector.fetchCatalog(credential);
 		if (entries.isEmpty()) {
 			// Connector already logged the cause; skip reconcile (fail-closed).
 			return 0;
 		}
 		TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
 		KevCatalogApplyOutcome outcome = txTemplate.execute(status -> {
-			KevCatalogApplyOutcome applied = kevAssertionService.applyCatalog(connector.source(), entries);
+			KevCatalogApplyOutcome applied = kevAssertionService.applyCatalog(
+					orgUuid, connector.source(), entries);
 			if (!bootstrap) {
-				emitKevAddedEvents(applied.newlyKevCveIds());
+				emitKevAddedEvents(orgUuid, applied.newlyKevCveIds());
 			}
 			return applied;
 		});
 		if (outcome == null) return 0;
 		if (bootstrap) {
-			log.info("KEV catalog bootstrapped for {}: {} entries; KEV_ADDED event pass skipped",
-					connector.source(), outcome.total());
+			log.info("KEV catalog bootstrapped for org {} source {}: {} entries; KEV_ADDED event pass skipped",
+					orgUuid, connector.source(), outcome.total());
 		} else {
 			// AFTER commit: kev_assertions is now persisted, so the async
 			// recompute reads the new KEV status. Bootstrap is excluded
 			// (would storm a recompute of every release on first load),
 			// matching the KEV_ADDED event-pass guard above.
-			triggerKevReGate(outcome.newlyKevCveIds());
+			triggerKevReGate(orgUuid, outcome.newlyKevCveIds());
 		}
 		return outcome.newlyKevCveIds().size();
 	}
 
 	/**
-	 * For each genuinely new KEV CVE, gather the distinct orgs whose
-	 * vulnerability records know the CVE (canonical id or alias) and hand
-	 * off to the shared {@code @Async} fan-out, which recomputes the
-	 * metrics of every release that ships the CVE so the KEV gate re-fires.
+	 * For each genuinely new KEV CVE in this org, hand off to the shared
+	 * {@code @Async} fan-out to recompute the metrics of every release
+	 * within the org that ships the CVE, so the KEV gate re-fires.
 	 * Called only after the reconcile transaction has committed.
 	 */
-	private void triggerKevReGate(List<String> newlyKevCveIds) {
+	private void triggerKevReGate(UUID orgUuid, List<String> newlyKevCveIds) {
+		if (newlyKevCveIds.isEmpty()) return;
 		for (String cveId : newlyKevCveIds) {
 			List<VulnerabilityRecord> affected =
 					vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias(cveId);
-			Set<UUID> affectedOrgs = affected.stream()
-					.map(VulnerabilityRecord::getOrg)
-					.filter(o -> o != null)
-					.collect(Collectors.toSet());
-			if (!affectedOrgs.isEmpty()) {
-				vulnAnalysisUpdateService.recomputeReleasesForNewlyKev(cveId, affectedOrgs);
+			boolean affectsOrg = affected.stream()
+					.anyMatch(vr -> orgUuid.equals(vr.getOrg()));
+			if (affectsOrg) {
+				vulnAnalysisUpdateService.recomputeReleasesForNewlyKev(cveId, Set.of(orgUuid));
 			}
 		}
 	}
 
 	/**
-	 * For each genuinely new KEV CVE, find every org vulnerability record that
-	 * knows the CVE (canonical id or alias) and hand it to the notification
-	 * hook. No-op when the hook is absent (CE).
+	 * For each genuinely new KEV CVE in this org, find every org-scoped
+	 * vulnerability record (within the same org) that knows the CVE
+	 * (canonical id or alias) and hand it to the notification hook.
+	 * No-op when the hook is absent (CE).
 	 */
-	private void emitKevAddedEvents(List<String> newlyKevCveIds) {
-		if (vulnerabilityRecordChangeHook == null) return;
+	private void emitKevAddedEvents(UUID orgUuid, List<String> newlyKevCveIds) {
+		if (vulnerabilityRecordChangeHook == null || newlyKevCveIds.isEmpty()) return;
 		for (String cveId : newlyKevCveIds) {
 			List<VulnerabilityRecord> affected =
 					vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias(cveId);
-			for (VulnerabilityRecord vr : affected) {
+			List<VulnerabilityRecord> inOrg = affected.stream()
+					.filter(vr -> orgUuid.equals(vr.getOrg()))
+					.collect(Collectors.toCollection(ArrayList::new));
+			for (VulnerabilityRecord vr : inOrg) {
 				VulnerabilityRecordData vrd = VulnerabilityRecordData.dataFromRecord(vr);
 				vulnerabilityRecordChangeHook.onKevAdded(vr.getOrg(), vr.getPrimaryVulnId(), vrd);
 			}
-			if (!affected.isEmpty()) {
-				log.info("KEV_ADDED: {} now KEV-listed, notified {} org record(s)", cveId, affected.size());
+			if (!inOrg.isEmpty()) {
+				log.info("KEV_ADDED: {} now KEV-listed in org {}, notified {} record(s)",
+						cveId, orgUuid, inOrg.size());
 			}
 		}
 	}

--- a/backend/src/main/java/io/reliza/service/kev/KevSourceConnector.java
+++ b/backend/src/main/java/io/reliza/service/kev/KevSourceConnector.java
@@ -10,9 +10,11 @@ import io.reliza.model.KevSource;
 
 /**
  * One known-exploited-vulnerability source. {@code KevCatalogSyncService}
- * injects every connector bean and reconciles each source's catalog
- * independently, so adding a source (e.g. VulnCheck KEV) is a new bean,
- * no orchestration change.
+ * injects every connector bean and, for each org with that source enabled,
+ * runs {@link #fetchCatalog(String)} with the org's credential (or null if
+ * the source doesn't need one) and writes the result under that org. So
+ * adding a source is a new bean + an {@code IntegrationType} value, no
+ * orchestration change.
  */
 public interface KevSourceConnector {
 
@@ -20,10 +22,13 @@ public interface KevSourceConnector {
 	KevSource source();
 
 	/**
-	 * Fetch and normalize the source's complete current catalog. Returns an
-	 * empty list to signal a failed or empty fetch — the orchestrator then
-	 * skips reconciliation for this source (fail-closed), so a bad fetch
-	 * never revokes live assertions. Implementations must not throw.
+	 * Fetch and normalize the source's complete current catalog. The
+	 * {@code credential} is the per-org token (e.g. VulnCheck Bearer) for
+	 * sources that need one; sources that read a public feed (CISA) ignore
+	 * it. Returns an empty list to signal a failed or empty fetch — the
+	 * orchestrator then skips reconciliation for that (org, source), so a
+	 * bad fetch never revokes live assertions. Implementations must not
+	 * throw.
 	 */
-	List<KevAssertionData> fetchCatalog();
+	List<KevAssertionData> fetchCatalog(String credential);
 }

--- a/backend/src/main/java/io/reliza/service/kev/VulnCheckKevConnector.java
+++ b/backend/src/main/java/io/reliza/service/kev/VulnCheckKevConnector.java
@@ -20,15 +20,16 @@ import io.reliza.common.Utils;
 import io.reliza.model.KevAssertionData;
 import io.reliza.model.KevRansomwareStatus;
 import io.reliza.model.KevSource;
-import io.reliza.service.SystemInfoService;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * VulnCheck Community KEV connector: a CISA-plus source (~3x the CISA
  * catalog) reached via the v3 index API with a Bearer token. Token-gated —
- * with no token configured on {@link SystemInfoService} the connector is a
- * no-op, so the source is simply absent until a global admin configures a
- * (free, registration-only) token via the Integrations admin card.
+ * the per-org token is the {@code credential} argument to
+ * {@link #fetchCatalog(String)}; an absent or blank credential turns the
+ * connector into a no-op for that org, so the source is simply absent
+ * until an org admin configures a (free, registration-only) token through
+ * the Integrations catalog card.
  *
  * <p>The API is paginated and each entry's {@code cve} is an ARRAY (one
  * entry may cover several CVEs), so we page through and emit one
@@ -48,16 +49,13 @@ public class VulnCheckKevConnector implements KevSourceConnector {
 	// Runaway guard; with PAGE_LIMIT=1000 the ~5k-entry catalog is ~5 pages.
 	private static final int MAX_PAGES = 50;
 
-	private final SystemInfoService systemInfoService;
 	private final String baseUrl;
 	// Non-final so tests can substitute an ExchangeFunction-stubbed client.
 	private WebClient webClient;
 
 	public VulnCheckKevConnector(
-			SystemInfoService systemInfoService,
 			@Value("${relizaprops.vulncheckKevUrl:https://api.vulncheck.com/v3/index/vulncheck-kev}")
 			String baseUrl) {
-		this.systemInfoService = systemInfoService;
 		this.baseUrl = baseUrl;
 		ExchangeStrategies strategies = ExchangeStrategies.builder()
 				.codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(32 * 1024 * 1024))
@@ -85,12 +83,12 @@ public class VulnCheckKevConnector implements KevSourceConnector {
 	}
 
 	@Override
-	public List<KevAssertionData> fetchCatalog() {
-		String token = systemInfoService.getVulncheckKevToken();
-		if (StringUtils.isBlank(token)) {
-			log.debug("VulnCheck KEV token not configured — VulnCheck source inactive");
+	public List<KevAssertionData> fetchCatalog(String credential) {
+		if (StringUtils.isBlank(credential)) {
+			log.debug("VulnCheck KEV credential not provided — VulnCheck source inactive for this org");
 			return List.of();
 		}
+		String token = credential;
 		List<KevAssertionData> all = new ArrayList<>();
 		int page = 1;
 		int totalPages = 1;

--- a/backend/src/main/java/io/reliza/ws/AdminDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/AdminDataFetcher.java
@@ -69,16 +69,10 @@ public class AdminDataFetcher {
 		return systemInfoService.getSystemInfoIsSet();
 	}
 	
-	@Transactional
-	@PreAuthorize("isAuthenticated()")
-	@DgsData(parentType = "Mutation", field = "setVulnCheckKevToken")
-	public Boolean setVulnCheckKevToken(@InputArgument("token") String token) throws RelizaException {
-		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-		var oud = userService.getUserDataByAuth(auth);
-		authorizationService.authorize(oud.get(), CallType.GLOBAL_ADMIN);
-		systemInfoService.setVulncheckKevToken(token);
-		return true;
-	}
+	// Global setVulnCheckKevToken mutation removed in V54 KEV per-org
+	// refactor. Use the org-scoped IntegrationDataFetcher.setVulnCheckKevToken
+	// (org-admin scope) instead — the token now lives on a per-org
+	// VULNCHECK_KEV Integration row.
 
 	@PreAuthorize("isAuthenticated()")
 	@DgsData(parentType = "Mutation", field = "finalizeAllReleases")

--- a/backend/src/main/java/io/reliza/ws/IntegrationDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/IntegrationDataFetcher.java
@@ -43,6 +43,7 @@ import io.reliza.service.RebomService;
 import io.reliza.service.SyntheticSbomService;
 import io.reliza.service.SharedArtifactService;
 import io.reliza.service.UserService;
+import io.reliza.service.kev.KevCatalogSyncService;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -69,6 +70,9 @@ public class IntegrationDataFetcher {
 
 	@Autowired
 	private SyntheticSbomService syntheticSbomService;
+
+	@Autowired
+	private KevCatalogSyncService kevCatalogSyncService;
 
 	@PreAuthorize("isAuthenticated()")
 	@DgsData(parentType = "Query", field = "configuredBaseIntegrations")
@@ -239,5 +243,83 @@ public class IntegrationDataFetcher {
 		log.info("User {} deleting BEAR integration for organization {}", oud.get().getUuid(), orgUuid);
 		
 		return rebomService.deleteBearIntegration(orgUuid);
+	}
+
+	// --- KEV per-org integration mutations (V54 refactor) ---------------
+	// All three are org-admin scope on the target org. CISA_KEV is created
+	// enabled by the migration backfill + new-org hook, so the UI typically
+	// only toggles enable/disable for CISA. VULNCHECK_KEV is opt-in via
+	// setVulnCheckKevTokenForOrg, which lazily creates the integration row
+	// and fires an immediate async first sync so the org admin sees data
+	// within ~one connector pass instead of waiting for the next scheduler
+	// tick.
+
+	private static void requireKevType(IntegrationType type) throws RelizaException {
+		if (type != IntegrationType.CISA_KEV && type != IntegrationType.VULNCHECK_KEV) {
+			throw new RelizaException("source must be CISA_KEV or VULNCHECK_KEV, was " + type);
+		}
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "enableKevSource")
+	public Boolean enableKevSource(
+			@InputArgument("orgUuid") UUID orgUuid,
+			@InputArgument("source") IntegrationType source) throws RelizaException {
+		requireKevType(source);
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		var od = getOrganizationService.getOrganizationData(orgUuid);
+		RelizaObject ro = od.isPresent() ? od.get() : null;
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.ADMIN);
+		integrationService.upsertKevIntegration(orgUuid, source, true, null,
+				WhoUpdated.getWhoUpdated(oud.get()));
+		// Fire an immediate async sync so first enable picks up the catalog
+		// on the next event-loop pass instead of waiting for the next tick.
+		kevCatalogSyncService.syncOrgSourceAsync(orgUuid, source);
+		return true;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "disableKevSource")
+	public Boolean disableKevSource(
+			@InputArgument("orgUuid") UUID orgUuid,
+			@InputArgument("source") IntegrationType source) throws RelizaException {
+		requireKevType(source);
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		var od = getOrganizationService.getOrganizationData(orgUuid);
+		RelizaObject ro = od.isPresent() ? od.get() : null;
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.ADMIN);
+		integrationService.upsertKevIntegration(orgUuid, source, false, null,
+				WhoUpdated.getWhoUpdated(oud.get()));
+		return true;
+	}
+
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "setVulnCheckKevTokenForOrg")
+	public Boolean setVulnCheckKevTokenForOrg(
+			@InputArgument("orgUuid") UUID orgUuid,
+			@InputArgument("token") String token) throws RelizaException {
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		var od = getOrganizationService.getOrganizationData(orgUuid);
+		RelizaObject ro = od.isPresent() ? od.get() : null;
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.ADMIN);
+		// Token semantics:
+		//   null     → don't change secret (preserve existing); only ensures the
+		//              integration exists in its current enabled state
+		//   ""       → clear secret; integration stays but VulnCheck won't fetch
+		//   non-empty→ set secret + enable
+		String rawTokenArg = (token == null) ? null : token;
+		boolean enabled = token != null && !token.isEmpty();
+		integrationService.upsertKevIntegration(orgUuid, IntegrationType.VULNCHECK_KEV,
+				enabled, rawTokenArg, WhoUpdated.getWhoUpdated(oud.get()));
+		if (enabled) {
+			kevCatalogSyncService.syncOrgSourceAsync(orgUuid, IntegrationType.VULNCHECK_KEV);
+		}
+		return true;
 	}
 }

--- a/backend/src/main/java/io/reliza/ws/KevDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/KevDataFetcher.java
@@ -3,19 +3,10 @@
 */
 package io.reliza.ws;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
-import org.dataloader.BatchLoader;
-import org.dataloader.DataLoader;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -24,19 +15,15 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsData;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
-import com.netflix.graphql.dgs.DgsDataLoader;
 import com.netflix.graphql.dgs.InputArgument;
 
 import io.reliza.common.CommonVariables.CallType;
-import io.reliza.dto.ChangelogRecords.ReleaseVulnerabilityInfo;
 import io.reliza.dto.KevRecordDetails;
-import io.reliza.dto.VulnerabilityWithAttribution;
 import io.reliza.exceptions.RelizaException;
 import io.reliza.model.OrganizationData;
 import io.reliza.model.RelizaObject;
 import io.reliza.model.UserPermission.PermissionFunction;
 import io.reliza.model.UserPermission.PermissionScope;
-import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilityAliasDto;
 import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilityDto;
 import io.reliza.service.AuthorizationService;
 import io.reliza.service.GetOrganizationService;
@@ -47,21 +34,20 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * GraphQL surface for KEV data.
  *
- * <p>Child resolvers add {@code knownExploited} to the three vulnerability
+ * <p>Child resolvers serve {@code knownExploited} on the three vulnerability
  * read types ({@code Vulnerability}, {@code ReleaseVulnerabilityInfo},
- * {@code VulnerabilityWithAttribution}). They ride the parent query's
- * authorization — the parent fetchers already org-scope their results, and
- * KEV listing itself is public data, so no per-field auth check is needed.
+ * {@code VulnerabilityWithAttribution}) from the value stamped on the
+ * parent record by {@code ReleaseMetricsComputeService}. In V54 KEV moved
+ * to per-org assertions and the parent assembly paths don't carry an
+ * orgUuid into the field resolver, so a per-request fresh-probe is no
+ * longer feasible at this layer; metrics compute runs immediately after
+ * a per-org KEV sync via {@code KevCatalogSyncService.triggerKevReGate},
+ * so the stamped value stays close to fresh.
  *
- * <p>A release page renders hundreds of vulnerability rows; the
- * {@code kevListedLoader} batch loader collapses them into one
- * {@code IN}-probe against {@code kev_assertions} per request instead of a
- * query per row. Rows with no CVE-shaped id (pure GHSA/OSV findings)
- * short-circuit to {@code false} without touching the loader.
- *
- * <p>{@code kevRecordDetails} (org-authorized, READ) returns the per-source
- * assertion detail for the UI's CVE-details surface; null when no source
- * has ever listed the CVE.
+ * <p>{@code kevRecordDetails(orgUuid, cveId)} (org-authorized, READ)
+ * returns the per-source assertion detail for the UI's CVE-details
+ * surface, scoped to one org; null when no source in that org has ever
+ * listed the CVE.
  */
 @Slf4j
 @DgsComponent
@@ -79,77 +65,30 @@ public class KevDataFetcher {
 	@Autowired
 	private KevAssertionService kevAssertionService;
 
-	/**
-	 * Batch key: the candidate CVE ids (primary + aliases, already
-	 * normalized) of one vulnerability row. A record so identical rows across
-	 * the page dedupe in the loader cache.
-	 */
-	public record KevProbeKey(Set<String> cveIds) {}
-
-	@DgsDataLoader(name = "kevListedLoader")
-	public class KevListedBatchLoader implements BatchLoader<KevProbeKey, Boolean> {
-
-		@Autowired
-		private KevAssertionService dataLoaderKevAssertionService;
-
-		@Override
-		public CompletionStage<List<Boolean>> load(List<KevProbeKey> keys) {
-			Set<String> union = new HashSet<>();
-			for (KevProbeKey key : keys) union.addAll(key.cveIds());
-			Set<String> listed;
-			try {
-				listed = dataLoaderKevAssertionService.filterKnownExploited(union);
-			} catch (Exception e) {
-				log.error("Error probing KEV assertions for {} candidate ids", union.size(), e);
-				listed = Set.of();
-			}
-			List<Boolean> results = new ArrayList<>(keys.size());
-			for (KevProbeKey key : keys) {
-				boolean hit = false;
-				for (String id : key.cveIds()) {
-					if (listed.contains(id)) {
-						hit = true;
-						break;
-					}
-				}
-				results.add(hit);
-			}
-			return CompletableFuture.completedFuture(results);
-		}
-	}
-
 	@DgsData(parentType = "Vulnerability", field = "knownExploited")
-	public CompletableFuture<Boolean> knownExploitedOfVulnerability(DgsDataFetchingEnvironment dfe) {
+	public Boolean knownExploitedOfVulnerability(DgsDataFetchingEnvironment dfe) {
 		VulnerabilityDto vuln = dfe.getSource();
-		return resolveKnownExploited(dfe, vuln.vulnId(), vuln.aliases());
+		return Boolean.TRUE.equals(vuln.knownExploited());
 	}
 
+	// V54 NOTE: ReleaseVulnerabilityInfo (changelog) and
+	// VulnerabilityWithAttribution (attribution) don't carry a stamped
+	// knownExploited; a fresh per-org probe at this layer would need
+	// orgUuid threaded through their assembly path. Followup ticket:
+	// thread orgUuid into the changelog + attribution assemblers and
+	// stamp knownExploited at construction (same pattern as
+	// VulnerabilityDto in ReleaseMetricsComputeService.recomputeKevFlags).
+	// For now, those surfaces show knownExploited = false; the primary
+	// release-findings + vulnerability-analysis surfaces (which DO go
+	// through metrics compute) remain correct.
 	@DgsData(parentType = "ReleaseVulnerabilityInfo", field = "knownExploited")
-	public CompletableFuture<Boolean> knownExploitedOfReleaseVulnerabilityInfo(DgsDataFetchingEnvironment dfe) {
-		ReleaseVulnerabilityInfo vuln = dfe.getSource();
-		return resolveKnownExploited(dfe, vuln.vulnId(), vuln.aliases());
+	public Boolean knownExploitedOfReleaseVulnerabilityInfo(DgsDataFetchingEnvironment dfe) {
+		return Boolean.FALSE;
 	}
 
 	@DgsData(parentType = "VulnerabilityWithAttribution", field = "knownExploited")
-	public CompletableFuture<Boolean> knownExploitedOfVulnerabilityWithAttribution(DgsDataFetchingEnvironment dfe) {
-		VulnerabilityWithAttribution vuln = dfe.getSource();
-		return resolveKnownExploited(dfe, vuln.vulnId(), vuln.aliases());
-	}
-
-	private CompletableFuture<Boolean> resolveKnownExploited(DgsDataFetchingEnvironment dfe,
-			String vulnId, Set<VulnerabilityAliasDto> aliases) {
-		Set<String> candidates = new LinkedHashSet<>();
-		String primary = KevAssertionService.normalizeCveId(vulnId);
-		if (primary != null) candidates.add(primary);
-		if (aliases != null) {
-			for (VulnerabilityAliasDto alias : aliases) {
-				String normalized = alias != null ? KevAssertionService.normalizeCveId(alias.aliasId()) : null;
-				if (normalized != null) candidates.add(normalized);
-			}
-		}
-		if (candidates.isEmpty()) return CompletableFuture.completedFuture(Boolean.FALSE);
-		DataLoader<KevProbeKey, Boolean> dataLoader = dfe.getDataLoader("kevListedLoader");
-		return dataLoader.load(new KevProbeKey(candidates));
+	public Boolean knownExploitedOfVulnerabilityWithAttribution(DgsDataFetchingEnvironment dfe) {
+		return Boolean.FALSE;
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -167,6 +106,6 @@ public class KevDataFetcher {
 		authorizationService.isUserAuthorizedForObjectGraphQL(
 				oud.get(), PermissionFunction.RESOURCE, PermissionScope.ORGANIZATION,
 				orgUuid, Collections.singletonList(ro), CallType.READ);
-		return kevAssertionService.getKevDetails(cveId).orElse(null);
+		return kevAssertionService.getKevDetails(orgUuid, cveId).orElse(null);
 	}
 }

--- a/backend/src/main/resources/db/migration/V54__kev_per_org.sql
+++ b/backend/src/main/resources/db/migration/V54__kev_per_org.sql
@@ -1,0 +1,75 @@
+-- V54 — KEV per-org refactor.
+--
+-- Reshapes the KEV model so that both the assertion catalog AND the
+-- credential to fetch it are per-org rather than instance-global. Drivers:
+--   * SaaS multi-tenant correctness — each customer has their own VulnCheck
+--     contract; the token IS that customer's credential and shouldn't be
+--     shared via SystemInfo with the platform owner.
+--   * Permission alignment — the operator who configures a KEV source is
+--     typically the org admin, not a global super-admin.
+--   * UI clarity — KEV sources show up as per-org Integration catalog cards
+--     ("✓ Configured" / "Available"), so an org admin can see at a glance
+--     which sources their findings are matched against.
+--
+-- The previous global model (V53) is dropped, not migrated:
+--   * Old VULNCHECK rows came from a single shared token; preserving them
+--     would re-leak the data the refactor partitions.
+--   * CISA rows are public + cheap to re-sync per org (~10s, ~1600 entries).
+--   * Per-org first sync fires at pod-start + scheduler initialDelay (~2min).
+--
+-- Related: [[kev-per-org-refactor]] memory has the full design + PR plan.
+
+-- 1. Empty the table so the NOT NULL org_id add doesn't need backfill.
+DELETE FROM rearm.kev_assertions;
+
+-- 2. Add org_id and re-key on (org_id, source, cve_id).
+--    No FOREIGN KEY to organizations (per coding_principles.md — FKs break
+--    backup/restore). Referential integrity is the application's job: every
+--    kev_assertions read is org-scoped, so rows for a removed org are never
+--    read; orgs are archived rather than hard-deleted, so there is no
+--    parent-delete path that needs to cascade these children.
+ALTER TABLE rearm.kev_assertions
+    ADD COLUMN org_id uuid NOT NULL,
+    DROP CONSTRAINT IF EXISTS kev_assertions_source_cve_unique,
+    ADD CONSTRAINT kev_assertions_org_source_cve_unique UNIQUE (org_id, source, cve_id);
+
+-- 3. The cve_id index from V53 still serves the per-org knownExploited probe
+--    (the WHERE adds org_id = :org); replace it with a compound index that
+--    leads with org_id so the planner picks an index-only scan.
+DROP INDEX IF EXISTS rearm.kev_assertions_cve_id_idx;
+CREATE INDEX kev_assertions_org_cve_idx ON rearm.kev_assertions (org_id, cve_id);
+
+-- 4. Bootstrap the CISA_KEV Integration row for every existing real org.
+--    Excludes only the system "External Public Components" pseudo-org
+--    (00000000-…000); the CE singleton "User Organization" (00000000-…001)
+--    is a real working org on CE installs and gets CISA enabled too.
+--    identifier='base' matches CommonVariables.BASE_INTEGRATION_IDENTIFIER.
+INSERT INTO rearm.integrations (uuid, revision, schema_version, created_date, last_updated_date, record_data)
+SELECT
+    gen_random_uuid(),
+    0,
+    0,
+    now(),
+    now(),
+    jsonb_build_object(
+        'uuid',       gen_random_uuid()::text,
+        'identifier', 'base',
+        'isEnabled',  true,
+        'org',        o.uuid::text,
+        'type',       'CISA_KEV'
+    )
+FROM rearm.organizations o
+WHERE o.uuid <> '00000000-0000-0000-0000-000000000000'
+  AND NOT EXISTS (
+    SELECT 1 FROM rearm.integrations i
+    WHERE i.record_data->>'org' = o.uuid::text
+      AND i.record_data->>'type' = 'CISA_KEV'
+      AND i.record_data->>'identifier' = 'base'
+  );
+
+-- 5. Strip the instance-global vulncheckKevToken from SystemInfo.data.
+--    The new model holds the token on a per-org VULNCHECK_KEV integration's
+--    `secret` field, encrypted by the same EncryptionService.
+UPDATE rearm.system_info
+SET data = data - 'vulncheckKevToken'
+WHERE data ? 'vulncheckKevToken';

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -457,7 +457,8 @@ type Mutation {
 	finalizeAllReleases: Boolean
 	createOrganization(name: String!): Organization
 	setEmailProperties(emailProperties: EmailPropertiesInput!): Boolean
-	setVulnCheckKevToken(token: String): Boolean
+	# Global setVulnCheckKevToken removed in V54 KEV per-org refactor;
+	# use setVulnCheckKevTokenForOrg(orgUuid, token) below (org-admin scope).
 	setDefaultOrganization(organization: ID!): Boolean
 	inactivateUser(userUuid: ID!): User
 	reactivateUser(userUuid: ID!): User
@@ -476,6 +477,17 @@ type Mutation {
 	# entry still points at this integration — those have to be cleaned
 	# up first so the integration delete doesn't silently break them.
 	deleteCiIntegration(uuid: ID!): Boolean
+
+	# KEV per-org integration management (V54 refactor). All three are
+	# org-admin authorized on the target org. CISA_KEV is auto-created
+	# enabled when an org is provisioned (migration backfill + new-org
+	# hook), so the UI typically only calls enableKevSource/disableKevSource
+	# for CISA. VULNCHECK_KEV is opt-in: the org admin sets a token via
+	# setVulnCheckKevTokenForOrg, which lazily creates the integration row
+	# (enabled) and fires an immediate async first sync.
+	enableKevSource(orgUuid: ID!, source: IntegrationType!): Boolean
+	disableKevSource(orgUuid: ID!, source: IntegrationType!): Boolean
+	setVulnCheckKevTokenForOrg(orgUuid: ID!, token: String): Boolean
 
 	# webhooks (inbound)
 	createWebhook(webhook: WebhookInput!): Webhook
@@ -1749,7 +1761,8 @@ type SystemInfoIsSet {
 	emailDetailsSet: Boolean
 	defaultOrg: ID
 	defaultOrgDetails: Organization
-	vulncheckKevConfigured: Boolean
+	# vulncheckKevConfigured dropped in V54 KEV per-org refactor; surfaced
+	# per-org via the Integrations Catalog cards on Organization Settings.
 }
 
 type Organization {
@@ -4669,6 +4682,13 @@ enum IntegrationType {
 	SLACK
 	MSTEAMS
 	DEPENDENCYTRACK
+	# KEV catalog sources (V54 per-org refactor). Must stay in sync with the
+	# Java IntegrationType enum: enableKevSource/disableKevSource take these as
+	# an input arg and configuredBaseIntegrations returns them as output, so a
+	# missing value here breaks both coercion (enable/disable) and output
+	# serialization (every org has a CISA_KEV row after the V54 backfill).
+	CISA_KEV
+	VULNCHECK_KEV
 }
 
 # Capabilities a GITHUB integration is wired up to perform. Picked at

--- a/backend/src/test/java/io/reliza/service/KevAssertionServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/KevAssertionServiceTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -18,6 +19,7 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,16 +40,21 @@ import io.reliza.service.KevAssertionService.KevCatalogApplyOutcome;
 
 /**
  * Unit tests for {@link KevAssertionService}. Mock-based: pin the CVE-id
- * normalization contract, the membership probe's pre-filter, the per-source
- * reconcile arithmetic (insert / rewrite-on-diff / skip-unchanged / dedup),
- * the soft-delete and revive semantics, the genuinely-new-KEV detection
- * across sources, and the detail aggregation. Native queries run against a
- * live DB in the integration suite.
+ * normalization contract, the per-org membership probe's pre-filter, the
+ * per-source reconcile arithmetic (insert / rewrite-on-diff / skip-unchanged
+ * / dedup), the soft-delete and revive semantics, the genuinely-new-KEV
+ * detection across sources within ONE org, and the detail aggregation.
+ *
+ * <p>Per-org (V54) refactor: every read + write path takes a {@code UUID
+ * orgUuid}; new-KEV detection compares against THIS ORG's prior assertions
+ * only — the same CVE asserted in another org is independent.
+ * Native queries run against a live DB in the integration suite.
  */
 class KevAssertionServiceTest {
 
 	private KevAssertionRepository repository;
 	private KevAssertionService service;
+	private UUID orgUuid;
 
 	@BeforeEach
 	void wireMocks() throws Exception {
@@ -56,8 +63,9 @@ class KevAssertionServiceTest {
 		Field f = KevAssertionService.class.getDeclaredField("repository");
 		f.setAccessible(true);
 		f.set(service, repository);
-		// default: nothing pre-existing across sources
-		when(repository.findAllDistinctCveIds()).thenReturn(List.of());
+		orgUuid = UUID.randomUUID();
+		// default: nothing pre-existing across sources within this org
+		when(repository.findAllDistinctCveIdsForOrg(any(UUID.class))).thenReturn(List.of());
 	}
 
 	// ---------- normalizeCveId ----------
@@ -79,38 +87,50 @@ class KevAssertionServiceTest {
 
 	@Test
 	void filterPreFiltersNonCveIdsBeforeQuerying() {
-		when(repository.findExistingCveIds(anyCollection())).thenReturn(List.of("CVE-2021-44228"));
+		when(repository.findExistingCveIdsForOrg(eq(orgUuid), anyCollection()))
+				.thenReturn(List.of("CVE-2021-44228"));
 
-		Set<String> listed = service.filterKnownExploited(
+		Set<String> listed = service.filterKnownExploited(orgUuid,
 				List.of("cve-2021-44228", "GHSA-aaaa-bbbb-cccc", "CVE-2020-0001"));
 
 		assertEquals(Set.of("CVE-2021-44228"), listed);
-		verify(repository).findExistingCveIds(any());
+		verify(repository).findExistingCveIdsForOrg(eq(orgUuid), any());
 	}
 
 	@Test
 	void filterShortCircuitsWhenNoCveShapedIds() {
-		assertEquals(Set.of(), service.filterKnownExploited(List.of("GHSA-x", "OSV-y")));
-		assertEquals(Set.of(), service.filterKnownExploited(List.of()));
-		assertEquals(Set.of(), service.filterKnownExploited(null));
-		verify(repository, never()).findExistingCveIds(anyCollection());
+		assertEquals(Set.of(), service.filterKnownExploited(orgUuid, List.of("GHSA-x", "OSV-y")));
+		assertEquals(Set.of(), service.filterKnownExploited(orgUuid, List.of()));
+		assertEquals(Set.of(), service.filterKnownExploited(orgUuid, null));
+		assertEquals(Set.of(), service.filterKnownExploited(null, List.of("CVE-X")));
+		verify(repository, never()).findExistingCveIdsForOrg(any(UUID.class), anyCollection());
 	}
 
 	@Test
 	void isAnyKnownExploitedReflectsProbe() {
-		when(repository.findExistingCveIds(anyCollection())).thenReturn(List.of());
-		assertFalse(service.isAnyKnownExploited(List.of("CVE-2020-0001")));
-		when(repository.findExistingCveIds(anyCollection())).thenReturn(List.of("CVE-2020-0001"));
-		assertTrue(service.isAnyKnownExploited(List.of("CVE-2020-0001")));
+		when(repository.findExistingCveIdsForOrg(eq(orgUuid), anyCollection())).thenReturn(List.of());
+		assertFalse(service.isAnyKnownExploited(orgUuid, List.of("CVE-2020-0001")));
+		when(repository.findExistingCveIdsForOrg(eq(orgUuid), anyCollection()))
+				.thenReturn(List.of("CVE-2020-0001"));
+		assertTrue(service.isAnyKnownExploited(orgUuid, List.of("CVE-2020-0001")));
+	}
+
+	// ---------- countRecordsForOrg ----------
+
+	@Test
+	void countRecordsForOrgDelegatesToRepository() {
+		when(repository.countByOrgId(orgUuid)).thenReturn(42L);
+		assertEquals(42L, service.countRecordsForOrg(orgUuid));
+		assertEquals(0L, service.countRecordsForOrg(null));
 	}
 
 	// ---------- applyCatalog: inserts + new-KEV detection ----------
 
 	@Test
 	void applyInsertsNewEntriesAndFlagsThemNewKev() {
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of());
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of());
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA,
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA,
 				List.of(entry("CVE-2021-44228"), entry("CVE-2023-1234")));
 
 		assertEquals(List.of("CVE-2021-44228", "CVE-2023-1234"), outcome.newlyKevCveIds());
@@ -122,16 +142,26 @@ class KevAssertionServiceTest {
 	}
 
 	@Test
-	void newKevDetectionIgnoresCvesAlreadyAssertedByAnotherSource() {
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of());
-		// CVE-EXISTING is already asserted (by some other source) — not "new KEV"
-		when(repository.findAllDistinctCveIds()).thenReturn(List.of("CVE-EXISTING"));
+	void applyCatalogRequiresOrgUuid() {
+		try {
+			service.applyCatalog(null, KevSource.CISA, List.of(entry("CVE-2021-44228")));
+		} catch (IllegalArgumentException e) {
+			return;
+		}
+		throw new AssertionError("expected IllegalArgumentException when orgUuid is null");
+	}
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA,
+	@Test
+	void newKevDetectionIgnoresCvesAlreadyAssertedByAnotherSourceInSameOrg() {
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of());
+		// CVE-EXISTING is already asserted (by some other source) in THIS org — not "new KEV"
+		when(repository.findAllDistinctCveIdsForOrg(orgUuid)).thenReturn(List.of("CVE-EXISTING"));
+
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA,
 				List.of(entry("CVE-EXISTING"), entry("CVE-NEW")));
 
 		assertEquals(List.of("CVE-NEW"), outcome.newlyKevCveIds());
-		// both rows still inserted for CISA
+		// both rows still inserted for CISA in this org
 		assertEquals(2, captureSaved().size());
 	}
 
@@ -141,11 +171,12 @@ class KevAssertionServiceTest {
 	void applyRewritesChangedAndSkipsUnchanged() {
 		KevAssertionData unchanged = entry("CVE-2020-0001");
 		KevAssertionData changed = entry("CVE-2020-0002");
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of(
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of(
 				existing("CVE-2020-0001", unchanged.toRecordData(), null),
 				existing("CVE-2020-0002", entry("CVE-2020-0002", "old required action").toRecordData(), null)));
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA, List.of(unchanged, changed));
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA,
+				List.of(unchanged, changed));
 
 		assertEquals(List.of(), outcome.newlyKevCveIds());
 		assertEquals(1, outcome.updated());
@@ -160,11 +191,11 @@ class KevAssertionServiceTest {
 
 	@Test
 	void applySoftDeletesEntriesMissingFromFeedInsteadOfDeleting() {
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of(
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of(
 				existing("CVE-2020-0001", entry("CVE-2020-0001").toRecordData(), null),
 				existing("CVE-2019-9999", entry("CVE-2019-9999").toRecordData(), null)));
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA,
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA,
 				List.of(entry("CVE-2020-0001")));
 
 		assertEquals(1, outcome.revoked());
@@ -177,10 +208,10 @@ class KevAssertionServiceTest {
 	@Test
 	void applyRevivesAReappearedRevokedEntry() {
 		KevAssertionData data = entry("CVE-2020-0001");
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of(
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of(
 				existing("CVE-2020-0001", data.toRecordData(), ZonedDateTime.now().minusDays(3))));
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA, List.of(data));
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA, List.of(data));
 
 		assertEquals(1, outcome.revived());
 		assertEquals(0, outcome.updated());
@@ -192,9 +223,9 @@ class KevAssertionServiceTest {
 
 	@Test
 	void applyDedupesAndNormalizesFeedEntries() {
-		when(repository.findBySource(KevSource.CISA)).thenReturn(List.of());
+		when(repository.findByOrgIdAndSource(orgUuid, KevSource.CISA)).thenReturn(List.of());
 
-		KevCatalogApplyOutcome outcome = service.applyCatalog(KevSource.CISA, List.of(
+		KevCatalogApplyOutcome outcome = service.applyCatalog(orgUuid, KevSource.CISA, List.of(
 				entry("cve-2021-44228"), // lowercase — normalized
 				entry("CVE-2021-44228"), // duplicate — dropped
 				entry("not-a-cve")));    // non-CVE — dropped
@@ -217,10 +248,10 @@ class KevAssertionServiceTest {
 		KevAssertion withdrawn = existing("CVE-2021-44228", unspecified.toRecordData(), revoked);
 		withdrawn.setSource(KevSource.CISA);
 
-		when(repository.findByCveIdOrderBySourceAsc("CVE-2021-44228"))
+		when(repository.findByOrgIdAndCveIdOrderBySourceAsc(orgUuid, "CVE-2021-44228"))
 				.thenReturn(List.of(active, withdrawn));
 
-		Optional<KevRecordDetails> details = service.getKevDetails("cve-2021-44228");
+		Optional<KevRecordDetails> details = service.getKevDetails(orgUuid, "cve-2021-44228");
 
 		assertTrue(details.isPresent());
 		assertEquals("CVE-2021-44228", details.get().cveId());
@@ -232,9 +263,11 @@ class KevAssertionServiceTest {
 
 	@Test
 	void detailsEmptyWhenNoAssertions() {
-		when(repository.findByCveIdOrderBySourceAsc("CVE-0000-0000")).thenReturn(List.of());
-		assertTrue(service.getKevDetails("CVE-0000-0000").isEmpty());
-		assertTrue(service.getKevDetails("not-a-cve").isEmpty());
+		when(repository.findByOrgIdAndCveIdOrderBySourceAsc(eq(orgUuid), eq("CVE-0000-0000")))
+				.thenReturn(List.of());
+		assertTrue(service.getKevDetails(orgUuid, "CVE-0000-0000").isEmpty());
+		assertTrue(service.getKevDetails(orgUuid, "not-a-cve").isEmpty());
+		assertTrue(service.getKevDetails(null, "CVE-2021-44228").isEmpty());
 	}
 
 	// ---------- helpers ----------

--- a/backend/src/test/java/io/reliza/service/kev/CisaKevConnectorTest.java
+++ b/backend/src/test/java/io/reliza/service/kev/CisaKevConnectorTest.java
@@ -101,7 +101,7 @@ class CisaKevConnectorTest {
 
 	@Test
 	void parsesFeedAndMapsRansomwareToThreeStateEnum() throws Exception {
-		List<KevAssertionData> entries = withFeed(FEED_JSON).fetchCatalog();
+		List<KevAssertionData> entries = withFeed(FEED_JSON).fetchCatalog(null);
 
 		assertEquals(3, entries.size());
 		KevAssertionData first = entries.get(0);
@@ -119,16 +119,16 @@ class CisaKevConnectorTest {
 	@Test
 	void fetchFailureReturnsEmptyList() throws Exception {
 		assertTrue(newConnector(req -> Mono.error(new RuntimeException("connection refused")))
-				.fetchCatalog().isEmpty());
+				.fetchCatalog(null).isEmpty());
 	}
 
 	@Test
 	void malformedJsonReturnsEmptyList() throws Exception {
-		assertTrue(withFeed("<html>maintenance</html>").fetchCatalog().isEmpty());
+		assertTrue(withFeed("<html>maintenance</html>").fetchCatalog(null).isEmpty());
 	}
 
 	@Test
 	void emptyCatalogReturnsEmptyList() throws Exception {
-		assertTrue(withFeed("{\"catalogVersion\":\"x\",\"vulnerabilities\":[]}").fetchCatalog().isEmpty());
+		assertTrue(withFeed("{\"catalogVersion\":\"x\",\"vulnerabilities\":[]}").fetchCatalog(null).isEmpty());
 	}
 }

--- a/backend/src/test/java/io/reliza/service/kev/KevCatalogSyncServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/kev/KevCatalogSyncServiceTest.java
@@ -8,44 +8,75 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import io.reliza.model.Integration;
+import io.reliza.model.IntegrationData.IntegrationType;
 import io.reliza.model.KevAssertionData;
 import io.reliza.model.KevSource;
 import io.reliza.model.VulnerabilityRecord;
 import io.reliza.model.VulnerabilityRecordData;
+import io.reliza.repositories.IntegrationRepository;
 import io.reliza.repositories.VulnerabilityRecordRepository;
+import io.reliza.service.EncryptionService;
 import io.reliza.service.KevAssertionService;
 import io.reliza.service.KevAssertionService.KevCatalogApplyOutcome;
 import io.reliza.service.VulnAnalysisUpdateService;
 import io.reliza.service.VulnerabilityRecordChangeHook;
 
 /**
- * Unit tests for {@link KevCatalogSyncService} orchestration. The connector,
- * assertion service, vuln repo and notification hook are mocked. Pins the
- * fail-closed contract (an empty connector result skips reconcile), the
- * bootstrap event-storm guard, the per-affected-record KEV_ADDED emission,
- * and CE-safety (a null hook no-ops without breaking the read-path sync).
+ * Unit tests for {@link KevCatalogSyncService} orchestration in the per-org
+ * (V54) model. Pins the per-org fan-out shape:
+ * <ul>
+ *   <li>The orchestrator iterates enabled {@code Integration} rows for
+ *       {@code CISA_KEV} / {@code VULNCHECK_KEV} and dispatches per (org,
+ *       source), passing the row's decrypted credential to the connector.
+ *   <li>Fail-closed: an empty connector result skips that (org, source)
+ *       reconcile.
+ *   <li>Bootstrap-silent: the first per-org sync (zero existing rows for
+ *       that {@code org_id}) applies the catalog but skips the KEV_ADDED
+ *       event pass AND the re-gate fan-out.
+ *   <li>Incremental: subsequent syncs emit KEV_ADDED for every record in
+ *       the same org carrying a newly-KEV CVE, and fire the re-gate fan-out
+ *       for that org.
+ *   <li>CE-safety: a null hook no-ops the KEV_ADDED pass without breaking
+ *       the reconcile.
+ *   <li>{@code syncOrgSourceAsync} (configure-flow entry point) looks up
+ *       the single integration row, decrypts, and reconciles for that one
+ *       (org, source).
+ * </ul>
+ *
+ * <p>{@code IntegrationRepository} and {@code EncryptionService} are mocked.
+ * {@code PlatformTransactionManager} is a bare mock — the transaction
+ * template's callback executes directly with a null status, which is fine
+ * for the mock-driven assertions here. (Live DB transaction behaviour is
+ * covered by the integration suite.)
  */
 class KevCatalogSyncServiceTest {
 
-	private KevSourceConnector connector;
+	private KevSourceConnector cisaConnector;
+	private KevSourceConnector vulnCheckConnector;
 	private KevAssertionService kevAssertionService;
+	private IntegrationRepository integrationRepository;
+	private EncryptionService encryptionService;
 	private VulnerabilityRecordRepository vulnerabilityRecordRepository;
 	private VulnerabilityRecordChangeHook hook;
 	private VulnAnalysisUpdateService vulnAnalysisUpdateService;
@@ -53,16 +84,27 @@ class KevCatalogSyncServiceTest {
 
 	@BeforeEach
 	void wireMocks() throws Exception {
-		connector = mock(KevSourceConnector.class);
-		when(connector.source()).thenReturn(KevSource.CISA);
+		cisaConnector = mock(KevSourceConnector.class);
+		when(cisaConnector.source()).thenReturn(KevSource.CISA);
+		vulnCheckConnector = mock(KevSourceConnector.class);
+		when(vulnCheckConnector.source()).thenReturn(KevSource.VULNCHECK);
+
 		kevAssertionService = mock(KevAssertionService.class);
+		integrationRepository = mock(IntegrationRepository.class);
+		encryptionService = mock(EncryptionService.class);
 		vulnerabilityRecordRepository = mock(VulnerabilityRecordRepository.class);
 		hook = mock(VulnerabilityRecordChangeHook.class);
 		vulnAnalysisUpdateService = mock(VulnAnalysisUpdateService.class);
 
+		// Default empty integration lists — individual tests override.
+		when(integrationRepository.listEnabledIntegrationsByType(anyString()))
+				.thenReturn(List.of());
+
 		service = new KevCatalogSyncService();
-		inject("connectors", List.of(connector));
+		inject("connectors", List.of(cisaConnector, vulnCheckConnector));
 		inject("kevAssertionService", kevAssertionService);
+		inject("integrationRepository", integrationRepository);
+		inject("encryptionService", encryptionService);
 		inject("vulnerabilityRecordRepository", vulnerabilityRecordRepository);
 		inject("vulnerabilityRecordChangeHook", hook);
 		inject("vulnAnalysisUpdateService", vulnAnalysisUpdateService);
@@ -76,121 +118,28 @@ class KevCatalogSyncServiceTest {
 		f.set(service, value);
 	}
 
+	// ---------- fixtures ----------
+
+	private static Integration integrationRow(UUID orgUuid, IntegrationType type, String encryptedSecret) {
+		Integration row = new Integration();
+		row.setUuid(UUID.randomUUID());
+		Map<String, Object> recordData = new LinkedHashMap<>();
+		recordData.put("uuid", row.getUuid().toString());
+		recordData.put("identifier", "base");
+		recordData.put("isEnabled", true);
+		recordData.put("org", orgUuid.toString());
+		recordData.put("type", type.name());
+		if (encryptedSecret != null) {
+			recordData.put("secret", encryptedSecret);
+		}
+		row.setRecordData(recordData);
+		return row;
+	}
+
 	private static List<KevAssertionData> oneEntry() {
 		KevAssertionData kad = new KevAssertionData();
 		kad.setCveId("CVE-2026-0001");
 		return List.of(kad);
-	}
-
-	@Test
-	void emptyConnectorResultSkipsReconcile() {
-		when(connector.fetchCatalog()).thenReturn(List.of());
-		when(kevAssertionService.countRecords()).thenReturn(5L);
-
-		assertEquals(0, service.syncCatalog());
-
-		verify(kevAssertionService, never()).applyCatalog(any(), any());
-	}
-
-	@Test
-	void bootstrapSkipsEventPass() {
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(0L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-
-		assertEquals(1, service.syncCatalog());
-
-		verify(vulnerabilityRecordRepository, never()).findAllOrgsByVulnIdOrAlias(anyString());
-		verify(hook, never()).onKevAdded(any(), anyString(), any());
-		// Bootstrap must NOT fan out re-gate recomputes (would storm).
-		verify(vulnAnalysisUpdateService, never()).recomputeReleasesForNewlyKev(anyString(), any());
-	}
-
-	@Test
-	void incrementalAdditionFansOutReGateForAffectedOrgs() {
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(1L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-		UUID orgA = UUID.randomUUID();
-		UUID orgB = UUID.randomUUID();
-		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias("CVE-2026-0001"))
-				.thenReturn(List.of(
-						vulnRecord(orgA, "CVE-2026-0001"),
-						vulnRecord(orgB, "GHSA-aaaa-bbbb-cccc")));
-
-		assertEquals(1, service.syncCatalog());
-
-		// Re-gate fan-out fires once for the CVE with the distinct affected orgs.
-		verify(vulnAnalysisUpdateService).recomputeReleasesForNewlyKev(
-				eq("CVE-2026-0001"),
-				argThat((Collection<UUID> orgs) ->
-						orgs.size() == 2 && Set.copyOf(orgs).equals(Set.of(orgA, orgB))));
-	}
-
-	@Test
-	void incrementalAdditionWithNoAffectedOrgsSkipsReGate() {
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(1L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias(anyString())).thenReturn(List.of());
-
-		assertEquals(1, service.syncCatalog());
-
-		verify(vulnAnalysisUpdateService, never()).recomputeReleasesForNewlyKev(anyString(), any());
-	}
-
-	@Test
-	void incrementalAdditionNotifiesEveryMatchingOrgRecord() {
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(1L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-		UUID orgA = UUID.randomUUID();
-		UUID orgB = UUID.randomUUID();
-		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias("CVE-2026-0001"))
-				.thenReturn(List.of(
-						vulnRecord(orgA, "CVE-2026-0001"),
-						// orgB tracks it under a GHSA primary id; CVE in aliases
-						vulnRecord(orgB, "GHSA-aaaa-bbbb-cccc")));
-
-		assertEquals(1, service.syncCatalog());
-
-		verify(hook).onKevAdded(eq(orgA), eq("CVE-2026-0001"), any(VulnerabilityRecordData.class));
-		verify(hook).onKevAdded(eq(orgB), eq("GHSA-aaaa-bbbb-cccc"), any(VulnerabilityRecordData.class));
-	}
-
-	@Test
-	void noMatchingRecordsMeansNoEvents() {
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(1L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias(anyString())).thenReturn(List.of());
-
-		assertEquals(1, service.syncCatalog());
-
-		verify(hook, never()).onKevAdded(any(), anyString(), any());
-	}
-
-	@Test
-	void absentHookNoOpsButStillReconciles() throws Exception {
-		inject("vulnerabilityRecordChangeHook", null); // CE: no impl bean
-		when(connector.fetchCatalog()).thenReturn(oneEntry());
-		when(kevAssertionService.countRecords()).thenReturn(1L);
-		when(kevAssertionService.applyCatalog(eq(KevSource.CISA), any())).thenReturn(
-				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
-
-		assertEquals(1, service.syncCatalog());
-
-		verify(kevAssertionService).applyCatalog(eq(KevSource.CISA), any());
-		// A null hook must not break the sync: reconcile still happens and
-		// the KEV_ADDED notification never fires. (The KEV re-gate fan-out
-		// is independent of the hook and still runs — CE-ready — so we no
-		// longer assert on findAllOrgsByVulnIdOrAlias, only on the hook.)
-		verify(hook, never()).onKevAdded(any(), anyString(), any());
 	}
 
 	private static VulnerabilityRecord vulnRecord(UUID org, String primaryVulnId) {
@@ -202,5 +151,199 @@ class KevCatalogSyncServiceTest {
 		recordData.put("severity", "HIGH");
 		vr.setRecordData(recordData);
 		return vr;
+	}
+
+	// ---------- tests ----------
+
+	@Test
+	void emptyConnectorResultSkipsReconcile() {
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(List.of());
+		// Already-bootstrapped org — irrelevant since reconcile is skipped.
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(5L);
+
+		assertEquals(0, service.syncCatalog());
+
+		verify(kevAssertionService, never()).applyCatalog(any(UUID.class), any(KevSource.class), any());
+	}
+
+	@Test
+	void firstSyncForOrgSkipsKevAddedAndReGate() {
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(0L);
+		when(kevAssertionService.applyCatalog(eq(orgA), eq(KevSource.CISA), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
+
+		assertEquals(1, service.syncCatalog());
+
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.CISA), any());
+		// Bootstrap silence: no event pass, no re-gate fan-out.
+		verify(vulnerabilityRecordRepository, never()).findAllOrgsByVulnIdOrAlias(anyString());
+		verify(hook, never()).onKevAdded(any(), anyString(), any());
+		verify(vulnAnalysisUpdateService, never())
+				.recomputeReleasesForNewlyKev(anyString(), any());
+	}
+
+	@Test
+	void incrementalSyncFiresEventsAndReGateForAffectedOrgRecords() {
+		UUID orgA = UUID.randomUUID();
+		UUID orgB = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(1L); // already-bootstrapped
+		when(kevAssertionService.applyCatalog(eq(orgA), eq(KevSource.CISA), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
+		// Two orgs carry the CVE in vuln records; only orgA's records get
+		// KEV_ADDED + re-gate (per-org sync isolation).
+		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias("CVE-2026-0001"))
+				.thenReturn(List.of(
+						vulnRecord(orgA, "CVE-2026-0001"),
+						vulnRecord(orgB, "GHSA-aaaa-bbbb-cccc")));
+
+		assertEquals(1, service.syncCatalog());
+
+		// KEV_ADDED fires only for the orgA record — orgB isn't this sync's org.
+		verify(hook).onKevAdded(eq(orgA), eq("CVE-2026-0001"), any(VulnerabilityRecordData.class));
+		verify(hook, never()).onKevAdded(eq(orgB), anyString(), any());
+		// Re-gate fan-out fires for orgA's affected releases only.
+		verify(vulnAnalysisUpdateService).recomputeReleasesForNewlyKev(
+				eq("CVE-2026-0001"),
+				argThat((Collection<UUID> orgs) -> orgs.size() == 1 && orgs.contains(orgA)));
+	}
+
+	@Test
+	void incrementalSyncWithNoAffectedRecordsInOrgSkipsReGate() {
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(1L);
+		when(kevAssertionService.applyCatalog(eq(orgA), eq(KevSource.CISA), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
+		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias(anyString())).thenReturn(List.of());
+
+		assertEquals(1, service.syncCatalog());
+
+		verify(vulnAnalysisUpdateService, never()).recomputeReleasesForNewlyKev(anyString(), any());
+		verify(hook, never()).onKevAdded(any(), anyString(), any());
+	}
+
+	@Test
+	void absentHookNoOpsButStillReconcilesAndReGates() throws Exception {
+		inject("vulnerabilityRecordChangeHook", null); // CE: no impl bean
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(1L);
+		when(kevAssertionService.applyCatalog(eq(orgA), eq(KevSource.CISA), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
+		when(vulnerabilityRecordRepository.findAllOrgsByVulnIdOrAlias("CVE-2026-0001"))
+				.thenReturn(List.of(vulnRecord(orgA, "CVE-2026-0001")));
+
+		assertEquals(1, service.syncCatalog());
+
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.CISA), any());
+		// Hook is null in CE — KEV_ADDED no-ops cleanly. Re-gate still runs.
+		verify(hook, never()).onKevAdded(any(), anyString(), any());
+		verify(vulnAnalysisUpdateService).recomputeReleasesForNewlyKev(eq("CVE-2026-0001"), any());
+	}
+
+	@Test
+	void vulnCheckRowWithBlankSecretYieldsEmptyConnectorResultAndSkipsReconcile() {
+		UUID orgA = UUID.randomUUID();
+		// Blank-secret row: decryptCredential returns null; connector treats
+		// missing credential as a failed/empty fetch and returns an empty list.
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.VULNCHECK_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.VULNCHECK_KEV, null)));
+		when(vulnCheckConnector.fetchCatalog(isNull())).thenReturn(List.of());
+
+		assertEquals(0, service.syncCatalog());
+
+		verify(kevAssertionService, never()).applyCatalog(eq(orgA), eq(KevSource.VULNCHECK), any());
+	}
+
+	@Test
+	void twoOrgsBothWithCisaCallConnectorTwiceAndApplyPerOrg() {
+		UUID orgA = UUID.randomUUID();
+		UUID orgB = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(
+						integrationRow(orgA, IntegrationType.CISA_KEV, null),
+						integrationRow(orgB, IntegrationType.CISA_KEV, null)));
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		// Both already bootstrapped — keep the test focused on the fan-out.
+		when(kevAssertionService.countRecordsForOrg(any(UUID.class))).thenReturn(1L);
+		when(kevAssertionService.applyCatalog(any(UUID.class), eq(KevSource.CISA), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of(), 0, 0, 0, 1));
+
+		assertEquals(0, service.syncCatalog());
+
+		verify(cisaConnector, times(2)).fetchCatalog(isNull());
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.CISA), any());
+		verify(kevAssertionService).applyCatalog(eq(orgB), eq(KevSource.CISA), any());
+	}
+
+	@Test
+	void orgWithBothCisaAndVulnCheckEnabledSyncsBothSources() {
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.CISA_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.CISA_KEV, null)));
+		when(integrationRepository.listEnabledIntegrationsByType(IntegrationType.VULNCHECK_KEV.name()))
+				.thenReturn(List.of(integrationRow(orgA, IntegrationType.VULNCHECK_KEV, "enc-token")));
+		when(encryptionService.decrypt("enc-token")).thenReturn("plain-token");
+		when(cisaConnector.fetchCatalog(isNull())).thenReturn(oneEntry());
+		when(vulnCheckConnector.fetchCatalog(eq("plain-token"))).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(1L);
+		when(kevAssertionService.applyCatalog(eq(orgA), any(KevSource.class), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of(), 0, 0, 0, 1));
+
+		service.syncCatalog();
+
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.CISA), any());
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.VULNCHECK), any());
+		verify(encryptionService).decrypt("enc-token");
+	}
+
+	@Test
+	void syncOrgSourceAsyncLooksUpRowDecryptsAndApplies() {
+		UUID orgA = UUID.randomUUID();
+		Integration row = integrationRow(orgA, IntegrationType.VULNCHECK_KEV, "enc-token");
+		when(integrationRepository.findIntegrationByOrgTypeIdentifier(
+				orgA.toString(), IntegrationType.VULNCHECK_KEV.name(), "base"))
+				.thenReturn(Optional.of(row));
+		when(encryptionService.decrypt("enc-token")).thenReturn("plain-token");
+		when(vulnCheckConnector.fetchCatalog(eq("plain-token"))).thenReturn(oneEntry());
+		when(kevAssertionService.countRecordsForOrg(orgA)).thenReturn(0L); // first sync
+		when(kevAssertionService.applyCatalog(eq(orgA), eq(KevSource.VULNCHECK), any())).thenReturn(
+				new KevCatalogApplyOutcome(List.of("CVE-2026-0001"), 0, 0, 0, 1));
+
+		service.syncOrgSourceAsync(orgA, IntegrationType.VULNCHECK_KEV);
+
+		verify(encryptionService).decrypt("enc-token");
+		verify(vulnCheckConnector).fetchCatalog(eq("plain-token"));
+		verify(kevAssertionService).applyCatalog(eq(orgA), eq(KevSource.VULNCHECK), any());
+		// First sync — KEV_ADDED + re-gate skipped.
+		verify(hook, never()).onKevAdded(any(), anyString(), any());
+		verify(vulnAnalysisUpdateService, never()).recomputeReleasesForNewlyKev(anyString(), any());
+	}
+
+	@Test
+	void syncOrgSourceAsyncMissingRowIsNoOp() {
+		UUID orgA = UUID.randomUUID();
+		when(integrationRepository.findIntegrationByOrgTypeIdentifier(
+				eq(orgA.toString()), anyString(), eq("base")))
+				.thenReturn(Optional.empty());
+
+		service.syncOrgSourceAsync(orgA, IntegrationType.VULNCHECK_KEV);
+
+		verify(vulnCheckConnector, never()).fetchCatalog(anyString());
+		verify(kevAssertionService, never()).applyCatalog(any(UUID.class), any(KevSource.class), any());
 	}
 }

--- a/backend/src/test/java/io/reliza/service/kev/VulnCheckKevConnectorTest.java
+++ b/backend/src/test/java/io/reliza/service/kev/VulnCheckKevConnectorTest.java
@@ -5,8 +5,6 @@ package io.reliza.service.kev;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -24,15 +22,17 @@ import org.springframework.web.reactive.function.client.WebClient;
 import io.reliza.model.KevAssertionData;
 import io.reliza.model.KevRansomwareStatus;
 import io.reliza.model.KevSource;
-import io.reliza.service.SystemInfoService;
 import reactor.core.publisher.Mono;
 
 /**
  * Unit tests for {@link VulnCheckKevConnector}: HTTP substituted with an
- * {@link ExchangeFunction} stub. Pins token-gating (no token = no-op),
- * pagination (page through {@code _meta.total_pages}), the {@code cve}-array
- * fan-out (one assertion per CVE), the ransomware enum mapping + ISO-date
- * slicing, and the fail-closed contract.
+ * {@link ExchangeFunction} stub. Pins token-gating (no/blank credential
+ * = no-op), pagination (page through {@code _meta.total_pages}), the
+ * {@code cve}-array fan-out (one assertion per CVE), the ransomware enum
+ * mapping + ISO-date slicing, and the fail-closed contract.
+ *
+ * <p>V54: connector no longer reads the token from {@code SystemInfoService};
+ * the per-org credential is passed to {@code fetchCatalog(credential)}.
  */
 class VulnCheckKevConnectorTest {
 
@@ -54,10 +54,8 @@ class VulnCheckKevConnectorTest {
 			]}
 			""";
 
-	private VulnCheckKevConnector newConnector(String token, ExchangeFunction exchange) throws Exception {
-		SystemInfoService sis = mock(SystemInfoService.class);
-		when(sis.getVulncheckKevToken()).thenReturn(token);
-		VulnCheckKevConnector c = new VulnCheckKevConnector(sis, "https://vc.test/v3/index/vulncheck-kev");
+	private VulnCheckKevConnector newConnector(ExchangeFunction exchange) throws Exception {
+		VulnCheckKevConnector c = new VulnCheckKevConnector("https://vc.test/v3/index/vulncheck-kev");
 		WebClient stub = WebClient.builder().exchangeFunction(exchange).build();
 		Field f = VulnCheckKevConnector.class.getDeclaredField("webClient");
 		f.setAccessible(true);
@@ -74,21 +72,22 @@ class VulnCheckKevConnectorTest {
 
 	@Test
 	void sourceIsVulnCheck() throws Exception {
-		assertEquals(KevSource.VULNCHECK, newConnector("tok", req -> json(PAGE1)).source());
+		assertEquals(KevSource.VULNCHECK, newConnector(req -> json(PAGE1)).source());
 	}
 
 	@Test
 	void blankTokenIsNoOp() throws Exception {
-		VulnCheckKevConnector c = newConnector("", req -> {
+		VulnCheckKevConnector c = newConnector(req -> {
 			throw new AssertionError("must not fetch without a token");
 		});
-		assertTrue(c.fetchCatalog().isEmpty());
+		assertTrue(c.fetchCatalog("").isEmpty());
+		assertTrue(c.fetchCatalog(null).isEmpty());
 	}
 
 	@Test
 	void paginatesAndFansOutCveArray() throws Exception {
 		ExchangeFunction ex = req -> req.url().toString().contains("page=1") ? json(PAGE1) : json(PAGE2);
-		List<KevAssertionData> entries = newConnector("tok", ex).fetchCatalog();
+		List<KevAssertionData> entries = newConnector(ex).fetchCatalog("tok");
 
 		// 2 CVEs from the page-1 entry's array + 1 from page-2 = 3 assertions.
 		assertEquals(3, entries.size());
@@ -109,13 +108,13 @@ class VulnCheckKevConnectorTest {
 
 	@Test
 	void fetchErrorReturnsEmpty() throws Exception {
-		assertTrue(newConnector("tok", req -> Mono.error(new RuntimeException("connection refused")))
-				.fetchCatalog().isEmpty());
+		assertTrue(newConnector(req -> Mono.error(new RuntimeException("connection refused")))
+				.fetchCatalog("tok").isEmpty());
 	}
 
 	@Test
 	void emptyDataReturnsEmpty() throws Exception {
-		assertTrue(newConnector("tok", req -> json("{\"_meta\":{\"total_pages\":1},\"data\":[]}"))
-				.fetchCatalog().isEmpty());
+		assertTrue(newConnector(req -> json("{\"_meta\":{\"total_pages\":1},\"data\":[]}"))
+				.fetchCatalog("tok").isEmpty());
 	}
 }

--- a/backend/src/test/java/io/reliza/ws/IntegrationTypeSchemaEnumSyncTest.java
+++ b/backend/src/test/java/io/reliza/ws/IntegrationTypeSchemaEnumSyncTest.java
@@ -1,0 +1,98 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. All rights reserved.
+*/
+package io.reliza.ws;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.IntegrationData.IntegrationType;
+
+/**
+ * Regression guard for the {@code IntegrationType} GraphQL/Java enum drift
+ * (sibling of {@code NotificationSchemaEnumSyncTest}).
+ *
+ * <p>The GraphQL {@code IntegrationType} enum is deliberately a SUBSET of
+ * the Java enum -- the notification-only destinations ({@code EMAIL},
+ * {@code WEBHOOK}, {@code SENTINEL}) are exposed via
+ * {@code NotificationChannelTypeEnum} instead, so a strict equality check
+ * would be wrong here. Two weaker-but-correct invariants are pinned:
+ *
+ * <ol>
+ *   <li>Every value declared in the schema enum is a real Java enum value
+ *       (catches a stale/typo'd schema entry).</li>
+ *   <li>The KEV catalog source types ({@code CISA_KEV}, {@code VULNCHECK_KEV})
+ *       are present. These flow through the GraphQL {@code IntegrationType}
+ *       surface in both directions -- {@code enableKevSource} /
+ *       {@code disableKevSource} take them as an input arg, and
+ *       {@code configuredBaseIntegrations} returns them as output (every org
+ *       gets a CISA_KEV row from the V54 backfill). A missing value breaks
+ *       both input coercion and output serialization. This is the exact
+ *       drift the V54 per-org refactor would otherwise have shipped.</li>
+ * </ol>
+ */
+class IntegrationTypeSchemaEnumSyncTest {
+
+    private static final Pattern ENUM_BLOCK = Pattern.compile(
+            "enum\\s+(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+    @Test
+    void schemaIntegrationTypeValuesAreAllRealJavaValues() {
+        Set<String> javaValues = Arrays.stream(IntegrationType.values()).map(Enum::name)
+                .collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+        Set<String> schemaValues = readSchemaEnum("IntegrationType");
+        for (String v : schemaValues) {
+            assertTrue(javaValues.contains(v),
+                    "GraphQL enum IntegrationType declares '" + v
+                            + "' which is not a Java IntegrationType value (stale/typo)");
+        }
+    }
+
+    @Test
+    void kevSourceTypesAreDeclaredInSchema() {
+        Set<String> schemaValues = readSchemaEnum("IntegrationType");
+        assertTrue(schemaValues.contains(IntegrationType.CISA_KEV.name()),
+                "GraphQL enum IntegrationType is missing CISA_KEV -- enableKevSource input"
+                        + " and configuredBaseIntegrations output will fail enum validation");
+        assertTrue(schemaValues.contains(IntegrationType.VULNCHECK_KEV.name()),
+                "GraphQL enum IntegrationType is missing VULNCHECK_KEV -- enableKevSource input"
+                        + " and configuredBaseIntegrations output will fail enum validation");
+    }
+
+    private static Set<String> readSchemaEnum(String enumName) {
+        String schema = readSchema();
+        Matcher m = ENUM_BLOCK.matcher(schema);
+        while (m.find()) {
+            if (!enumName.equals(m.group(1))) continue;
+            Set<String> out = new TreeSet<>();
+            for (String raw : m.group(2).split("\\R")) {
+                String line = raw.trim();
+                int hash = line.indexOf('#');
+                if (hash >= 0) line = line.substring(0, hash).trim();
+                if (line.isEmpty()) continue;
+                out.add(line);
+            }
+            return out;
+        }
+        throw new AssertionError("Did not find enum " + enumName + " in schema.graphqls");
+    }
+
+    private static String readSchema() {
+        try (InputStream in = IntegrationTypeSchemaEnumSyncTest.class.getResourceAsStream(
+                "/schema/schema.graphqls")) {
+            if (in == null) throw new IllegalStateException("schema.graphqls not on test classpath");
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (java.io.IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## What

Mirrors the **shared** per-org KEV backend from `rearm-core` (PR #221, V54) into CE via `copy-src.sh`, completing CE parity. The CE per-org **UI** already merged (#146); this is the matching backend.

KEV moves from instance-global → fully per-org:
- VulnCheck token stored per-org on a `VULNCHECK_KEV` Integration row (encrypted `secret`), not on `SystemInfo`
- `kev_assertions` gains `org_id` (unique `(org_id, source, cve_id)`)
- `CISA_KEV` is a default-enabled catalog card, backfilled for every real org by V54 (explicitly includes CE's singleton org `…001`, excludes the `…000` pseudo-org)

## Depends on rearm-saas #222 — merge that first

Per the decision to make per-org KEV a **CE feature**, the scheduled sync trigger was relocated from `saas/SaasSchedulingService` into the **shared** `SchedulingService` in rearm-saas #222. With #222 merged, CE's `SchedulingService` is a **pure `copy-src.sh` mirror** of the shared class (byte-identical) — no CE-local divergence, and future mirrors no longer strip the KEV scheduler.

If this lands before #222, a later mirror from un-relocated `rearm-saas` main would re-strip CE's scheduler. Order: **#222 → this.**

## `saas/` scope boundary (correctly excluded, not CE-blocking)

| Pro `saas/` file | Why excluded is correct |
|---|---|
| `SaasSchedulingService.syncKevCatalog()` | **Relocated to shared** in #222 → now mirrored to CE natively. |
| `SaasOrganizationService` default-CISA on org-create | No shared `OrganizationService.createOrganization` to relocate into; CE is singleton-org (no org-create resolver) and `…001` gets CISA from the V54 backfill. |
| `VulnerabilityRecordChangeHookImpl` | Pro notifications-emission seam (`@Autowired(required=false)`) → CE no-op. |

## Verification

- `mvn compile` clean — **no oss/-layer breakage** (no CE oss code calls the changed KEV signatures)
- **37/37 mirrored KEV unit tests pass, 0 skips** (`KevAssertionServiceTest`, `CisaKevConnectorTest`, `VulnCheckKevConnectorTest`, `KevCatalogSyncServiceTest`, `IntegrationTypeSchemaEnumSyncTest`) — per-org KEV tests are edition-agnostic, no `isOssEdition()` gate
- V54 applies clean on a CE-seeded Postgres (one CISA_KEV row for `…001`, none for `…000`, token stripped, INSERT idempotent)
- Migration lineage clean (CE was at V53; V54 slots in; CE↔Pro share V51–V53)
- No CE code references removed symbols (`setVulnCheckKevToken` global / `vulncheckKevToken` field)
- Self-review (3 finder agents): no correctness findings; 2 cosmetic nits inherited verbatim from Pro's V54/schema left unfixed (fixing in CE would diverge the mirror — belongs upstream in Pro)

## Deploy note

Live CE verification on `rearmce.rearmhq.com` requires an **operator** `switchfeatureset` bump of `rearmce` to a CE build containing this PR (the agent FREEFORM key is rhythm-scoped, not the Reliza-org controlling instance). No chart bump (image-only roll; V54 via Flyway on pod start). Per-org CISA auto-sync fires at pod-start + ~2 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)