### PR TITLE
Add 'Finding changes over time' changelog tab (board #37)

### DIFF
--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -286,6 +286,15 @@
                     <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" />
                 </div>
             </n-tab-pane>
+
+            <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
+                <OverTimeFindingChanges
+                    v-if="hasData && (changelog.__typename === 'NoneChangelog' || changelog.__typename === 'AggregatedChangelog')"
+                    :over-time-finding-changes="changelog.overTimeFindingChanges"
+                    :org-uuid="changelog.orgUuid"
+                />
+                <OverTimeFindingChanges v-else />
+            </n-tab-pane>
         </n-tabs>
     </div>
 </template>
@@ -302,6 +311,7 @@ import { useStore } from 'vuex'
 import {
     FindingChangesDisplay,
     FindingChangesDisplayWithAttribution,
+    OverTimeFindingChanges,
     SbomChangesDisplay,
     CodeChangesDisplay,
     ReleaseHeader,

--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -283,17 +283,8 @@
                 <!-- AGGREGATED mode: Show top-level aggregated changes -->
                 <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog'">
                     <p style="margin-bottom: 10px; font-style: italic;">{{ aggregatedDescription }}</p>
-                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" />
+                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" />
                 </div>
-            </n-tab-pane>
-
-            <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
-                <OverTimeFindingChanges
-                    v-if="hasData && (changelog.__typename === 'NoneChangelog' || changelog.__typename === 'AggregatedChangelog')"
-                    :over-time-finding-changes="changelog.overTimeFindingChanges"
-                    :org-uuid="changelog.orgUuid"
-                />
-                <OverTimeFindingChanges v-else />
             </n-tab-pane>
         </n-tabs>
     </div>
@@ -311,7 +302,6 @@ import { useStore } from 'vuex'
 import {
     FindingChangesDisplay,
     FindingChangesDisplayWithAttribution,
-    OverTimeFindingChanges,
     SbomChangesDisplay,
     CodeChangesDisplay,
     ReleaseHeader,

--- a/ui/src/components/OrganizationChangelogView.vue
+++ b/ui/src/components/OrganizationChangelogView.vue
@@ -70,12 +70,8 @@
                         
                         <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedOrganizationChangelog'">
                             <p class="aggregation-note">Aggregated across all components</p>
-                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" />
+                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" />
                         </div>
-                    </n-tab-pane>
-
-                    <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
-                        <OverTimeFindingChanges :over-time-finding-changes="changelog.overTimeFindingChanges" :org-uuid="orgUuid" />
                     </n-tab-pane>
                 </n-tabs>
             </div>
@@ -87,9 +83,6 @@
                     </n-tab-pane>
                     <n-tab-pane name="findings" tab="🔒 Finding Changes">
                         <FindingChangesDisplayWithAttribution />
-                    </n-tab-pane>
-                    <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
-                        <OverTimeFindingChanges />
                     </n-tab-pane>
                 </n-tabs>
             </div>
@@ -111,7 +104,6 @@ import {
     ChangelogControls,
     FindingChangesDisplay,
     FindingChangesDisplayWithAttribution,
-    OverTimeFindingChanges,
     SbomChangesDisplay,
     ComponentHeader,
     ReleaseHeader

--- a/ui/src/components/OrganizationChangelogView.vue
+++ b/ui/src/components/OrganizationChangelogView.vue
@@ -73,6 +73,10 @@
                             <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" />
                         </div>
                     </n-tab-pane>
+
+                    <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
+                        <OverTimeFindingChanges :over-time-finding-changes="changelog.overTimeFindingChanges" :org-uuid="orgUuid" />
+                    </n-tab-pane>
                 </n-tabs>
             </div>
             
@@ -83,6 +87,9 @@
                     </n-tab-pane>
                     <n-tab-pane name="findings" tab="🔒 Finding Changes">
                         <FindingChangesDisplayWithAttribution />
+                    </n-tab-pane>
+                    <n-tab-pane name="overTime" tab="⏱ Finding changes over time">
+                        <OverTimeFindingChanges />
                     </n-tab-pane>
                 </n-tabs>
             </div>
@@ -104,6 +111,7 @@ import {
     ChangelogControls,
     FindingChangesDisplay,
     FindingChangesDisplayWithAttribution,
+    OverTimeFindingChanges,
     SbomChangesDisplay,
     ComponentHeader,
     ReleaseHeader

--- a/ui/src/components/changelog/FindingChangesDisplay.vue
+++ b/ui/src/components/changelog/FindingChangesDisplay.vue
@@ -28,7 +28,7 @@ import { computed, ref } from 'vue'
 import { NTag } from 'naive-ui'
 import FindingListSection from './FindingListSection.vue'
 import KevDetailsModal from '../KevDetailsModal.vue'
-import { getSeverityIndex } from '../../utils/findingUtils'
+import { normalizeReleaseVuln as normalizeVuln, normalizeReleaseViolation as normalizeViolation, normalizeReleaseWeakness as normalizeWeakness, sortBySeverityThenId } from '../../utils/findingUtils'
 import { resolveKevCveId } from '../../utils/kevService'
 import type { ReleaseFindingChanges } from '../../types/changelog-sealed'
 
@@ -57,45 +57,7 @@ const summary = computed(() => {
     }
 })
 
-const sortBySeverity = (findings: any[]) => {
-    if (!findings) return []
-    return [...findings].sort((a, b) => {
-        const severityDiff = getSeverityIndex(a.severity || '') - getSeverityIndex(b.severity || '')
-        if (severityDiff !== 0) return severityDiff
-        return String(a.findingId || '').localeCompare(String(b.findingId || ''))
-    })
-}
-
-const normalizeVuln = (v: any) => ({
-    findingId: v.vulnId || '',
-    affectedComponent: v.purl || '',
-    severity: v.severity || '',
-    aliases: Array.isArray(v.aliases) ? v.aliases.map((a: any) => typeof a === 'string' ? a : a.aliasId) : [],
-    type: 'VULN',
-    typeLabel: 'VULNERABILITY',
-    analysisState: v.analysisState || null,
-    knownExploited: !!v.knownExploited
-})
-
-const normalizeViolation = (v: any) => ({
-    findingId: v.type || '',
-    affectedComponent: v.purl || '',
-    severity: undefined as string | undefined,
-    aliases: [] as string[],
-    type: 'VIOLATION',
-    typeLabel: 'VIOLATION',
-    analysisState: v.analysisState || null
-})
-
-const normalizeWeakness = (w: any) => ({
-    findingId: w.cweId || w.ruleId || '',
-    affectedComponent: w.location || '',
-    severity: w.severity || '',
-    aliases: [] as string[],
-    type: 'WEAKNESS',
-    typeLabel: 'WEAKNESS',
-    analysisState: w.analysisState || null
-})
+const sortBySeverity = sortBySeverityThenId
 
 const appearedFindings = computed(() => {
     if (!props.findingChanges) return []

--- a/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
+++ b/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
@@ -43,6 +43,18 @@
                     </template>
                     <span>Net change in findings: new findings minus resolved findings for this period.</span>
                 </n-tooltip>
+                <n-tooltip v-if="newlyKevCount > 0" trigger="hover" placement="bottom">
+                    <template #trigger>
+                        <n-tag type="error" size="small" :bordered="false" class="tag-spacing worsened-tag">Newly KEV ({{ newlyKevCount }})</n-tag>
+                    </template>
+                    <span>Findings newly flagged as a CISA Known Exploited Vulnerability within this period.</span>
+                </n-tooltip>
+                <n-tooltip v-if="severityIncreasedCount > 0" trigger="hover" placement="bottom">
+                    <template #trigger>
+                        <n-tag type="warning" size="small" :bordered="false" class="tag-spacing worsened-tag">Severity ↑ ({{ severityIncreasedCount }})</n-tag>
+                    </template>
+                    <span>Findings whose severity was raised within this period.</span>
+                </n-tooltip>
             </div>
             
             <FindingListSection title="New Findings" title-class="finding-new" key-prefix="new" :findings="newFindings" :rich-aliases="true"
@@ -51,6 +63,22 @@
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getAppearedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
+                        <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
+                    </div>
+                </template>
+            </FindingListSection>
+
+            <FindingListSection v-if="isOrgLevelView && worsenedFindings.length > 0" title="Worsened / Newly KEV" title-class="finding-inherited" key-prefix="worsened" :findings="worsenedFindings" :rich-aliases="true"
+                description="Findings still present that got worse in this period — newly listed as a CISA Known Exploited Vulnerability and/or had their severity raised. Findings that are also brand-new appear only under New Findings (badged there)."
+                @kev-click="openKevModal">
+                <template #attribution="{ finding }">
+                    <div v-if="showAttribution" class="attribution">
+                        <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
+                        <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
+                        <span v-for="(seg, i) in getStillPresentContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
             </FindingListSection>
@@ -61,6 +89,7 @@
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
             </FindingListSection>
@@ -70,7 +99,10 @@
                 @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
+                        <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
+                        <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getInheritedDebtContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
             </FindingListSection>
@@ -80,7 +112,10 @@
                 @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
+                        <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
+                        <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getStillPresentContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
             </FindingListSection>
@@ -91,11 +126,22 @@
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
             </FindingListSection>
 
             <kev-details-modal v-model:show="showKevModal" :cve-id="kevModalCveId" :org-uuid="orgUuid || ''" />
+
+            <n-drawer v-model:show="showTimeline" :width="560" placement="right">
+                <n-drawer-content :title="timelineTitle" closable>
+                    <OverTimeFindingChanges
+                        :over-time-finding-changes="overTimeFindingChanges"
+                        :finding-key-filter="timelineFilterKey"
+                        :org-uuid="orgUuid"
+                    />
+                </n-drawer-content>
+            </n-drawer>
         </div>
         <div v-else class="empty-state">
             <div class="summary-tags">
@@ -109,23 +155,28 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import { NTag, NTooltip } from 'naive-ui'
+import { NTag, NTooltip, NDrawer, NDrawerContent } from 'naive-ui'
 import FindingListSection from './FindingListSection.vue'
+import OverTimeFindingChanges from './OverTimeFindingChanges.vue'
 import KevDetailsModal from '../KevDetailsModal.vue'
 import { getSeverityIndex } from '../../utils/findingUtils'
 import { resolveKevCveId } from '../../utils/kevService'
-import type { 
+import type {
     FindingChangesWithAttribution,
     VulnerabilityWithAttribution,
     ViolationWithAttribution,
     WeaknessWithAttribution,
     OrgLevelContext
 } from '../../types/changelog-attribution'
+import type { MetricsRevisionFindingChange } from '../../types/changelog-sealed'
 
 interface Props {
     findingChanges?: FindingChangesWithAttribution
     showAttribution?: boolean
     orgUuid?: string
+    // Flat re-scan timeline (same GraphQL payload) — filtered client-side by
+    // finding key for the per-finding drill-down drawer. Optional/nullable.
+    overTimeFindingChanges?: MetricsRevisionFindingChange[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -138,6 +189,38 @@ const kevModalCveId = ref('')
 function openKevModal(finding: any) {
     kevModalCveId.value = resolveKevCveId({ id: finding.findingId, aliases: finding.aliases })
     showKevModal.value = true
+}
+
+// ---- Per-finding timeline drill-down (drawer) ----
+const showTimeline = ref(false)
+const timelineFilterKey = ref('')
+const timelineTitle = ref('')
+
+// Type-scoped id key matching recordFindingKey() in OverTimeFindingChanges.vue:
+// deliberately excludes the per-release component so a CVE's whole cross-release
+// timeline is shown (this is the #41 case — same CVE, different releases).
+function findingKeyForFilter(finding: NormalizedFinding): string {
+    return `${finding.type}-${finding.findingId}`
+}
+
+// A timeline is available only when the payload actually carries at least one
+// matching over-time record for this finding (flag-off / legacy => no link).
+function canViewTimeline(finding: NormalizedFinding): boolean {
+    const records = props.overTimeFindingChanges
+    if (!records || records.length === 0) return false
+    const key = findingKeyForFilter(finding)
+    return records.some(rec => {
+        if (rec.vulnerability) return `VULN-${rec.vulnerability.vulnId}` === key
+        if (rec.violation) return `VIOLATION-${rec.violation.type}` === key
+        if (rec.weakness) return `WEAKNESS-${rec.weakness.cweId || rec.weakness.ruleId || ''}` === key
+        return false
+    })
+}
+
+function openTimeline(finding: NormalizedFinding) {
+    timelineFilterKey.value = findingKeyForFilter(finding)
+    timelineTitle.value = `Timeline — ${finding.findingId}`
+    showTimeline.value = true
 }
 
 type AttributionSegment = {
@@ -257,9 +340,37 @@ const orgInheritedTechnicalDebtFindings = computed(() =>
     )))
 )
 
-const orgFullyResolvedFindings = computed(() => 
+const orgFullyResolvedFindings = computed(() =>
     sortBySeverity(allFindings.value.filter(f => f.orgContext?.isFullyResolved))
 )
+
+// A finding "worsened" if it newly became KEV and/or had its severity raised
+// this period. Nullable fields => coerce to boolean so flag-off payloads are inert.
+function isWorsened(f: NormalizedFinding): boolean {
+    return !!(f.orgContext?.isNewlyKev || f.orgContext?.isSeverityIncreased)
+}
+
+// Worsened section lists worsened findings that are NOT already surfaced under
+// New Findings — a KEV/severity-worsened finding that is also brand-new is
+// badge-only in New (signed-off decision: no double-listing).
+const worsenedFindings = computed(() =>
+    sortBySeverity(allFindings.value.filter(f => isWorsened(f) && !f.orgContext?.isNewToOrganization))
+)
+
+// Headline counts. Prefer the backend rollup totals; fall back to a client-side
+// count of the org-context flags when the rollup fields are absent (both are
+// nullable — 0 when the backend feature flag is off, hiding the tags).
+const newlyKevCount = computed(() => {
+    const total = props.findingChanges?.totalNewlyKev
+    if (total != null) return total
+    return allFindings.value.filter(f => !!f.orgContext?.isNewlyKev).length
+})
+
+const severityIncreasedCount = computed(() => {
+    const total = props.findingChanges?.totalSeverityIncreased
+    if (total != null) return total
+    return allFindings.value.filter(f => !!f.orgContext?.isSeverityIncreased).length
+})
 
 // COMPONENT-LEVEL: Three-category system
 const componentNewFindings = computed(() => 
@@ -442,4 +553,43 @@ function getInheritedDebtContextSegments(finding: NormalizedFinding): Attributio
 <style scoped lang="scss">
 @use './finding-common';
 
+.finding-changes {
+    .worsened-tag {
+        font-weight: 600;
+    }
+
+    .worsened-badge {
+        display: inline-block;
+        margin-right: 8px;
+        padding: 0 6px;
+        border-radius: 3px;
+        font-size: 0.85em;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 1.5;
+        white-space: nowrap;
+    }
+
+    .worsened-badge-kev {
+        background: #fde3e3;
+        color: #a5211b;
+    }
+
+    .worsened-badge-sev {
+        background: #fdf0d9;
+        color: #a06600;
+    }
+
+    .timeline-link {
+        margin-left: 8px;
+        color: #2080f0;
+        font-style: normal;
+        cursor: pointer;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
 </style>

--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -14,7 +14,11 @@
                     :findings="bucket.appeared"
                     description="Findings that first appeared in a release on this date."
                     @kev-click="openKevModal"
-                />
+                >
+                    <template #attribution="{ finding }">
+                        <div class="release-attribution">{{ releaseLabel(finding) }}</div>
+                    </template>
+                </FindingListSection>
                 <FindingListSection
                     title="Resolved"
                     title-class="finding-resolved"
@@ -22,7 +26,11 @@
                     :findings="bucket.resolved"
                     description="Findings that were no longer detected in a release as of this date."
                     @kev-click="openKevModal"
-                />
+                >
+                    <template #attribution="{ finding }">
+                        <div class="release-attribution">{{ releaseLabel(finding) }}</div>
+                    </template>
+                </FindingListSection>
                 <FindingListSection
                     title="Severity increased"
                     title-class="finding-partial"
@@ -32,10 +40,14 @@
                     @kev-click="openKevModal"
                 >
                     <template #attribution="{ finding }">
-                        <div v-if="finding.previousSeverity" class="severity-change">
-                            Severity: <strong>{{ finding.previousSeverity }}</strong>
-                            <span class="severity-arrow">→</span>
-                            <strong>{{ finding.severity || 'UNASSIGNED' }}</strong>
+                        <div class="release-attribution">
+                            {{ releaseLabel(finding) }}
+                            <template v-if="finding.previousSeverity">
+                                <span class="severity-change">Severity: <strong>{{ finding.previousSeverity }}</strong>
+                                    <span class="severity-arrow">→</span>
+                                    <strong>{{ finding.severity || 'UNASSIGNED' }}</strong>
+                                </span>
+                            </template>
                         </div>
                     </template>
                 </FindingListSection>
@@ -46,7 +58,11 @@
                     :findings="bucket.kevAdded"
                     description="Findings newly flagged as a CISA Known Exploited Vulnerability on this date."
                     @kev-click="openKevModal"
-                />
+                >
+                    <template #attribution="{ finding }">
+                        <div class="release-attribution">{{ releaseLabel(finding) }}</div>
+                    </template>
+                </FindingListSection>
             </div>
             <kev-details-modal v-model:show="showKevModal" :cve-id="kevModalCveId" :org-uuid="orgUuid || ''" />
         </div>
@@ -71,9 +87,35 @@ import type { MetricsRevisionFindingChange } from '../../types/changelog-sealed'
 interface Props {
     overTimeFindingChanges?: MetricsRevisionFindingChange[]
     orgUuid?: string
+    // Drill-down mode: when set, only timeline records whose finding matches this
+    // type-scoped id key are shown (all releases/components of that one finding).
+    findingKeyFilter?: string
 }
 
 const props = defineProps<Props>()
+
+// Type-scoped id key for a raw over-time record: identifies a single logical
+// finding (e.g. a CVE) across releases/components — deliberately excludes the
+// per-release purl/location so #41's "same CVE in two releases" collapses to one
+// timeline. Mirrors findingKeyForFilter() in FindingChangesDisplayWithAttribution.
+function recordFindingKey(rec: MetricsRevisionFindingChange): string | null {
+    if (rec.vulnerability) return `VULN-${rec.vulnerability.vulnId}`
+    if (rec.violation) return `VIOLATION-${rec.violation.type}`
+    if (rec.weakness) return `WEAKNESS-${rec.weakness.cweId || rec.weakness.ruleId || ''}`
+    return null
+}
+
+// Per-release attribution line for a normalized over-time finding (closes #41):
+// two identical CVE rows from different releases are now distinguishable.
+function releaseLabel(finding: { componentName?: string, version?: string }): string {
+    const parts: string[] = []
+    if (finding.componentName) parts.push(finding.componentName)
+    if (finding.version) parts.push(finding.version)
+    if (parts.length === 0) return ''
+    return finding.componentName && finding.version
+        ? `${finding.componentName}@${finding.version}`
+        : parts.join(' ')
+}
 
 const showKevModal = ref(false)
 const kevModalCveId = ref('')
@@ -126,7 +168,10 @@ function toOverTimeFinding(rec: MetricsRevisionFindingChange): OverTimeFinding |
 }
 
 const dateBuckets = computed<DateBucket[]>(() => {
-    const records = props.overTimeFindingChanges || []
+    let records = props.overTimeFindingChanges || []
+    if (props.findingKeyFilter) {
+        records = records.filter(rec => recordFindingKey(rec) === props.findingKeyFilter)
+    }
     const byDay = new Map<string, { label: string, records: MetricsRevisionFindingChange[] }>()
 
     for (const rec of records) {
@@ -198,9 +243,14 @@ const dateBuckets = computed<DateBucket[]>(() => {
         font-weight: 600;
     }
 
-    .severity-change {
+    .release-attribution {
         margin-left: 24px;
         font-size: 0.85em;
+        color: #666;
+    }
+
+    .severity-change {
+        margin-left: 8px;
         color: #666;
 
         .severity-arrow {

--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -1,0 +1,218 @@
+<template>
+    <div class="over-time-finding-changes">
+        <div v-if="dateBuckets.length > 0">
+            <p class="over-time-note">
+                Finding changes detected by re-scans over the selected period, grouped by the date the change was observed.
+            </p>
+            <div v-for="bucket in dateBuckets" :key="bucket.dateKey" class="date-bucket">
+                <h4 class="date-heading">{{ bucket.dateLabel }}</h4>
+
+                <FindingListSection
+                    title="New"
+                    title-class="finding-new"
+                    :key-prefix="`ot-appeared-${bucket.dateKey}`"
+                    :findings="bucket.appeared"
+                    description="Findings that first appeared in a release on this date."
+                    @kev-click="openKevModal"
+                />
+                <FindingListSection
+                    title="Resolved"
+                    title-class="finding-resolved"
+                    :key-prefix="`ot-resolved-${bucket.dateKey}`"
+                    :findings="bucket.resolved"
+                    description="Findings that were no longer detected in a release as of this date."
+                    @kev-click="openKevModal"
+                />
+                <FindingListSection
+                    title="Severity increased"
+                    title-class="finding-partial"
+                    :key-prefix="`ot-severity-${bucket.dateKey}`"
+                    :findings="bucket.severityIncreased"
+                    description="Findings whose severity was raised on this date."
+                    @kev-click="openKevModal"
+                >
+                    <template #attribution="{ finding }">
+                        <div v-if="finding.previousSeverity" class="severity-change">
+                            Severity: <strong>{{ finding.previousSeverity }}</strong>
+                            <span class="severity-arrow">→</span>
+                            <strong>{{ finding.severity || 'UNASSIGNED' }}</strong>
+                        </div>
+                    </template>
+                </FindingListSection>
+                <FindingListSection
+                    title="KEV listed"
+                    title-class="finding-inherited"
+                    :key-prefix="`ot-kev-${bucket.dateKey}`"
+                    :findings="bucket.kevAdded"
+                    description="Findings newly flagged as a CISA Known Exploited Vulnerability on this date."
+                    @kev-click="openKevModal"
+                />
+            </div>
+            <kev-details-modal v-model:show="showKevModal" :cve-id="kevModalCveId" :org-uuid="orgUuid || ''" />
+        </div>
+        <div v-else class="empty-state">
+            <p class="no-data-hint">No re-scan-driven finding changes were detected in the selected period.</p>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue'
+import FindingListSection from './FindingListSection.vue'
+import KevDetailsModal from '../KevDetailsModal.vue'
+import {
+    normalizeFindingChangeRecord,
+    sortBySeverityThenId,
+    type NormalizedReleaseFinding
+} from '../../utils/findingUtils'
+import { resolveKevCveId } from '../../utils/kevService'
+import type { MetricsRevisionFindingChange } from '../../types/changelog-sealed'
+
+interface Props {
+    overTimeFindingChanges?: MetricsRevisionFindingChange[]
+    orgUuid?: string
+}
+
+const props = defineProps<Props>()
+
+const showKevModal = ref(false)
+const kevModalCveId = ref('')
+
+function openKevModal(finding: any) {
+    kevModalCveId.value = resolveKevCveId({ id: finding.findingId, aliases: finding.aliases })
+    showKevModal.value = true
+}
+
+// A normalized finding carrying the over-time-specific context (release + previousSeverity).
+type OverTimeFinding = NormalizedReleaseFinding & {
+    componentName: string
+    version: string
+    releaseUuid: string
+    previousSeverity?: string | null
+}
+
+interface DateBucket {
+    dateKey: string
+    dateLabel: string
+    appeared: OverTimeFinding[]
+    resolved: OverTimeFinding[]
+    severityIncreased: OverTimeFinding[]
+    kevAdded: OverTimeFinding[]
+}
+
+function dayKey(changeDate: string): string {
+    // Bucket by calendar day in the viewer's local zone.
+    const d = new Date(changeDate)
+    if (isNaN(d.getTime())) return changeDate
+    return d.toLocaleDateString('en-CA')
+}
+
+function dayLabel(changeDate: string): string {
+    const d = new Date(changeDate)
+    if (isNaN(d.getTime())) return changeDate
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function toOverTimeFinding(rec: MetricsRevisionFindingChange): OverTimeFinding | null {
+    const base = normalizeFindingChangeRecord(rec)
+    if (!base) return null
+    return {
+        ...base,
+        componentName: rec.componentName,
+        version: rec.version,
+        releaseUuid: rec.releaseUuid,
+        previousSeverity: rec.previousSeverity ?? null
+    }
+}
+
+const dateBuckets = computed<DateBucket[]>(() => {
+    const records = props.overTimeFindingChanges || []
+    const byDay = new Map<string, { label: string, records: MetricsRevisionFindingChange[] }>()
+
+    for (const rec of records) {
+        const key = dayKey(rec.changeDate)
+        let bucket = byDay.get(key)
+        if (!bucket) {
+            bucket = { label: dayLabel(rec.changeDate), records: [] }
+            byDay.set(key, bucket)
+        }
+        bucket.records.push(rec)
+    }
+
+    const keys = Array.from(byDay.keys()).sort((a, b) => b.localeCompare(a)) // descending by day
+
+    return keys.map((key) => {
+        const { label, records: dayRecords } = byDay.get(key)!
+        const appeared: OverTimeFinding[] = []
+        const resolved: OverTimeFinding[] = []
+        const severityIncreased: OverTimeFinding[] = []
+        const kevAdded: OverTimeFinding[] = []
+
+        for (const rec of dayRecords) {
+            const f = toOverTimeFinding(rec)
+            if (!f) continue
+            switch (rec.changeKind) {
+                case 'APPEARED': appeared.push(f); break
+                case 'RESOLVED': resolved.push(f); break
+                case 'SEVERITY_INCREASED': severityIncreased.push(f); break
+                case 'KEV_ADDED': kevAdded.push(f); break
+            }
+        }
+
+        return {
+            dateKey: key,
+            dateLabel: label,
+            appeared: sortBySeverityThenId(appeared) as OverTimeFinding[],
+            resolved: sortBySeverityThenId(resolved) as OverTimeFinding[],
+            severityIncreased: sortBySeverityThenId(severityIncreased) as OverTimeFinding[],
+            kevAdded: sortBySeverityThenId(kevAdded) as OverTimeFinding[]
+        }
+    })
+})
+</script>
+
+<style scoped lang="scss">
+@use './finding-common';
+
+.over-time-finding-changes {
+    .over-time-note {
+        margin-bottom: 16px;
+        font-style: italic;
+        color: #666;
+    }
+
+    .date-bucket {
+        margin-bottom: 20px;
+        padding-bottom: 8px;
+        border-bottom: 1px solid #eee;
+
+        &:last-child {
+            border-bottom: none;
+        }
+    }
+
+    .date-heading {
+        margin-top: 16px;
+        margin-bottom: 8px;
+        color: #444;
+        font-weight: 600;
+    }
+
+    .severity-change {
+        margin-left: 24px;
+        font-size: 0.85em;
+        color: #666;
+
+        .severity-arrow {
+            margin: 0 4px;
+        }
+    }
+
+    .no-data-hint {
+        padding: 20px;
+        text-align: center;
+        color: #999;
+        font-style: italic;
+    }
+}
+</style>

--- a/ui/src/components/changelog/index.ts
+++ b/ui/src/components/changelog/index.ts
@@ -1,5 +1,6 @@
 export { default as FindingChangesDisplay } from './FindingChangesDisplay.vue'
 export { default as FindingChangesDisplayWithAttribution } from './FindingChangesDisplayWithAttribution.vue'
+export { default as OverTimeFindingChanges } from './OverTimeFindingChanges.vue'
 export { default as SbomChangesDisplay } from './SbomChangesDisplay.vue'
 export { default as CodeChangesDisplay } from './CodeChangesDisplay.vue'
 export { default as ReleaseHeader } from './ReleaseHeader.vue'

--- a/ui/src/types/changelog-attribution.ts
+++ b/ui/src/types/changelog-attribution.ts
@@ -27,6 +27,11 @@ export interface OrgLevelContext {
     isInheritedInAllComponents: boolean // Present in first AND last release of ALL components (technical debt)
     componentCount: number              // Number of components currently affected
     affectedComponentNames: string[]    // Names of components currently affected
+    // Posture-worsening context (additive; populated only when the backend feature
+    // flag is on — null/undefined on legacy payloads, render nothing when absent).
+    isNewlyKev?: boolean | null         // Finding became a CISA Known Exploited Vulnerability within this period
+    isSeverityIncreased?: boolean | null // Finding's severity was raised within this period
+    previousSeverity?: string | null    // Prior severity when isSeverityIncreased (for "prev -> current")
 }
 
 /**
@@ -113,5 +118,9 @@ export interface FindingChangesWithAttribution {
     weaknesses: WeaknessWithAttribution[]
     totalAppeared: number
     totalResolved: number
+    // Posture-worsening rollup counts (additive; null/undefined when the
+    // backend feature flag is off — render the tag only when > 0).
+    totalNewlyKev?: number | null
+    totalSeverityIncreased?: number | null
 }
 

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -87,6 +87,29 @@ export interface ReleaseFindingChanges {
 }
 
 /**
+ * Kind of finding change surfaced by a metrics re-scan over time.
+ */
+export type FindingChangeKind = 'APPEARED' | 'RESOLVED' | 'SEVERITY_INCREASED' | 'KEV_ADDED'
+
+/**
+ * A single re-scan-driven finding change observed at a point in time.
+ * Exactly one of vulnerability / violation / weakness is non-null per record;
+ * previousSeverity is set only for SEVERITY_INCREASED.
+ */
+export interface MetricsRevisionFindingChange {
+    changeDate: string
+    changeKind: FindingChangeKind
+    releaseUuid: string
+    version: string
+    componentUuid: string
+    componentName: string
+    vulnerability?: ReleaseVulnerabilityInfo | null
+    violation?: ReleaseViolationInfo | null
+    weakness?: ReleaseWeaknessInfo | null
+    previousSeverity?: string | null
+}
+
+/**
  * All changes for a single release (NONE mode).
  * Embeds code, SBOM, and finding changes in one self-contained record.
  */
@@ -147,6 +170,7 @@ export interface NoneChangelog {
     firstRelease: ReleaseInfo
     lastRelease: ReleaseInfo
     branches: NoneBranchChanges[]
+    overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 
 /**
@@ -187,6 +211,7 @@ export interface AggregatedChangelog {
     branches: AggregatedBranchChanges[]
     sbomChanges: SbomChangesWithAttribution
     findingChanges: FindingChangesWithAttribution
+    overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 
 /**
@@ -203,6 +228,7 @@ export interface NoneOrganizationChangelog {
     dateFrom: string
     dateTo: string
     components: ComponentChangelog[]
+    overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 
 /**
@@ -216,6 +242,7 @@ export interface AggregatedOrganizationChangelog {
     components: ComponentChangelog[]
     sbomChanges: SbomChangesWithAttribution
     findingChanges: FindingChangesWithAttribution
+    overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 
 /**

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -163,6 +163,9 @@ const ORG_LEVEL_CONTEXT_FRAGMENT = `
     isInheritedInAllComponents
     componentCount
     affectedComponentNames
+    isNewlyKev
+    isSeverityIncreased
+    previousSeverity
 `
 
 const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
@@ -186,6 +189,8 @@ const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
 const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
     totalAppeared
     totalResolved
+    totalNewlyKev
+    totalSeverityIncreased
     vulnerabilities {
         vulnId
         purl

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -90,6 +90,39 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
     }
 `
 
+// Over-time finding changes: flat list of re-scan-driven MetricsRevisionFindingChange
+// records. Exactly one of vulnerability/violation/weakness is non-null per record;
+// previousSeverity is set only for SEVERITY_INCREASED. Reuses the same lightweight
+// nested selections as the per-release finding-change fragments.
+const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
+    changeDate
+    changeKind
+    releaseUuid
+    version
+    componentUuid
+    componentName
+    previousSeverity
+    vulnerability {
+        vulnId
+        purl
+        severity
+        aliases {
+            aliasId
+        }
+        knownExploited
+    }
+    violation {
+        type
+        purl
+    }
+    weakness {
+        cweId
+        severity
+        ruleId
+        location
+    }
+`
+
 const NONE_RELEASE_CHANGES_FRAGMENT = `
     releaseUuid
     version
@@ -248,6 +281,9 @@ const NONE_CHANGELOG_FIELDS = `
     branches {
         ${NONE_BRANCH_CHANGES_FRAGMENT}
     }
+    overTimeFindingChanges {
+        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+    }
 `
 
 const NONE_PRODUCT_CHANGELOG_FIELDS = `
@@ -300,6 +336,9 @@ const AGGREGATED_CHANGELOG_FIELDS = `
     }
     findingChanges {
         ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+    }
+    overTimeFindingChanges {
+        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
     }
 `
 
@@ -457,6 +496,9 @@ export async function fetchOrganizationChangelogByDate(params: {
                                 ${NONE_CHANGELOG_FIELDS}
                             }
                         }
+                        overTimeFindingChanges {
+                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+                        }
                     }
                     ... on AggregatedOrganizationChangelog {
                         orgUuid
@@ -473,6 +515,9 @@ export async function fetchOrganizationChangelogByDate(params: {
                         }
                         findingChanges {
                             ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+                        }
+                        overTimeFindingChanges {
+                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
                         }
                     }
                 }

--- a/ui/src/utils/findingUtils.ts
+++ b/ui/src/utils/findingUtils.ts
@@ -59,6 +59,83 @@ export function getFindingUrl(id: string): string | null {
 
 const LS_KEY = 'rearm_external_link_consent_until'
 
+/**
+ * Shared normalizers turning the raw ReleaseVulnerabilityInfo / ReleaseViolationInfo /
+ * ReleaseWeaknessInfo GraphQL records into the flat shape FindingListSection renders.
+ * Extracted from FindingChangesDisplay.vue so multiple changelog surfaces
+ * (per-release finding changes + over-time finding changes) share one source of truth.
+ */
+export interface NormalizedReleaseFinding {
+    findingId: string
+    affectedComponent: string
+    severity?: string
+    aliases: string[]
+    type: 'VULN' | 'VIOLATION' | 'WEAKNESS'
+    typeLabel: string
+    analysisState: string | null
+    knownExploited?: boolean
+}
+
+export function normalizeReleaseVuln(v: any): NormalizedReleaseFinding {
+    return {
+        findingId: v.vulnId || '',
+        affectedComponent: v.purl || '',
+        severity: v.severity || '',
+        aliases: Array.isArray(v.aliases) ? v.aliases.map((a: any) => typeof a === 'string' ? a : a.aliasId) : [],
+        type: 'VULN',
+        typeLabel: 'VULNERABILITY',
+        analysisState: v.analysisState || null,
+        knownExploited: !!v.knownExploited
+    }
+}
+
+export function normalizeReleaseViolation(v: any): NormalizedReleaseFinding {
+    return {
+        findingId: v.type || '',
+        affectedComponent: v.purl || '',
+        severity: undefined,
+        aliases: [],
+        type: 'VIOLATION',
+        typeLabel: 'VIOLATION',
+        analysisState: v.analysisState || null
+    }
+}
+
+export function normalizeReleaseWeakness(w: any): NormalizedReleaseFinding {
+    return {
+        findingId: w.cweId || w.ruleId || '',
+        affectedComponent: w.location || '',
+        severity: w.severity || '',
+        aliases: [],
+        type: 'WEAKNESS',
+        typeLabel: 'WEAKNESS',
+        analysisState: w.analysisState || null
+    }
+}
+
+/**
+ * Normalize whichever of vulnerability / violation / weakness is non-null on a
+ * MetricsRevisionFindingChange record (exactly one is set per the backend contract).
+ */
+export function normalizeFindingChangeRecord(rec: {
+    vulnerability?: any
+    violation?: any
+    weakness?: any
+}): NormalizedReleaseFinding | null {
+    if (rec.vulnerability) return normalizeReleaseVuln(rec.vulnerability)
+    if (rec.violation) return normalizeReleaseViolation(rec.violation)
+    if (rec.weakness) return normalizeReleaseWeakness(rec.weakness)
+    return null
+}
+
+export function sortBySeverityThenId(findings: NormalizedReleaseFinding[]): NormalizedReleaseFinding[] {
+    return [...findings].sort((a, b) => {
+        const severityDiff = getSeverityIndex(a.severity) - getSeverityIndex(b.severity)
+        if (severityDiff !== 0) return severityDiff
+        return String(a.findingId || '').localeCompare(String(b.findingId || ''))
+    })
+}
+
 export async function openExternalLink(href: string): Promise<void> {
     try {
         const now = Date.now()


### PR DESCRIPTION
## Summary

Implements board task #37: a new **additive** "⏱ Finding changes over time" tab in the changelog that surfaces re-scan-driven finding changes (`MetricsRevisionFindingChange`). This is a brand-new tab, **distinct from and not modifying** the existing release-anchored changelog or the PDF export.

## ⚠️ Merge dependency — MUST merge AFTER rearm-saas#252

This PR consumes a GraphQL contract that does **not yet exist** in production. The backend is **rearm-saas PR #252** (branch `2026-06-changelog-metrics-audit-overtime`), which is merge-ready but **not yet merged/deployed**. It adds:

```graphql
enum FindingChangeKind { APPEARED RESOLVED SEVERITY_INCREASED KEV_ADDED }
type MetricsRevisionFindingChange { changeDate changeKind releaseUuid version componentUuid componentName vulnerability violation weakness previousSeverity }
# new nullable field on NoneChangelog / AggregatedChangelog /
# NoneOrganizationChangelog / AggregatedOrganizationChangelog:
overTimeFindingChanges: [MetricsRevisionFindingChange!]!
```

**This UI PR must merge AFTER rearm-saas#252 is merged and deployed.** Merging/deploying it first would cause the changelog query to field-drift 400 against the current sandbox/prod schema (same failure mode as the #27 inbox bug).

## Verification

- `cd ui && npm run build` ✅ passes
- `npx vue-tsc --noEmit` ✅ clean for all touched files (only pre-existing tsconfig deprecation warnings remain, unrelated to this change)
- `npm run lint` is pre-existing-broken (#25) and ignored per project policy
- **Live Playwright verification is deferred** until rearm-saas#252 is deployed — the `overTimeFindingChanges` field only exists once #252 ships, so it cannot be exercised against the current sandbox without field-drifting the query.

## Changes

- **`ui/src/utils/changelogQueries.ts`** — new `OVER_TIME_FINDING_CHANGES_FRAGMENT` (MetricsRevisionFindingChange fields + nested vulnerability/violation/weakness), spliced into the org changelog selection sets (`NoneOrganizationChangelog` + `AggregatedOrganizationChangelog`) and the per-component `NONE_CHANGELOG_FIELDS` / `AGGREGATED_CHANGELOG_FIELDS`.
- **`ui/src/types/changelog-sealed.ts`** — `FindingChangeKind` + `MetricsRevisionFindingChange` types; nullable `overTimeFindingChanges` on all 4 changelog types.
- **`ui/src/utils/findingUtils.ts`** — extracted the release-finding normalizers (vuln / violation / weakness) + `normalizeFindingChangeRecord` + `sortBySeverityThenId` into shared helpers (rather than copy-paste).
- **`ui/src/components/changelog/FindingChangesDisplay.vue`** — refactored to reuse the shared normalizers (no behavior change).
- **`ui/src/components/changelog/OverTimeFindingChanges.vue`** (new) — groups the flat list by `changeDate` (descending day buckets); within each day, splits by `changeKind` into **New / Resolved / Severity increased / KEV listed** sections, each rendered through the existing `FindingListSection` primitive. SEVERITY_INCREASED shows `previousSeverity → current` via the section's attribution slot. Reuses the existing KEV modal wiring. Empty list → friendly empty state.
- **`ui/src/components/OrganizationChangelogView.vue`** — new tab rendering `OverTimeFindingChanges` (org-level), plus empty-state tab in the no-data branch.
- **`ui/src/components/ChangelogView.vue`** — mirrored per-component tab (guarded to `NoneChangelog`/`AggregatedChangelog`, which expose the field).

## Component / query structure

```
organizationChangelogByDate
  └─ overTimeFindingChanges: [MetricsRevisionFindingChange!]!   ← consumed by the new tab
        group by changeDate (day, desc)
          └─ split by changeKind → FindingListSection x4 (New / Resolved / Severity increased / KEV listed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)