### PR TITLE
Notifications: card-style inbox rows (#29)

### DIFF
--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -108,9 +108,13 @@
                             v-for="c in inboxCards"
                             :key="c.row.uuid"
                             class="inbox-card"
-                            :class="{ unread: !c.row.readAt }"
+                            :class="{ unread: !c.row.readAt, read: !!c.row.readAt }"
                             data-testid="inbox-row"
                         >
+                            <!-- Left rail always signals: severity colour (canonical
+                                 vuln palette) for vuln/vex rows, neutral grey for
+                                 lifecycle (release/approval) rows. -->
+                            <span class="inbox-rail" :style="{ backgroundColor: c.rail }"></span>
                             <div class="inbox-card-select">
                                 <n-checkbox
                                     v-if="!c.row.readAt"
@@ -121,6 +125,7 @@
                             </div>
                             <div class="inbox-card-main">
                                 <div class="inbox-card-head">
+                                    <span v-if="!c.row.readAt" class="inbox-unread-dot" aria-hidden="true"></span>
                                     <button
                                         type="button"
                                         class="inbox-message-link"
@@ -129,52 +134,60 @@
                                     >
                                         <span class="inbox-message-title" data-testid="inbox-message-title">{{ c.title }}</span>
                                     </button>
-                                    <div class="inbox-card-tags">
-                                        <!-- Severity is optional (release/approval events carry none):
-                                             the card omits the tag entirely rather than showing an
-                                             empty-cell em-dash, so the inbox-cell-severity testid is
-                                             present iff the row has a severity. -->
-                                        <n-tag
-                                            v-if="c.row.severity"
-                                            :type="severityTagType(c.row.severity)"
-                                            size="small"
-                                            data-testid="inbox-cell-severity"
-                                        >{{ c.row.severity }}</n-tag>
-                                        <n-tag
-                                            :type="deliveryStatusTagType(c.row.status)"
-                                            size="small"
-                                            data-testid="inbox-cell-status"
-                                        >{{ c.row.status }}</n-tag>
-                                    </div>
+                                    <!-- Severity tag when the row has one; otherwise a neutral
+                                         kind pill (RELEASE/APPROVAL/...) so the head always
+                                         carries a category. inbox-cell-severity is present iff
+                                         the row has a severity. -->
+                                    <n-tag
+                                        v-if="c.row.severity"
+                                        :type="severityTagType(c.row.severity)"
+                                        size="small"
+                                        :bordered="false"
+                                        data-testid="inbox-cell-severity"
+                                    >{{ c.row.severity }}</n-tag>
+                                    <n-tag
+                                        v-else
+                                        size="small"
+                                        :bordered="false"
+                                        class="inbox-kind-tag"
+                                        data-testid="inbox-cell-kind"
+                                    >{{ c.kind }}</n-tag>
                                 </div>
                                 <div v-if="c.row.description" class="inbox-message-desc muted-12">{{ c.row.description }}</div>
-                                <div class="inbox-card-meta muted-12">
-                                    <span data-testid="inbox-cell-channel">
-                                        <span :class="{ 'muted-12': c.channel.muted }" :title="c.channel.title">{{ c.channel.text }}</span>
-                                    </span>
+                                <div class="inbox-card-sub">
+                                    <n-tag
+                                        :type="deliveryStatusTagType(c.row.status)"
+                                        size="small"
+                                        :bordered="false"
+                                        data-testid="inbox-cell-status"
+                                    >{{ c.row.status }}</n-tag>
                                     <span class="inbox-meta-sep">&middot;</span>
-                                    <span data-testid="inbox-cell-when">{{ formatHistoryTimestamp(c.row.sentAt || c.row.createdDate) }}</span>
-                                    <span class="inbox-card-actions">
-                                        <n-button
-                                            v-if="!c.row.readAt"
-                                            size="tiny"
-                                            secondary
-                                            type="primary"
-                                            :disabled="!canWrite"
-                                            @click="markRowRead(c.row)"
-                                        >
-                                            <template #icon><n-icon><Check /></n-icon></template>
-                                            Mark read
-                                        </n-button>
-                                        <n-button
-                                            v-else
-                                            size="tiny"
-                                            secondary
-                                            :disabled="!canWrite"
-                                            @click="markRowUnread(c.row)"
-                                        >Unread</n-button>
-                                    </span>
+                                    <span
+                                        data-testid="inbox-cell-channel"
+                                        :class="['inbox-chan', { fail: c.failed, 'muted-12': !c.failed && c.channel.muted }]"
+                                        :title="c.channel.title"
+                                    >{{ c.channel.text }}</span>
+                                    <span v-if="c.failed" class="inbox-fail-note">&mdash; message was not delivered</span>
                                 </div>
+                            </div>
+                            <div class="inbox-card-side">
+                                <span class="inbox-time muted-12" data-testid="inbox-cell-when" :title="c.timeAbs">{{ c.timeRel }}</span>
+                                <n-button
+                                    v-if="!c.row.readAt"
+                                    class="inbox-mark-read"
+                                    size="tiny"
+                                    tertiary
+                                    type="primary"
+                                    :disabled="!canWrite"
+                                    @click="markRowRead(c.row)"
+                                >Mark read</n-button>
+                                <n-button
+                                    v-else
+                                    size="tiny"
+                                    quaternary
+                                    :disabled="!canWrite"
+                                    @click="markRowUnread(c.row)"
+                                >Unread</n-button>
                             </div>
                         </div>
                     </div>
@@ -367,10 +380,11 @@ import { useStore } from 'vuex'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
+import constants from '@/utils/constants'
 import {
     InboxRow, deliveryStatusOptions, eventTypeOptions,
     deliveryStatusTagType, severityTagType,
-    formatHistoryTimestamp, extractError
+    formatHistoryTimestamp, relativeTime, extractError
 } from '@/utils/notificationsCommon'
 import { loadNotificationInboxPage } from '@/utils/notificationInboxQuery'
 
@@ -900,16 +914,51 @@ function channelLabel (row: InboxRow | null): { text: string, muted: boolean, ti
 
 const drawerChannel = computed(() => channelLabel(inboxDrawerRow.value))
 
+// Neutral grey rail for rows with no severity (release/approval lifecycle
+// events) -- a UI accent, not a severity, so it stays out of the vuln palette.
+const RAIL_KIND_COLOR = '#c9ccd4'
+
+// Left-rail colour from the canonical severity palette (constants.Vulnerability-
+// Colors, shared with the vuln charts / PDF export) so severity reads the same
+// hue here as everywhere else; grey for lifecycle rows so the rail always signals.
+function railColor (severity: string | null): string {
+    if (!severity) return RAIL_KIND_COLOR
+    return (constants.VulnerabilityColors as Record<string, string>)[severity] || RAIL_KIND_COLOR
+}
+
+// Neutral kind pill shown in place of a severity tag for events that carry no
+// severity, so the head line always names the category.
+function kindLabel (eventType: string | null): string {
+    if (!eventType) return 'EVENT'
+    if (eventType.startsWith('RELEASE')) return 'RELEASE'
+    if (eventType.startsWith('APPROVAL')) return 'APPROVAL'
+    if (eventType.startsWith('VEX')) return 'VEX'
+    if (eventType.includes('VULN')) return 'VULN'
+    return 'EVENT'
+}
+
 // Card-list view model. Resolve each row's display title (server title, else
-// the event-type label, else a placeholder) and channel label ONCE here so the
-// template renders straight fields instead of recomputing per binding.
-const inboxCards = computed(() => inboxItems.value.map(row => ({
-    row,
-    title: row.title || (row.eventType
-        ? row.eventType.replace(/_/g, ' ').toLowerCase()
-        : '(no content)'),
-    channel: channelLabel(row),
-})))
+// the event-type label, else a placeholder), channel label, rail colour, kind
+// pill, and failed-delivery flag ONCE here so the template renders straight
+// fields instead of recomputing per binding.
+const inboxCards = computed(() => inboxItems.value.map(row => {
+    const ts = row.sentAt || row.createdDate
+    return {
+        row,
+        title: row.title || (row.eventType
+            ? row.eventType.replace(/_/g, ' ').toLowerCase()
+            : '(no content)'),
+        channel: channelLabel(row),
+        rail: railColor(row.severity),
+        kind: row.severity ? null : kindLabel(row.eventType),
+        // FAILED = the delivery didn't reach the channel; surfaced inline so a
+        // "why didn't my alert arrive" scan lands immediately.
+        failed: row.status === 'FAILED',
+        // Relative time for the scan; absolute timestamp shown on hover.
+        timeRel: relativeTime(ts),
+        timeAbs: formatHistoryTimestamp(ts),
+    }
+}))
 
 // Selection is a plain uuid array (was n-data-table checked-row-keys). Only
 // unread cards render a checkbox, mirroring the old selection-column disable.
@@ -1088,30 +1137,57 @@ onUnmounted(() => {
 .inbox-empty { padding: 24px 4px; text-align: center; }
 .inbox-card {
     display: flex;
+    align-items: stretch;
     gap: 10px;
-    padding: 12px 6px 12px 9px;
+    padding: 12px 4px 12px 0;
     border-bottom: 1px solid var(--n-border-color, #efeff5);
-    border-left: 3px solid transparent;
 }
-/* Unread rows get a left accent + faint tint so the triage queue reads at a
- * glance; read rows sit flat and slightly muted. */
-.inbox-card.unread {
-    border-left-color: var(--n-color-primary, #2080f0);
-    background: var(--inbox-unread-bg, rgba(32, 128, 240, 0.045));
-}
+.inbox-card:hover { background: var(--inbox-hover-bg, rgba(32, 128, 240, 0.035)); }
+/* Unread rows get a faint tint + bolder title so the triage queue reads at a
+ * glance; read rows sit flat and slightly muted. The left rail (below) carries
+ * the severity/kind colour independent of read state. */
+.inbox-card.unread { background: var(--inbox-unread-bg, rgba(32, 128, 240, 0.03)); }
 .inbox-card.unread .inbox-message-title { font-weight: 600; }
-.inbox-card:not(.unread) .inbox-message-title {
+.inbox-card.read .inbox-message-title {
     font-weight: 400;
     color: var(--n-text-color-2, #666);
 }
-.inbox-card-select { flex: 0 0 auto; width: 22px; padding-top: 2px; }
+
+/* Left rail: 4px severity/kind colour bar. Colour is bound inline from the
+ * shared severity palette (constants.VulnerabilityColors) via :style. */
+.inbox-rail { flex: 0 0 4px; width: 4px; border-radius: 2px; align-self: stretch; }
+
+.inbox-card-select { flex: 0 0 auto; width: 20px; padding-top: 2px; }
 .inbox-card-main { flex: 1 1 auto; min-width: 0; }
-.inbox-card-head { display: flex; align-items: flex-start; gap: 8px; }
+.inbox-card-head { display: flex; align-items: center; gap: 8px; }
 .inbox-card-head .inbox-message-link { flex: 1 1 auto; min-width: 0; }
-.inbox-card-tags { display: flex; flex: 0 0 auto; gap: 5px; align-items: center; }
-.inbox-card-meta { display: flex; align-items: center; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
+.inbox-unread-dot {
+    flex: 0 0 8px;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--n-color-primary, #2080f0);
+}
+.inbox-kind-tag { font-weight: 600; letter-spacing: 0.04em; }
+
+/* Sub-line: status pill, channel, and (on failure) an inline not-delivered
+ * note so a missed alert is obvious without opening the row. */
+.inbox-card-sub { display: flex; align-items: center; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
 .inbox-meta-sep { opacity: 0.5; }
-.inbox-card-actions { margin-left: auto; }
+.inbox-chan.fail { color: #d03050; font-weight: 600; }
+.inbox-fail-note { color: #d03050; font-size: 12px; }
+
+/* Right column: timestamp over the per-row read/unread action. */
+.inbox-card-side {
+    flex: 0 0 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 6px;
+    padding-top: 1px;
+}
+.inbox-time { white-space: nowrap; }
+.inbox-card.unread .inbox-time { color: var(--n-text-color-2, #606266); font-weight: 600; }
 
 /* Inbox drawer — payload viewer. Monospace + wrap-on-word so a deeply-nested
  * JSON doesn't blow the drawer's horizontal extent. */

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -90,16 +90,95 @@
                     Some inbox details are unavailable on this server version, so a few columns (such as channel name) may be missing. Your notifications are shown below.
                 </n-alert>
 
-                <n-data-table
-                    :data="inboxItems"
-                    :columns="inboxColumns"
-                    :loading="inboxLoading"
-                    :single-line="false"
-                    :bordered="false"
-                    :scroll-x="1000"
-                    :row-key="(row) => row.uuid"
-                    v-model:checked-row-keys="selectedInboxRows"
-                />
+                <!-- Card-style rows (replaces the old 7-column data-table that
+                     overflowed the drawer): title + severity/status tags on top,
+                     description below, then a compact channel-dot-time meta line.
+                     Unread rows carry a left accent + selection checkbox for the
+                     bulk mark-read action. -->
+                <n-spin :show="inboxLoading">
+                    <div class="inbox-list" data-testid="inbox-list">
+                        <div
+                            v-if="inboxCards.length === 0 && !inboxLoading"
+                            class="inbox-empty muted-12"
+                            data-testid="inbox-empty"
+                        >
+                            {{ inboxUnreadOnly ? 'No unread notifications.' : 'No notifications to show.' }}
+                        </div>
+                        <div
+                            v-for="c in inboxCards"
+                            :key="c.row.uuid"
+                            class="inbox-card"
+                            :class="{ unread: !c.row.readAt }"
+                            data-testid="inbox-row"
+                        >
+                            <div class="inbox-card-select">
+                                <n-checkbox
+                                    v-if="!c.row.readAt"
+                                    :checked="selectedInboxRows.includes(c.row.uuid)"
+                                    :disabled="!canWrite"
+                                    @update:checked="(v) => toggleInboxSelect(c.row.uuid, v)"
+                                />
+                            </div>
+                            <div class="inbox-card-main">
+                                <div class="inbox-card-head">
+                                    <button
+                                        type="button"
+                                        class="inbox-message-link"
+                                        data-testid="inbox-message-link"
+                                        @click="openInboxRow(c.row)"
+                                    >
+                                        <span class="inbox-message-title" data-testid="inbox-message-title">{{ c.title }}</span>
+                                    </button>
+                                    <div class="inbox-card-tags">
+                                        <!-- Severity is optional (release/approval events carry none):
+                                             the card omits the tag entirely rather than showing an
+                                             empty-cell em-dash, so the inbox-cell-severity testid is
+                                             present iff the row has a severity. -->
+                                        <n-tag
+                                            v-if="c.row.severity"
+                                            :type="severityTagType(c.row.severity)"
+                                            size="small"
+                                            data-testid="inbox-cell-severity"
+                                        >{{ c.row.severity }}</n-tag>
+                                        <n-tag
+                                            :type="deliveryStatusTagType(c.row.status)"
+                                            size="small"
+                                            data-testid="inbox-cell-status"
+                                        >{{ c.row.status }}</n-tag>
+                                    </div>
+                                </div>
+                                <div v-if="c.row.description" class="inbox-message-desc muted-12">{{ c.row.description }}</div>
+                                <div class="inbox-card-meta muted-12">
+                                    <span data-testid="inbox-cell-channel">
+                                        <span :class="{ 'muted-12': c.channel.muted }" :title="c.channel.title">{{ c.channel.text }}</span>
+                                    </span>
+                                    <span class="inbox-meta-sep">&middot;</span>
+                                    <span data-testid="inbox-cell-when">{{ formatHistoryTimestamp(c.row.sentAt || c.row.createdDate) }}</span>
+                                    <span class="inbox-card-actions">
+                                        <n-button
+                                            v-if="!c.row.readAt"
+                                            size="tiny"
+                                            secondary
+                                            type="primary"
+                                            :disabled="!canWrite"
+                                            @click="markRowRead(c.row)"
+                                        >
+                                            <template #icon><n-icon><Check /></n-icon></template>
+                                            Mark read
+                                        </n-button>
+                                        <n-button
+                                            v-else
+                                            size="tiny"
+                                            secondary
+                                            :disabled="!canWrite"
+                                            @click="markRowUnread(c.row)"
+                                        >Unread</n-button>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </n-spin>
 
                 <div v-if="inboxTotalCount > inboxPageSize" class="history-pagination">
                     <n-pagination
@@ -280,7 +359,7 @@ import {
     NDrawer, NDrawerContent, NDataTable, NButton, NIcon, NSpace, NGrid, NGi,
     NFormItem, NSelect, NRadioGroup, NRadioButton, NPagination, NTag,
     NDescriptions, NDescriptionsItem, NAlert, NCollapse, NCollapseItem,
-    NBadge, NTabs, NTabPane, useDialog, useMessage
+    NBadge, NTabs, NTabPane, NCheckbox, NSpin, useDialog, useMessage
 } from 'naive-ui'
 import { Bell, Check, Refresh } from '@vicons/tabler'
 import { RouterLink, useRouter } from 'vue-router'
@@ -656,6 +735,10 @@ async function markRowRead (row: InboxRow): Promise<void> {
         // Optimistic update — patch the row in place rather than reload.
         const idx = inboxItems.value.findIndex(r => r.uuid === row.uuid)
         if (idx >= 0) inboxItems.value[idx].readAt = readAt
+        // A read row drops its selection checkbox (v-if unread), so prune it
+        // from the pending bulk set too -- otherwise its uuid would linger and
+        // keep the "Mark N read" count inflated in the all-visible view.
+        selectedInboxRows.value = selectedInboxRows.value.filter(u => u !== row.uuid)
         if (inboxUnreadCount.value > 0) inboxUnreadCount.value -= 1
         if (inboxUnreadOnly.value) {
             inboxItems.value = inboxItems.value.filter(r => r.uuid !== row.uuid)
@@ -817,106 +900,26 @@ function channelLabel (row: InboxRow | null): { text: string, muted: boolean, ti
 
 const drawerChannel = computed(() => channelLabel(inboxDrawerRow.value))
 
-const inboxColumns = computed(() => [
-    {
-        type: 'selection' as const,
-        // Selection cell only meaningful for unread rows — read rows can't
-        // be re-marked-read.
-        disabled: (row: InboxRow) => !!row.readAt,
-    },
-    {
-        title: 'When', key: 'when', width: 170,
-        render: (row: InboxRow) => h(
-            'span',
-            { 'data-testid': 'inbox-cell-when' },
-            formatHistoryTimestamp(row.sentAt || row.createdDate),
-        ),
-    },
-    {
-        title: 'Status', key: 'status', width: 110,
-        render: (row: InboxRow) => h(
-            NTag,
-            { type: deliveryStatusTagType(row.status), size: 'small', 'data-testid': 'inbox-cell-status' },
-            { default: () => row.status },
-        ),
-    },
-    {
-        title: 'Message', key: 'message', minWidth: 220,
-        render: (row: InboxRow) => {
-            // The Message cell is the click target that opens the inbox
-            // drawer. Title is bold; description sits below as muted helper
-            // text. Fallback to the eventType label when the server-rendered
-            // title is null (malformed payload path).
-            const titleText = row.title || (row.eventType
-                ? row.eventType.replace(/_/g, ' ').toLowerCase()
-                : '(no content)')
-            const description = row.description
-            // <button type="button">, not <a href="#">. The cell is an
-            // action (open drawer), not navigation — anchor semantics would
-            // mis-announce as "link" to screen readers.
-            return h(
-                'button',
-                {
-                    type: 'button',
-                    class: 'inbox-message-link',
-                    'data-testid': 'inbox-message-link',
-                    onClick: () => openInboxRow(row),
-                },
-                {
-                    default: () => [
-                        h('div', { class: 'inbox-message-title' }, titleText),
-                        description
-                            ? h('div', { class: 'inbox-message-desc muted-12' }, description)
-                            : null,
-                    ],
-                },
-            )
-        },
-    },
-    {
-        title: 'Severity', key: 'severity', width: 110,
-        render: (row: InboxRow) => row.severity
-            ? h(
-                NTag,
-                { type: severityTagType(row.severity), size: 'small', 'data-testid': 'inbox-cell-severity' },
-                { default: () => row.severity },
-            )
-            : h('span', { class: 'muted-12', 'data-testid': 'inbox-cell-severity' }, '—'),
-    },
-    {
-        title: 'Channel', key: 'channelUuid', width: 150,
-        // Null channel = Phase 4a targeted delivery (personal inbox copy,
-        // no transmission channel) — not a deleted channel. channelName is
-        // resolved server-side and rides along on the row, so no admin-only
-        // channel-list fetch is needed; a null name on a real channelUuid
-        // means the channel was deleted.
-        render: (row: InboxRow) => {
-            const { text, muted, title } = channelLabel(row)
-            return h('span', { 'data-testid': 'inbox-cell-channel' },
-                [muted ? h('span', { class: 'muted-12', title }, text) : text])
-        },
-    },
-    {
-        title: 'Read', key: 'readAt', width: 200,
-        render: (row: InboxRow) => row.readAt
-            ? h(NSpace, { size: 'small', align: 'center' }, {
-                default: () => [
-                    h('span', { class: 'muted-12' }, formatHistoryTimestamp(row.readAt)),
-                    h(NButton, {
-                        size: 'tiny', secondary: true,
-                        onClick: () => markRowUnread(row),
-                        disabled: !canWrite.value,
-                        title: 'Mark unread',
-                    }, { default: () => 'Unread' }),
-                ],
-            })
-            : h(NButton, {
-                size: 'tiny', secondary: true, type: 'primary',
-                onClick: () => markRowRead(row),
-                disabled: !canWrite.value,
-            }, { icon: () => h(NIcon, null, { default: () => h(Check) }), default: () => 'Mark read' }),
-    },
-])
+// Card-list view model. Resolve each row's display title (server title, else
+// the event-type label, else a placeholder) and channel label ONCE here so the
+// template renders straight fields instead of recomputing per binding.
+const inboxCards = computed(() => inboxItems.value.map(row => ({
+    row,
+    title: row.title || (row.eventType
+        ? row.eventType.replace(/_/g, ' ').toLowerCase()
+        : '(no content)'),
+    channel: channelLabel(row),
+})))
+
+// Selection is a plain uuid array (was n-data-table checked-row-keys). Only
+// unread cards render a checkbox, mirroring the old selection-column disable.
+function toggleInboxSelect (uuid: string, checked: boolean): void {
+    if (checked) {
+        if (!selectedInboxRows.value.includes(uuid)) selectedInboxRows.value.push(uuid)
+    } else {
+        selectedInboxRows.value = selectedInboxRows.value.filter(u => u !== uuid)
+    }
+}
 
 // Deep-link navigation target sits behind the 760px drawer — close it on
 // click or the user lands on a page they can't see.
@@ -1070,13 +1073,45 @@ onUnmounted(() => {
     max-width: 100%;
 }
 .inbox-message-desc {
-    margin-top: 2px;
-    line-height: 1.3;
+    margin-top: 3px;
+    line-height: 1.35;
+    /* Two-line clamp in the card layout -- enough to preview the event without
+     * letting a long description dominate the row. */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 100%;
 }
+
+/* --- Card-style inbox rows (replaces the old overflowing data-table) ------ */
+.inbox-list { display: flex; flex-direction: column; }
+.inbox-empty { padding: 24px 4px; text-align: center; }
+.inbox-card {
+    display: flex;
+    gap: 10px;
+    padding: 12px 6px 12px 9px;
+    border-bottom: 1px solid var(--n-border-color, #efeff5);
+    border-left: 3px solid transparent;
+}
+/* Unread rows get a left accent + faint tint so the triage queue reads at a
+ * glance; read rows sit flat and slightly muted. */
+.inbox-card.unread {
+    border-left-color: var(--n-color-primary, #2080f0);
+    background: var(--inbox-unread-bg, rgba(32, 128, 240, 0.045));
+}
+.inbox-card.unread .inbox-message-title { font-weight: 600; }
+.inbox-card:not(.unread) .inbox-message-title {
+    font-weight: 400;
+    color: var(--n-text-color-2, #666);
+}
+.inbox-card-select { flex: 0 0 auto; width: 22px; padding-top: 2px; }
+.inbox-card-main { flex: 1 1 auto; min-width: 0; }
+.inbox-card-head { display: flex; align-items: flex-start; gap: 8px; }
+.inbox-card-head .inbox-message-link { flex: 1 1 auto; min-width: 0; }
+.inbox-card-tags { display: flex; flex: 0 0 auto; gap: 5px; align-items: center; }
+.inbox-card-meta { display: flex; align-items: center; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
+.inbox-meta-sep { opacity: 0.5; }
+.inbox-card-actions { margin-left: auto; }
 
 /* Inbox drawer — payload viewer. Monospace + wrap-on-word so a deeply-nested
  * JSON doesn't blow the drawer's horizontal extent. */

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// notificationsCommon imports commonFunctions, which pulls in the graphql
+// client + keycloak init as an import side effect. Stub it so this pure-helper
+// spec doesn't boot keycloak; relativeTime only needs dateDisplay for its
+// past-30d absolute fallback.
+vi.mock('@/utils/commonFunctions', () => ({
+    default: { dateDisplay: (s: string) => `ABS:${s}` },
+}))
+
+import { relativeTime } from './notificationsCommon'
+
+// relativeTime is a pure function with an injectable `now`, so these are
+// deterministic (no dependence on the wall clock).
+describe('relativeTime', () => {
+    const now = Date.parse('2026-07-08T12:00:00Z')
+    const ago = (ms: number) => new Date(now - ms).toISOString()
+    const SEC = 1000, MIN = 60 * SEC, HR = 60 * MIN, DAY = 24 * HR
+
+    it('returns empty string for null/blank/invalid input', () => {
+        expect(relativeTime(null, now)).toBe('')
+        expect(relativeTime('', now)).toBe('')
+        expect(relativeTime('not-a-date', now)).toBe('')
+    })
+
+    it('reads sub-minute (and future/skew) as "just now"', () => {
+        expect(relativeTime(ago(0), now)).toBe('just now')
+        expect(relativeTime(ago(59 * SEC), now)).toBe('just now')
+        expect(relativeTime(new Date(now + 5 * MIN).toISOString(), now)).toBe('just now')
+    })
+
+    it('formats minutes, hours, and days', () => {
+        expect(relativeTime(ago(MIN), now)).toBe('1m ago')
+        expect(relativeTime(ago(59 * MIN), now)).toBe('59m ago')
+        expect(relativeTime(ago(HR), now)).toBe('1h ago')
+        expect(relativeTime(ago(23 * HR), now)).toBe('23h ago')
+        expect(relativeTime(ago(DAY), now)).toBe('1d ago')
+        expect(relativeTime(ago(29 * DAY), now)).toBe('29d ago')
+    })
+
+    it('falls back to an absolute date past ~30 days', () => {
+        const out = relativeTime(ago(40 * DAY), now)
+        expect(out).not.toMatch(/ago$/)
+        expect(out.length).toBeGreaterThan(0)
+    })
+})

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -221,6 +221,26 @@ export function formatHistoryTimestamp (s: string | null): string {
     try { return commonFunctions.dateDisplay(s) } catch { return s }
 }
 
+// Compact relative time for the inbox triage list: "just now", "5m ago",
+// "3h ago", "2d ago". Past ~30 days it falls back to the absolute date so
+// ancient rows stay legible. Call sites show the absolute timestamp on hover
+// (title attr). nowMs is injectable so the pure function stays unit-testable.
+export function relativeTime (s: string | null, nowMs: number = Date.now()): string {
+    if (!s) return ''
+    const t = new Date(s).getTime()
+    if (isNaN(t)) return ''
+    const sec = Math.floor((nowMs - t) / 1000)
+    // Clock skew / future-dated rows read as "just now" rather than negatives.
+    if (sec < 60) return 'just now'
+    const min = Math.floor(sec / 60)
+    if (min < 60) return `${min}m ago`
+    const hr = Math.floor(min / 60)
+    if (hr < 24) return `${hr}h ago`
+    const day = Math.floor(hr / 24)
+    if (day < 30) return `${day}d ago`
+    return formatHistoryTimestamp(s)
+}
+
 export function truncate (s: string | null, n: number): string {
     if (!s) return ''
     return s.length > n ? `${s.slice(0, n - 1)}…` : s


### PR DESCRIPTION
## What
Redesign the notification inbox list from a dense 7-column `n-data-table` into **card-style rows** (task `#29` / `-16452`), then refined into a Claude-designed "blend" with a live design pass.

**Before:** 7 columns (When | Status | Message | Severity | Channel | Read) in a 760px drawer -> Channel and Read columns clipped off the right edge.

**After — one card per notification:**
- **Left severity rail**, colored from the canonical palette (`constants.VulnerabilityColors`, shared with the vuln charts / PDF export) so severity reads the same hue app-wide; neutral grey rail for lifecycle rows so the rail always signals.
- **Unread dot** + bold title + faint tint; read rows flat + muted.
- **Severity tag** when present; otherwise a neutral **kind pill** (`RELEASE` / `APPROVAL` / `VEX` / `VULN`) so the head always names a category.
- **Sub-line**: `status · channel`, and for **FAILED** rows the channel goes red with an inline **"message was not delivered"** cue (pairs with the failure-diagnosis deep-link, #173).
- **Relative timestamps** (`just now` / `Xm` / `Xh` / `Xd ago`, absolute date past ~30d) with the exact timestamp on hover.

## Implementation
- Removed `inboxColumns` (h()-render defs) + `<n-data-table>`; `v-for` card list over an `inboxCards` computed (`{ row, title, channel, rail, kind, failed, timeRel, timeAbs }`).
- Selection moved from `checked-row-keys` to a `string[]` + `toggleInboxSelect`; a just-read row is pruned from the pending selection.
- New shared, unit-tested `relativeTime()` in `notificationsCommon` (4 vitest cases) — History can reuse it.
- Preserved every `data-testid` the harness uses (`inbox-message-link/title`, conditional `inbox-cell-severity`, `inbox-cell-status/channel/when`); added `inbox-row/inbox-list/inbox-empty/inbox-cell-kind`.

## Harness
Companion PR **relizaio/rearm-playwright#5** re-points `InboxDrawer.ts` + `inbox.spec.ts` at the card DOM. The design refinement kept all those testids, so #5 needs no further change (A5's "no severity tag on RELEASE rows" still holds — those rows now carry the kind pill). Coordinated with claude1 (harness owner).

## Verification
- `vite build` clean; util tests 33/33 (incl. the 4 relativeTime cases).
- Live on the claude2 sandbox across CRITICAL/HIGH/read/failed/lifecycle rows (before/after + iteration screenshots in the task thread); functional check green (checkbox -> "Mark N read", title -> detail drawer, all testids present).
- Two-layer review gate passed on both the base redesign and the refinement (Layer 1: no correctness bugs; Layer 2: the one palette finding resolved by reusing `constants.VulnerabilityColors`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)