### PR TITLE
Notifications: schema-drift fallback for subscriptions, groups, approvals lists

### DIFF
--- a/ui/src/components/ChannelGroupsOfOrg.vue
+++ b/ui/src/components/ChannelGroupsOfOrg.vue
@@ -15,6 +15,16 @@
             </n-button>
         </div>
 
+        <n-alert
+            v-if="channelGroupsDegraded"
+            type="warning"
+            :show-icon="false"
+            style="margin-bottom: 12px;"
+            data-testid="groups-degraded-alert"
+        >
+            Some group details are unavailable on this server version, so a few columns (such as created/updated dates) may be missing. Your channel groups are shown below.
+        </n-alert>
+
         <n-data-table
             :data="channelGroups"
             :columns="channelGroupColumns"
@@ -84,8 +94,9 @@ import { CirclePlus, Trash, Edit as EditIcon } from '@vicons/tabler'
 import graphqlClient from '@/utils/graphql'
 import {
     ChannelRow, ChannelGroupRow, TYPE_LABELS, LIST_CHANNELS_QUERY,
-    LIST_GROUPS_QUERY, extractError, isConflictError, formatHistoryTimestamp
+    LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY, extractError, isConflictError, formatHistoryTimestamp
 } from '@/utils/notificationsCommon'
+import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 import gql from 'graphql-tag'
 
 const props = defineProps<{
@@ -113,6 +124,9 @@ function freshGroupForm (): ChannelGroupForm {
 const channels = ref<ChannelRow[]>([])
 const channelGroups = ref<ChannelGroupRow[]>([])
 const channelGroupsLoading = ref<boolean>(false)
+// True when the backend rejected the full group selection and we fell back to
+// core fields (created/updated columns may be absent) -- see PR #169 pattern.
+const channelGroupsDegraded = ref<boolean>(false)
 const showGroupModal = ref<boolean>(false)
 const savingGroup = ref<boolean>(false)
 const groupModalError = ref<string>('')
@@ -155,13 +169,16 @@ async function loadChannels (): Promise<void> {
 async function loadChannelGroups (): Promise<void> {
     channelGroupsLoading.value = true
     try {
-        const res = await graphqlClient.query({
-            query: LIST_GROUPS_QUERY,
+        const { data, degraded } = await loadWithSchemaDriftFallback(graphqlClient, {
+            fullQuery: LIST_GROUPS_QUERY,
+            coreQuery: LIST_GROUPS_CORE_QUERY,
             variables: { orgUuid: orgUuid.value },
-            fetchPolicy: 'network-only',
+            extractPath: (d: any) => d?.notificationChannelGroups,
         })
-        channelGroups.value = res.data?.notificationChannelGroups || []
+        channelGroups.value = data || []
+        channelGroupsDegraded.value = degraded
     } catch (e: any) {
+        channelGroupsDegraded.value = false
         message.error(`Failed to load channel groups: ${extractError(e)}`)
     } finally {
         channelGroupsLoading.value = false

--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -90,7 +90,7 @@ import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 import {
     ChannelRow, SubscriptionRow, DeliveryRow, TYPE_LABELS,
     deliveryStatusOptions, deliveryOriginOptions,
-    LIST_CHANNELS_QUERY, LIST_SUBSCRIPTIONS_QUERY,
+    LIST_CHANNELS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
     deliveryStatusTagType, formatHistoryTimestamp, truncate,
     buildNameMap, extractError
 } from '@/utils/notificationsCommon'
@@ -186,8 +186,10 @@ async function loadChannels (): Promise<void> {
 
 async function loadSubscriptions (): Promise<void> {
     try {
+        // History only needs subscription names (uuid -> name map), so the CORE
+        // query is enough and can't drift on the Pro-ahead config fields.
         const res = await graphqlClient.query({
-            query: LIST_SUBSCRIPTIONS_QUERY,
+            query: LIST_SUBSCRIPTIONS_CORE_QUERY,
             variables: { orgUuid: orgUuid.value },
             fetchPolicy: 'network-only',
         })

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -219,6 +219,15 @@
                             Refresh
                         </n-button>
                     </div>
+                    <n-alert
+                        v-if="approvalsDegraded"
+                        type="warning"
+                        :show-icon="false"
+                        style="margin-bottom: 12px;"
+                        data-testid="approvals-degraded-alert"
+                    >
+                        Some approval details are unavailable on this server version, so a few fields may be missing. Your pending approvals are shown below.
+                    </n-alert>
                     <n-data-table
                         :data="approvalsItems"
                         :columns="approvalsColumns"
@@ -387,6 +396,7 @@ import {
     formatHistoryTimestamp, relativeTime, extractError
 } from '@/utils/notificationsCommon'
 import { loadNotificationInboxPage } from '@/utils/notificationInboxQuery'
+import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 
 const props = defineProps<{
     orguuid: string
@@ -466,6 +476,9 @@ interface ReleasePendingApproval {
 
 const approvalsItems = ref<ReleasePendingApproval[]>([])
 const approvalsLoading = ref<boolean>(false)
+// True when the backend rejected the full approvals selection and we fell back
+// to core fields (componentType/pendingRoleIds absent) -- see PR #169 pattern.
+const approvalsDegraded = ref<boolean>(false)
 // A ref, not items.length: the badge poll uses a slim releaseUuid-only
 // query so it can refresh the count every minute without shipping full
 // rows; the full row load syncs it too.
@@ -584,6 +597,18 @@ const RELEASES_NEEDING_MY_APPROVAL_QUERY = gql`
     }
 `
 
+// Core selection without the Pro-ahead fields (componentType, pendingRoleIds)
+// so the approvals tab degrades to rows instead of blanking when a CE mirror
+// lags those fields -- see loadWithSchemaDriftFallback / PR #169.
+const RELEASES_NEEDING_MY_APPROVAL_CORE_QUERY = gql`
+    query releasesNeedingMyApproval($orgUuid: ID!) {
+        releasesNeedingMyApproval(orgUuid: $orgUuid) {
+            releaseUuid version componentUuid componentName lifecycle
+            pendingEntries { approvalEntryUuid approvalName }
+        }
+    }
+`
+
 // Slim variant for the 60s badge poll — same field, releaseUuid-only
 // selection, so polling the count doesn't ship full rows + nested
 // entries org-wide every minute.
@@ -622,16 +647,19 @@ async function loadApprovals (): Promise<void> {
     const myToken = ++approvalsInflightToken
     approvalsLoading.value = true
     try {
-        const res = await graphqlClient.query({
-            query: RELEASES_NEEDING_MY_APPROVAL_QUERY,
+        const { data, degraded } = await loadWithSchemaDriftFallback(graphqlClient, {
+            fullQuery: RELEASES_NEEDING_MY_APPROVAL_QUERY,
+            coreQuery: RELEASES_NEEDING_MY_APPROVAL_CORE_QUERY,
             variables: { orgUuid: orgUuid.value },
-            fetchPolicy: 'network-only',
+            extractPath: (d: any) => d?.releasesNeedingMyApproval,
         })
         if (myToken !== approvalsInflightToken) return
-        approvalsItems.value = res.data?.releasesNeedingMyApproval || []
+        approvalsItems.value = data || []
         approvalsCount.value = approvalsItems.value.length
+        approvalsDegraded.value = degraded
     } catch (e: any) {
         if (myToken !== approvalsInflightToken) return
+        approvalsDegraded.value = false
         message.error(`Failed to load pending approvals: ${extractError(e)}`)
     } finally {
         if (myToken === approvalsInflightToken) approvalsLoading.value = false

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -16,6 +16,16 @@
             </n-button>
         </div>
 
+        <n-alert
+            v-if="subscriptionsDegraded"
+            type="warning"
+            :show-icon="false"
+            style="margin-bottom: 12px;"
+            data-testid="subscriptions-degraded-alert"
+        >
+            Some subscription details are unavailable on this server version, so a few fields (filter, routes, dedup/rate-limit) may be missing. Your subscriptions are shown below.
+        </n-alert>
+
         <n-data-table
             :data="subscriptions"
             :columns="subscriptionColumns"
@@ -240,9 +250,11 @@ import graphqlClient from '@/utils/graphql'
 import {
     ChannelRow, ChannelGroupRow, SubscriptionRow, TYPE_LABELS,
     subscriptionStatusOptions, eventTypeOptions, severityOptions,
-    LIST_CHANNELS_QUERY, LIST_GROUPS_QUERY, LIST_SUBSCRIPTIONS_QUERY,
+    LIST_CHANNELS_QUERY, LIST_GROUPS_CORE_QUERY,
+    LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
     extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType
 } from '@/utils/notificationsCommon'
+import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 
 const props = defineProps<{
     orguuid: string
@@ -313,6 +325,9 @@ const channels = ref<ChannelRow[]>([])
 const channelGroups = ref<ChannelGroupRow[]>([])
 const subscriptions = ref<SubscriptionRow[]>([])
 const subscriptionsLoading = ref<boolean>(false)
+// True when the backend rejected the full subscription selection and we fell
+// back to core fields (config columns may be absent) -- see PR #169 pattern.
+const subscriptionsDegraded = ref<boolean>(false)
 const showSubscriptionModal = ref<boolean>(false)
 const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
@@ -406,8 +421,10 @@ async function loadChannels (): Promise<void> {
 
 async function loadChannelGroups (): Promise<void> {
     try {
+        // Only names + channels are needed here (route group multiselect), so
+        // use the CORE query -- it can't drift on the Pro-ahead group fields.
         const res = await graphqlClient.query({
-            query: LIST_GROUPS_QUERY,
+            query: LIST_GROUPS_CORE_QUERY,
             variables: { orgUuid: orgUuid.value },
             fetchPolicy: 'network-only',
         })
@@ -420,13 +437,16 @@ async function loadChannelGroups (): Promise<void> {
 async function loadSubscriptions (): Promise<void> {
     subscriptionsLoading.value = true
     try {
-        const res = await graphqlClient.query({
-            query: LIST_SUBSCRIPTIONS_QUERY,
+        const { data, degraded } = await loadWithSchemaDriftFallback(graphqlClient, {
+            fullQuery: LIST_SUBSCRIPTIONS_QUERY,
+            coreQuery: LIST_SUBSCRIPTIONS_CORE_QUERY,
             variables: { orgUuid: orgUuid.value },
-            fetchPolicy: 'network-only',
+            extractPath: (d: any) => d?.notificationSubscriptions,
         })
-        subscriptions.value = res.data?.notificationSubscriptions || []
+        subscriptions.value = data || []
+        subscriptionsDegraded.value = degraded
     } catch (e: any) {
+        subscriptionsDegraded.value = false
         message.error(`Failed to load subscriptions: ${extractError(e)}`)
     } finally {
         subscriptionsLoading.value = false

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -8,7 +8,41 @@ vi.mock('@/utils/commonFunctions', () => ({
     default: { dateDisplay: (s: string) => `ABS:${s}` },
 }))
 
-import { relativeTime } from './notificationsCommon'
+import { print } from 'graphql'
+import {
+    relativeTime,
+    LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY,
+    LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
+} from './notificationsCommon'
+
+// Pin the CORE vs ENRICHMENT split of the drift-fallback list queries: CORE
+// must carry every always-present render field and NONE of the Pro-ahead
+// enrichment fields (else a CE mirror would re-blank the surface), and FULL
+// must select both sets. Word-boundary match so "org" doesn't spuriously hit
+// the $orgUuid variable.
+describe('notification list query CORE / FULL split', () => {
+    const has = (doc: any, field: string) => new RegExp(`\\b${field}\\b`).test(print(doc))
+
+    const GROUP_CORE = ['uuid', 'org', 'resourceGroup', 'name', 'channels', 'revision']
+    const GROUP_ENRICHMENT = ['createdDate', 'lastUpdatedDate']
+    it('groups CORE has the render essentials and no enrichment fields', () => {
+        GROUP_CORE.forEach(f => expect(has(LIST_GROUPS_CORE_QUERY, f), `core should have ${f}`).toBe(true))
+        GROUP_ENRICHMENT.forEach(f => expect(has(LIST_GROUPS_CORE_QUERY, f), `core should NOT have ${f}`).toBe(false))
+    })
+    it('groups FULL has both core and enrichment fields', () => {
+        [...GROUP_CORE, ...GROUP_ENRICHMENT].forEach(f => expect(has(LIST_GROUPS_QUERY, f), `full should have ${f}`).toBe(true))
+    })
+
+    const SUB_CORE = ['uuid', 'org', 'resourceGroup', 'name', 'status', 'eventTypes', 'revision']
+    const SUB_ENRICHMENT = ['filter', 'routes', 'dedupWindowMinutes', 'rateLimit']
+    it('subscriptions CORE has the render essentials and no enrichment fields', () => {
+        SUB_CORE.forEach(f => expect(has(LIST_SUBSCRIPTIONS_CORE_QUERY, f), `core should have ${f}`).toBe(true))
+        SUB_ENRICHMENT.forEach(f => expect(has(LIST_SUBSCRIPTIONS_CORE_QUERY, f), `core should NOT have ${f}`).toBe(false))
+    })
+    it('subscriptions FULL has both core and enrichment fields', () => {
+        [...SUB_CORE, ...SUB_ENRICHMENT].forEach(f => expect(has(LIST_SUBSCRIPTIONS_QUERY, f), `full should have ${f}`).toBe(true))
+    })
+})
 
 // relativeTime is a pure function with an injectable `now`, so these are
 // deterministic (no dependence on the wall clock).

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -283,19 +283,30 @@ export const LIST_CHANNELS_QUERY = gql`
     }
 `
 
-export const LIST_GROUPS_QUERY = gql`
-    query notificationChannelGroups($orgUuid: ID!) {
-        notificationChannelGroups(orgUuid: $orgUuid) {
-            uuid org resourceGroup name channels revision createdDate lastUpdatedDate
-        }
-    }
-`
+// Channel-group + subscription list queries are split CORE vs ENRICHMENT so
+// the list surfaces can degrade gracefully instead of blanking when the
+// deployed backend (a CE mirror lagging the Pro schema) lacks a Pro-ahead
+// field -- see loadWithSchemaDriftFallback / PR #169. CORE = the identity +
+// render essentials that always exist; ENRICHMENT = the newer fields.
 
-export const LIST_SUBSCRIPTIONS_QUERY = gql`
-    query notificationSubscriptions($orgUuid: ID!) {
-        notificationSubscriptions(orgUuid: $orgUuid) {
-            uuid org resourceGroup name status eventTypes
-            filter routes dedupWindowMinutes rateLimit revision
-        }
-    }
-`
+const GROUP_CORE_FIELDS = 'uuid org resourceGroup name channels revision'
+const GROUP_ENRICHMENT_FIELDS = 'createdDate lastUpdatedDate'
+function buildGroupsQuery (fields: string) {
+    return gql`
+        query notificationChannelGroups($orgUuid: ID!) {
+            notificationChannelGroups(orgUuid: $orgUuid) { ${fields} }
+        }`
+}
+export const LIST_GROUPS_QUERY = buildGroupsQuery(`${GROUP_CORE_FIELDS} ${GROUP_ENRICHMENT_FIELDS}`)
+export const LIST_GROUPS_CORE_QUERY = buildGroupsQuery(GROUP_CORE_FIELDS)
+
+const SUBSCRIPTION_CORE_FIELDS = 'uuid org resourceGroup name status eventTypes revision'
+const SUBSCRIPTION_ENRICHMENT_FIELDS = 'filter routes dedupWindowMinutes rateLimit'
+function buildSubscriptionsQuery (fields: string) {
+    return gql`
+        query notificationSubscriptions($orgUuid: ID!) {
+            notificationSubscriptions(orgUuid: $orgUuid) { ${fields} }
+        }`
+}
+export const LIST_SUBSCRIPTIONS_QUERY = buildSubscriptionsQuery(`${SUBSCRIPTION_CORE_FIELDS} ${SUBSCRIPTION_ENRICHMENT_FIELDS}`)
+export const LIST_SUBSCRIPTIONS_CORE_QUERY = buildSubscriptionsQuery(SUBSCRIPTION_CORE_FIELDS)


### PR DESCRIPTION
## What

Generalizes the schema-drift fallback (`loadWithSchemaDriftFallback`, PR #169) to
the remaining notification list surfaces so they **degrade to core rows + a
warning banner** instead of blanking when the deployed CE backend (a delayed
mirror of the Pro schema) lacks a Pro-ahead field.

Background: the same UI ships to Pro and CE. GraphQL validates the whole
document, so one Pro-ahead field the UI selects that hasn't mirrored to CE yet
rejects the **entire** query -> the surface blanks for every CE user during the
mirror-lag window. #169 fixed this for the inbox; later PRs did the catalog
(#170/#171) and Delivery History (#170). This finishes the set.

### Surfaces fixed (the 3 that still hand-selected full fields)
- **Subscriptions list** (`SubscriptionsOfOrg.vue`) — enrichment: `filter`,
  `routes`, `dedupWindowMinutes`, `rateLimit`.
- **Channel groups list** (`ChannelGroupsOfOrg.vue`) — enrichment:
  `createdDate`, `lastUpdatedDate`.
- **"Needs my approval" tab** (`NotificationInbox.vue`) — enrichment:
  `componentType`, `pendingEntries { pendingRoleIds }`.

### Changes
- `notificationsCommon.ts`: split `LIST_GROUPS_QUERY` / `LIST_SUBSCRIPTIONS_QUERY`
  into CORE + FULL via `buildGroupsQuery` / `buildSubscriptionsQuery` (mirrors the
  inbox/history `build*Query` pattern); added `*_CORE_QUERY` exports.
- Each surface: `loadWithSchemaDriftFallback(FULL -> CORE)` + a `*Degraded` ref +
  a `*-degraded-alert` banner (same shape/copy as the inbox/history banners).
- **De-risked the secondary uses** too: `NotificationHistory`'s subscription
  name-map load and `SubscriptionsOfOrg`'s route-group options load now use the
  CORE queries (they only need name/channels), so they can't drift either.

## Verification (the #169 way)
Injected a bogus enrichment field into each FULL query against the sandbox:
- **Drift path:** all 3 surfaces render **core rows + the degraded banner**
  (approvals shows banner + empty-state) — no blank, no error toast.
- **Clean path:** no banner, rows render normally (byte-identical to before).

Also confirmed every degraded-path field access is guarded (`row.routes ?
JSON.parse(...) : []`, `(entry.pendingRoleIds || [])`,
`formatHistoryTimestamp(null) -> "-"`), so a missing enrichment field can't crash
a column render.

`vite build` clean; two-layer review gate passed.

## Note
This closes the sibling-drift task; catalog (#1) + history (#5) from the original
scope were already done in #170/#171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
