### PR TITLE
fix(ui-integrations): prevent empty GitHub App key save (B6 customer P1)

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -552,7 +552,7 @@
                         <n-form-item
                             v-if="createIntegrationObject.type === 'GITHUB'"
                             label="Capabilities"
-                            description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments. WEBHOOK (PR Webhook): receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch."
+                            description="What this GitHub App is wired up to do. PR_VALIDATE: post check-runs / PR comments — requires the App private key and App ID below. WEBHOOK (PR Webhook): receive inbound pull_request events. WORKFLOW_DISPATCH: trigger repository_dispatch."
                         >
                             <n-checkbox-group v-model:value="createIntegrationObject.capabilities">
                                 <n-space>
@@ -738,6 +738,17 @@ const createIntegrationObject: Ref<any> = ref({
 
 const secretInputMode = ref<'paste' | 'upload'>('upload')
 const uploadedSecretFileName = ref('')
+
+// Both Upload and Paste write the same createIntegrationObject.secret. When the
+// user toggles between them, clear the secret AND the uploaded-file label so a
+// stale "Loaded: <file>" line can never mask an emptied value. This is the exact
+// interaction that produced the customer's empty App key: upload a .pem, switch
+// to Paste, clear the textarea, switch back to Upload (the old filename label
+// stayed, hiding the now-empty secret), then Save.
+watch(secretInputMode, () => {
+    createIntegrationObject.value.secret = ''
+    uploadedSecretFileName.value = ''
+})
 
 const bearForm = ref({
     uri: '',
@@ -1087,6 +1098,24 @@ async function onAddBaseIntegration(type: string) {
 }
 
 async function addCiIntegration() {
+    // Hard stop on a blank GitHub App private key or App ID. Both fields are
+    // always shown and required for a GitHub integration; saving without either
+    // yields a silently broken PR channel (no check-runs / comments) -- the
+    // customer's empty-key incident (the App ID is the JWT issuer). Mirrors the
+    // backend #230 validation so the user gets an immediate, clear error instead
+    // of a server round-trip.
+    if (createIntegrationObject.value.type === 'GITHUB') {
+        if (!(createIntegrationObject.value.secret || '').trim()) {
+            notify('error', 'GitHub App private key required',
+                'Upload the .pem or paste the GitHub App private key before saving.')
+            return
+        }
+        if (!String(createIntegrationObject.value.schedule ?? '').trim()) {
+            notify('error', 'GitHub App ID required',
+                'Enter the GitHub Application ID before saving.')
+            return
+        }
+    }
     try {
         const resp = await graphqlClient.mutate({
             mutation: gql`


### PR DESCRIPTION
Customer P1: a GitHub App private key could be saved **empty**, producing a silently-broken PR-validation channel. Root cause is a UI reactivity gap in the GitHub integration create form (`OrgIntegrations.vue`). This is the urgent UI fix (also going to the 26.05.78 customer line).

## The bug (B6)
Both the "Upload .pem" and "Paste" modes write the same `createIntegrationObject.secret`, with no watcher on `secretInputMode`. Repro: upload a .pem → switch to Paste → clear the textarea → switch back to Upload **without re-uploading** → the stale `Loaded: <file> (0 chars)` label hides the now-empty secret → Save stores an empty key.

## Changes
1. **Watcher on `secretInputMode`** — clears both `createIntegrationObject.secret` and `uploadedSecretFileName` on every Upload↔Paste toggle, so a stale filename can never mask an emptied value.
2. **Pre-submit guard** in `addCiIntegration` — blocks save with a clear error when a GitHub integration has a blank **private key** or **App ID** (client mirror of backend #230 — `rearm-saas` #232).
3. **Help text** — the Capabilities description now states PR_VALIDATE requires the App private key + App ID.

## Notes / decisions
- **Clear-on-every-toggle is deliberate** (per the fix spec): a user who flips the radio to peek at the other mode sees an obviously-empty field rather than a half-populated, ambiguous one, and the pre-submit guard backstops any empty save. A strictly-less-destructive option (clear only the filename label) exists if product later wants to reduce the papercut.
- The guard blocks **all** blank-key/blank-App-ID GitHub saves. Both fields are always shown and `required` for GitHub in this form, so this matches the existing form contract (the backend's WEBHOOK-only-empty-key allowance is a programmatic path, not a UI flow).
- Extended the guard to also require the App ID after review (same silent-failure class — App ID is the App-JWT issuer).

## Verification
- `npm run build` ✓. (`npm run lint` is broken on this branch and base main alike — pre-existing eslint v9/v10 flat-config migration issue, `--ignore-path` unsupported — unrelated to this change.)
- 2-layer review (correctness + conventions/UX): no blockers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)