### PR TITLE
Notifications: form-honesty on the subscription form (#32) + hide dead VEX event type

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -52,12 +52,13 @@
                         <n-form-item label="Event types">
                             <n-select
                                 v-model:value="subForm.eventTypes"
-                                :options="eventTypeOptions"
+                                :options="eventTypeOptionsForForm"
                                 multiple
                                 placeholder="Pick one or more event types"
                                 data-testid="sub-eventtypes"
                             />
                         </n-form-item>
+                        <div class="field-hint">This subscription fires only when a selected event type is actually emitted. "VEX state changed" is reserved and not emitted yet, so it isn't selectable (an existing selection can still be removed).</div>
 
                         <n-form-item label="Filter mode">
                             <n-radio-group v-model:value="subForm.filterMode">
@@ -71,9 +72,16 @@
                                 type="textarea"
                                 :autosize="{ minRows: 3, maxRows: 8 }"
                                 style="font-family: monospace; font-size: 12px;"
-                                placeholder='e.g. event.severity == "CRITICAL" && size(affectedReleases) > 0'
+                                placeholder='e.g. event.severity == "CRITICAL" && size(event.affectedReleases) > 0'
                             />
                         </n-form-item>
+                        <div v-if="subForm.filterMode === 'ADVANCED'" class="field-hint">
+                            A CEL boolean over the event. Examples:
+                            <code>event.severity == "CRITICAL"</code>,
+                            <code>event.kevListed == true</code>,
+                            <code>size(event.affectedReleases) &gt; 0</code>.
+                            Leave Preset mode to match on event type alone.
+                        </div>
 
                         <div class="routes-section">
                             <div class="routes-header">
@@ -159,10 +167,11 @@
                                         v-model:value="subForm.dedupWindowMinutes"
                                         :min="0"
                                         clearable
-                                        placeholder="None"
+                                        placeholder="Default: 1440 (24h)"
                                         style="width: 100%;"
                                     />
                                 </n-form-item>
+                                <div class="field-hint">Suppresses repeat deliveries of the same event within the window. Leave empty for the 24h default; set 0 to deliver every matching event.</div>
                             </n-gi>
                             <n-gi>
                                 <n-space>
@@ -185,6 +194,7 @@
                                         />
                                     </n-form-item>
                                 </n-space>
+                                <div class="field-hint">Stored but not enforced yet -- rate limiting is planned; leave empty for now.</div>
                             </n-gi>
                         </n-grid>
 
@@ -307,6 +317,20 @@ const showSubscriptionModal = ref<boolean>(false)
 const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
+
+// Event-type options for THIS form. The shared eventTypeOptions marks
+// VEX_STATE_CHANGED disabled (no backend producer yet), which also makes
+// naive-ui suppress its tag "x" (closable: !disabled). That would trap a
+// legacy subscription that already selected VEX -- it could never be
+// removed via the form. So keep VEX disabled only while it is NOT already
+// selected: unselectable for new subs, still removable when editing an
+// existing VEX subscription (after removal it re-disables, no re-add).
+const eventTypeOptionsForForm = computed(() =>
+    eventTypeOptions.map(o =>
+        o.value === 'VEX_STATE_CHANGED'
+            ? { ...o, disabled: !subForm.value.eventTypes.includes('VEX_STATE_CHANGED') }
+            : o)
+)
 
 const channelOptions = computed(() =>
     channels.value
@@ -812,6 +836,22 @@ onMounted(async () => {
 }
 .routes-title { font-size: 13px; font-weight: 600; }
 .routes-hint { font-size: 12px; color: var(--n-text-color-3, #888); margin-bottom: 10px; }
+/* Inline honesty/help hints under form fields -- matches routes-hint tone but
+   sits directly beneath a field, with a touch of negative top margin to pull
+   it up against n-form-item's bottom padding. */
+.field-hint {
+    font-size: 12px;
+    color: var(--n-text-color-3, #888);
+    margin: -6px 0 12px;
+    line-height: 1.45;
+}
+.field-hint code {
+    font-family: monospace;
+    font-size: 11px;
+    background: var(--n-color-embedded, rgba(128, 128, 128, 0.12));
+    padding: 1px 4px;
+    border-radius: 3px;
+}
 .route-row + .route-row { margin-top: 6px; }
 .route-remove-cell { display: flex; align-items: flex-end; }
 </style>

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -127,10 +127,14 @@ export const subscriptionStatusOptions = [
     { label: 'Preview (rows land but no dispatch)', value: 'PREVIEW' },
 ]
 
+// VEX_STATE_CHANGED has no event producer in the backend yet, so a
+// subscription on it would never fire (a silent trap). Disable it here until
+// a producer ships -- prefer VULNERABILITY_RECORD_UPDATED for vuln-state
+// changes. See rearm-core SyntheticEventTemplates / notifications.md.
 export const eventTypeOptions = [
     { label: 'New vuln affects releases', value: 'NEW_VULN_AFFECTS_RELEASES' },
     { label: 'Vulnerability record updated', value: 'VULNERABILITY_RECORD_UPDATED' },
-    { label: 'VEX state changed', value: 'VEX_STATE_CHANGED' },
+    { label: 'VEX state changed (not yet available)', value: 'VEX_STATE_CHANGED', disabled: true },
     { label: 'Release created', value: 'RELEASE_CREATED' },
     { label: 'Release lifecycle changed', value: 'RELEASE_LIFECYCLE_CHANGED' },
     { label: 'Release BOM diff', value: 'RELEASE_BOM_DIFF' },


### PR DESCRIPTION
## What

Form-honesty pass on the notification **subscription** create/edit form so the
UI stops advertising capabilities the backend doesn't (yet) deliver. Closes the
"#32 form-honesty" and "hide dead VEX event type" trust-win tasks as one small,
cohesive change.

### Changes
- **Disable `VEX_STATE_CHANGED`.** There is no event producer for VEX state
  changes in the backend yet (`SyntheticEventTemplates` has only a *synthetic*
  VEX template; no real emitter), so a subscription on it would silently never
  fire. The option is relabeled *"VEX state changed (not yet available)"* and
  disabled. To avoid trapping a legacy subscription that already selected VEX
  (naive-ui suppresses a disabled option's tag "x": `closable: !disabled`), the
  disable is **conditional** via a form-scoped computed (`eventTypeOptionsForForm`):
  VEX is unselectable for new subscriptions but stays removable when it is
  already selected on an edited subscription (re-disables after removal, no
  re-add). Prefer `VULNERABILITY_RECORD_UPDATED`.
- **Dedup honesty.** Placeholder `"None"` -> `"Default: 1440 (24h)"` (matches
  `NotificationSubscriptionData.DEFAULT_DEDUP_WINDOW_MINUTES = 1440`), plus a
  hint that empty = 24h default and `0` = deliver every matching event.
- **Rate-limit honesty.** Inline note that the field is *stored but not enforced
  yet* (backend persists `rateLimit` but no code reads it / sets `RATE_LIMITED`).
- **CEL help.** Fixed the placeholder from bare `affectedReleases` ->
  `event.affectedReleases` (only `event` is a top-level CEL var, so the old
  example would fail to compile), and added an examples hint
  (`event.severity`, `event.kevListed`, `size(event.affectedReleases)`).
- New `.field-hint` CSS class for the inline help text (follows the repo's
  existing per-context hint-class pattern, e.g. `.routes-hint`).

## Why
The subscription form let admins configure things that quietly do nothing (VEX
subs that never fire, a rate limit that isn't enforced) and showed a CEL example
that wouldn't compile. This erodes trust in the whole notifications surface.

## Verification
- `vitest run src/utils` green (29); `vite build` compiles.
- Live on the claude2 sandbox via hot-swap: new-subscription VEX renders
  greyed/disabled (hard-asserted `disabled:true` for VEX, `false` for the other
  7 options); all four hints render; dedup placeholder shows `Default: 1440
  (24h)`; CEL advanced view shows the corrected examples. Separately seeded a
  VEX subscription via GraphQL and confirmed the edit form shows a **removable**
  VEX tag (close "x" present), then deleted the seed. Screenshots in the task thread.
- Two-layer review gate: Layer 1 (correctness) + Layer 2 (ReARM conventions).
  Layer 2 flagged one U+2014 em-dash in a CSS comment (fixed). Layer 1 flagged
  the legacy-edit trap above, now fixed by the conditional-disable computed and
  re-verified live.
