### PR TITLE
feat(ui): add "Send test notification" button to channel cards

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -2150,19 +2150,6 @@ function openEditChannelForCard(card: CardConfig, ch: ChannelCatalogRow) {
 // without needing to reassign a new Set each time.
 const testingChannels: Ref<Set<string>> = ref(new Set())
 
-const TEST_NOTIFICATION_CHANNEL_MUTATION = gql`
-    mutation testNotificationChannel($channelUuid: ID!) {
-        testNotificationChannel(channelUuid: $channelUuid) { uuid status }
-    }
-`
-const TEST_DELIVERY_POLL_QUERY = gql`
-    query testDeliveryPoll($orgUuid: ID!, $eventUuid: ID!, $channelUuid: ID!) {
-        notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, channelUuid: $channelUuid, limit: 1) {
-            items { status lastError }
-        }
-    }
-`
-
 // testNotificationChannel bypasses subscription matching/dedup and always
 // produces a visible delivery, but dispatch is still async (fan-out +
 // worker), so the mutation itself only returns a PENDING outbox event uuid
@@ -2172,9 +2159,20 @@ const TEST_DELIVERY_POLL_QUERY = gql`
 // regardless of whether this tab is still watching.
 async function sendChannelTest(ch: ChannelCatalogRow) {
     testingChannels.value.add(ch.uuid)
+    // Snapshot the org this test started in. orguuid is a live computed over
+    // props.orguuid, and this component is reused (not remounted) across an
+    // org switch -- reading orguuid.value fresh on each poll iteration would
+    // send the wrong org on the query after a mid-poll switch, and the
+    // event/channel pair wouldn't exist under the new org, silently forcing
+    // every poll to a "still pending" timeout even if the original test
+    // resolved seconds later.
+    const testOrgUuid = orguuid.value
     try {
         const res = await graphqlClient.mutate({
-            mutation: TEST_NOTIFICATION_CHANNEL_MUTATION,
+            mutation: gql`
+                mutation testNotificationChannel($channelUuid: ID!) {
+                    testNotificationChannel(channelUuid: $channelUuid) { uuid status }
+                }`,
             variables: { channelUuid: ch.uuid },
             fetchPolicy: 'no-cache'
         })
@@ -2186,9 +2184,17 @@ async function sendChannelTest(ch: ChannelCatalogRow) {
         const maxAttempts = 40
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
             await new Promise(resolve => setTimeout(resolve, 1500))
+            // The org was switched away from mid-poll -- abandon quietly
+            // rather than show a toast about a different org's context.
+            if (orguuid.value !== testOrgUuid) return
             const pollRes = await graphqlClient.query({
-                query: TEST_DELIVERY_POLL_QUERY,
-                variables: { orgUuid: orguuid.value, eventUuid, channelUuid: ch.uuid },
+                query: gql`
+                    query notificationDeliveriesForChannelTest($orgUuid: ID!, $eventUuid: ID!, $channelUuid: ID!) {
+                        notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, channelUuid: $channelUuid, limit: 1) {
+                            items { status lastError }
+                        }
+                    }`,
+                variables: { orgUuid: testOrgUuid, eventUuid, channelUuid: ch.uuid },
                 fetchPolicy: 'no-cache'
             })
             const delivery = pollRes.data?.notificationDeliveries?.items?.[0]
@@ -2203,7 +2209,9 @@ async function sendChannelTest(ch: ChannelCatalogRow) {
             }
             // Still PENDING (or another non-terminal status) -- keep polling.
         }
-        notify('warning', 'Still Pending', `Test to "${ch.name}" is still processing. Check Notification History for the result.`)
+        if (orguuid.value === testOrgUuid) {
+            notify('warning', 'Still Pending', `Test to "${ch.name}" is still processing. Check Notification History for the result.`)
+        }
     } catch (err: any) {
         notify('error', 'Error', extractError(err))
     } finally {
@@ -2623,8 +2631,9 @@ watch(() => props.orguuid, async () => {
 }
 .instance-icon:hover { color: var(--ink); background: var(--bg-tint); }
 .instance-icon.danger:hover { color: var(--danger); background: #FCEEEC; }
-.instance-icon.icon-spin { cursor: default; animation: instance-icon-spin 1s linear infinite; }
-@keyframes instance-icon-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+/* Reuses the global `spin` keyframe (App.vue) rather than redefining an
+   identical rotate-0-to-360 animation. */
+.instance-icon.icon-spin { cursor: default; animation: spin 1s linear infinite; }
 
 /* ---- + Add another ------------------------------------------------------ */
 .add-another {

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -115,6 +115,13 @@
                                                 :title="ch.status === 'ENABLED' ? 'Disable channel (pauses sending, keeps configuration)' : 'Enable channel'"
                                                 @click="toggleChannelStatus(ch)"
                                             ><PlayerPause v-if="ch.status === 'ENABLED'" /><PlayerPlay v-else /></n-icon>
+                                            <n-icon
+                                                class="instance-icon"
+                                                :class="{ 'icon-spin': testingChannels.has(ch.uuid) }"
+                                                size="20"
+                                                :title="testingChannels.has(ch.uuid) ? 'Sending test...' : 'Send test notification'"
+                                                @click="!testingChannels.has(ch.uuid) && sendChannelTest(ch)"
+                                            ><Refresh v-if="testingChannels.has(ch.uuid)" /><Send v-else /></n-icon>
                                             <n-icon class="instance-icon" size="20" :title="`Edit ${card.name} channel`" @click="openEditChannelForCard(card, ch)"><EditIcon /></n-icon>
                                             <n-icon class="instance-icon danger" size="20" :title="`Delete ${card.name} channel`" @click="onDeleteChannel(card, ch)"><Trash /></n-icon>
                                         </div>
@@ -830,7 +837,7 @@ import {
 import {
     Edit as EditIcon, Trash, Refresh, CirclePlus, CloudUpload,
     BrandGithub, BrandGitlab, BrandSlack, Mail, PlayerPlay, PlayerPause,
-    PlugConnected, ShieldCheck, LayoutGrid, Bell, Users
+    PlugConnected, ShieldCheck, LayoutGrid, Bell, Users, Send
 } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import { FetchPolicy } from '@apollo/client'
@@ -2138,6 +2145,72 @@ function openEditChannelForCard(card: CardConfig, ch: ChannelCatalogRow) {
     else if (card.id === 'SENTINEL') openEditSentinelChannel(ch)
 }
 
+// Channel uuids with an in-flight test. A ref wrapping a Set is reactive
+// under Vue 3's collection handling -- .add()/.delete() trigger updates
+// without needing to reassign a new Set each time.
+const testingChannels: Ref<Set<string>> = ref(new Set())
+
+const TEST_NOTIFICATION_CHANNEL_MUTATION = gql`
+    mutation testNotificationChannel($channelUuid: ID!) {
+        testNotificationChannel(channelUuid: $channelUuid) { uuid status }
+    }
+`
+const TEST_DELIVERY_POLL_QUERY = gql`
+    query testDeliveryPoll($orgUuid: ID!, $eventUuid: ID!, $channelUuid: ID!) {
+        notificationDeliveries(orgUuid: $orgUuid, eventUuid: $eventUuid, channelUuid: $channelUuid, limit: 1) {
+            items { status lastError }
+        }
+    }
+`
+
+// testNotificationChannel bypasses subscription matching/dedup and always
+// produces a visible delivery, but dispatch is still async (fan-out +
+// worker), so the mutation itself only returns a PENDING outbox event uuid
+// -- poll notificationDeliveries for the terminal status. ~1.5s cadence,
+// up to 40 attempts (~60s) before giving up client-side and telling the
+// user to check History; the delivery keeps processing server-side
+// regardless of whether this tab is still watching.
+async function sendChannelTest(ch: ChannelCatalogRow) {
+    testingChannels.value.add(ch.uuid)
+    try {
+        const res = await graphqlClient.mutate({
+            mutation: TEST_NOTIFICATION_CHANNEL_MUTATION,
+            variables: { channelUuid: ch.uuid },
+            fetchPolicy: 'no-cache'
+        })
+        const eventUuid = res.data?.testNotificationChannel?.uuid
+        if (!eventUuid) {
+            notify('error', 'Test Failed', `No test event was created for "${ch.name}".`)
+            return
+        }
+        const maxAttempts = 40
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            await new Promise(resolve => setTimeout(resolve, 1500))
+            const pollRes = await graphqlClient.query({
+                query: TEST_DELIVERY_POLL_QUERY,
+                variables: { orgUuid: orguuid.value, eventUuid, channelUuid: ch.uuid },
+                fetchPolicy: 'no-cache'
+            })
+            const delivery = pollRes.data?.notificationDeliveries?.items?.[0]
+            if (!delivery) continue
+            if (delivery.status === 'SENT' || delivery.status === 'ACKED') {
+                notify('success', 'Test Sent', `Test notification delivered to "${ch.name}".`)
+                return
+            }
+            if (delivery.status === 'FAILED') {
+                notify('error', 'Test Failed', delivery.lastError || `Delivery to "${ch.name}" failed.`)
+                return
+            }
+            // Still PENDING (or another non-terminal status) -- keep polling.
+        }
+        notify('warning', 'Still Pending', `Test to "${ch.name}" is still processing. Check Notification History for the result.`)
+    } catch (err: any) {
+        notify('error', 'Error', extractError(err))
+    } finally {
+        testingChannels.value.delete(ch.uuid)
+    }
+}
+
 async function toggleChannelStatus(ch: ChannelCatalogRow) {
     const next = ch.status === 'ENABLED' ? 'DISABLED' : 'ENABLED'
     try {
@@ -2550,6 +2623,8 @@ watch(() => props.orguuid, async () => {
 }
 .instance-icon:hover { color: var(--ink); background: var(--bg-tint); }
 .instance-icon.danger:hover { color: var(--danger); background: #FCEEEC; }
+.instance-icon.icon-spin { cursor: default; animation: instance-icon-spin 1s linear infinite; }
+@keyframes instance-icon-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 
 /* ---- + Add another ------------------------------------------------------ */
 .add-another {


### PR DESCRIPTION
## Summary
Board task #31: `testNotificationChannel` has been fully implemented server-side since the notifications framework shipped (bypasses subscription matching/dedup, always produces a visible delivery via the outbox -> fan-out -> worker pipeline), but there was no UI to trigger it -- every channel type's config could only be verified by waiting for a real event to route to it.

Adds a "Send test notification" icon to each channel card's instance row, alongside the existing enable/disable, edit, and delete actions. On click: calls `testNotificationChannel(channelUuid)`, then polls `notificationDeliveries(orgUuid, eventUuid, channelUuid)` at a 1.5s cadence for up to 60s for the terminal delivery status, showing a spin animation while in flight. Resolves to a success toast (SENT/ACKED), an error toast with the delivery's `lastError` (FAILED), or a "still pending, check History" toast if the poll window elapses first.

## Related
- rearm-core PR (test-delivery-fast-fail): a broken webhook was taking over an hour to reach FAILED (borrowed backoff curve from an unrelated subsystem) -- fixed so test deliveries fail fast, found while validating this button live.
- rearm-playwright PR (send-test-affordance): flips the harness's B7/B8 tests and adds B9 exercising the real click-to-delivery round trip.

## Verification
- Built locally and live-verified against the claude2 sandbox via the real feature-set CI/deploy pipeline (not a mocked/interception-based test) using two real webhook channels seeded server-side (one deliverable, one broken)
- Confirmed: icon renders on every channel-card row, spins while in flight, resolves to correct success/failure toast, mutual state doesn't leak across rows
- Operator walkthrough completed live on the sandbox, confirmed working (including the paired backend fast-fail fix)

## Test plan
- [x] `npm run build` succeeds
- [x] Live-verified end-to-end on the deployed sandbox (real CI build, not local override) for both success and failure paths
- [x] Confirmed no non-ASCII introduced (byte-level check on the diff)
- [ ] Two-layer self-review (in progress)