### PR TITLE
fix(ui): split hidden 3-state disapprove checkbox into separate controls

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1265,7 +1265,7 @@ import { Icon } from '@vicons/utils'
 import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regular, ChevronLeft20Regular, ChevronRight20Regular } from '@vicons/fluent'
 import { UpCircleOutlined } from '@vicons/antd'
 import type { SelectOption } from 'naive-ui'
-import { NBadge, NButton, NCard, NCheckbox, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
+import { NBadge, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
 import Swal from 'sweetalert2'
 import { Component, ComputedRef, Ref, computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
@@ -4997,7 +4997,7 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                     // always visible rather than only discoverable by clicking twice.
                     const approveIcon = h(NIcon,
                         {
-                            class: isDisabled ? '' : 'clickable',
+                            class: isDisabled ? 'icons' : 'icons clickable',
                             size: 22,
                             title: isApproved && isDisabled ? 'Approved' : (isApproved ? 'Your Approval Pending (click to clear)' : 'Approve'),
                             'data-testid': `approval-approve-${row.uuid}-${aid}`,
@@ -5012,7 +5012,7 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                     )
                     const disapproveIcon = h(NIcon,
                         {
-                            class: isDisabled ? '' : 'clickable',
+                            class: isDisabled ? 'icons' : 'icons clickable',
                             size: 22,
                             title: isDisapproved && isDisabled ? 'Disapproved' : (isDisapproved ? 'Your Disapproval Pending (click to clear)' : 'Disapprove'),
                             'data-testid': `approval-disapprove-${row.uuid}-${aid}`,

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -824,6 +824,11 @@
                                 </li>
                             </ul>
                         </div>
+                        <n-space v-if="approvalEntries.length" align="center" :size="16" style="margin-bottom: 6px; font-size: 12px; color: #888;" data-testid="approval-legend">
+                            <span><n-icon size="14" color="#18a058" style="vertical-align: -2px;"><Check /></n-icon> Approve</span>
+                            <span><n-icon size="14" color="#d03050" style="vertical-align: -2px;"><X /></n-icon> Disapprove</span>
+                            <span>Click an icon to set your vote, click it again to clear</span>
+                        </n-space>
                         <n-data-table :data="releaseApprovalTableData" :columns="releaseApprovalTableFields" :row-key="approvalRowKey" />
                         <n-space v-if="hasApprovalChanges" style="margin-top: 5px;">
                             <n-spin :show="approvalPending" small>
@@ -1255,7 +1260,7 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { GlobeAdd24Regular, Info24Regular, Edit24Regular } from '@vicons/fluent'
-import { Bell, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh } from '@vicons/tabler'
+import { Bell, Check, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh, X } from '@vicons/tabler'
 import { Icon } from '@vicons/utils'
 import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regular, ChevronLeft20Regular, ChevronRight20Regular } from '@vicons/fluent'
 import { UpCircleOutlined } from '@vicons/antd'
@@ -4985,43 +4990,44 @@ const releaseApprovalTableFields: ComputedRef<DataTableColumns<any>> = computed(
                     if (!isDisabled && givenApprovals.value[row.uuid]) isDisabled = (givenApprovals.value[row.uuid][aid]?.length > 0)
                     const isDisapproved = approvalMatrixCheckboxes.value[row.uuid] ? approvalMatrixCheckboxes.value[row.uuid][aid] === 'DISAPPROVED' : false
                     const isApproved = approvalMatrixCheckboxes.value[row.uuid] ? approvalMatrixCheckboxes.value[row.uuid][aid] === 'APPROVED' : false
-                    let title: string
-                    if (isApproved && isDisabled) {
-                        title = 'Approved'
-                    } else if (isApproved) {
-                        title = 'Your Approval Pending'
-                    } else if (isDisapproved && isDisabled) {
-                        title = 'Disapproved'
-                    } else if (isDisapproved) {
-                        title = 'Your Disapproval Pending'
-                    } else {
-                        title = 'Unset'
-                    }
-                    // Machine-readable cell state for the test harness. Today
-                    // the tri-state is only inferable from title/indeterminate;
-                    // surface it explicitly as data-state on the checkbox.
+                    // Machine-readable cell state for the test harness.
                     const approvalState = isApproved ? 'APPROVED' : (isDisapproved ? 'DISAPPROVED' : 'UNSET')
-                    const checkBoxEl = h(NCheckbox,
+                    // Approve and Disapprove are two separate controls (not one checkbox
+                    // cycling through a hidden third state) so the disapprove option is
+                    // always visible rather than only discoverable by clicking twice.
+                    const approveIcon = h(NIcon,
                         {
-                            checked: isApproved,
-                            indeterminate: isDisapproved,
-                            disabled: isDisabled,
-                            title,
-                            'data-testid': `approval-cell-${row.uuid}-${aid}`,
+                            class: isDisabled ? '' : 'clickable',
+                            size: 22,
+                            title: isApproved && isDisabled ? 'Approved' : (isApproved ? 'Your Approval Pending (click to clear)' : 'Approve'),
+                            'data-testid': `approval-approve-${row.uuid}-${aid}`,
                             'data-state': approvalState,
-                            style: isDisapproved ? "--n-color-checked: red; --n-color-disabled: red;" : "",
-                            size: 'large',
-                            onClick: (e: any, i: any) => {
-                                e.preventDefault()
-                                if (!isDisabled && isApproved) {
-                                    updateMatrixCheckbox('DISAPPROVED', {uuid: row.uuid, approval: aid})
-                                } else if (!isDisabled && isDisapproved) {
-                                    updateMatrixCheckbox('UNSET', {uuid: row.uuid, approval: aid})
-                                } else if (!isDisabled) {
-                                    updateMatrixCheckbox('APPROVED', {uuid: row.uuid, approval: aid})
-                                }
+                            color: isApproved ? '#18a058' : '#c2c2c2',
+                            style: isDisabled ? 'opacity: 0.5;' : '',
+                            onClick: () => {
+                                if (isDisabled) return
+                                updateMatrixCheckbox(isApproved ? 'UNSET' : 'APPROVED', {uuid: row.uuid, approval: aid})
                             }
-                        }
+                        }, () => h(Check)
+                    )
+                    const disapproveIcon = h(NIcon,
+                        {
+                            class: isDisabled ? '' : 'clickable',
+                            size: 22,
+                            title: isDisapproved && isDisabled ? 'Disapproved' : (isDisapproved ? 'Your Disapproval Pending (click to clear)' : 'Disapprove'),
+                            'data-testid': `approval-disapprove-${row.uuid}-${aid}`,
+                            'data-state': approvalState,
+                            color: isDisapproved ? '#d03050' : '#c2c2c2',
+                            style: isDisabled ? 'opacity: 0.5;' : '',
+                            onClick: () => {
+                                if (isDisabled) return
+                                updateMatrixCheckbox(isDisapproved ? 'UNSET' : 'DISAPPROVED', {uuid: row.uuid, approval: aid})
+                            }
+                        }, () => h(X)
+                    )
+                    const checkBoxEl = h(NSpace,
+                        { size: 8, align: 'center', 'data-testid': `approval-cell-${row.uuid}-${aid}` },
+                        () => [approveIcon, disapproveIcon]
                     )
                     // Add Admin Override icon for org admins on DRAFT releases when approval is already given
                     const isOrgAdmin = myUser?.permissions?.permissions?.some((p: any) => 


### PR DESCRIPTION
## Summary
Board task: Approvals disapprove hidden 3-state checkbox cycle -- separate control/legend.

The approval matrix used a single checkbox overloading Naive UI's `indeterminate` state to mean "disapproved" (styled red via a CSS-var override). Disapprove was only discoverable by clicking an already-approved checkbox a second time -- nothing on screen indicated the option existed.

Replaced with two adjacent icon buttons (green check / red X), independently clickable, mutually exclusive. Added a small legend above the approval table explaining them. Disabled/admin-override/comment-field behavior is unchanged -- only the vote control itself changed.

## Verification
Built locally and verified live against the claude2 sandbox with Playwright, using a seeded release with a real open approval request (not a mock):
- Both icons render with the legend visible
- Colors switch correctly: green only when approved, red only when disapproved, gray at rest
- Mutual exclusivity confirmed (clicking one clears the other)
- Click-to-clear confirmed (clicking the active icon again resets to unset)
- Save/Reset Approvals controls appear correctly once there's a pending change

Caught and fixed one real bug during verification, not just eyeballing the diff: `NIcon` takes its color via a dedicated `color` prop, not `style.color` -- the component computes and overwrites its own inline style internally, so the first version silently rendered both icons in a default blue instead of green/red. Confirmed via `getComputedStyle` in the same Playwright run before and after the fix.

## Test plan
- [x] `npm run build` succeeds
- [x] Live-verified on sandbox: render, color states, mutual exclusivity, click-to-clear, save/reset visibility
- [x] Confirmed no non-ASCII introduced (byte-level check on the diff)
- [x] Two-layer self-review (see PR comments)