### PR TITLE
Add data-testid hooks to notification Vue components (Playwright de-brittle)

### DIFF
--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -1,7 +1,7 @@
 <template>
     <span class="inbox-nav-trigger">
-        <n-badge :value="navBadgeCount" :max="99" :show="navBadgeCount > 0">
-            <n-icon class="clickable" title="Notifications" size="20" @click="openInboxDrawer">
+        <n-badge :value="navBadgeCount" :max="99" :show="navBadgeCount > 0" data-testid="inbox-badge">
+            <n-icon class="clickable" title="Notifications" size="20" @click="openInboxDrawer" data-testid="inbox-bell">
                 <Bell />
             </n-icon>
         </n-badge>
@@ -13,7 +13,7 @@
         <n-drawer v-model:show="inboxListDrawerOpen" :width="760" placement="right">
             <n-drawer-content title="Notifications" closable>
                 <n-tabs v-model:value="drawerTab" type="line" animated>
-                <n-tab-pane name="inbox" tab="Inbox">
+                <n-tab-pane name="inbox" tab="Inbox" data-testid="inbox-tab">
                 <div class="tab-toolbar">
                     <div class="tab-toolbar-info">
                         Your personal triage queue. Org-admins see every delivery; perspective-members see deliveries that touch a release in one of their perspectives.
@@ -25,6 +25,7 @@
                             type="primary"
                             @click="bulkMarkRead"
                             :loading="inboxBulkLoading"
+                            data-testid="mark-selected-read"
                         >
                             <template #icon><n-icon><Check /></n-icon></template>
                             Mark {{ selectedInboxRows.length }} read
@@ -35,6 +36,7 @@
                             secondary
                             @click="markAllReadConfirm"
                             :loading="inboxMarkAllLoading"
+                            data-testid="mark-all-read"
                         >
                             Mark all read
                         </n-button>
@@ -105,7 +107,7 @@
                      a user with no approval roles sees an empty list. Acting
                      on an approval still happens on the release page — this
                      tab is the triage surface, the Version link is the hop. -->
-                <n-tab-pane name="approvals" :tab="approvalsTabLabel">
+                <n-tab-pane name="approvals" :tab="approvalsTabLabel" data-testid="approvals-tab">
                     <div class="tab-toolbar">
                         <div class="tab-toolbar-info">
                             Releases with an approval pending on one of your approval roles. Open the release to approve or disapprove.
@@ -758,13 +760,17 @@ const inboxColumns = computed(() => [
     },
     {
         title: 'When', key: 'when', width: 170,
-        render: (row: InboxRow) => formatHistoryTimestamp(row.sentAt || row.createdDate),
+        render: (row: InboxRow) => h(
+            'span',
+            { 'data-testid': 'inbox-cell-when' },
+            formatHistoryTimestamp(row.sentAt || row.createdDate),
+        ),
     },
     {
         title: 'Status', key: 'status', width: 110,
         render: (row: InboxRow) => h(
             NTag,
-            { type: deliveryStatusTagType(row.status), size: 'small' },
+            { type: deliveryStatusTagType(row.status), size: 'small', 'data-testid': 'inbox-cell-status' },
             { default: () => row.status },
         ),
     },
@@ -787,6 +793,7 @@ const inboxColumns = computed(() => [
                 {
                     type: 'button',
                     class: 'inbox-message-link',
+                    'data-testid': 'inbox-message-link',
                     onClick: () => openInboxRow(row),
                 },
                 {
@@ -805,10 +812,10 @@ const inboxColumns = computed(() => [
         render: (row: InboxRow) => row.severity
             ? h(
                 NTag,
-                { type: severityTagType(row.severity), size: 'small' },
+                { type: severityTagType(row.severity), size: 'small', 'data-testid': 'inbox-cell-severity' },
                 { default: () => row.severity },
             )
-            : h('span', { class: 'muted-12' }, '—'),
+            : h('span', { class: 'muted-12', 'data-testid': 'inbox-cell-severity' }, '—'),
     },
     {
         title: 'Channel', key: 'channelUuid', width: 150,
@@ -817,10 +824,14 @@ const inboxColumns = computed(() => [
         // resolved server-side and rides along on the row, so no admin-only
         // channel-list fetch is needed; a null name on a real channelUuid
         // means the channel was deleted.
-        render: (row: InboxRow) => (row.channelUuid
-            ? (row.channelName
-                || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
-            : h('span', { class: 'muted-12' }, 'Direct')),
+        render: (row: InboxRow) => h(
+            'span',
+            { 'data-testid': 'inbox-cell-channel' },
+            row.channelUuid
+                ? (row.channelName
+                    || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
+                : h('span', { class: 'muted-12' }, 'Direct'),
+        ),
     },
     {
         title: 'Read', key: 'readAt', width: 200,
@@ -858,10 +869,12 @@ const approvalsColumns = computed(() => [
     {
         title: 'Component', key: 'componentName',
         render: (row: ReleasePendingApproval) => {
-            if (!row.componentUuid) return h('span', { class: 'muted-12' }, row.componentName || '—')
-            const base = row.componentType === 'PRODUCT' ? 'productsOfOrg' : 'componentsOfOrg'
-            return approvalLink(`/${base}/${orgUuid.value}/${row.componentUuid}`,
-                row.componentName || row.componentUuid)
+            const inner = !row.componentUuid
+                ? h('span', { class: 'muted-12' }, row.componentName || '—')
+                : approvalLink(
+                    `/${row.componentType === 'PRODUCT' ? 'productsOfOrg' : 'componentsOfOrg'}/${orgUuid.value}/${row.componentUuid}`,
+                    row.componentName || row.componentUuid)
+            return h('span', { 'data-testid': 'approval-pending-row' }, inner)
         },
     },
     {

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -45,6 +45,7 @@
                         :key="card.id"
                         class="card"
                         :class="{ 'card-configured': isCardConfigured(card), 'card-available': !isCardConfigured(card) }"
+                        :data-testid="`catalog-card-${card.id}`"
                     >
                         <!-- card header: logo + title + vendor + status pill -->
                         <div class="card-head">
@@ -83,7 +84,7 @@
                                     </template>
                                     Configured by an instance administrator in System Settings
                                 </n-tooltip>
-                                <n-button v-else size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)">
+                                <n-button v-else size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
                                     <template #icon><n-icon><CirclePlus /></n-icon></template>
                                     {{ card.externalConfig ? 'Configure' : 'Add' }}
                                 </n-button>
@@ -95,10 +96,10 @@
                             <div class="instance-list">
                                 <!-- Notification channels (Email / Webhook / Sentinel) -->
                                 <template v-if="isChannelCard(card)">
-                                    <div v-for="ch in channelRowsForCard(card)" :key="ch.uuid" class="instance-row">
+                                    <div v-for="ch in channelRowsForCard(card)" :key="ch.uuid" class="instance-row" :data-testid="`channel-instance-${card.id}`">
                                         <div class="instance-status"><span class="ddot" :class="ch.status === 'ENABLED' ? 'ok' : 'off'" /></div>
                                         <div class="instance-body">
-                                            <div class="instance-name">{{ ch.name }}</div>
+                                            <div class="instance-name" data-testid="channel-instance-name">{{ ch.name }}</div>
                                             <div v-if="card.id === 'EMAIL'" class="instance-meta">
                                                 <span class="instance-scope">{{ emailRecipientsSummary(ch) }}</span>
                                             </div>
@@ -167,7 +168,7 @@
                             </div>
 
                             <!-- + Add another for multi-instance only -->
-                            <button v-if="card.multiInstance" class="add-another" @click="openAddForCard(card)">
+                            <button v-if="card.multiInstance" class="add-another" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
                                 <n-icon size="14"><CirclePlus /></n-icon>
                                 <span>Add another {{ card.name }}</span>
                             </button>
@@ -301,7 +302,7 @@
                         </n-alert>
 
                         <n-space>
-                            <n-button :loading="slackChSaveLoading" @click="saveSlackChannel" type="success">Save</n-button>
+                            <n-button :loading="slackChSaveLoading" @click="saveSlackChannel" type="success" data-testid="save-SLACK-channel">Save</n-button>
                             <n-button @click="showSlackChModal = false" type="default">Cancel</n-button>
                         </n-space>
                     </n-space>
@@ -341,7 +342,7 @@
                         </n-alert>
 
                         <n-space>
-                            <n-button :loading="teamsChSaveLoading" @click="saveTeamsChannel" type="success">Save</n-button>
+                            <n-button :loading="teamsChSaveLoading" @click="saveTeamsChannel" type="success" data-testid="save-MSTEAMS-channel">Save</n-button>
                             <n-button @click="showTeamsChModal = false" type="default">Cancel</n-button>
                         </n-space>
                     </n-space>
@@ -394,7 +395,7 @@
                         </n-alert>
 
                         <n-space>
-                            <n-button :loading="emailSaveLoading" @click="saveEmailChannel" type="success">Save</n-button>
+                            <n-button :loading="emailSaveLoading" @click="saveEmailChannel" type="success" data-testid="save-EMAIL-channel">Save</n-button>
                             <n-button @click="showEmailModal = false" type="default">Cancel</n-button>
                         </n-space>
                     </n-space>
@@ -448,7 +449,7 @@
                         </n-alert>
 
                         <n-space>
-                            <n-button :loading="webhookChSaveLoading" @click="saveWebhookChannel" type="success">Save</n-button>
+                            <n-button :loading="webhookChSaveLoading" @click="saveWebhookChannel" type="success" data-testid="save-WEBHOOK-channel">Save</n-button>
                             <n-button @click="showWebhookChModal = false" type="default">Cancel</n-button>
                         </n-space>
                     </n-space>
@@ -501,7 +502,7 @@
                         </n-alert>
 
                         <n-space>
-                            <n-button :loading="sentinelSaveLoading" @click="saveSentinelChannel" type="success">Save</n-button>
+                            <n-button :loading="sentinelSaveLoading" @click="saveSentinelChannel" type="success" data-testid="save-SENTINEL-channel">Save</n-button>
                             <n-button @click="showSentinelModal = false" type="default">Cancel</n-button>
                         </n-space>
                     </n-space>

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -173,20 +173,11 @@
                             </button>
                         </template>
 
-                        <!-- Pro-only hint for messaging cards: security and
-                             vulnerability alerts route through the
-                             Subscriptions sub-tab (same Integrations surface)
-                             rather than these base Slack/Teams credentials.
-                             Gated on Pro so the OSS catalog stays the same. -->
-                        <div
-                            v-if="showCiFeatures && (card.id === 'SLACK' || card.id === 'MSTEAMS')"
-                            class="card-pro-hint"
-                        >
-                            Security and vulnerability alerts use a separate destination —
-                            manage in
-                            <a class="pro-hint-link" @click="switchSubTab('subscriptions')">Subscriptions</a>
-                            →
-                        </div>
+                        <!-- Once a messaging channel is configured, events only
+                             reach it when a subscription routes them there.
+                             Applies to every channel card (Slack/Teams/Email/
+                             Webhook/Sentinel). Gated on Pro so the OSS catalog
+                             stays the same. -->
                         <div
                             v-if="showCiFeatures && isChannelCard(card) && isCardConfigured(card)"
                             class="card-pro-hint"
@@ -279,31 +270,80 @@
 
         <!-- ================================= MODALS ================================= -->
 
-        <!-- Slack -->
-        <n-modal v-model:show="showSlackModal" preset="dialog" :show-icon="false">
-            <n-card style="width: 600px" size="huge" title="Add Slack integration" :bordered="false" role="dialog" aria-modal="true">
-                <n-form>
-                    <n-form-item label="Secret" description="Slack integration secret">
-                        <n-input type="password" v-model:value="createIntegrationObject.secret" required placeholder="Enter Slack integration secret" />
-                    </n-form-item>
-                    <n-space>
-                        <n-button @click="onAddBaseIntegration('SLACK')" type="success">Submit</n-button>
-                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
+        <!-- Slack notification channel ADD / EDIT -->
+        <n-modal v-model:show="showSlackChModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 640px" size="huge" :title="slackChForm.uuid ? 'Edit Slack channel' : 'Add Slack channel'" :bordered="false" role="dialog" aria-modal="true">
+                <n-form :model="slackChForm">
+                    <n-space vertical size="large">
+                        <n-form-item label="Name" :show-feedback="false">
+                            <n-input v-model:value="slackChForm.name" required placeholder="e.g. #security-alerts" />
+                        </n-form-item>
+                        <n-form-item label="Incoming-webhook URL" :show-feedback="false">
+                            <n-input
+                                type="password"
+                                show-password-on="click"
+                                v-model:value="slackChForm.webhookUrl"
+                                :placeholder="slackChForm.uuid ? '(unchanged — leave blank to keep the current webhook URL)' : 'https://hooks.slack.com/services/...'"
+                            />
+                        </n-form-item>
+                        <n-text depth="3" style="font-size: 12px;">
+                            Create an incoming webhook in your Slack workspace and paste its URL here. The URL is the
+                            credential — it is stored encrypted and not displayed; re-enter it to change the destination.
+                        </n-text>
+
+                        <n-alert v-if="slackChModalError" type="error" :show-icon="false">
+                            {{ slackChModalError }}
+                            <template v-if="isConflictError(slackChModalError)" #action>
+                                <n-button size="small" type="primary" @click="reloadSlackChannelFromServer">
+                                    Reload from server
+                                </n-button>
+                            </template>
+                        </n-alert>
+
+                        <n-space>
+                            <n-button :loading="slackChSaveLoading" @click="saveSlackChannel" type="success">Save</n-button>
+                            <n-button @click="showSlackChModal = false" type="default">Cancel</n-button>
+                        </n-space>
                     </n-space>
                 </n-form>
             </n-card>
         </n-modal>
 
-        <!-- MS Teams -->
-        <n-modal v-model:show="showMsteamsModal" preset="dialog" :show-icon="false">
-            <n-card style="width: 600px" size="huge" title="Add MS Teams integration" :bordered="false" role="dialog" aria-modal="true">
-                <n-form>
-                    <n-form-item label="Secret" description="MS Teams integration URI">
-                        <n-input type="password" v-model:value="createIntegrationObject.secret" required placeholder="Enter MS Teams integration URI" />
-                    </n-form-item>
-                    <n-space>
-                        <n-button @click="onAddBaseIntegration('MSTEAMS')" type="success">Submit</n-button>
-                        <n-button @click="resetCreateIntegrationObject" type="error">Reset</n-button>
+        <!-- Microsoft Teams notification channel ADD / EDIT -->
+        <n-modal v-model:show="showTeamsChModal" preset="dialog" :show-icon="false">
+            <n-card style="width: 640px" size="huge" :title="teamsChForm.uuid ? 'Edit Microsoft Teams channel' : 'Add Microsoft Teams channel'" :bordered="false" role="dialog" aria-modal="true">
+                <n-form :model="teamsChForm">
+                    <n-space vertical size="large">
+                        <n-form-item label="Name" :show-feedback="false">
+                            <n-input v-model:value="teamsChForm.name" required placeholder="e.g. SecOps channel" />
+                        </n-form-item>
+                        <n-form-item label="Workflows webhook URL" :show-feedback="false">
+                            <n-input
+                                type="password"
+                                show-password-on="click"
+                                v-model:value="teamsChForm.webhookUrl"
+                                :placeholder="teamsChForm.uuid ? '(unchanged — leave blank to keep the current webhook URL)' : 'https://...logic.azure.com/... or https://...powerplatform.com/...'"
+                            />
+                        </n-form-item>
+                        <n-text depth="3" style="font-size: 12px;">
+                            Create a "Post to a channel when a webhook request is received" flow in Power Automate
+                            Workflows and paste its URL here. The URL is the credential — it is stored encrypted and not
+                            displayed; re-enter it to change the destination.
+                        </n-text>
+
+                        <n-alert v-if="teamsChModalError" type="error" :show-icon="false">
+                            {{ teamsChModalError }}
+                            <template v-if="isConflictError(teamsChModalError)" #action>
+                                <n-button size="small" type="primary" @click="reloadTeamsChannelFromServer">
+                                    Reload from server
+                                </n-button>
+                            </template>
+                        </n-alert>
+
+                        <n-space>
+                            <n-button :loading="teamsChSaveLoading" @click="saveTeamsChannel" type="success">Save</n-button>
+                            <n-button @click="showTeamsChModal = false" type="default">Cancel</n-button>
+                        </n-space>
                     </n-space>
                 </n-form>
             </n-card>
@@ -871,8 +911,6 @@ const bearForm = ref({
 const showVulncheckModal = ref(false)
 const vulncheckForm = ref({ token: '' })
 
-const showSlackModal = ref(false)
-const showMsteamsModal = ref(false)
 const showDtModal = ref(false)
 const showBearModal = ref(false)
 const showCiAddModal = ref(false)
@@ -922,6 +960,9 @@ const notificationChannelRows: Ref<ChannelCatalogRow[]> = ref([])
 const emailChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'EMAIL'))
 const webhookChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'WEBHOOK'))
 const sentinelChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'SENTINEL'))
+const slackChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'SLACK'))
+// Backend channel-type name for Teams is MS_TEAMS, not the MSTEAMS card id.
+const msteamsChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'MS_TEAMS'))
 
 const showEmailModal = ref(false)
 const emailSaveLoading = ref(false)
@@ -991,8 +1032,8 @@ interface CardConfig {
 
 const CARDS: CardConfig[] = [
     // Messaging
-    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Push release notifications to a Slack channel.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: false },
-    { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Push release notifications to a Microsoft Teams channel.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: false },
+    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Send security and operational notifications to a Slack channel via an incoming-webhook URL.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: true, proOnly: true },
+    { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Send security and operational notifications to a Microsoft Teams channel via a Power Automate Workflows webhook URL.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: true, proOnly: true },
     { id: 'EMAIL', name: 'Email', vendor: 'Reliza', category: 'messaging', description: 'Send security and operational notifications to a list of email recipients, batched into periodic digest emails.', logoBg: '#2D8F4E', iconComponent: Mail, multiInstance: true, proOnly: true },
     // SendGrid is not a per-org notification channel — it is the
     // instance-wide email delivery provider (EmailSendType.SENDGRID),
@@ -1030,12 +1071,25 @@ const visibleSections = computed(() => {
 })
 
 // ---- Card status helpers ---------------------------------------------------
+// SLACK/MSTEAMS are notification-channel destinations too (the unified
+// IntegrationType model folded the retired NotificationChannelType in), so
+// their catalog cards render configured channels exactly like EMAIL/WEBHOOK/
+// SENTINEL rather than the legacy secret-based base integration.
 function isChannelCard(card: CardConfig): boolean {
-    return card.id === 'EMAIL' || card.id === 'WEBHOOK' || card.id === 'SENTINEL'
+    return card.id === 'SLACK' || card.id === 'MSTEAMS'
+        || card.id === 'EMAIL' || card.id === 'WEBHOOK' || card.id === 'SENTINEL'
+}
+
+// Card ids and notification-channel type names match for every channel kind
+// except Teams: the card id is 'MSTEAMS' but the channel type the backend
+// emits (and accepts) is 'MS_TEAMS'. Normalize so the filter lines up.
+function channelTypeForCard(card: CardConfig): string {
+    return card.id === 'MSTEAMS' ? 'MS_TEAMS' : card.id
 }
 
 function channelRowsForCard(card: CardConfig): ChannelCatalogRow[] {
-    return notificationChannelRows.value.filter(c => c.type === card.id)
+    const t = channelTypeForCard(card)
+    return notificationChannelRows.value.filter(c => c.type === t)
 }
 
 function isCardConfigured(card: CardConfig): boolean {
@@ -1127,7 +1181,7 @@ function kindLabel(t: string): string {
 // ---- Modal openers ---------------------------------------------------------
 function openAddForCard(card: CardConfig) {
     if (card.proOnly && !showCiFeatures.value) return
-    if (card.id === 'SLACK') { showSlackModal.value = true; return }
+    if (card.id === 'SLACK') { openAddSlackChannel(); return }
     if (card.id === 'EMAIL') { openAddEmailChannel(); return }
     // SendGrid is instance-wide config, not a per-org channel — send the
     // user to System Settings → Email Sending Configuration (global-admin
@@ -1135,7 +1189,7 @@ function openAddForCard(card: CardConfig) {
     if (card.id === 'SENDGRID') { router.push({ name: 'systemSettings' }); return }
     if (card.id === 'WEBHOOK') { openAddWebhookChannel(); return }
     if (card.id === 'SENTINEL') { openAddSentinelChannel(); return }
-    if (card.id === 'MSTEAMS') { showMsteamsModal.value = true; return }
+    if (card.id === 'MSTEAMS') { openAddTeamsChannel(); return }
     if (card.id === 'DEPENDENCYTRACK') { showDtModal.value = true; return }
     if (card.id === 'BEAR') { openBearAddModal(); return }
     if (card.id === 'CISA_KEV') { confirmToggleCisaKev(); return }
@@ -1236,8 +1290,6 @@ async function onAddBaseIntegration(type: string) {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     } finally {
         resetCreateIntegrationObject()
-        showSlackModal.value = false
-        showMsteamsModal.value = false
         showDtModal.value = false
     }
 }
@@ -1905,9 +1957,182 @@ async function reloadSentinelChannelFromServer() {
     }
 }
 
-// ---- Shared channel actions (all three channel cards) ------------------------
+// ---- Slack / Teams channel CRUD ----------------------------------------------
+// Slack and Teams channels carry a single secret credential: the incoming-
+// webhook URL (Slack) / Power Automate Workflows webhook URL (Teams). Like the
+// webhook channel, the URL is encrypted server-side and never read back, so on
+// edit a blank URL preserves the stored one (rename-only) and a new URL
+// replaces it. The on-the-wire channel type is SLACK / MS_TEAMS.
+const showSlackChModal = ref(false)
+const slackChSaveLoading = ref(false)
+const slackChModalError = ref('')
+const slackChForm = ref({
+    uuid: '',
+    expectedRevision: null as number | null,
+    name: '',
+    webhookUrl: ''
+})
+
+function openAddSlackChannel() {
+    slackChForm.value = { uuid: '', expectedRevision: null, name: '', webhookUrl: '' }
+    slackChModalError.value = ''
+    showSlackChModal.value = true
+}
+
+function openEditSlackChannel(ch: ChannelCatalogRow) {
+    slackChForm.value = { uuid: ch.uuid, expectedRevision: ch.revision, name: ch.name, webhookUrl: '' }
+    slackChModalError.value = ''
+    showSlackChModal.value = true
+}
+
+async function saveSlackChannel() {
+    slackChModalError.value = ''
+    const name = (slackChForm.value.name || '').trim()
+    if (!name) {
+        slackChModalError.value = 'Channel name is required.'
+        return
+    }
+    const isEdit = !!slackChForm.value.uuid
+    // Secrets may be whitespace-significant; trim only for the blank-check.
+    const url = (slackChForm.value.webhookUrl || '').trim()
+    let slackConfig: any = null
+    if (url) {
+        if (!url.toLowerCase().startsWith('https://')) {
+            slackChModalError.value = 'Slack webhook URL must be HTTPS.'
+            return
+        }
+        slackConfig = { webhookUrl: url }
+    } else if (!isEdit) {
+        slackChModalError.value = 'Slack incoming-webhook URL is required.'
+        return
+    }
+    slackChSaveLoading.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation upsertNotificationChannel($input: NotificationChannelInput!) {
+                    upsertNotificationChannel(input: $input) { uuid }
+                }`,
+            variables: {
+                input: {
+                    uuid: isEdit ? slackChForm.value.uuid : null,
+                    expectedRevision: isEdit ? slackChForm.value.expectedRevision : null,
+                    org: orguuid.value,
+                    name,
+                    type: 'SLACK',
+                    slackConfig
+                }
+            },
+            fetchPolicy: 'no-cache'
+        })
+        showSlackChModal.value = false
+        await loadNotificationChannels(false)
+        notify('success', isEdit ? 'Channel Updated' : 'Channel Added', `${cardName('SLACK')} channel "${name}" saved.`)
+    } catch (err: any) {
+        slackChModalError.value = extractError(err)
+    } finally {
+        slackChSaveLoading.value = false
+    }
+}
+
+async function reloadSlackChannelFromServer() {
+    await loadNotificationChannels(false)
+    const fresh = slackChannels.value.find(c => c.uuid === slackChForm.value.uuid)
+    if (fresh) {
+        openEditSlackChannel(fresh)
+    } else {
+        showSlackChModal.value = false
+        notify('warning', 'Channel Removed', 'This channel no longer exists on the server.')
+    }
+}
+
+const showTeamsChModal = ref(false)
+const teamsChSaveLoading = ref(false)
+const teamsChModalError = ref('')
+const teamsChForm = ref({
+    uuid: '',
+    expectedRevision: null as number | null,
+    name: '',
+    webhookUrl: ''
+})
+
+function openAddTeamsChannel() {
+    teamsChForm.value = { uuid: '', expectedRevision: null, name: '', webhookUrl: '' }
+    teamsChModalError.value = ''
+    showTeamsChModal.value = true
+}
+
+function openEditTeamsChannel(ch: ChannelCatalogRow) {
+    teamsChForm.value = { uuid: ch.uuid, expectedRevision: ch.revision, name: ch.name, webhookUrl: '' }
+    teamsChModalError.value = ''
+    showTeamsChModal.value = true
+}
+
+async function saveTeamsChannel() {
+    teamsChModalError.value = ''
+    const name = (teamsChForm.value.name || '').trim()
+    if (!name) {
+        teamsChModalError.value = 'Channel name is required.'
+        return
+    }
+    const isEdit = !!teamsChForm.value.uuid
+    const url = (teamsChForm.value.webhookUrl || '').trim()
+    let teamsConfig: any = null
+    if (url) {
+        if (!url.toLowerCase().startsWith('https://')) {
+            teamsChModalError.value = 'Teams webhook URL must be HTTPS.'
+            return
+        }
+        teamsConfig = { webhookUrl: url }
+    } else if (!isEdit) {
+        teamsChModalError.value = 'Teams Workflows webhook URL is required.'
+        return
+    }
+    teamsChSaveLoading.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation upsertNotificationChannel($input: NotificationChannelInput!) {
+                    upsertNotificationChannel(input: $input) { uuid }
+                }`,
+            variables: {
+                input: {
+                    uuid: isEdit ? teamsChForm.value.uuid : null,
+                    expectedRevision: isEdit ? teamsChForm.value.expectedRevision : null,
+                    org: orguuid.value,
+                    name,
+                    type: 'MS_TEAMS',
+                    teamsConfig
+                }
+            },
+            fetchPolicy: 'no-cache'
+        })
+        showTeamsChModal.value = false
+        await loadNotificationChannels(false)
+        notify('success', isEdit ? 'Channel Updated' : 'Channel Added', `${cardName('MSTEAMS')} channel "${name}" saved.`)
+    } catch (err: any) {
+        teamsChModalError.value = extractError(err)
+    } finally {
+        teamsChSaveLoading.value = false
+    }
+}
+
+async function reloadTeamsChannelFromServer() {
+    await loadNotificationChannels(false)
+    const fresh = msteamsChannels.value.find(c => c.uuid === teamsChForm.value.uuid)
+    if (fresh) {
+        openEditTeamsChannel(fresh)
+    } else {
+        showTeamsChModal.value = false
+        notify('warning', 'Channel Removed', 'This channel no longer exists on the server.')
+    }
+}
+
+// ---- Shared channel actions (all channel cards) ------------------------------
 function openEditChannelForCard(card: CardConfig, ch: ChannelCatalogRow) {
-    if (card.id === 'EMAIL') openEditEmailChannel(ch)
+    if (card.id === 'SLACK') openEditSlackChannel(ch)
+    else if (card.id === 'MSTEAMS') openEditTeamsChannel(ch)
+    else if (card.id === 'EMAIL') openEditEmailChannel(ch)
     else if (card.id === 'WEBHOOK') openEditWebhookChannel(ch)
     else if (card.id === 'SENTINEL') openEditSentinelChannel(ch)
 }

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -772,7 +772,7 @@
                         <p>Open this tab to load underlying artifact details.</p>
                     </div>
                 </n-tab-pane>
-                <n-tab-pane v-if="myUser && myUser.installationType && myUser.installationType !== 'OSS'" name="approvals" tab="Approvals">
+                <n-tab-pane v-if="myUser && myUser.installationType && myUser.installationType !== 'OSS'" name="approvals" tab="Approvals" data-testid="release-approvals-tab">
                     <div class="container" v-if="updatedRelease.type !== 'PLACEHOLDER'">
                         <div v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'" style="margin-bottom: 10px;">
                             <strong>Approved Environments: </strong>
@@ -808,7 +808,7 @@
                             </template>
                         </div>
                         <n-space v-if="isWritable && approvalEntries.length" style="margin-bottom: 10px;">
-                            <n-button @click="requestApprovals" :loading="requestApprovalsPending" :disabled="requestApprovalsPending" title="Notify everyone who can still approve this release">
+                            <n-button @click="requestApprovals" :loading="requestApprovalsPending" :disabled="requestApprovalsPending" title="Notify everyone who can still approve this release" data-testid="request-approvals">
                                 <template #icon>
                                     <n-icon><Bell /></n-icon>
                                 </template>
@@ -827,7 +827,7 @@
                         <n-data-table :data="releaseApprovalTableData" :columns="releaseApprovalTableFields" :row-key="approvalRowKey" />
                         <n-space v-if="hasApprovalChanges" style="margin-top: 5px;">
                             <n-spin :show="approvalPending" small>
-                                <n-button @click="triggerApproval" :disabled="approvalPending">
+                                <n-button @click="triggerApproval" :disabled="approvalPending" data-testid="save-approvals">
                                     <template #icon>
                                         <n-icon><ClipboardCheck /></n-icon>
                                     </template>
@@ -835,7 +835,7 @@
                                     <span v-else>Save Approvals</span>
                                 </n-button>
                             </n-spin>
-                            <n-button type="warning" @click="resetApprovals">
+                            <n-button type="warning" @click="resetApprovals" data-testid="reset-approvals">
                                 <template #icon>
                                     <n-icon><Refresh /></n-icon>
                                 </template>
@@ -4997,12 +4997,18 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                     } else {
                         title = 'Unset'
                     }
+                    // Machine-readable cell state for the test harness. Today
+                    // the tri-state is only inferable from title/indeterminate;
+                    // surface it explicitly as data-state on the checkbox.
+                    const approvalState = isApproved ? 'APPROVED' : (isDisapproved ? 'DISAPPROVED' : 'UNSET')
                     const checkBoxEl = h(NCheckbox,
                         {
                             checked: isApproved,
                             indeterminate: isDisapproved,
                             disabled: isDisabled,
                             title,
+                            'data-testid': `approval-cell-${row.uuid}-${aid}`,
+                            'data-state': approvalState,
                             style: isDisapproved ? "--n-color-checked: red; --n-color-disabled: red;" : "",
                             size: 'large',
                             onClick: (e: any, i: any) => {

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -9,6 +9,7 @@
                 type="primary"
                 size="small"
                 @click="openCreateSubscription"
+                data-testid="add-subscription"
             >
                 <template #icon><n-icon><CirclePlus /></n-icon></template>
                 Add subscription
@@ -54,6 +55,7 @@
                                 :options="eventTypeOptions"
                                 multiple
                                 placeholder="Pick one or more event types"
+                                data-testid="sub-eventtypes"
                             />
                         </n-form-item>
 
@@ -76,7 +78,7 @@
                         <div class="routes-section">
                             <div class="routes-header">
                                 <div class="routes-title">Routes</div>
-                                <n-button size="tiny" @click="addRoute">
+                                <n-button size="tiny" @click="addRoute" data-testid="add-route">
                                     <template #icon><n-icon><CirclePlus /></n-icon></template>
                                     Add route
                                 </n-button>
@@ -84,7 +86,7 @@
                             <div class="routes-hint">
                                 A route's Perspectives filter gates which events this channel actually <strong>delivers</strong> — it does not affect the in-app inbox/bell visibility. Leave empty for no restriction.
                             </div>
-                            <div v-for="(r, i) in subForm.routes" :key="i" class="route-row">
+                            <div v-for="(r, i) in subForm.routes" :key="i" class="route-row" :data-testid="`route-row-${i}`">
                                 <n-grid :cols="24" :x-gap="8" item-responsive>
                                     <n-gi :span="8">
                                         <n-form-item :label="i === 0 ? 'Minimum severity' : ''" :show-feedback="false">
@@ -93,6 +95,7 @@
                                                 :options="severityOptions"
                                                 placeholder="Any"
                                                 clearable
+                                                data-testid="route-severity"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -103,6 +106,7 @@
                                                 :options="channelOptions"
                                                 multiple
                                                 placeholder="Pick channels (and/or groups below)"
+                                                data-testid="route-channels"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -128,6 +132,7 @@
                                                 multiple
                                                 placeholder="(none)"
                                                 clearable
+                                                data-testid="route-channelgroups"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -139,6 +144,7 @@
                                                 multiple
                                                 clearable
                                                 placeholder="All perspectives (no restriction)"
+                                                data-testid="route-perspectives"
                                             />
                                         </n-form-item>
                                     </n-gi>
@@ -197,6 +203,7 @@
                                 type="primary"
                                 :loading="savingSubscription"
                                 :disabled="!subForm.name.trim() || subForm.eventTypes.length === 0 || subForm.routes.length === 0"
+                                data-testid="save-subscription"
                             >
                                 Save
                             </n-button>
@@ -581,6 +588,7 @@ const subscriptionColumns = computed(() => [
                     size: 'tiny', secondary: true,
                     onClick: () => openEditSubscription(row),
                     disabled: !canWrite.value,
+                    'data-testid': 'edit-subscription',
                 }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
                 h(NButton, {
                     size: 'tiny', secondary: true,


### PR DESCRIPTION
## What

Board task #36. Adds stable `data-testid` hooks (plus one `data-state` attribute) to the 4 notification Vue components so the Playwright integration-test harness stops being hostage to naive-ui generated class names.

**ADD-ONLY** — no behavior/logic changes. Render-function cells that previously returned a bare string or a conditional expression are wrapped in a single `<span>` carrying the testid; everything else is a plain attribute addition. `cd ui && npm run build` is green. (`npm run lint` is pre-existing-broken, see #25 — not touched.)

> **Stacked on #161** (`2026-06-slack-teams-catalog-channels`). **Merge #161 first** — this branch is cut from it because #161 heavily reworks `OrgIntegrations.vue` and merging this against `main` first would conflict.

## testids added per component

**NotificationInbox.vue**
- `inbox-bell` (bell nav trigger), `inbox-badge` (unread badge)
- `inbox-tab` / `approvals-tab` (the two drawer tab panes)
- `mark-all-read`, `mark-selected-read`, `inbox-message-link`
- pure-h() cells with no anchor: `inbox-cell-when`, `inbox-cell-status`, `inbox-cell-severity`, `inbox-cell-channel`
- `approval-pending-row` (needs-my-approval rows)

**OrgIntegrations.vue**
- `catalog-card-{id}` (id = SLACK/MSTEAMS/EMAIL/WEBHOOK/SENTINEL/GITHUB/…)
- `channel-instance-{id}` (configured channel rows) + `channel-instance-name`
- `add-channel-{id}` (card Add button + the multi-instance "Add another")
- `save-{SLACK,MSTEAMS,EMAIL,WEBHOOK,SENTINEL}-channel` (channel modal Save buttons)

**SubscriptionsOfOrg.vue**
- `add-subscription`, `edit-subscription`, `save-subscription`
- `sub-eventtypes` (event-types select)
- `add-route`, `route-row-{i}` with `route-severity` / `route-channels` / `route-channelgroups`
- `route-perspectives` (delivery-filter select)

**ReleaseView.vue (approvals matrix)**
- `release-approvals-tab`, `request-approvals`, `save-approvals`, `reset-approvals`
- **The big one:** the tri-state approval `NCheckbox` in `releaseApprovalTableFields` now carries `data-testid="approval-cell-{entryUuid}-{roleId}"` **and** a machine-readable `data-state="UNSET|APPROVED|DISAPPROVED"`. Previously the cell's state was only inferable from `title`/`indeterminate` — the worst gap for the harness.

## Out of scope

Updating the harness specs to *consume* these hooks is a separate follow-up (lands once both this and the harness change are in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)