### PR TITLE
feat(ui-integrations): notifications/integration card polish

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -67,7 +67,23 @@
                             <div class="card-desc">{{ card.description }}</div>
                             <div class="card-foot">
                                 <span class="muted-12">{{ cardFootHint(card) }}</span>
-                                <n-button size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)">
+                                <!-- externalConfig kinds (SendGrid) are configured on a
+                                     global-admin-only page. Keep the card discoverable for
+                                     everyone, but for non-global-admins render the action
+                                     informational (disabled + tooltip) so it can't dead-end
+                                     them on a blank /sysSettings body. -->
+                                <n-tooltip v-if="card.externalConfig && !isGlobalAdmin" trigger="hover">
+                                    <template #trigger>
+                                        <span class="card-foot-action">
+                                            <n-button size="small" disabled>
+                                                <template #icon><n-icon><CirclePlus /></n-icon></template>
+                                                Configure
+                                            </n-button>
+                                        </span>
+                                    </template>
+                                    Configured by an instance administrator in System Settings
+                                </n-tooltip>
+                                <n-button v-else size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)">
                                     <template #icon><n-icon><CirclePlus /></n-icon></template>
                                     {{ card.externalConfig ? 'Configure' : 'Add' }}
                                 </n-button>
@@ -657,7 +673,7 @@ import { useRoute, useRouter } from 'vue-router'
 import {
     NIcon, NButton, NCard, NModal, NForm, NFormItem, NInput, NCheckbox, NCheckboxGroup,
     NRadioGroup, NRadioButton, NRadio, NSelect, NAlert, NSpace, NText, NDynamicInput,
-    NUpload, NUploadTrigger
+    NUpload, NUploadTrigger, NTooltip
 } from 'naive-ui'
 import {
     Edit as EditIcon, Trash, Refresh, CirclePlus, CloudUpload,
@@ -694,6 +710,7 @@ const notify = (type: NotificationType, title: string, content: string) => {
 const showCiFeatures = computed(() => props.installationType !== 'OSS')
 const orguuid = computed(() => props.orguuid)
 const isOrgAdmin = computed(() => props.isOrgAdmin)
+const isGlobalAdmin = computed(() => props.isGlobalAdmin)
 const isWritable = computed(() => props.isWritable)
 
 // ---- Sub-tab state, URL-synced ---------------------------------------------
@@ -915,6 +932,12 @@ function cardStatusLabel(card: CardConfig): string {
 
 function cardStatusClass(card: CardConfig): string {
     return isCardConfigured(card) ? 'pill-success' : 'pill-neutral'
+}
+
+// Display name for a card kind, sourced from CARDS so user-facing copy
+// (e.g. channel toasts) tracks the card label and can't drift from it.
+function cardName(id: CardConfig['id']): string {
+    return CARDS.find(c => c.id === id)?.name || id
 }
 
 // Footer hint for the AVAILABLE state. externalConfig kinds (SendGrid) are
@@ -1502,7 +1525,7 @@ async function saveWebhookChannel() {
         })
         showWebhookChModal.value = false
         await loadNotificationChannels(false)
-        notify('success', isEdit ? 'Channel Updated' : 'Channel Added', `Webhook channel "${name}" saved.`)
+        notify('success', isEdit ? 'Channel Updated' : 'Channel Added', `${cardName('WEBHOOK')} channel "${name}" saved.`)
     } catch (err: any) {
         webhookChModalError.value = extractError(err)
     } finally {

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -347,7 +347,7 @@
 
         <!-- Webhook notification channel ADD / EDIT -->
         <n-modal v-model:show="showWebhookChModal" preset="dialog" :show-icon="false">
-            <n-card style="width: 640px" size="huge" :title="webhookChForm.uuid ? 'Edit Webhook channel' : 'Add Webhook channel'" :bordered="false" role="dialog" aria-modal="true">
+            <n-card style="width: 640px" size="huge" :title="webhookChForm.uuid ? 'Edit Notification Webhook channel' : 'Add Notification Webhook channel'" :bordered="false" role="dialog" aria-modal="true">
                 <n-form :model="webhookChForm">
                     <n-space vertical size="large">
                         <n-form-item label="Name" :show-feedback="false">

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -66,10 +66,10 @@
                         <template v-if="!isCardConfigured(card)">
                             <div class="card-desc">{{ card.description }}</div>
                             <div class="card-foot">
-                                <span class="muted-12">{{ card.proOnly && !showCiFeatures ? 'Available in ReARM Pro' : 'Not configured' }}</span>
+                                <span class="muted-12">{{ cardFootHint(card) }}</span>
                                 <n-button size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)">
                                     <template #icon><n-icon><CirclePlus /></n-icon></template>
-                                    Add
+                                    {{ card.externalConfig ? 'Configure' : 'Add' }}
                                 </n-button>
                             </div>
                         </template>
@@ -189,9 +189,11 @@
             <div class="info-banner">
                 <n-icon size="20"><ShieldCheck /></n-icon>
                 <div>
-                    <div class="info-banner-title">Inbound webhooks</div>
+                    <div class="info-banner-title">Inbound PR webhooks</div>
                     <div class="info-banner-body">
-                        Each webhook is bound to a CI integration with the <span class="cap-chip">WEBHOOK</span> capability.
+                        Inbound endpoints that receive pull-request events from your SCM — distinct from the outbound
+                        Notification Webhook channel in the Catalog. Each is bound to a CI integration with the
+                        <span class="cap-chip">WEBHOOK</span> capability.
                         <template v-if="webhookCapableInstances.length">
                             Available:
                             <strong v-for="(n, i) in webhookCapableInstances" :key="n">
@@ -318,6 +320,11 @@
                         </n-form-item>
                         <n-text depth="3" style="font-size: 12px;">
                             Actionable emails (approval requests and resolutions) always send immediately, regardless of digest settings.
+                        </n-text>
+                        <n-text depth="3" style="font-size: 12px;">
+                            This channel only controls recipients and digest batching. The email provider that actually
+                            delivers these messages (SMTP or SendGrid) is configured instance-wide by an administrator
+                            in System Settings → Email Sending Configuration.
                         </n-text>
 
                         <n-alert v-if="emailModalError" type="error" :show-icon="false">
@@ -529,13 +536,13 @@
                         <n-form-item
                             v-if="createIntegrationObject.type === 'GITHUB'"
                             label="Capabilities"
-                            description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK: receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch."
+                            description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK (PR Webhook): receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch."
                         >
                             <n-checkbox-group v-model:value="createIntegrationObject.capabilities">
                                 <n-space>
                                     <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
                                     <n-checkbox value="PR_VALIDATE" label="PR Validate" />
-                                    <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                    <n-checkbox value="WEBHOOK" label="PR Webhook (inbound)" />
                                 </n-space>
                             </n-checkbox-group>
                         </n-form-item>
@@ -625,7 +632,7 @@
                                 <n-space>
                                     <n-checkbox value="WORKFLOW_DISPATCH" label="Workflow Dispatch" />
                                     <n-checkbox value="PR_VALIDATE" label="PR Validate" />
-                                    <n-checkbox value="WEBHOOK" label="Webhook (inbound)" />
+                                    <n-checkbox value="WEBHOOK" label="PR Webhook (inbound)" />
                                 </n-space>
                             </n-checkbox-group>
                         </n-form-item>
@@ -806,7 +813,7 @@ function emailRecipientsSummary(ch: ChannelCatalogRow): string {
 // when @vicons doesn't have a brand icon for the kind.
 type Category = 'messaging' | 'ci' | 'security'
 interface CardConfig {
-    id: 'SLACK' | 'MSTEAMS' | 'EMAIL' | 'WEBHOOK' | 'SENTINEL' | 'GITHUB' | 'GITLAB' | 'JENKINS' | 'ADO' | 'DEPENDENCYTRACK' | 'BEAR' | 'CISA_KEV' | 'VULNCHECK_KEV'
+    id: 'SLACK' | 'MSTEAMS' | 'EMAIL' | 'SENDGRID' | 'WEBHOOK' | 'SENTINEL' | 'GITHUB' | 'GITLAB' | 'JENKINS' | 'ADO' | 'DEPENDENCYTRACK' | 'BEAR' | 'CISA_KEV' | 'VULNCHECK_KEV'
     name: string
     vendor: string
     category: Category
@@ -818,14 +825,27 @@ interface CardConfig {
     // Pro-only kinds still show in the OSS catalog, but with a "Pro"
     // pill and a disabled Add button instead of being hidden.
     proOnly?: boolean
+    // Instance-wide config that lives outside this per-org surface (e.g.
+    // SendGrid, configured in System Settings). The card's action routes
+    // to that page instead of opening a per-org modal, and its footer
+    // hint says where it is configured rather than "Not configured".
+    externalConfig?: boolean
 }
 
 const CARDS: CardConfig[] = [
     // Messaging
     { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Push release notifications to a Slack channel.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: false },
     { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Push release notifications to a Microsoft Teams channel.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: false },
-    { id: 'EMAIL', name: 'Email', vendor: 'ReARM', category: 'messaging', description: 'Send security and operational notifications to a list of email recipients, batched into periodic digest emails.', logoBg: '#2D8F4E', iconComponent: Mail, multiInstance: true, proOnly: true },
-    { id: 'WEBHOOK', name: 'Webhook', vendor: 'ReARM', category: 'messaging', description: 'POST notification events to any HTTPS endpoint — PagerDuty, Opsgenie, Splunk, or in-house receivers — with optional bearer-token or HMAC-SHA256 signing.', logoBg: '#37474F', iconComponent: PlugConnected, multiInstance: true, proOnly: true },
+    { id: 'EMAIL', name: 'Email', vendor: 'Reliza', category: 'messaging', description: 'Send security and operational notifications to a list of email recipients, batched into periodic digest emails.', logoBg: '#2D8F4E', iconComponent: Mail, multiInstance: true, proOnly: true },
+    // SendGrid is not a per-org notification channel — it is the
+    // instance-wide email delivery provider (EmailSendType.SENDGRID),
+    // configured in System Settings → Email Sending Configuration. The
+    // card surfaces it in the catalog for discoverability; its Configure
+    // action routes to that system page instead of opening a per-org
+    // channel modal. The Email card above is the per-org recipient/digest
+    // channel that rides on top of whichever provider this configures.
+    { id: 'SENDGRID', name: 'SendGrid', vendor: 'Twilio SendGrid', category: 'messaging', description: 'Instance-wide email delivery provider used to send Email channel notifications and account emails. Configured in System Settings.', logoBg: '#1A82E2', logoMark: 'SG', multiInstance: false, externalConfig: true },
+    { id: 'WEBHOOK', name: 'Notification Webhook', vendor: 'Reliza', category: 'messaging', description: 'POST notification events to any HTTPS endpoint — PagerDuty, Opsgenie, Splunk, or in-house receivers — with optional bearer-token or HMAC-SHA256 signing.', logoBg: '#37474F', iconComponent: PlugConnected, multiInstance: true, proOnly: true },
     { id: 'SENTINEL', name: 'Microsoft Sentinel', vendor: 'Microsoft', category: 'messaging', description: 'Stream notification events to Microsoft Sentinel (Azure Log Analytics) via the Logs Ingestion API.', logoBg: '#0078D4', iconComponent: ShieldCheck, multiInstance: true, proOnly: true },
     // CI/CD & Source Control
     { id: 'GITHUB', name: 'GitHub', vendor: 'GitHub', category: 'ci', description: 'GitHub App for PR validation, inbound webhooks, and repository_dispatch.', logoBg: '#1F2328', iconComponent: BrandGithub, multiInstance: true },
@@ -897,6 +917,15 @@ function cardStatusClass(card: CardConfig): string {
     return isCardConfigured(card) ? 'pill-success' : 'pill-neutral'
 }
 
+// Footer hint for the AVAILABLE state. externalConfig kinds (SendGrid) are
+// configured on another page, so "Not configured" would be misleading —
+// point to where the setting actually lives instead.
+function cardFootHint(card: CardConfig): string {
+    if (card.externalConfig) return 'Set in System Settings'
+    if (card.proOnly && !showCiFeatures.value) return 'Available in ReARM Pro'
+    return 'Not configured'
+}
+
 function singleInstanceLabel(card: CardConfig): string {
     if (card.id === 'BEAR') return 'Configured'
     return 'Configured'
@@ -937,6 +966,10 @@ function openAddForCard(card: CardConfig) {
     if (card.proOnly && !showCiFeatures.value) return
     if (card.id === 'SLACK') { showSlackModal.value = true; return }
     if (card.id === 'EMAIL') { openAddEmailChannel(); return }
+    // SendGrid is instance-wide config, not a per-org channel — send the
+    // user to System Settings → Email Sending Configuration (global-admin
+    // gated on that page) rather than opening a local modal.
+    if (card.id === 'SENDGRID') { router.push({ name: 'systemSettings' }); return }
     if (card.id === 'WEBHOOK') { openAddWebhookChannel(); return }
     if (card.id === 'SENTINEL') { openAddSentinelChannel(); return }
     if (card.id === 'MSTEAMS') { showMsteamsModal.value = true; return }


### PR DESCRIPTION
## Summary
Copy/config polish of the **Connected systems** catalog in `ui/src/components/OrgIntegrations.vue`. UI-only (card config + help text); no auth/secrets/crypto, no backend changes. Local `vite build` + `vue-tsc --noEmit` pass clean.

Four items from the polish request, with the structural decisions for (b)/(c) called out below.

### (a) Vendor label — DEFINITE
`Email` and `Webhook` cards: `vendor: 'ReARM'` → `vendor: 'Reliza'`.
**Audit of other cards:** these two were the *only* cards using `'ReARM'`. `BEAR` already uses `'Reliza'` (the correct precedent). `Microsoft Sentinel` / `Azure DevOps` use `'Microsoft'`, `Dependency-Track` uses `'OWASP'`, etc. — all correct, left untouched.

### (b) Webhook disambiguation — **decision: rename labels, no new card**
There are two different "webhook" concepts users were conflating:
- the **outbound** Messaging webhook *channel* (`NotificationChannelTypeEnum.WEBHOOK`) — POSTs notification events to an HTTPS endpoint; and
- the **inbound** CI `WEBHOOK` capability — receives `pull_request` events from the SCM (drives PR Validation).

Cleanest fix is label-only (no structural/new-card change, lowest regression risk):
- Messaging card `Webhook` → **`Notification Webhook`** (outbound destination).
- Inbound CI capability checkbox `Webhook (inbound)` → **`PR Webhook (inbound)`** (both Add + Edit CI modals), and the GitHub capability description now reads `WEBHOOK (PR Webhook)`.
- Webhooks sub-tab banner title `Inbound webhooks` → **`Inbound PR webhooks`**, with a sentence stating it is distinct from the outbound Notification Webhook channel.

I deliberately left the **`WEBHOOK` cap-chip** text and the `webhooks` sub-tab routing key unchanged — those mirror the backend capability enum value / URL query param, and changing them would risk test/selector drift for no clarity gain.

### (c) SendGrid card — **decision: dedicated card that routes to System Settings (NOT a per-org channel)**
Investigated how SendGrid is modeled first. **SendGrid is not a per-org channel** — there is no `SENDGRID` in `NotificationChannelTypeEnum`; the schema comment on `EMAIL` is explicit: *"SMTP / SendGrid creds come from system config."* SendGrid is the **instance-wide** email transport (`EmailSendType.SENDGRID`), configured in **System Settings → Email Sending Configuration** (`SystemSettings.vue`, `/sysSettings`).

So wiring a SendGrid card "like Email" as a per-org channel would fabricate a backend concept that doesn't exist and break on use. Instead:
- Added a dedicated Messaging card (`id: 'SENDGRID'`, `vendor: 'Twilio SendGrid'`, `logoMark: 'SG'`, `logoBg: '#1A82E2'`, description noting it's the instance-wide provider).
- New `externalConfig?` card flag: its action button reads **Configure** and routes to System Settings (`router.push({ name: 'systemSettings' })`) instead of opening a per-org modal; footer hint reads **"Set in System Settings"** rather than the misleading "Not configured" (new `cardFootHint()` helper).

**Notes / things a reviewer may want to weigh in on:**
- The card is shown to all viewers of the Integrations tab; System Settings is global-admin-gated, so a non-global-admin who clicks Configure lands on a page they can't fully edit. Kept it discoverable on purpose (pairs with the (d) help text telling org admins the provider is set "by an administrator"). Easy to gate behind `isGlobalAdmin` if preferred.
- Status pill shows `Available` (we don't load instance email-provider state into this per-org component, and I kept the change to one file/no new query). It's honest enough ("available to configure"); happy to wire a real configured/unconfigured state if desired.

### (d) Email help text
Added an `<n-text depth="3">` line in the Email channel modal (mirrors the existing actionable-emails note): clarifies this channel only controls recipients + digest batching, and the actual provider (SMTP / SendGrid) is configured instance-wide in System Settings.

## Build / verify
- `npm run build` (vite) — ✅ success.
- `npx vue-tsc --noEmit` — ✅ clean (only two **pre-existing** tsconfig deprecation warnings: `moduleResolution=node10`, `baseUrl`; unrelated to this change).
- `npm run lint` — ⚠️ **pre-existing host breakage** unrelated to this PR: the installed eslint (v10) rejects the script's `--ignore-path` flag and the legacy `.eslintrc.js` format (eslint ≥9 needs `eslint.config.js`). `package.json`/`.eslintrc.js` are unchanged by this PR.
- Not visually screenshotted — cards are static config and build + type-check cover the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)