### PR TITLE
docs: add notifications, approval queues, and Sentinel documentation

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -29,7 +29,9 @@ function sidebar() {
           {text: 'Committers & Commit Signing', link: '/workflows/committers'}
         ]},
         {text: 'Configure', link: '/configure/', items: [
-          {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'}
+          {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'},
+          {text: 'Notifications', link: '/configure/notifications'},
+          {text: 'Approval Queues', link: '/configure/approval-queues'}
         ]},
         {text: 'Transparency Exchange API', link: '/tea/' },
         {text: 'Integrations', link: '/integrations/',
@@ -62,6 +64,7 @@ function sidebar() {
             },
             {text: 'Slack', link: '/integrations/slack'},
             {text: 'Microsoft Teams', link: '/integrations/msteams'},
+            {text: 'Microsoft Sentinel', link: '/integrations/sentinel'},
             {text: 'Dependency-Track', link: '/integrations/dtrack'},
             {text: 'Identity Providers', link: '/integrations/identityProviders',
               items: [

--- a/documentation_site/docs/configure/approval-queues.md
+++ b/documentation_site/docs/configure/approval-queues.md
@@ -1,11 +1,10 @@
-
 ---
 sidebarDepth: 2
 ---
 
 # Approval Queues
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 :::
 
 An **approval policy** on a release can require a minimum number of approvals

--- a/documentation_site/docs/configure/approval-queues.md
+++ b/documentation_site/docs/configure/approval-queues.md
@@ -1,0 +1,66 @@
+
+---
+sidebarDepth: 2
+---
+
+# Approval Queues
+
+::: info ReARM Pro only
+:::
+
+An **approval policy** on a release can require a minimum number of approvals
+(and set a maximum number of disapprovals before the release is vetoed) from
+users holding specific **approval roles**, before the release can be
+considered fully approved. This page covers where those pending approvals
+show up and who gets notified about them -- see [Manage Users and User Group
+Permissions](./user-and-user-group-permissions) for how approval roles and
+permissions are granted in the first place.
+
+## Where to find pending approvals
+
+Open **Notification Inbox -> Needs my approval**. This tab lists every
+release that is currently waiting on *your* vote -- it's computed live from
+each release's approval policy and current votes, not a saved list, so it's
+always current.
+
+This is different from **Notification History**, which is an org-admin audit
+log of every notification ReARM has sent -- the approval-queue tab only shows
+what's still actionable for you specifically.
+
+## Casting a vote vs. being asked to vote
+
+These are two different things, and they don't always go together:
+
+- **Casting a vote (approve/disapprove) on a release:** any user holding an
+  approval role that the release's policy accepts can vote. **Organization
+  Admins can always vote, on any release, regardless of role** -- this is the
+  existing rule described in [Manage Users and User Group
+  Permissions](./user-and-user-group-permissions#3-organization-wide-approval-permissions).
+- **Showing up in "Needs my approval" / getting an `APPROVAL_REQUESTED`
+  notification:** this is driven **only** by whether you hold an explicit
+  approval role that the release's policy accepts -- the Organization Admin
+  override does **not** put releases in your queue or trigger a notification
+  to you.
+
+::: warning An Org Admin with no approval role has a quiet inbox
+Being an Organization Admin gives you the *capability* to approve anything,
+but not *visibility* into what's waiting. If you want an admin to be
+proactively notified and see items in their approval queue, grant them an
+explicit approval role in addition to Admin -- Admin alone is not enough for
+that. This is intentional (it keeps an admin's queue from filling up with
+every pending release org-wide), but it surprises people who expect "Admin"
+to imply "sees everything."
+:::
+
+## Requesting an approval
+
+Requesting an approval on a release notifies the release's eligible approvers
+(the same role-based set described above -- Organization Admins without an
+approval role are not included in the notification, for the same reason they
+don't appear in the queue). A request is advisory: it doesn't change what's
+required to approve the release, and a release can still be approved or
+disapproved without ever having a request opened on it.
+
+Approval-related notifications (`APPROVAL_REQUESTED` and `APPROVAL_RESOLVED`,
+see [Notifications](./notifications#event-types)) always deliver immediately,
+even on channels configured for digest/batched delivery elsewhere.

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -1,0 +1,128 @@
+
+---
+sidebarDepth: 2
+---
+
+# Notifications
+
+::: info ReARM Pro only
+Everything on this page -- channels, subscriptions, routes, and KEV alerts --
+is part of ReARM Pro's security-and-operational notification framework,
+configured under **Organization Settings -> Integrations -> Notifications**.
+This is separate from the CE-level Slack/Teams **release** notifications
+described on the [Slack](../integrations/slack) and [Microsoft
+Teams](../integrations/msteams) pages -- see the callout on the Microsoft
+Teams page if you're not sure which one you need.
+:::
+
+## How it fits together
+
+1. A **channel** is a named destination: Slack, Microsoft Teams, a generic
+   webhook, email, or [Microsoft Sentinel](../integrations/sentinel). Add one
+   from the **Notifications -> Channels** tab.
+2. A **subscription** decides which events go to which channels. Add one from
+   the **Notifications -> Subscriptions** tab: pick the event types you care
+   about, an optional filter, and one or more **routes** -- each route pairs a
+   minimum severity with a set of channels (or channel groups).
+3. A **channel group** (Notifications -> Channel Groups) is just a named,
+   reusable list of channels you can reference from a route instead of
+   repeating the same channels on every subscription.
+
+Nothing is delivered until both a channel *and* a subscription routing to it
+exist -- adding a channel alone does not send you anything.
+
+## Event types
+
+A subscription's `eventTypes` list controls what it can match:
+
+| Event | Fires when |
+|---|---|
+| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability is newly linked to one of your releases |
+| `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
+| `VEX_STATE_CHANGED` | A VEX (exploitability) status changes on a finding |
+| `RELEASE_CREATED` | A new release is created |
+| `RELEASE_LIFECYCLE_CHANGED` | A release moves lifecycle stage |
+| `RELEASE_BOM_DIFF` | A release's BOM diff is computed |
+| `APPROVAL_REQUESTED` | Someone requests approval on a release -- see [Approval queues](./approval-queues) |
+| `APPROVAL_RESOLVED` | An approval request is satisfied or disapproved |
+
+## Filters, severity, and routes
+
+- A subscription can carry an optional filter, built either with the preset
+  toggles or as an advanced expression. Advanced filters run under limits
+  (size, nesting depth, iteration count, and a short evaluation timeout) so a
+  runaway expression can't stall delivery for the rest of the org -- a filter
+  that exceeds its budget fails that one delivery rather than blocking others.
+- Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
+  `MEDIUM` / ...); only events at or above that threshold on that route are
+  sent to its channels.
+
+## Duplicate delivery protection
+
+ReARM deduplicates deliveries to the same channel from the same subscription
+within a rolling window (configurable per subscription; several hours by
+default), so a flapping upstream signal won't repeat-fire the same alert to
+the same channel over and over. Test/synthetic events (see
+[Testing](#testing-channels-and-subscriptions) below) intentionally bypass
+dedup, so a test always produces a visible delivery.
+
+::: warning Per-subscription rate limit is not enforced yet
+The subscription rate-limit fields (`maxPerWindow` / `windowMinutes`) are
+present and saved, but do not currently throttle delivery volume at
+fan-out -- setting them has no runtime effect. This is a known, deliberate
+gap, not a bug you need to work around; if you're relying on a specific
+delivery cap today, use your destination's own rate limiting (e.g. a Slack
+app's built-in limits) in the meantime.
+:::
+
+## Retention
+
+Notification history (deliveries and inbox rows) is retained for a
+configurable number of days per organization, with an enforced 14-day floor --
+an org can't set retention short enough to delete a row that might still be
+scheduled to send (e.g. one parked in an email digest).
+
+## Testing channels and subscriptions
+
+::: warning No "send test" button yet
+Sending a real test event to a channel currently has no UI -- the backend
+supports it, but you'll need a direct API call (or ask someone with API
+access) until the button ships. Documenting the current state here rather
+than the button because this comes up as soon as you add a channel and want
+to confirm it works.
+:::
+
+If you have API access, two mutations exist for confirming a channel or
+subscription actually works, without waiting for a real event: one that pings
+a single channel directly (bypassing subscription matching, filters, and
+severity gates, so it always produces a visible delivery), and one that
+injects a synthetic event of a chosen scenario (e.g. a critical vulnerability
+on a single shipped release, a newly-KEV-listed CVE) through the normal
+subscription-matching path, so you can confirm your filters and routes behave
+the way you expect. Both bypass the dedup window described above.
+
+## KEV (Known Exploited Vulnerabilities) notifications
+
+ReARM can alert you when a vulnerability affecting your releases is added to
+a Known Exploited Vulnerabilities catalog. Two sources are supported:
+
+- **CISA KEV** -- the public CISA catalog, enabled by default for every
+  organization, no credential required.
+- **VulnCheck KEV** -- opt-in, requires your own VulnCheck API token
+  (Organization Settings -> Integrations).
+
+When a CVE is newly added to an enabled KEV source **and** it affects one of
+your existing vulnerability records, ReARM emits a `VULNERABILITY_RECORD_UPDATED`
+event your subscriptions can route on.
+
+::: tip You won't get flooded with historical KEV alerts on day one
+The *first* KEV sync for a newly enabled source treats every existing catalog
+entry as a baseline rather than "newly added," so enabling CISA KEV (or
+VulnCheck KEV) doesn't fire years of historical listings at you all at once.
+Only CVEs that become KEV-listed *after* that first sync trigger a
+notification.
+:::
+
+A CVE dropping off a KEV catalog does not currently un-list it on ReARM's
+side -- KEV status is treated as sticky once observed, so a temporary upstream
+catalog issue can't make your org's KEV picture shrink unexpectedly.

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -1,11 +1,10 @@
-
 ---
 sidebarDepth: 2
 ---
 
 # Notifications
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 Everything on this page -- channels, subscriptions, routes, and KEV alerts --
 is part of ReARM Pro's security-and-operational notification framework,
 configured under **Organization Settings -> Integrations -> Notifications**.
@@ -60,7 +59,7 @@ A subscription's `eventTypes` list controls what it can match:
 ## Duplicate delivery protection
 
 ReARM deduplicates deliveries to the same channel from the same subscription
-within a rolling window (configurable per subscription; several hours by
+within a rolling window (configurable per subscription; 24 hours by
 default), so a flapping upstream signal won't repeat-fire the same alert to
 the same channel over and over. Test/synthetic events (see
 [Testing](#testing-channels-and-subscriptions) below) intentionally bypass

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -18,7 +18,8 @@ Teams page if you're not sure which one you need.
 
 1. A **channel** is a named destination: Slack, Microsoft Teams, a generic
    webhook, email, or [Microsoft Sentinel](../integrations/sentinel). Add one
-   from the **Notifications -> Channels** tab.
+   from the **Integrations -> Catalog** tab -- each channel type is a card
+   there; click **Add** on the card to configure a destination.
 2. A **subscription** decides which events go to which channels. Add one from
    the **Notifications -> Subscriptions** tab: pick the event types you care
    about, an optional filter, and one or more **routes** -- each route pairs a
@@ -38,7 +39,7 @@ A subscription's `eventTypes` list controls what it can match:
 |---|---|
 | `NEW_VULN_AFFECTS_RELEASES` | A vulnerability is newly linked to one of your releases |
 | `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
-| `VEX_STATE_CHANGED` | A VEX (exploitability) status changes on a finding |
+| `VEX_STATE_CHANGED` | Reserved for VEX (exploitability) status changes. No event source emits this yet, so a subscription on it will not fire today -- prefer `VULNERABILITY_RECORD_UPDATED` for vulnerability-state changes |
 | `RELEASE_CREATED` | A new release is created |
 | `RELEASE_LIFECYCLE_CHANGED` | A release moves lifecycle stage |
 | `RELEASE_BOM_DIFF` | A release's BOM diff is computed |
@@ -83,22 +84,25 @@ scheduled to send (e.g. one parked in an email digest).
 
 ## Testing channels and subscriptions
 
-::: warning No "send test" button yet
-Sending a real test event to a channel currently has no UI -- the backend
-supports it, but you'll need a direct API call (or ask someone with API
-access) until the button ships. Documenting the current state here rather
-than the button because this comes up as soon as you add a channel and want
-to confirm it works.
-:::
+You can confirm a channel or subscription works without waiting for a real
+event, straight from the UI:
 
-If you have API access, two mutations exist for confirming a channel or
-subscription actually works, without waiting for a real event: one that pings
-a single channel directly (bypassing subscription matching, filters, and
-severity gates, so it always produces a visible delivery), and one that
-injects a synthetic event of a chosen scenario (e.g. a critical vulnerability
-on a single shipped release, a newly-KEV-listed CVE) through the normal
-subscription-matching path, so you can confirm your filters and routes behave
-the way you expect. Both bypass the dedup window described above.
+- **Test a channel** -- on the channel's card in **Integrations -> Catalog**,
+  use the **Send test** (paper-plane) action on the configured instance. This
+  pings that one channel directly, bypassing subscription matching, filters,
+  and severity gates, so it always produces a visible delivery -- the fastest
+  way to confirm a webhook URL is reachable and authorized.
+- **Test a subscription** -- in **Integrations -> Subscriptions**, use the
+  **Test** action on a subscription row and pick a synthetic scenario (e.g. a
+  critical vulnerability on a single shipped release, a newly-KEV-listed CVE).
+  The event is injected through the normal subscription-matching path, so you
+  can confirm your filters, severity gates, and routes behave the way you
+  expect. Note this injects a real synthetic event for the whole organization,
+  so any *other* active subscription matching the same event type will also
+  fire -- the UI asks you to confirm before sending.
+
+Both bypass the dedup window described above, so a test always produces a
+delivery you can see in **Delivery History**.
 
 ## KEV (Known Exploited Vulnerabilities) notifications
 

--- a/documentation_site/docs/configure/user-and-user-group-permissions.md
+++ b/documentation_site/docs/configure/user-and-user-group-permissions.md
@@ -90,6 +90,13 @@ All functions are always available for `Administrator` permission type.
 
 If set, allow users to set granted approvals for all objects in the organization. Organization Admins can always set granted approvals.
 
+::: tip Approving vs. being notified
+The "Admins can always approve" rule above only covers the capability to
+*cast* a vote -- it does not put releases in an admin's approval queue or
+notify them. See [Approval Queues](./approval-queues) for the distinction and
+how to give an admin visibility, not just capability.
+:::
+
 ### 4) Scoped Permissions
 
 Both users and user groups support scoped overrides for:

--- a/documentation_site/docs/integrations/index.md
+++ b/documentation_site/docs/integrations/index.md
@@ -14,6 +14,7 @@ Generic integrations with ReARM can be done using [ReARM CLI](./rearmcli).
 ## Notification Integrations
 1. [Slack](./slack)
 2. [Microsoft Teams](./msteams)
+3. [Microsoft Sentinel](./sentinel)
 
 ## Integrations with Cyber-Security Tools
 1. [Dependency-Track](./dtrack)

--- a/documentation_site/docs/integrations/sentinel.md
+++ b/documentation_site/docs/integrations/sentinel.md
@@ -1,7 +1,6 @@
-
 # Microsoft Sentinel
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 Microsoft Sentinel is a **security and operational notification channel** (routed
 through **Notifications -> Channels**), not a release-notification integration.
 It streams the same event feed described in [Notifications](../configure/notifications)
@@ -46,10 +45,12 @@ the DCE/DCR/service-principal trio if you don't have them yet.
 4. Click **Save**.
 
 ::: tip Editing later
-On edit, the tenant ID / client ID / client secret fields show as
-`(unchanged)` -- leave them blank to keep the existing credentials, or fill in
-all three together to rotate them. The DCR endpoint / immutable ID / stream
-name always show their current values and can be changed independently.
+On edit, all six fields show blank with an `(unchanged)` placeholder --
+credentials and DCR routing are stored and replaced together as one unit.
+Leave all six blank to keep everything as-is, or fill in all six together to
+replace the whole configuration (e.g. to point at a different DCR, you must
+re-enter the tenant ID / client ID / client secret too, even if those
+haven't changed).
 :::
 
 ## Route events to the channel

--- a/documentation_site/docs/integrations/sentinel.md
+++ b/documentation_site/docs/integrations/sentinel.md
@@ -1,0 +1,72 @@
+
+# Microsoft Sentinel
+
+::: info ReARM Pro only
+Microsoft Sentinel is a **security and operational notification channel** (routed
+through **Notifications -> Channels**), not a release-notification integration.
+It streams the same event feed described in [Notifications](../configure/notifications)
+into Microsoft Sentinel (Azure Log Analytics) via the [Logs Ingestion
+API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview).
+:::
+
+## Prerequisites
+
+Before adding a Sentinel channel in ReARM, you need, in the Azure portal:
+
+1. **A Data Collection Endpoint (DCE)** and its ingestion URL, e.g.
+   `https://<dce-name>.<region>.ingest.monitor.azure.com`.
+2. **A Data Collection Rule (DCR)** that targets your Sentinel/Log Analytics table,
+   its **immutable ID** (`dcr-...`), and the **stream name** it exposes
+   (typically `Custom-<TableName>_CL`).
+3. **An Azure AD app registration (service principal)** with the **Monitoring
+   Metrics Publisher** role assigned on the DCR, giving you a **tenant ID**,
+   **client ID**, and **client secret**.
+
+Microsoft's own [Sentinel data connector
+docs](https://learn.microsoft.com/en-us/azure/sentinel/) walk through creating
+the DCE/DCR/service-principal trio if you don't have them yet.
+
+## Add the Sentinel channel in ReARM
+
+1. Open **Organization Settings -> Integrations**, then the **Notifications ->
+   Channels** tab.
+2. Click the **Microsoft Sentinel** card in the catalog to open **Add Microsoft
+   Sentinel channel**.
+3. Fill in all six fields -- ReARM requires all of them together when you first
+   create the channel:
+   - **Name** -- a label for this channel, e.g. `SOC workspace`.
+   - **Tenant ID** -- your Azure AD tenant ID.
+   - **Client ID** -- the app registration's client ID.
+   - **Client secret** -- the app registration's client secret.
+   - **DCR endpoint** -- the DCE ingestion URL, e.g.
+     `https://<dce-name>.<region>.ingest.monitor.azure.com`. Must be HTTPS at an
+     `azure.com` host, or the save is rejected.
+   - **DCR immutable ID** -- e.g. `dcr-...`.
+   - **Stream name** -- e.g. `Custom-<TableName>_CL`.
+4. Click **Save**.
+
+::: tip Editing later
+On edit, the tenant ID / client ID / client secret fields show as
+`(unchanged)` -- leave them blank to keep the existing credentials, or fill in
+all three together to rotate them. The DCR endpoint / immutable ID / stream
+name always show their current values and can be changed independently.
+:::
+
+## Route events to the channel
+
+Adding the channel doesn't send anything by itself -- you also need a
+**subscription** with a route pointing at it. See
+[Notifications](../configure/notifications) for event types, severity gates,
+and how routes work. ReARM doesn't currently offer a UI button to send a test
+event to a Sentinel channel; the only way to confirm delivery today is to
+route a real (or synthetic, via the API) event to it and check your Log
+Analytics table for the resulting rows.
+
+## What gets sent
+
+Each delivery is an array of flattened log records, one per matched event,
+posted to your DCE's Logs Ingestion API endpoint for the configured stream.
+Authentication is a short-lived Azure AD OAuth token acquired with your
+service-principal credentials (cached for the token's lifetime and refreshed
+automatically) -- ReARM never stores a long-lived Sentinel-side secret beyond
+the client secret you provided.


### PR DESCRIPTION
## Summary
Notifications, KEV alerts, approval queues, and Microsoft Sentinel had no user-facing documentation despite being fully shipped Pro features (board task: Notifications documentation -- Sentinel/Teams/KEV/approval queues).

- **`configure/notifications.md`** -- channels/subscriptions/routes model, event types, filters/severity, dedup, the rate-limit fields that are saved but not enforced at fan-out, retention, current testing story (backend mutations exist, no UI button yet), and KEV notification behavior (bootstrap-sync suppression, sticky KEV status).
- **`configure/approval-queues.md`** -- where pending approvals show up, and the distinction between "can vote" (org admins always can) and "shows up in the queue / gets notified" (role-gated only, admins NOT auto-included by design).
- **`integrations/sentinel.md`** -- setup guide mirroring the existing Slack/Teams pages: all six required config fields, the HTTPS+azure.com endpoint validation.
- Cross-link from `user-and-user-group-permissions.md`'s existing "Admins can always approve" line to the queue-visibility distinction.
- Sidebar + integrations index entries for all three new pages.

## Accuracy notes
Every code-level claim (schema mutations, validator rules, UI modal field labels, service-layer javadoc) was checked directly against source rather than taken from the initial research pass. One claim from that pass -- "no UI exists to create a named Slack/Teams notification channel" -- turned out to be stale against a just-merged PR (#161) and was corrected before writing anything into the doc. Specific verifications:
- `NotificationSentinelChannelConfigInput`'s six fields and "all required on create" -- verified in `schema.graphqls` and `NotificationChannelService.validateSentinelConfig`.
- `SentinelEndpointValidator` HTTPS + `azure.com`-suffix rule -- read directly.
- Sentinel/Slack/Teams modal field labels and placeholders -- read directly from `OrgIntegrations.vue`.
- `testNotificationChannel`/`injectSyntheticEvent` exist in schema but have zero UI wiring -- confirmed via `grep -r` on `ui/src` (post-pull, so not stale).
- Rate limit fields saved but unenforced -- confirmed via `grep -r RateLimit` across `NotificationFanOutService`/`NotificationDeliveryWorker`, no hits outside DTO plumbing.
- Approval "admins not auto-listed in queue" -- quoted from `ApprovalNeedsService`'s own class-level javadoc, verified word-for-word.

## Test plan
- [x] `npm run docs:build` succeeds, default VitePress dead-link checking active (no `ignoreDeadLinks` override), zero warnings
- [x] Confirmed all three new pages render in `dist/`
- [x] Confirmed new content passes the (now-fixed, see PR #258 on rearm-saas) byte-level ASCII guard
- [x] Two-layer self-review (see PR comments)