### PR TITLE
fix(ui): drift-tolerant notification catalog + delivery history

### DIFF
--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -46,6 +46,16 @@
             </n-gi>
         </n-grid>
 
+        <n-alert
+            v-if="historyDegraded"
+            type="warning"
+            :show-icon="false"
+            style="margin-bottom: 12px;"
+            data-testid="history-degraded-alert"
+        >
+            Some delivery details are unavailable on this server version, so a few columns (such as error and retry info) may be missing. Your delivery history is shown below.
+        </n-alert>
+
         <n-data-table
             :data="deliveries"
             :columns="deliveryColumns"
@@ -70,11 +80,13 @@
 import { ref, computed, h, onMounted } from 'vue'
 import {
     NDataTable, NButton, NIcon, NFormItem, NSelect, NGrid, NGi, NTag,
-    NPagination, useMessage
+    NPagination, NAlert, useMessage
 } from 'naive-ui'
 import { Refresh } from '@vicons/tabler'
 import gql from 'graphql-tag'
+import type { DocumentNode } from 'graphql'
 import graphqlClient from '@/utils/graphql'
+import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 import {
     ChannelRow, SubscriptionRow, DeliveryRow, TYPE_LABELS,
     deliveryStatusOptions, deliveryOriginOptions,
@@ -94,6 +106,9 @@ const channels = ref<ChannelRow[]>([])
 const subscriptions = ref<SubscriptionRow[]>([])
 const deliveries = ref<DeliveryRow[]>([])
 const deliveriesLoading = ref<boolean>(false)
+// True when the backend rejected the full delivery selection and we fell back
+// to the core fields (retry/error detail columns may be absent).
+const historyDegraded = ref<boolean>(false)
 const historyPage = ref<number>(1)
 const historyPageSize = ref<number>(25)
 const historyTotalCount = ref<number>(0)
@@ -118,32 +133,37 @@ const channelFilterOptions = computed(() =>
 const channelNameById = computed<Record<string, string>>(() => buildNameMap(channels.value))
 const subscriptionNameById = computed<Record<string, string>>(() => buildNameMap(subscriptions.value))
 
-const HISTORY_DELIVERIES_QUERY = gql`
-    query notificationDeliveriesPage(
-        $orgUuid: ID!,
-        $channelUuid: ID,
-        $status: NotificationDeliveryStatusEnum,
-        $origin: NotificationDeliveryOriginEnum,
-        $limit: Int,
-        $offset: Int
-    ) {
-        notificationDeliveries(
-            orgUuid: $orgUuid,
-            channelUuid: $channelUuid,
-            status: $status,
-            origin: $origin,
-            limit: $limit,
-            offset: $offset
+// CORE = identity + status + time needed to render a delivery row.
+// ENRICHMENT = retry/error detail; if a backend lacks one of these (CE mirror
+// lagging Pro) the history table degrades to core rows instead of blanking.
+const HISTORY_CORE_ITEM_FIELDS = 'uuid org outboxEventUuid subscriptionUuid channelUuid status origin createdDate'
+const HISTORY_ENRICHMENT_ITEM_FIELDS = 'dedupKey attemptCount nextAttemptAt sentAt lastError'
+function buildHistoryQuery (itemFields: string): DocumentNode {
+    return gql`
+        query notificationDeliveriesPage(
+            $orgUuid: ID!,
+            $channelUuid: ID,
+            $status: NotificationDeliveryStatusEnum,
+            $origin: NotificationDeliveryOriginEnum,
+            $limit: Int,
+            $offset: Int
         ) {
-            items {
-                uuid org outboxEventUuid subscriptionUuid channelUuid
-                status origin dedupKey attemptCount nextAttemptAt sentAt
-                lastError createdDate
+            notificationDeliveries(
+                orgUuid: $orgUuid,
+                channelUuid: $channelUuid,
+                status: $status,
+                origin: $origin,
+                limit: $limit,
+                offset: $offset
+            ) {
+                items { ${itemFields} }
+                totalCount limit offset
             }
-            totalCount limit offset
         }
-    }
-`
+    `
+}
+const HISTORY_DELIVERIES_FULL = buildHistoryQuery(`${HISTORY_CORE_ITEM_FIELDS} ${HISTORY_ENRICHMENT_ITEM_FIELDS}`)
+const HISTORY_DELIVERIES_CORE = buildHistoryQuery(HISTORY_CORE_ITEM_FIELDS)
 
 async function loadChannels (): Promise<void> {
     try {
@@ -183,8 +203,9 @@ async function loadDeliveries (): Promise<void> {
     deliveriesLoading.value = true
     try {
         const offset = (historyPage.value - 1) * historyPageSize.value
-        const res = await graphqlClient.query({
-            query: HISTORY_DELIVERIES_QUERY,
+        const { data: page, degraded } = await loadWithSchemaDriftFallback(graphqlClient, {
+            fullQuery: HISTORY_DELIVERIES_FULL,
+            coreQuery: HISTORY_DELIVERIES_CORE,
             variables: {
                 orgUuid: orgUuid.value,
                 channelUuid: historyFilters.value.channelUuid,
@@ -193,14 +214,15 @@ async function loadDeliveries (): Promise<void> {
                 limit: historyPageSize.value,
                 offset,
             },
-            fetchPolicy: 'network-only',
+            extractPath: (d: any) => d?.notificationDeliveries,
         })
         if (myToken !== historyInflightToken) return  // stale response
-        const page = res.data?.notificationDeliveries
+        historyDegraded.value = degraded
         deliveries.value = page?.items || []
         historyTotalCount.value = page?.totalCount || 0
     } catch (e: any) {
         if (myToken !== historyInflightToken) return  // stale failure
+        historyDegraded.value = false
         message.error(`Failed to load history: ${extractError(e)}`)
     } finally {
         if (myToken === historyInflightToken) deliveriesLoading.value = false
@@ -259,7 +281,9 @@ const deliveryColumns = computed(() => [
     },
     {
         title: 'Attempts', key: 'attemptCount',
-        render: (row: DeliveryRow) => `${row.attemptCount}`,
+        // attemptCount is an ENRICHMENT field -- absent (not just null) on a
+        // degraded load, so guard against rendering the literal "undefined".
+        render: (row: DeliveryRow) => row.attemptCount != null ? `${row.attemptCount}` : '',
     },
     {
         title: 'Last error', key: 'lastError',

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -845,6 +845,7 @@ import Swal from 'sweetalert2'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '../utils/commonFunctions'
 import { extractError, isConflictError, webhookAuthOptions } from '../utils/notificationsCommon'
+import { loadWithSchemaDriftFallback } from '../utils/graphqlDriftFallback'
 import WebhooksOfOrg from './WebhooksOfOrg.vue'
 import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
 import SubscriptionsOfOrg from './SubscriptionsOfOrg.vue'
@@ -2344,27 +2345,47 @@ async function loadCiIntegrations(useCache: boolean) {
     }
 }
 
+// CORE = fields every channel card needs to render an instance row.
+// ENRICHMENT = EMAIL-only digest display; the card still renders without it,
+// so a backend that lacks these (CE mirror lagging Pro) degrades the digest
+// summary instead of blanking every channel on its card.
+const CATALOG_CHANNELS_CORE = gql`
+    query notificationChannelsForCatalog($orgUuid: ID!) {
+        notificationChannels(orgUuid: $orgUuid) {
+            uuid name type status revision
+        }
+    }`
+const CATALOG_CHANNELS_FULL = gql`
+    query notificationChannelsForCatalog($orgUuid: ID!) {
+        notificationChannels(orgUuid: $orgUuid) {
+            uuid name type status revision digestMode digestInterval emailRecipients
+        }
+    }`
+
 async function loadNotificationChannels(useCache: boolean) {
     // Channel queries are a Pro surface — skip on OSS, where the
     // EMAIL / WEBHOOK / SENTINEL cards render in their "Pro" state instead.
     if (!showCiFeatures.value) return
     const cachePolicy: FetchPolicy = useCache ? 'cache-first' : 'network-only'
     try {
-        const resp = await graphqlClient.query({
-            query: gql`
-                query notificationChannelsForCatalog($orgUuid: ID!) {
-                    notificationChannels(orgUuid: $orgUuid) {
-                        uuid name type status revision digestMode digestInterval emailRecipients
-                    }
-                }`,
-            variables: { orgUuid: orguuid.value },
-            fetchPolicy: cachePolicy
-        })
-        if (resp.data?.notificationChannels) {
-            notificationChannelRows.value = resp.data.notificationChannels
+        const { data, degraded } = await loadWithSchemaDriftFallback(
+            { query: (o: any) => graphqlClient.query({ ...o, fetchPolicy: cachePolicy }) },
+            {
+                fullQuery: CATALOG_CHANNELS_FULL,
+                coreQuery: CATALOG_CHANNELS_CORE,
+                variables: { orgUuid: orguuid.value },
+                extractPath: (d: any) => d?.notificationChannels,
+            },
+        )
+        if (data) notificationChannelRows.value = data
+        if (degraded) {
+            notify('warning', 'Notification channels',
+                'Some channel details are unavailable on this server version; digest settings may not show.')
         }
-    } catch (err) {
-        console.error(err)
+    } catch (err: any) {
+        // Real failure (network / auth / server) -- surface it instead of the
+        // previous silent console-only swallow that left the cards blank.
+        notify('error', 'Notification channels', `Failed to load channels: ${extractError(err)}`)
     }
 }
 


### PR DESCRIPTION
## What
Extends the reusable \`loadWithSchemaDriftFallback\` (shipped in #169, so far used only by the inbox) to two more notification surfaces, so they **degrade gracefully instead of blanking** when the deployed backend lacks a selected field -- the CE-mirror-lag drift class #169 fixed for the inbox.

- **Catalog channels** (\`OrgIntegrations.vue\`): CORE (\`uuid name type status revision\`) + ENRICHMENT (\`digestMode digestInterval emailRecipients\`); serve CORE when the full selection is rejected.
  - **Also fixes a real current bug:** \`loadNotificationChannels\` previously did \`catch { console.error(err) }\` -- any load failure (drift, auth, network, 5xx) **silently emptied the channel cards** with zero user feedback. Now a hard failure surfaces a \`notify('error')\` and a drift degrade surfaces a \`notify('warning')\`.
- **Delivery history** (\`NotificationHistory.vue\`): CORE (identity/status/time) + ENRICHMENT (\`dedupKey attemptCount nextAttemptAt sentAt lastError\`); degraded banner + reset-on-error; guarded the Attempts column against a missing enrichment field.

## Why (grounding)
A notifications exploration found the drift-tolerance #169 shipped was **only wired to the inbox** -- every sibling query still blanks its whole surface on one missing field during a CE mirror-lag window. This lands the two highest-value siblings: the catalog (highest-traffic + the real console-swallow bug) and history (the diagnosis surface). Subscriptions/groups/approvals have more load-bearing fields and are deferred as follow-up on the same board task.

## Review
- Focused correctness + conventions review: **clean**; one LOW cosmetic finding (Attempts column showing "undefined" when degraded) caught + fixed before commit. Reuses the merged, tested \`loadWithSchemaDriftFallback\` primitive (no changes to it). No new deps; each file keeps its own feedback primitive (\`notify\` vs \`message\`).

## Test plan
- [x] \`npm run build\` clean; existing 29 drift tests green (helper unchanged)
- [x] Plain-ASCII byte-scan on the diff
- [x] **Live on sandbox (both paths):** normal load shows all channels + all history rows, no banner/error; with a bogus enrichment field forced on each query, both surfaces still render (8 channels / 26 history rows) plus the degrade notice instead of blanking. The catalog swallow-fix verified: a failure now shows a toast, not a silent empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)