### PR TITLE
Notifications: "View delivery log" failure-diagnosis deep-link from the inbox

### DIFF
--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -97,6 +97,12 @@ import {
 
 const props = defineProps<{
     orguuid: string
+    // Optional deep-link seeds (e.g. "View delivery log" from the inbox drawer
+    // or a channel card). Applied once to the filters on mount; the parent
+    // remounts this component when they change (keyed on the deep-link), so a
+    // fresh seed always takes effect. Manual filter changes are independent.
+    initialChannelUuid?: string | null
+    initialStatus?: string | null
 }>()
 
 const message = useMessage()
@@ -294,6 +300,10 @@ const deliveryColumns = computed(() => [
 ])
 
 onMounted(async () => {
+    // Seed filters from a deep-link BEFORE the first load so the initial
+    // query is already scoped (no flash of the full list, no extra fetch).
+    if (props.initialChannelUuid) historyFilters.value.channelUuid = props.initialChannelUuid
+    if (props.initialStatus) historyFilters.value.status = props.initialStatus
     // Channels + subscriptions feed the name-resolution maps; deliveries
     // is the actual table. Load all three in parallel.
     await Promise.all([loadChannels(), loadSubscriptions(), loadDeliveries()])

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -259,6 +259,13 @@
                         >
                             Mark unread
                         </n-button>
+                        <n-button
+                            v-if="isOrgAdmin && inboxDrawerRow.channelUuid"
+                            tertiary
+                            @click="viewDeliveryLog"
+                        >
+                            View delivery log
+                        </n-button>
                         <n-button @click="inboxDrawerOpen = false">Close</n-button>
                     </n-space>
                 </n-space>
@@ -276,7 +283,7 @@ import {
     NBadge, NTabs, NTabPane, useDialog, useMessage
 } from 'naive-ui'
 import { Bell, Check, Refresh } from '@vicons/tabler'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
@@ -292,6 +299,7 @@ const props = defineProps<{
     orguuid: string
 }>()
 
+const router = useRouter()
 const store = useStore()
 const dialog = useDialog()
 const message = useMessage()
@@ -606,6 +614,28 @@ async function loadInbox (): Promise<void> {
 function applyInboxFilters (): void {
     inboxPage.value = 1
     loadInbox()
+}
+
+// "View delivery log": jump from this inbox row to the Delivery History audit
+// surface pre-filtered to the row's channel, so a user going "my alert didn't
+// arrive -> why" lands on that channel's full send log. Failures open the log
+// filtered to FAILED. Admin-only (the Audit tab is admin-gated); the button is
+// hidden otherwise, and hidden for channel-less rows (targeted approvals).
+function viewDeliveryLog (): void {
+    const row = inboxDrawerRow.value
+    if (!row || !row.channelUuid) return
+    inboxDrawerOpen.value = false
+    inboxListDrawerOpen.value = false
+    router.push({
+        name: 'OrgSettings',
+        params: { orguuid: orgUuid.value },
+        query: {
+            tab: 'audit',
+            auditTab: 'deliveryHistory',
+            historyChannel: row.channelUuid,
+            ...(row.status === 'FAILED' ? { historyStatus: 'FAILED' } : {}),
+        },
+    })
 }
 
 function openInboxRow (row: InboxRow): void {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1071,7 +1071,12 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
                         <DownloadLogView />
                     </n-tab-pane>
                     <n-tab-pane name="deliveryHistory" tab="Delivery History" v-if="myUser.installationType !== 'OSS'">
-                        <NotificationHistory :orguuid="orgResolved" />
+                        <NotificationHistory
+                            :orguuid="orgResolved"
+                            :initial-channel-uuid="(route.query.historyChannel as string) || null"
+                            :initial-status="(route.query.historyStatus as string) || null"
+                            :key="`hist-${route.query.historyChannel || ''}-${route.query.historyStatus || ''}`"
+                        />
                     </n-tab-pane>
                 </n-tabs>
             </n-tab-pane>
@@ -1127,7 +1132,7 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
   
 <script lang="ts" setup>
 import { NSpace, NIcon, NCheckbox, NCheckboxGroup, NDropdown, NInput, NModal, NCard, NDataTable, NForm, NInputGroup, NButton, NFormItem, NSelect, NRadioGroup, NRadioButton, NTabs, NTabPane, NTooltip, NotificationType, useNotification, NFlex, NH5, NText, NGrid, NGi, DataTableColumns, NDynamicInput, NSwitch, NInputNumber, NAlert, NRadio, NDivider, NPopconfirm } from 'naive-ui'
-import { ComputedRef, h, ref, Ref, computed, onMounted, reactive } from 'vue'
+import { ComputedRef, h, ref, Ref, computed, onMounted, reactive, watch } from 'vue'
 import type { SelectOption } from 'naive-ui'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
@@ -1427,9 +1432,32 @@ const currentTab = ref(isTabAccessible(requestedTab) ? requestedTab : defaultTab
 // Default Policies sub-tab is approvalPoliciesInner (Approval Policies) — the
 // most common entry point. Approval Roles / Entries are configuration of
 // vocabulary used inside the policies.
-const policySubTab = ref(route.query.policyTab as string || 'approvalPoliciesInner')
+// Default sub-tabs, shared by the ref initializers and the query->tab sync
+// watch below so the fallbacks stay in one place.
+const DEFAULT_POLICY_SUBTAB = 'approvalPoliciesInner'
+const DEFAULT_AUDIT_SUBTAB = 'downloadLog'
+const policySubTab = ref(route.query.policyTab as string || DEFAULT_POLICY_SUBTAB)
 // Audit sub-tab: Download Log (all editions) + Delivery History (Pro).
-const auditSubTab = ref(route.query.auditTab as string || 'downloadLog')
+const auditSubTab = ref(route.query.auditTab as string || DEFAULT_AUDIT_SUBTAB)
+
+// Keep the tab selection in sync when the URL query changes while OrgSettings
+// stays mounted -- e.g. an in-app "View delivery log" deep-link pushing
+// ?tab=audit&auditTab=deliveryHistory from a child (channel card, subscription
+// row). Fresh navigations pick these up at setup; this covers same-page pushes,
+// which the setup-time reads would otherwise miss. Idempotent: each branch
+// no-ops when the value is unchanged, so a user's own handleTabSwitch push
+// doesn't double-load.
+watch(() => [route.query.tab, route.query.auditTab, route.query.policyTab], () => {
+    const t = (route.query.tab as string) || defaultTab
+    if (isTabAccessible(t) && t !== currentTab.value) {
+        currentTab.value = t
+        loadTabSpecificData(t)
+    }
+    const at = (route.query.auditTab as string) || DEFAULT_AUDIT_SUBTAB
+    if (at !== auditSubTab.value) auditSubTab.value = at
+    const pt = (route.query.policyTab as string) || DEFAULT_POLICY_SUBTAB
+    if (pt !== policySubTab.value) policySubTab.value = pt
+})
 
 const approvalRoleFields: any[] = [
     {


### PR DESCRIPTION
## What

First increment of the notifications **failure-diagnosis UX** (task
`-24912`): a "View delivery log" deep-link so a user going *"my alert didn't
arrive -> why?"* can jump straight from an inbox notification to that channel's
full delivery log.

### Changes
- **`NotificationInbox.vue`** (the global TopNavBar bell): the row-detail drawer
  gets a **"View delivery log"** button. It `router.push`-es to
  `OrgSettings -> Audit -> Delivery History` pre-filtered to the row's channel,
  and to `status=FAILED` when the delivery failed (so it opens on the relevant
  rows). Shown only to org admins (the Audit tab is admin-gated) and only for
  channel-bound rows (hidden for targeted approval/Direct rows).
- **`OrgSettings.vue`**: a `watch` keeps the tab selection in sync when the URL
  query changes while OrgSettings stays mounted -- needed because the bell is
  global, so "View delivery log" is often a *same-page* navigation. It also
  fixes latent browser back/forward tab desync (tabs are now truly URL-driven).
  Passes `initial-channel-uuid`/`initial-status` (+ a `:key`) to
  `NotificationHistory` from the route query.
- **`NotificationHistory.vue`**: optional `initialChannelUuid`/`initialStatus`
  props, seeded into the filters on mount *before* the first load (no full-list
  flash, no extra fetch). Uses only filters the backend already supports
  (`channelUuid`, `status`).

## Why
Diagnosis was a dead-end: the delivery log lives under a different top-level tab
(OrgSettings Audit) from where notifications surface (the bell / Integrations),
with no path between them. This wires the primary journey.

## Verification
- `vite build` compiles.
- Live on the claude2 sandbox via hot-swap, both ends:
  - **Receiving:** navigating `?tab=audit&auditTab=deliveryHistory&historyChannel=<uuid>&historyStatus=FAILED`
    lands on Delivery History with Channel = "SOC Workspace" and Status = FAILED
    pre-applied (screenshot in task thread).
  - **Sending:** the inbox drawer's "View delivery log" button navigates to
    `?tab=audit&auditTab=deliveryHistory&historyChannel=<uuid>` (and correctly
    omits `historyStatus` for a non-failed row).
- Two-layer review gate (Layer 1 correctness + Layer 2 ReARM conventions).

## Scope / follow-up (`-26317`)
Deliberately scoped to the keystone inbox deep-link. Deferred to a coordinated
backend+UI follow-up (needs backend work, pairs with #273's `disabledReason`):
- **Subscription** "View deliveries" -- needs a `subscriptionUuid` filter on the
  `notificationDeliveries` query (not present today).
- **Channel-card** "View deliveries" -- needs a uuid resolver for the
  single-instance (Slack/Teams) card layout.
- Distinguishing **deleted vs disabled/misconfigured** in the channel label --
  needs `isEnabled`/`disabledReason` carried on inbox/history channel resolution
  (`NotificationDataFetcher` resolves name only today).
