### PR TITLE
feat(ui): surface auto-disabled channel reason in the Integrations catalog

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -107,6 +107,11 @@
                                                 <span v-if="card.id === 'EMAIL'" class="cap-chip">{{ digestChipLabel(ch) }}</span>
                                                 <span v-if="ch.status !== 'ENABLED'" class="cap-chip chip-muted">DISABLED</span>
                                             </div>
+                                            <!-- Auto-disabled channel: explain WHY + prompt a re-verify, so the
+                                                 failure isn't only visible as FAILED Delivery History rows. -->
+                                            <div v-if="ch.disabledReason" class="instance-disabled-reason" data-testid="channel-disabled-reason">
+                                                {{ ch.disabledReason }}
+                                            </div>
                                         </div>
                                         <div class="instance-actions">
                                             <n-icon
@@ -964,6 +969,9 @@ interface ChannelCatalogRow {
     digestMode: string | null
     digestInterval: string | null
     emailRecipients: string[] | null
+    // Operator-facing reason the channel was auto-disabled (e.g. bad webhook
+    // URL). Null when enabled or manually disabled.
+    disabledReason: string | null
 }
 const notificationChannelRows: Ref<ChannelCatalogRow[]> = ref([])
 const emailChannels = computed(() => notificationChannelRows.value.filter(c => c.type === 'EMAIL'))
@@ -2358,7 +2366,7 @@ const CATALOG_CHANNELS_CORE = gql`
 const CATALOG_CHANNELS_FULL = gql`
     query notificationChannelsForCatalog($orgUuid: ID!) {
         notificationChannels(orgUuid: $orgUuid) {
-            uuid name type status revision digestMode digestInterval emailRecipients
+            uuid name type status revision digestMode digestInterval emailRecipients disabledReason
         }
     }`
 
@@ -2642,6 +2650,12 @@ watch(() => props.orguuid, async () => {
     background: var(--chip);
     border-color: var(--line);
     color: var(--muted);
+}
+.instance-disabled-reason {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.35;
+    color: var(--danger, #d03050);
 }
 .instance-actions { display: flex; gap: 6px; flex-shrink: 0; }
 .instance-icon {


### PR DESCRIPTION
## What
Pairs with the rearm-saas backend change ([PR #273](https://github.com/relizaio/rearm-saas/pull/273)) that auto-disables a notification channel whose webhook URL is misconfigured (e.g. not a Slack host) and stamps an operator-facing `disabledReason`.

The **Catalog channel card** now renders that reason on a disabled channel instance, so an operator sees **why** a channel stopped delivering -- and can edit + re-enable it -- instead of the failure only showing up as FAILED rows in Delivery History.

- Select `disabledReason` on the catalog channels query as a **drift-tolerant enrichment field** (via the merged `loadWithSchemaDriftFallback`), so an older backend that lacks the field degrades gracefully rather than blanking the channel cards.
- Render it under the `DISABLED` chip in danger color.

## Test plan
- [x] `npm run build` clean; plain-ASCII byte-scan on the diff.
- [x] **Live on the sandbox** (backend + UI hot-swapped): a channel with the auto-disabled state renders the reason on its Slack card ("Webhook URL is not a Slack host (hooks.slack.com); re-enter a Slack incoming-webhook or Workflow URL, then re-enable."), and the GraphQL `disabledReason` field resolves correctly.

Depends on rearm-saas #273 for the `disabledReason` field; on an older backend the field is absent and the card degrades gracefully (no reason shown, no blank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)