### PR TITLE
fix(ui): keep the notification inbox from blanking on GraphQL schema drift

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -40,10 +40,12 @@
         "@vue/eslint-config-typescript": "^14.7.0",
         "eslint": "^10.1.0",
         "eslint-plugin-vue": "^10.8.0",
+        "graphql": "^16.14.0",
         "naive-ui": "^2.44.1",
         "sass": "^1.98.0",
         "typescript": "~5.9.3",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^3.2.7"
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.27.3",
@@ -1646,6 +1648,24 @@
         "graphql": "14 - 16"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2030,6 +2050,131 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue-macros/common": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
@@ -2356,6 +2501,16 @@
         "rxjs": "^7.3.0"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
@@ -2492,6 +2647,43 @@
       "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2874,6 +3066,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2924,6 +3126,13 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3221,6 +3430,16 @@
       "integrity": "sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/exsolve": {
       "version": "1.0.8",
@@ -3585,6 +3804,13 @@
       "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
       "license": "MIT"
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3723,6 +3949,13 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4045,6 +4278,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pdfkit": {
       "version": "0.18.0",
@@ -4439,6 +4682,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4447,6 +4697,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -4480,6 +4744,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/sweetalert2": {
       "version": "11.26.24",
       "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.26.24.tgz",
@@ -4494,6 +4771,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -4539,6 +4830,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5337,6 +5658,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5359,6 +5703,92 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5604,6 +6034,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src"
+    "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
+    "test": "vitest run",
+    "validate:graphql": "node scripts/validate-graphql.mjs"
   },
   "dependencies": {
     "@apollo/client": "^4.1.6",
@@ -41,10 +43,12 @@
     "@vue/eslint-config-typescript": "^14.7.0",
     "eslint": "^10.1.0",
     "eslint-plugin-vue": "^10.8.0",
+    "graphql": "^16.14.0",
     "naive-ui": "^2.44.1",
     "sass": "^1.98.0",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^3.2.7"
   },
   "optionalDependencies": {
     "@esbuild/linux-x64": "^0.27.3",

--- a/ui/scripts/validate-graphql.mjs
+++ b/ui/scripts/validate-graphql.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// Validate the UI's GraphQL documents against the backend schema(s) at build
+// time, so a field the UI selects that the backend doesn't have is caught in
+// CI instead of blanking a page in production.
+//
+// Two schemas matter because the SAME UI ships to both:
+//   - Pro   (rearm-core/backend/.../schema.graphqls)  = source of truth.
+//   - CE    (rearm/backend/.../schema.graphqls)        = delayed mirror.
+//
+// Policy:
+//   - REPORT-ONLY by default (always exit 0). Prints, per document:
+//       * [FAIL]  invalid against Pro  -- UI selects a field/type/arg absent
+//                 from the Pro schema (source of truth).
+//       * [WARN]  valid on Pro, absent on the CE mirror -- expected enrichment
+//                 lag, handled at runtime by the core/enrichment fallback
+//                 (see notificationInboxQuery.ts).
+//     It's report-only because a whole-app hard gate currently trips over a
+//     batch of PRE-EXISTING dead UI code paths (mutations/queries the backend
+//     never implemented -- tracked separately on the board), which are out of
+//     scope for the notifications drift work that introduced this script.
+//   - With --strict, exit 1 on any Pro failure. Use once the pre-existing
+//     dead-code paths are cleaned up, to turn this into a true CI gate.
+//
+// The notifications inbox drift itself IS hard-gated, by the vitest
+// schema-drift test (notificationInboxSchemaDrift.spec.ts) which fails the
+// build if the inbox CORE selection stops validating against the CE mirror.
+//
+// Statically-parseable `gql` documents are scanned from source. Documents
+// built dynamically (e.g. the inbox core/enrichment split, which interpolates
+// its field list) are skipped here and covered by the vitest schema-drift
+// test instead.
+
+const STRICT = process.argv.includes('--strict')
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join, relative } from 'path'
+import { buildSchema, parse, validate } from 'graphql'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const UI_ROOT = join(HERE, '..')
+const SRC = join(UI_ROOT, 'src')
+const PRO_SCHEMA = join(UI_ROOT, '../../rearm-core/backend/src/main/resources/schema/schema.graphqls')
+const CE_SCHEMA = join(UI_ROOT, '../backend/src/main/resources/schema/schema.graphqls')
+
+function loadSchema (path, label) {
+    if (!existsSync(path)) {
+        console.warn(`[validate-graphql] ${label} schema not found at ${path} -- skipping ${label} checks`)
+        return null
+    }
+    try {
+        return buildSchema(readFileSync(path, 'utf8'))
+    } catch (e) {
+        console.warn(`[validate-graphql] ${label} schema failed to build: ${e.message.split('\n')[0]} -- skipping ${label} checks`)
+        return null
+    }
+}
+
+function walk (dir) {
+    const out = []
+    for (const name of readdirSync(dir)) {
+        const p = join(dir, name)
+        const st = statSync(p)
+        if (st.isDirectory()) out.push(...walk(p))
+        else if (/\.(ts|vue|js|mjs)$/.test(name)) out.push(p)
+    }
+    return out
+}
+
+// Extract gql`...` template bodies. Skip any that interpolate (${...}) --
+// those are built dynamically and can't be statically parsed here.
+function extractGqlDocuments (source) {
+    const docs = []
+    const re = /gql`([\s\S]*?)`/g
+    let m
+    while ((m = re.exec(source)) !== null) {
+        const body = m[1]
+        if (body.includes('${')) continue
+        docs.push({ body, index: m.index })
+    }
+    return docs
+}
+
+function lineOf (source, index) {
+    return source.slice(0, index).split('\n').length
+}
+
+const pro = loadSchema(PRO_SCHEMA, 'Pro')
+const ce = loadSchema(CE_SCHEMA, 'CE')
+
+// Report-only means never hard-exit on a missing schema. The Pro schema lives
+// in the sibling rearm-core checkout, which isn't present in this repo's own
+// CI -- so when it's absent we skip the Pro pass and (if available) still run
+// the CE pass, rather than failing the build.
+if (!pro && !ce) {
+    console.warn('[validate-graphql] neither Pro nor CE schema available -- nothing to check. Skipping.')
+    process.exit(0)
+}
+if (!pro) console.warn('[validate-graphql] Pro schema not found (rearm-core not co-located) -- running CE checks only.')
+
+let hardFailures = 0
+let ceWarnings = 0
+let checked = 0
+let skipped = 0
+
+for (const file of walk(SRC)) {
+    const source = readFileSync(file, 'utf8')
+    for (const { body, index } of extractGqlDocuments(source)) {
+        let ast
+        try {
+            ast = parse(body)
+        } catch (e) {
+            skipped++ // syntax error -- not a parseable document
+            continue
+        }
+        // Skip documents with no operation (e.g. a bare `fragment` literal):
+        // parse() accepts them, but validate() flags them NoUnusedFragments,
+        // which is not the drift we're gating on.
+        if (!ast.definitions.some(d => d.kind === 'OperationDefinition')) {
+            skipped++
+            continue
+        }
+        checked++
+        const where = `${relative(UI_ROOT, file)}:${lineOf(source, index)}`
+
+        const proErrors = pro ? validate(pro, ast) : []
+        if (proErrors.length > 0) {
+            hardFailures++
+            console.error(`\n[FAIL] ${where} -- invalid against Pro schema:`)
+            for (const e of proErrors) console.error(`   - ${e.message}`)
+            continue
+        }
+        if (ce) {
+            const ceErrors = validate(ce, ast)
+            if (ceErrors.length > 0) {
+                ceWarnings++
+                console.warn(`\n[WARN] ${where} -- valid on Pro but not on the CE mirror (enrichment lag; must degrade gracefully at runtime):`)
+                for (const e of ceErrors) console.warn(`   - ${e.message}`)
+            }
+        }
+    }
+}
+
+console.log(`\n[validate-graphql] checked ${checked} documents (${skipped} dynamic/non-operation skipped), ` +
+    `${hardFailures} Pro failure(s), ${ceWarnings} CE drift warning(s).`)
+
+if (hardFailures > 0 && STRICT) {
+    console.error('[validate-graphql] FAILED (--strict): UI selects fields the Pro schema does not define.')
+    process.exit(1)
+}
+if (hardFailures > 0) {
+    console.log('[validate-graphql] report-only (no --strict): not failing the build on the above. ' +
+        'These are pre-existing dead UI code paths tracked separately.')
+}
+process.exit(0)

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -80,6 +80,16 @@
                     </n-gi>
                 </n-grid>
 
+                <n-alert
+                    v-if="inboxDegraded"
+                    type="warning"
+                    :show-icon="false"
+                    class="inbox-degraded-alert"
+                    data-testid="inbox-degraded-alert"
+                >
+                    Some inbox details are unavailable on this server version, so a few columns (such as channel name) may be missing. Your notifications are shown below.
+                </n-alert>
+
                 <n-data-table
                     :data="inboxItems"
                     :columns="inboxColumns"
@@ -174,9 +184,7 @@
                             <n-tag :type="deliveryStatusTagType(inboxDrawerRow.status)" size="small">{{ inboxDrawerRow.status }}</n-tag>
                         </n-descriptions-item>
                         <n-descriptions-item label="Channel">
-                            <span v-if="!inboxDrawerRow.channelUuid" class="muted-12">Direct</span>
-                            <span v-else-if="inboxDrawerRow.channelName">{{ inboxDrawerRow.channelName }}</span>
-                            <span v-else class="muted-12" :title="inboxDrawerRow.channelUuid">(deleted channel)</span>
+                            <span :class="{ 'muted-12': drawerChannel.muted }" :title="drawerChannel.title">{{ drawerChannel.text }}</span>
                         </n-descriptions-item>
                         <n-descriptions-item label="Delivered">
                             {{ formatHistoryTimestamp(inboxDrawerRow.sentAt || inboxDrawerRow.createdDate) }}
@@ -278,6 +286,7 @@ import {
     deliveryStatusTagType, severityTagType,
     formatHistoryTimestamp, extractError
 } from '@/utils/notificationsCommon'
+import { loadNotificationInboxPage } from '@/utils/notificationInboxQuery'
 
 const props = defineProps<{
     orguuid: string
@@ -317,6 +326,14 @@ let inboxLoadedOnce = false
 
 const inboxItems = ref<InboxRow[]>([])
 const inboxLoading = ref<boolean>(false)
+// True when the deployed backend rejected the full inbox selection (a field
+// it doesn't have yet -- e.g. a CE mirror lagging Pro) and we fell back to
+// the core selection. Rows still render; enrichment (channelName) is absent.
+const inboxDegraded = ref<boolean>(false)
+// Sticky within a session: set once the backend rejects the full selection so
+// later loads skip straight to the core query. Reset on org switch to re-probe
+// (e.g. if pointed at a different / upgraded backend).
+let inboxFullRejected = false
 const inboxTotalCount = ref<number>(0)
 const inboxUnreadCount = ref<number>(0)
 const inboxPage = ref<number>(1)
@@ -428,33 +445,10 @@ const approvalPayloadView = computed<ApprovalPayloadView | null>(() => {
     return null
 })
 
-const INBOX_QUERY = gql`
-    query notificationInbox(
-        $orgUuid: ID!,
-        $unreadOnly: Boolean,
-        $status: NotificationDeliveryStatusEnum,
-        $eventType: NotificationEventTypeEnum,
-        $limit: Int,
-        $offset: Int
-    ) {
-        notificationInbox(
-            orgUuid: $orgUuid,
-            unreadOnly: $unreadOnly,
-            status: $status,
-            eventType: $eventType,
-            limit: $limit,
-            offset: $offset
-        ) {
-            items {
-                uuid org outboxEventUuid subscriptionUuid channelUuid channelName
-                status origin dedupKey attemptCount nextAttemptAt sentAt
-                lastError createdDate readAt eventType severity
-                title description payloadJson
-            }
-            totalCount unreadCount limit offset
-        }
-    }
-`
+// The inbox query selection + its drift-tolerant loader live in
+// @/utils/notificationInboxQuery (loadNotificationInboxPage). Kept out of
+// this component so the core/enrichment field split has a single source of
+// truth that the schema-drift test can assert against.
 
 const INBOX_UNREAD_COUNT_QUERY = gql`
     query notificationUnreadCount($orgUuid: ID!) {
@@ -569,20 +563,20 @@ async function loadInbox (): Promise<void> {
     inboxLoading.value = true
     try {
         const offset = (inboxPage.value - 1) * inboxPageSize.value
-        const res = await graphqlClient.query({
-            query: INBOX_QUERY,
-            variables: {
-                orgUuid: orgUuid.value,
-                unreadOnly: inboxUnreadOnly.value,
-                status: inboxStatusFilter.value,
-                eventType: inboxEventTypeFilter.value,
-                limit: inboxPageSize.value,
-                offset,
-            },
-            fetchPolicy: 'network-only',
-        })
+        const { page, degraded } = await loadNotificationInboxPage(graphqlClient, {
+            orgUuid: orgUuid.value,
+            unreadOnly: inboxUnreadOnly.value,
+            status: inboxStatusFilter.value,
+            eventType: inboxEventTypeFilter.value,
+            limit: inboxPageSize.value,
+            offset,
+        }, inboxFullRejected)
         if (myToken !== inboxInflightToken) return
-        const page = res.data?.notificationInbox
+        inboxDegraded.value = degraded
+        // Once this backend has rejected the full selection, skip straight to
+        // the core selection on subsequent loads so we don't pay the
+        // reject-then-retry round-trip on every open/page/filter/refresh.
+        if (degraded) inboxFullRejected = true
         inboxItems.value = page?.items || []
         inboxTotalCount.value = page?.totalCount || 0
         // Don't write inboxUnreadCount from page.unreadCount: that value is
@@ -596,6 +590,9 @@ async function loadInbox (): Promise<void> {
         selectedInboxRows.value = selectedInboxRows.value.filter(uuid => visible.has(uuid))
     } catch (e: any) {
         if (myToken !== inboxInflightToken) return
+        // Clear the degraded banner on a hard failure so a stale "some details
+        // unavailable" hint doesn't linger above a generic load-error toast.
+        inboxDegraded.value = false
         message.error(`Failed to load inbox: ${extractError(e)}`)
     } finally {
         if (myToken === inboxInflightToken) inboxLoading.value = false
@@ -776,6 +773,20 @@ async function loadInboxUnreadCount (): Promise<void> {
     }
 }
 
+// Single source of truth for the Channel label, shared by the table cell and
+// the row-detail drawer so the deleted-vs-degraded distinction can't drift
+// between them. `muted` = render dim; `title` = hover text (the uuid) where
+// useful. States: no channelUuid => Direct; channelName present => the name;
+// channelName selected-but-null => the channel was deleted; channelName ABSENT
+// from the row (degraded fallback) => a neutral label, NOT a false "deleted".
+function channelLabel (row: InboxRow | null): { text: string, muted: boolean, title?: string } {
+    if (!row || !row.channelUuid) return { text: 'Direct', muted: true }
+    if (row.channelName) return { text: row.channelName, muted: false }
+    return { text: ('channelName' in row) ? '(deleted channel)' : 'Channel', muted: true, title: row.channelUuid }
+}
+
+const drawerChannel = computed(() => channelLabel(inboxDrawerRow.value))
+
 const inboxColumns = computed(() => [
     {
         type: 'selection' as const,
@@ -849,14 +860,11 @@ const inboxColumns = computed(() => [
         // resolved server-side and rides along on the row, so no admin-only
         // channel-list fetch is needed; a null name on a real channelUuid
         // means the channel was deleted.
-        render: (row: InboxRow) => h(
-            'span',
-            { 'data-testid': 'inbox-cell-channel' },
-            row.channelUuid
-                ? (row.channelName
-                    || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
-                : h('span', { class: 'muted-12' }, 'Direct'),
-        ),
+        render: (row: InboxRow) => {
+            const { text, muted, title } = channelLabel(row)
+            return h('span', { 'data-testid': 'inbox-cell-channel' },
+                [muted ? h('span', { class: 'muted-12', title }, text) : text])
+        },
     },
     {
         title: 'Read', key: 'readAt', width: 200,
@@ -942,6 +950,8 @@ watch(orgUuid, () => {
     inboxLoadedOnce = false
     inboxItems.value = []
     inboxTotalCount.value = 0
+    inboxDegraded.value = false
+    inboxFullRejected = false
     selectedInboxRows.value = []
     approvalsItems.value = []
     approvalsCount.value = 0
@@ -991,6 +1001,7 @@ onUnmounted(() => {
 .muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
 .history-filters { margin-bottom: 12px; }
 .history-pagination { margin-top: 12px; display: flex; justify-content: flex-end; }
+.inbox-degraded-alert { margin-bottom: 12px; }
 
 .approval-entry-line { line-height: 1.4; }
 .approval-entry-name { font-weight: 500; }

--- a/ui/src/utils/graphqlDriftFallback.spec.ts
+++ b/ui/src/utils/graphqlDriftFallback.spec.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import gql from 'graphql-tag'
+import {
+    classifyGraphqlError,
+    httpStatusOf,
+    isSchemaDriftError,
+    loadWithSchemaDriftFallback,
+    type DriftFallbackClient,
+} from './graphqlDriftFallback'
+import type { DocumentNode } from 'graphql'
+
+const FULL = gql`query q { thing { a b enrichment } }`
+const CORE = gql`query q { thing { a b } }`
+
+// --- Apollo v4 error-shape fixtures -------------------------------------
+
+// 200 + errors[] (CombinedGraphQLErrors): a classifiable validation verdict.
+function validationError (field = 'channelName'): any {
+    const err: any = new Error(`Validation error of type FieldUndefined: Field '${field}' is undefined`)
+    err.errors = [{
+        message: `Validation error of type FieldUndefined: Field '${field}' is undefined`,
+        extensions: { classification: 'ValidationError' },
+    }]
+    return err
+}
+// The live-sandbox shape: HTTP 400 whose GraphQL body a WAF replaced with HTML.
+function wafStripped400 (): any {
+    const err: any = new Error('Response not successful: Received status code 400')
+    err.statusCode = 400
+    err.bodyText = '<html><body>Your request has returned an error.</body></html>'
+    return err
+}
+function authError (): any {
+    const err: any = new Error('Response not successful: Received status code 401')
+    err.statusCode = 401
+    return err
+}
+function serverError (): any {
+    const err: any = new Error('Response not successful: Received status code 500')
+    err.statusCode = 500
+    return err
+}
+function transportError (): any {
+    return new Error('Failed to fetch') // no status anywhere
+}
+function abortError (): any {
+    const err: any = new Error('The operation was aborted')
+    err.name = 'AbortError'
+    return err
+}
+
+describe('classifyGraphqlError / httpStatusOf', () => {
+    it('validation: classified extension', () => expect(classifyGraphqlError(validationError())).toBe('validation'))
+    it('validation: graphql-js phrasing', () =>
+        expect(classifyGraphqlError(new Error('Cannot query field "x" on type "Y".'))).toBe('validation'))
+    it('network: plain fetch failure', () => expect(classifyGraphqlError(transportError())).toBe('network'))
+    it('network: abort/timeout', () => expect(classifyGraphqlError(abortError())).toBe('network'))
+    it('other: opaque WAF 400', () => expect(classifyGraphqlError(wafStripped400())).toBe('other'))
+    it('httpStatusOf reads nested + top-level status', () => {
+        expect(httpStatusOf(wafStripped400())).toBe(400)
+        expect(httpStatusOf({ networkError: { statusCode: 503 } })).toBe(503)
+        expect(httpStatusOf(transportError())).toBeUndefined()
+    })
+})
+
+describe('isSchemaDriftError (retry gate)', () => {
+    it('true for a classifiable validation error', () => expect(isSchemaDriftError(validationError())).toBe(true))
+    it('true for an opaque 400 (WAF-stripped validation)', () => expect(isSchemaDriftError(wafStripped400())).toBe(true))
+    it('FALSE for 401 auth', () => expect(isSchemaDriftError(authError())).toBe(false))
+    it('FALSE for 500 server error', () => expect(isSchemaDriftError(serverError())).toBe(false))
+    it('FALSE for a transport failure', () => expect(isSchemaDriftError(transportError())).toBe(false))
+})
+
+// --- loadWithSchemaDriftFallback ----------------------------------------
+
+function clientThatRejectsFullWith (err: any, coreData: any): DriftFallbackClient {
+    return {
+        async query ({ query }: { query: DocumentNode }) {
+            if (query === CORE) return { data: { thing: coreData } }
+            throw err
+        },
+    }
+}
+const opts = (overrides = {}) => ({
+    fullQuery: FULL, coreQuery: CORE, variables: {}, extractPath: (d: any) => d?.thing, ...overrides,
+})
+
+describe('loadWithSchemaDriftFallback', () => {
+    it('returns full data, not degraded, when full succeeds', async () => {
+        const client: DriftFallbackClient = { async query () { return { data: { thing: { a: 1, enrichment: 'e' } } } } }
+        const r = await loadWithSchemaDriftFallback(client, opts())
+        expect(r.degraded).toBe(false)
+        expect(r.data.enrichment).toBe('e')
+    })
+    it('degrades to core on a validation drift', async () => {
+        const r = await loadWithSchemaDriftFallback(clientThatRejectsFullWith(validationError(), { a: 1 }), opts())
+        expect(r.degraded).toBe(true)
+        expect(r.data.a).toBe(1)
+    })
+    it('degrades to core on an opaque WAF 400', async () => {
+        const r = await loadWithSchemaDriftFallback(clientThatRejectsFullWith(wafStripped400(), { a: 1 }), opts())
+        expect(r.degraded).toBe(true)
+    })
+    it('does NOT degrade on 401 -- rethrows so auth surfaces', async () => {
+        await expect(loadWithSchemaDriftFallback(clientThatRejectsFullWith(authError(), { a: 1 }), opts()))
+            .rejects.toThrow(/401/)
+    })
+    it('does NOT degrade on 500 -- rethrows', async () => {
+        await expect(loadWithSchemaDriftFallback(clientThatRejectsFullWith(serverError(), { a: 1 }), opts()))
+            .rejects.toThrow(/500/)
+    })
+    it('does NOT degrade on a transport failure -- rethrows without a second request', async () => {
+        let calls = 0
+        const client: DriftFallbackClient = { async query () { calls++; throw transportError() } }
+        await expect(loadWithSchemaDriftFallback(client, opts())).rejects.toThrow(/failed to fetch/i)
+        expect(calls).toBe(1) // no pointless core retry
+    })
+    it('rethrows the ORIGINAL error when the core retry also fails', async () => {
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                if (query === CORE) throw new Error('core also 400')
+                throw wafStripped400()
+            },
+        }
+        await expect(loadWithSchemaDriftFallback(client, opts())).rejects.toThrow(/status code 400/)
+    })
+    it('skipFull goes straight to core and is degraded, issuing one request', async () => {
+        let calls = 0
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                calls++
+                expect(query).toBe(CORE)
+                return { data: { thing: { a: 1 } } }
+            },
+        }
+        const r = await loadWithSchemaDriftFallback(client, opts({ skipFull: true }))
+        expect(r.degraded).toBe(true)
+        expect(calls).toBe(1)
+    })
+})

--- a/ui/src/utils/graphqlDriftFallback.ts
+++ b/ui/src/utils/graphqlDriftFallback.ts
@@ -1,0 +1,157 @@
+// Generic schema-drift tolerance for GraphQL queries.
+//
+// The SAME UI ships to a Pro backend and to CE installs whose backend is a
+// delayed mirror of Pro. A field the UI selects that exists in Pro but not
+// yet in the deployed schema makes the WHOLE document fail validation
+// (FieldUndefined) -> the query is rejected and whatever it feeds blanks for
+// every user, for the entire mirror-lag window.
+//
+// This module provides the reusable primitive: given a FULL document and a
+// narrower CORE document that selects only fields guaranteed to exist on
+// every backend, `loadWithSchemaDriftFallback` tries FULL and, if the server
+// rejects it as a schema-validation problem, retries CORE so the surface
+// still renders (flagged `degraded`). Transport / auth / server errors are
+// NOT swallowed -- they surface unchanged. Any query can adopt this by
+// passing its two documents and a data selector; see notificationInboxQuery.ts
+// for the inbox's use.
+
+import type { DocumentNode } from 'graphql'
+
+export type GraphqlErrorKind = 'validation' | 'network' | 'other'
+
+// Gather message strings, graphql-error `classification` extensions, and any
+// HTTP status, across the Apollo v4 error shapes:
+//   - CombinedGraphQLErrors (200 + errors[])  -> err.errors (+ extensions)
+//   - ServerError (non-2xx)                    -> err.statusCode + err.bodyText
+//   - legacy nesting                           -> err.networkError.result.errors
+//   - transport failure (no response)          -> no status anywhere
+// A validation error's body can be JSON (errors[]) OR stripped to an opaque
+// page by an edge proxy / WAF -- in which case the only surviving signal is
+// the HTTP status.
+function collectErrorSignals (err: any): { messages: string[], classifications: string[], statusCode?: number } {
+    const messages: string[] = []
+    const classifications: string[] = []
+    let statusCode: number | undefined
+    if (!err) return { messages, classifications, statusCode }
+    if (typeof err.message === 'string') messages.push(err.message)
+
+    const containers = [err, err.networkError, err.cause, err.response].filter(Boolean)
+    const gqlErrorArrays: any[] = []
+    for (const c of containers) {
+        if (typeof c.statusCode === 'number') statusCode ??= c.statusCode
+        else if (typeof c.status === 'number') statusCode ??= c.status
+        if (Array.isArray(c.errors)) gqlErrorArrays.push(c.errors)
+        if (Array.isArray(c.graphQLErrors)) gqlErrorArrays.push(c.graphQLErrors)
+        if (Array.isArray(c.result?.errors)) gqlErrorArrays.push(c.result.errors)
+        // Some links hand back the raw body as text; try to recover errors[].
+        if (typeof c.bodyText === 'string') {
+            try {
+                const parsed = JSON.parse(c.bodyText)
+                if (Array.isArray(parsed?.errors)) gqlErrorArrays.push(parsed.errors)
+            } catch { /* opaque (e.g. WAF HTML) -- status is the only signal */ }
+        }
+    }
+    for (const arr of gqlErrorArrays) {
+        for (const e of arr) {
+            if (typeof e?.message === 'string') messages.push(e.message)
+            const cls = e?.extensions?.classification
+            if (typeof cls === 'string') classifications.push(cls)
+        }
+    }
+    return { messages, classifications, statusCode }
+}
+
+// The HTTP status the server assigned, if any. Undefined for a transport
+// failure that never got a response.
+export function httpStatusOf (err: any): number | undefined {
+    return collectErrorSignals(err).statusCode
+}
+
+// Classify an Apollo error:
+//   - 'validation' : the server's verdict is that the document is invalid
+//                    against its schema (a selected field/type/arg is absent).
+//   - 'network'    : no response reached us (transport failure).
+//   - 'other'      : the server responded with an error we can't attribute
+//                    from its body (e.g. a WAF-stripped 400).
+export function classifyGraphqlError (err: any): GraphqlErrorKind {
+    const { messages, classifications, statusCode } = collectErrorSignals(err)
+    const validationClassified = classifications.some(c => c === 'ValidationError' || c === 'ExecutableDefinitionsRule')
+    // graphql-java / DGS phrasings and graphql-js phrasings both covered.
+    const validationPhrased = messages.some(m =>
+        /validation error/i.test(m)
+        || /cannot query field/i.test(m)
+        || /field\s+.+\s+is undefined/i.test(m)
+        || /fieldundefined/i.test(m)
+        || /unknown (field|type|argument)/i.test(m)
+        || /is not defined by type/i.test(m),
+    )
+    if (validationClassified || validationPhrased) return 'validation'
+    if (statusCode === undefined && messages.some(m => /failed to fetch|networkerror|network error|load failed|econn|etimedout|socket|fetch failed|aborted|timed out/i.test(m))) {
+        return 'network'
+    }
+    return 'other'
+}
+
+// Is this error plausibly *schema drift* (a selected field the deployed schema
+// lacks), such that retrying a narrower selection could succeed? Only two
+// cases qualify:
+//   - a classifiable validation verdict (200-with-errors, or JSON error body);
+//   - an HTTP 400, which per the GraphQL-over-HTTP spec is the status for a
+//     validation error -- even when an edge proxy strips the body to an opaque
+//     page, so the classifier can't read it.
+// Crucially NOT: 401/403 (auth), 5xx (server), or transport failures -- those
+// are transient/unrelated and must surface, never be silently degraded.
+export function isSchemaDriftError (err: any): boolean {
+    if (classifyGraphqlError(err) === 'validation') return true
+    return httpStatusOf(err) === 400
+}
+
+export interface DriftFallbackClient {
+    query (opts: { query: DocumentNode, variables: Record<string, any>, fetchPolicy?: string }): Promise<{ data?: any }>
+}
+
+export interface DriftFallbackOptions {
+    fullQuery: DocumentNode
+    coreQuery: DocumentNode
+    variables: Record<string, any>
+    // Pull the payload out of the query's data (e.g. d => d.notificationInbox).
+    extractPath: (data: any) => any
+    // When true, skip the FULL attempt and go straight to CORE. Callers set
+    // this once a prior load proved the deployed backend rejects FULL, to
+    // avoid paying the reject-then-retry round-trip on every subsequent load.
+    skipFull?: boolean
+}
+
+export interface DriftFallbackResult {
+    data: any
+    // true when only the CORE selection was served -- rows render but
+    // enrichment fields are absent.
+    degraded: boolean
+}
+
+export async function loadWithSchemaDriftFallback (
+    client: DriftFallbackClient,
+    opts: DriftFallbackOptions,
+): Promise<DriftFallbackResult> {
+    const { fullQuery, coreQuery, variables, extractPath, skipFull } = opts
+    let fullError: any
+    if (!skipFull) {
+        try {
+            const res = await client.query({ query: fullQuery, variables, fetchPolicy: 'network-only' })
+            return { data: extractPath(res.data), degraded: false }
+        } catch (err: any) {
+            // Only a schema-drift-shaped failure warrants a narrower retry.
+            // Transport / auth / server errors surface unchanged.
+            if (!isSchemaDriftError(err)) throw err
+            fullError = err
+        }
+    }
+    try {
+        const res = await client.query({ query: coreQuery, variables, fetchPolicy: 'network-only' })
+        return { data: extractPath(res.data), degraded: true }
+    } catch (err) {
+        // The narrower query failed too. If we had a FULL error, surface THAT
+        // (it reflects the real first failure); otherwise surface this one.
+        throw fullError ?? err
+    }
+}

--- a/ui/src/utils/notificationInboxQuery.spec.ts
+++ b/ui/src/utils/notificationInboxQuery.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+    loadNotificationInboxPage,
+    INBOX_QUERY_FULL,
+    INBOX_QUERY_CORE,
+    INBOX_CORE_ITEM_FIELDS,
+    INBOX_ENRICHMENT_ITEM_FIELDS,
+} from './notificationInboxQuery'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import type { DocumentNode } from 'graphql'
+
+// The generic retry/classify logic is covered in graphqlDriftFallback.spec.ts.
+// These tests cover the inbox WIRING: field partitioning, the two documents,
+// and that the wrapper maps degraded + page through correctly.
+
+function validationError (): any {
+    const err: any = new Error("Validation error of type FieldUndefined: Field 'channelName' is undefined")
+    err.errors = [{ message: "Field 'channelName' is undefined", extensions: { classification: 'ValidationError' } }]
+    return err
+}
+
+describe('inbox field partitioning', () => {
+    it('keeps core and enrichment field sets disjoint', () => {
+        const overlap = INBOX_CORE_ITEM_FIELDS.filter(f => INBOX_ENRICHMENT_ITEM_FIELDS.includes(f))
+        expect(overlap).toEqual([])
+    })
+    it('has a non-empty enrichment set (otherwise the split is pointless)', () => {
+        expect(INBOX_ENRICHMENT_ITEM_FIELDS.length).toBeGreaterThan(0)
+    })
+    it('builds distinct FULL and CORE documents', () => {
+        expect(INBOX_QUERY_FULL).not.toBe(INBOX_QUERY_CORE)
+    })
+})
+
+describe('loadNotificationInboxPage', () => {
+    it('returns the full page and is not degraded when the backend accepts full', async () => {
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                expect(query).toBe(INBOX_QUERY_FULL)
+                return { data: { notificationInbox: { items: [{ uuid: 'a', channelName: '#sec' }], totalCount: 1 } } }
+            },
+        }
+        const res = await loadNotificationInboxPage(client, { orgUuid: 'o1' })
+        expect(res.degraded).toBe(false)
+        expect(res.page.items[0].channelName).toBe('#sec')
+    })
+
+    it('falls back to core (degraded) when the full selection is rejected as drift', async () => {
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                if (query === INBOX_QUERY_CORE) {
+                    return { data: { notificationInbox: { items: [{ uuid: 'a' }], totalCount: 1 } } }
+                }
+                throw validationError()
+            },
+        }
+        const res = await loadNotificationInboxPage(client, { orgUuid: 'o1' })
+        expect(res.degraded).toBe(true)
+        expect(res.page.items).toHaveLength(1)
+        expect('channelName' in res.page.items[0]).toBe(false)
+    })
+
+    it('skipFull requests only the core document', async () => {
+        let calls = 0
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                calls++
+                expect(query).toBe(INBOX_QUERY_CORE)
+                return { data: { notificationInbox: { items: [], totalCount: 0 } } }
+            },
+        }
+        const res = await loadNotificationInboxPage(client, { orgUuid: 'o1' }, true)
+        expect(res.degraded).toBe(true)
+        expect(calls).toBe(1)
+    })
+})

--- a/ui/src/utils/notificationInboxQuery.ts
+++ b/ui/src/utils/notificationInboxQuery.ts
@@ -1,0 +1,89 @@
+// Inbox query selection + its drift-tolerant loader (built on the reusable
+// graphqlDriftFallback primitive).
+//
+// A field the inbox selects that exists in Pro but not yet in the deployed
+// (CE) schema would make the WHOLE notificationInbox document fail validation
+// and blank the inbox. Split the selection into CORE (fields a row must have
+// to render and function) and ENRICHMENT (server-side conveniences the UI can
+// live without); loadNotificationInboxPage serves CORE if the backend rejects
+// the full selection, so rows still render.
+
+import gql from 'graphql-tag'
+import type { DocumentNode } from 'graphql'
+import {
+    loadWithSchemaDriftFallback,
+    type DriftFallbackClient,
+} from '@/utils/graphqlDriftFallback'
+
+// Fields the inbox cannot render a useful row without. These MUST exist on
+// every backend the shared UI talks to (Pro and the CE mirror) -- the
+// schema-drift test asserts exactly that.
+export const INBOX_CORE_ITEM_FIELDS: string[] = [
+    'uuid', 'org', 'outboxEventUuid', 'subscriptionUuid', 'channelUuid',
+    'status', 'origin', 'dedupKey', 'attemptCount', 'nextAttemptAt', 'sentAt',
+    'lastError', 'createdDate', 'readAt', 'eventType', 'severity',
+    'title', 'description', 'payloadJson',
+]
+
+// Server-resolved conveniences. Allowed to be Pro-ahead-of-CE: their absence
+// degrades gracefully (e.g. channelName -> a neutral label) instead of
+// blanking the inbox. Every field added here MUST be read in the UI only
+// behind a presence guard (`'field' in row`) so a degraded row can't throw.
+export const INBOX_ENRICHMENT_ITEM_FIELDS: string[] = [
+    'channelName',
+]
+
+function buildInboxQuery (itemFields: string[]): DocumentNode {
+    return gql`
+        query notificationInbox(
+            $orgUuid: ID!,
+            $unreadOnly: Boolean,
+            $status: NotificationDeliveryStatusEnum,
+            $eventType: NotificationEventTypeEnum,
+            $limit: Int,
+            $offset: Int
+        ) {
+            notificationInbox(
+                orgUuid: $orgUuid,
+                unreadOnly: $unreadOnly,
+                status: $status,
+                eventType: $eventType,
+                limit: $limit,
+                offset: $offset
+            ) {
+                items { ${itemFields.join(' ')} }
+                totalCount unreadCount limit offset
+            }
+        }
+    `
+}
+
+export const INBOX_QUERY_FULL: DocumentNode = buildInboxQuery(
+    [...INBOX_CORE_ITEM_FIELDS, ...INBOX_ENRICHMENT_ITEM_FIELDS],
+)
+export const INBOX_QUERY_CORE: DocumentNode = buildInboxQuery(INBOX_CORE_ITEM_FIELDS)
+
+export interface InboxPageResult {
+    page: any
+    // true when the full selection was rejected and we fell back to core --
+    // rows are present but enrichment (e.g. channelName) is absent.
+    degraded: boolean
+}
+
+// Load one inbox page, tolerating schema drift. Pass `skipFull=true` once a
+// prior load has already proved the deployed backend rejects the full
+// selection, to skip the reject-then-retry round-trip on subsequent loads.
+export async function loadNotificationInboxPage (
+    client: DriftFallbackClient,
+    variables: Record<string, any>,
+    skipFull = false,
+): Promise<InboxPageResult> {
+    const { data, degraded } = await loadWithSchemaDriftFallback(client, {
+        fullQuery: INBOX_QUERY_FULL,
+        coreQuery: INBOX_QUERY_CORE,
+        variables,
+        extractPath: (d: any) => d?.notificationInbox,
+        skipFull,
+    })
+    return { page: data, degraded }
+}

--- a/ui/src/utils/notificationInboxSchemaDrift.spec.ts
+++ b/ui/src/utils/notificationInboxSchemaDrift.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { INBOX_QUERY_FULL, INBOX_QUERY_CORE, INBOX_ENRICHMENT_ITEM_FIELDS } from './notificationInboxQuery'
+
+// The CE mirror schema ships IN this repo -- always present, so its checks are
+// unconditional. The Pro schema lives in the sibling rearm-core checkout,
+// which is NOT present in this repo's own CI; those checks are skipped (not
+// failed) when it's absent, so the suite is green in a CE-only checkout and
+// still meaningful on a dev box that has both.
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+describe('inbox core selection vs the CE mirror schema (in-repo, always runs)', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    // The load-bearing invariant: every field the inbox HARD-REQUIRES exists on
+    // the CE mirror, so a CE install never blanks.
+    it('the CORE inbox selection is valid against the CE mirror', () => {
+        if (!ceSchema) return
+        expect(validate(ceSchema, INBOX_QUERY_CORE).map(e => e.message)).toEqual([])
+    })
+
+    // Proves the core/enrichment split is actually doing something: at least
+    // one enrichment field is genuinely absent from the CE mirror, so FULL is
+    // rejected there. If FULL ever validates clean against CE, the split has
+    // silently become meaningless (enrichment caught up, or a field was
+    // miscategorised) -- surface that so the partition gets revisited.
+    it('the FULL inbox selection is INVALID against the CE mirror (split is load-bearing)', () => {
+        if (!ceSchema) return
+        expect(INBOX_ENRICHMENT_ITEM_FIELDS.length).toBeGreaterThan(0)
+        expect(validate(ceSchema, INBOX_QUERY_FULL).length).toBeGreaterThan(0)
+    })
+})
+
+describe('inbox full selection vs the Pro schema (skipped if rearm-core absent)', () => {
+    it.runIf(proSchema)('the full inbox selection is valid against Pro (source of truth)', () => {
+        expect(validate(proSchema as GraphQLSchema, INBOX_QUERY_FULL).map(e => e.message)).toEqual([])
+    })
+})

--- a/ui/vitest.config.mjs
+++ b/ui/vitest.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath, URL } from 'url'
+
+// Standalone vitest config kept separate from vite.config.mjs so the app
+// build (vite build) never pulls in test-only settings. Node environment:
+// these are pure-logic + schema-validation tests, no DOM.
+export default defineConfig({
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['src/**/*.spec.ts', 'test/**/*.spec.ts'],
+    },
+})


### PR DESCRIPTION
## Problem (live on CE today)
The same UI ships to a Pro backend and to CE installs whose backend is a **delayed mirror** of Pro. GraphQL validates the whole document, so **one** field the inbox selects that the deployed backend lacks rejects the entire `notificationInbox` query -> the whole inbox blanks with a generic error, for every user, for the entire mirror-lag window. Confirmed real: `channelName` exists on the Pro schema but not the CE mirror, and the inbox query selects it -> every CE install currently blanks the inbox. (Same failure class as the `FieldsConflict` that blanked the changelog recently.)

## Containment (the fix)
- Split the inbox selection into **CORE** (fields a row must have to render/function) and **ENRICHMENT** (server-side conveniences the UI can live without, e.g. `channelName`). On a schema-drift failure the loader retries the CORE-only selection so rows still render, with a non-blocking banner; the Channel column shows a neutral label instead of a false `(deleted channel)`.
- The retry fires **only** for a schema-drift-shaped failure: a validation verdict, or an HTTP 400 whose GraphQL body an edge proxy/WAF may have stripped to an opaque page. **Transport / auth (401/403) / server (5xx)** errors surface unchanged rather than being silently degraded.
- Drift-tolerance is a **reusable primitive** (`loadWithSchemaDriftFallback` in `graphqlDriftFallback.ts`): any query can adopt it by passing a full doc, a core doc, and a data selector. The inbox is a thin wrapper -- other drift-exposed queries (approvals count, unread count, changelog) can follow.

## Prevention
- `notificationInboxSchemaDrift.spec.ts` hard-gates the invariant: the inbox CORE selection must validate against the in-repo CE mirror schema, and the FULL selection must be *rejected* there (proving the split is load-bearing). Pro-schema checks are skipped (not failed) when `rearm-core` isn't co-located, so this repo's own CI stays green.
- `scripts/validate-graphql.mjs` validates every static UI gql document against the backend schema(s). **Report-only** for now (a batch of ~14 pre-existing dead UI code paths would trip a hard gate -- tracked as a separate task) with an opt-in `--strict` to flip on once those are cleaned.

## Review
- **Layer 1** (high-effort, 8 finder angles + verify): 10 findings, all addressed. Notably a CI-break (drift test/script hard-failed without `rearm-core`), a false-degrade (retry gated too broadly -> transient 401/500 would wrongly degrade), and a stale-banner bug. Plus reusability extraction, a sticky-flag to avoid double-fetch under persistent drift, a `channelLabel` dedup, and a load-bearing-split assertion.
- **Layer 2** (ReARM conventions): clean, no violations. (Bumped vitest 2->3 to match the vite 7 peer range, per a non-blocking note.)

## Test plan
- [x] 29 unit tests (`npm test`): the generic fallback (validation/WAF-400 degrade; 401/500/abort/transport rethrow; skip-full; original-error-on-double-failure), the inbox wrapper, and schema-drift invariants
- [x] `npm run build` clean; `npm run validate:graphql` report-only
- [x] Live on sandbox: forcing the drift on a Pro backend, the inbox degrades to rows + banner instead of blanking; a normal backend shows channel names with no banner
- [x] Plain-ASCII byte-scan on the diff

## Notes
- New devDeps: `vitest` (repo had no test runner; task required tests) and `graphql` (used directly for schema validation; already a transitive apollo peer). `vitest.config.mjs` is separate from `vite.config.mjs` so the app build never pulls test settings.
- Follow-up filed for the ~14 pre-existing dead UI gql code paths surfaced by the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)