### PR TITLE
feat(notifications): expose subscription route perspectives delivery filter in UI (gap-3)

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -81,6 +81,9 @@
                                     Add route
                                 </n-button>
                             </div>
+                            <div class="routes-hint">
+                                A route's Perspectives filter gates which events this channel actually <strong>delivers</strong> — it does not affect the in-app inbox/bell visibility. Leave empty for no restriction.
+                            </div>
                             <div v-for="(r, i) in subForm.routes" :key="i" class="route-row">
                                 <n-grid :cols="24" :x-gap="8" item-responsive>
                                     <n-gi :span="8">
@@ -125,6 +128,17 @@
                                                 multiple
                                                 placeholder="(none)"
                                                 clearable
+                                            />
+                                        </n-form-item>
+                                    </n-gi>
+                                    <n-gi :span="22" :offset="0">
+                                        <n-form-item :label="i === 0 ? 'Perspectives (delivery filter)' : ''" :show-feedback="false">
+                                            <n-select
+                                                v-model:value="r.perspectives"
+                                                :options="perspectiveOptions"
+                                                multiple
+                                                clearable
+                                                placeholder="All perspectives (no restriction)"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -197,6 +211,7 @@
 
 <script lang="ts" setup>
 import { ref, computed, h, onMounted } from 'vue'
+import { useStore } from 'vuex'
 import {
     NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput,
     NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag,
@@ -219,6 +234,7 @@ const props = defineProps<{
 
 const dialog = useDialog()
 const message = useMessage()
+const store = useStore()
 
 const orgUuid = computed<string>(() => props.orguuid)
 const canWrite = computed<boolean>(() => props.isWritable)
@@ -227,10 +243,14 @@ interface SubscriptionRoute {
     whenSeverityAtLeast: string | null
     channels: string[]
     channelGroups: string[]
+    // Delivery filter: restricts which events this route's channels deliver
+    // to the listed perspectives. NOT the inbox/bell visibility gate. Empty
+    // = no restriction (all perspectives).
+    perspectives: string[]
     // Carries the as-loaded route object on edit so fields the UI still
-    // doesn't model (andEnvIn, andLifecycleIn, perspectives) survive an
-    // Edit → Save round-trip instead of being silently stripped.
-    // channels + channelGroups overlay this last and win. Empty on Create.
+    // doesn't model (andEnvIn, andLifecycleIn) survive an Edit → Save
+    // round-trip instead of being silently stripped. channels +
+    // channelGroups + perspectives overlay this last and win. Empty on Create.
     _raw?: Record<string, any>
 }
 
@@ -253,7 +273,7 @@ interface SubscriptionForm {
 }
 
 function freshRoute (): SubscriptionRoute {
-    return { whenSeverityAtLeast: null, channels: [], channelGroups: [] }
+    return { whenSeverityAtLeast: null, channels: [], channelGroups: [], perspectives: [] }
 }
 
 function freshSubscriptionForm (): SubscriptionForm {
@@ -291,6 +311,13 @@ const channelGroupOptions = computed(() =>
     channelGroups.value.map(g => ({
         label: `${g.name} (${g.channels.length} ch)`,
         value: g.uuid,
+    }))
+)
+
+const perspectiveOptions = computed(() =>
+    (store.getters.perspectivesOfOrg(orgUuid.value) || []).map((p: any) => ({
+        label: p.name,
+        value: p.uuid,
     }))
 )
 
@@ -392,6 +419,7 @@ function openEditSubscription (row: SubscriptionRow): void {
                 whenSeverityAtLeast: r.whenSeverityAtLeast || null,
                 channels: Array.isArray(r.channels) ? [...r.channels] : [],
                 channelGroups: Array.isArray(r.channelGroups) ? [...r.channelGroups] : [],
+                perspectives: Array.isArray(r.perspectives) ? [...r.perspectives] : [],
                 _raw: r,
             }))
         }
@@ -451,13 +479,14 @@ async function saveSubscription (): Promise<void> {
         eventTypes: f.eventTypes,
         filter: filterInput,
         // Spread the original route's still-unmodelled fields (andEnvIn,
-        // andLifecycleIn, perspectives) so an Edit → Save round-trip
-        // doesn't silently strip them. The modeled fields overlay last.
+        // andLifecycleIn) so an Edit → Save round-trip doesn't silently
+        // strip them. The modeled fields overlay last and win.
         routes: f.routes.map(r => ({
             ...(r._raw || {}),
             whenSeverityAtLeast: r.whenSeverityAtLeast,
             channels: r.channels,
             channelGroups: r.channelGroups,
+            perspectives: r.perspectives,
         })),
         dedupWindowMinutes: f.dedupWindowMinutes,
     }
@@ -569,7 +598,12 @@ const subscriptionColumns = computed(() => [
 ])
 
 onMounted(async () => {
-    await Promise.all([loadChannels(), loadChannelGroups(), loadSubscriptions()])
+    await Promise.all([
+        loadChannels(),
+        loadChannelGroups(),
+        loadSubscriptions(),
+        store.dispatch('fetchPerspectives', orgUuid.value),
+    ])
 })
 </script>
 
@@ -595,6 +629,7 @@ onMounted(async () => {
     margin-bottom: 8px;
 }
 .routes-title { font-size: 13px; font-weight: 600; }
+.routes-hint { font-size: 12px; color: var(--n-text-color-3, #888); margin-bottom: 10px; }
 .route-row + .route-row { margin-top: 6px; }
 .route-remove-cell { display: flex; align-items: flex-end; }
 </style>


### PR DESCRIPTION
## What

Adds a **Perspectives (delivery filter)** multi-select to each route in the notification-subscription form (`ui/src/components/SubscriptionsOfOrg.vue`).

## Why

The subscription route already carries a `perspectives` delivery filter in the GraphQL API (`NotificationRouteInput.perspectives`), but there was **no UI control** for it. Admins could neither see nor set it, and it was easily confused with the inbox-visibility perspective gate.

There are two distinct "perspective" gates in the notifications surface and they were being conflated:

1. **Route `perspectives`** — gates **channel DELIVERY**: which events actually route out to the channel. This is what this PR exposes.
2. The in-app **inbox/bell visibility** perspective gate — unrelated to a route's delivery.

The new control's helper text makes this explicit: *"A route's Perspectives filter gates which events this channel actually delivers — it does not affect the in-app inbox/bell visibility. Leave empty for no restriction."*

## Fields touched (all in `SubscriptionsOfOrg.vue`)

- `SubscriptionRoute` interface + `freshRoute()`: add `perspectives: string[]`.
- `openEditSubscription`: hydrate `perspectives` from the loaded route.
- `saveSubscription`: send `perspectives` as an explicit modeled field that overlays the `_raw` spread (so it wins); `_raw` still preserves the still-unmodeled `andEnvIn` / `andLifecycleIn`.
- New `perspectiveOptions` computed sourced from the `perspectivesOfOrg(org)` Vuex getter; `onMounted` now dispatches `fetchPerspectives` so the options aren't empty.
- New route-form `n-select` + helper line.

## Note

This filter gates **delivery**, not the inbox. No backend change is included here.

## Verification

- `npm run build` (includes `vue-tsc` type-check): passes.
- UI verified by deploying the branch's `rearm-ui` image to the sandbox and driving it with Playwright as the playground admin:
  - the Perspectives control renders in both Create and Edit route forms, with the org's `prod` perspective selectable;
  - it pre-populates from an existing `route.perspectives`;
  - the outgoing `upsertNotificationSubscription` payload carries the selected perspective uuid in the route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)