### PR TITLE
Notifications: "View deliveries" deep-links + subscription filter

### DIFF
--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -10,7 +10,7 @@
             </n-button>
         </div>
 
-        <n-grid :cols="3" :x-gap="12" class="history-filters">
+        <n-grid :cols="4" :x-gap="12" class="history-filters">
             <n-gi>
                 <n-form-item label="Status" :show-feedback="false">
                     <n-select
@@ -18,6 +18,7 @@
                         :options="deliveryStatusOptions"
                         placeholder="Any"
                         clearable
+                        data-testid="history-status-filter"
                         @update:value="applyHistoryFilters"
                     />
                 </n-form-item>
@@ -29,6 +30,7 @@
                         :options="deliveryOriginOptions"
                         placeholder="Any"
                         clearable
+                        data-testid="history-origin-filter"
                         @update:value="applyHistoryFilters"
                     />
                 </n-form-item>
@@ -40,6 +42,21 @@
                         :options="channelFilterOptions"
                         placeholder="Any"
                         clearable
+                        filterable
+                        data-testid="history-channel-filter"
+                        @update:value="applyHistoryFilters"
+                    />
+                </n-form-item>
+            </n-gi>
+            <n-gi>
+                <n-form-item label="Subscription" :show-feedback="false">
+                    <n-select
+                        v-model:value="historyFilters.subscriptionUuid"
+                        :options="subscriptionFilterOptions"
+                        placeholder="Any"
+                        clearable
+                        filterable
+                        data-testid="history-subscription-filter"
                         @update:value="applyHistoryFilters"
                     />
                 </n-form-item>
@@ -103,6 +120,7 @@ const props = defineProps<{
     // fresh seed always takes effect. Manual filter changes are independent.
     initialChannelUuid?: string | null
     initialStatus?: string | null
+    initialSubscriptionUuid?: string | null
 }>()
 
 const message = useMessage()
@@ -121,10 +139,11 @@ const historyTotalCount = ref<number>(0)
 const historyPageCount = computed<number>(() =>
     Math.max(1, Math.ceil(historyTotalCount.value / historyPageSize.value))
 )
-const historyFilters = ref<{ status: string | null, origin: string | null, channelUuid: string | null }>({
+const historyFilters = ref<{ status: string | null, origin: string | null, channelUuid: string | null, subscriptionUuid: string | null }>({
     status: null,
     origin: null,
     channelUuid: null,
+    subscriptionUuid: null,
 })
 
 // History channel filter spans ALL channels (incl. disabled) so a user
@@ -132,6 +151,9 @@ const historyFilters = ref<{ status: string | null, origin: string | null, chann
 // past deliveries.
 const channelFilterOptions = computed(() =>
     channels.value.map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
+)
+const subscriptionFilterOptions = computed(() =>
+    subscriptions.value.map(s => ({ label: s.name, value: s.uuid }))
 )
 
 // Cross-ref helpers — history rows carry uuids; resolve to names from
@@ -144,11 +166,20 @@ const subscriptionNameById = computed<Record<string, string>>(() => buildNameMap
 // lagging Pro) the history table degrades to core rows instead of blanking.
 const HISTORY_CORE_ITEM_FIELDS = 'uuid org outboxEventUuid subscriptionUuid channelUuid status origin createdDate'
 const HISTORY_ENRICHMENT_ITEM_FIELDS = 'dedupKey attemptCount nextAttemptAt sentAt lastError'
-function buildHistoryQuery (itemFields: string): DocumentNode {
+// withSub gates the subscriptionUuid ARGUMENT, which only newer backends accept.
+// We include it ONLY when the subscription filter is active, so the default
+// History query never sends an unknown arg (which would fail the whole query
+// and blank the table on a CE mirror lagging the Pro schema -- the same
+// blanking the field-level drift fallback guards against, but args can't
+// degrade to core since a missing arg rejects the document outright).
+function buildHistoryQuery (itemFields: string, withSub = false): DocumentNode {
+    const subVar = withSub ? '$subscriptionUuid: ID,' : ''
+    const subArg = withSub ? 'subscriptionUuid: $subscriptionUuid,' : ''
     return gql`
         query notificationDeliveriesPage(
             $orgUuid: ID!,
             $channelUuid: ID,
+            ${subVar}
             $status: NotificationDeliveryStatusEnum,
             $origin: NotificationDeliveryOriginEnum,
             $limit: Int,
@@ -157,6 +188,7 @@ function buildHistoryQuery (itemFields: string): DocumentNode {
             notificationDeliveries(
                 orgUuid: $orgUuid,
                 channelUuid: $channelUuid,
+                ${subArg}
                 status: $status,
                 origin: $origin,
                 limit: $limit,
@@ -168,8 +200,12 @@ function buildHistoryQuery (itemFields: string): DocumentNode {
         }
     `
 }
-const HISTORY_DELIVERIES_FULL = buildHistoryQuery(`${HISTORY_CORE_ITEM_FIELDS} ${HISTORY_ENRICHMENT_ITEM_FIELDS}`)
+const FULL_FIELDS = `${HISTORY_CORE_ITEM_FIELDS} ${HISTORY_ENRICHMENT_ITEM_FIELDS}`
+const HISTORY_DELIVERIES_FULL = buildHistoryQuery(FULL_FIELDS)
 const HISTORY_DELIVERIES_CORE = buildHistoryQuery(HISTORY_CORE_ITEM_FIELDS)
+// Variants that also filter by subscriptionUuid (used only when that filter is set).
+const HISTORY_DELIVERIES_FULL_SUB = buildHistoryQuery(FULL_FIELDS, true)
+const HISTORY_DELIVERIES_CORE_SUB = buildHistoryQuery(HISTORY_CORE_ITEM_FIELDS, true)
 
 async function loadChannels (): Promise<void> {
     try {
@@ -211,9 +247,10 @@ async function loadDeliveries (): Promise<void> {
     deliveriesLoading.value = true
     try {
         const offset = (historyPage.value - 1) * historyPageSize.value
+        const subUuid = historyFilters.value.subscriptionUuid
         const { data: page, degraded } = await loadWithSchemaDriftFallback(graphqlClient, {
-            fullQuery: HISTORY_DELIVERIES_FULL,
-            coreQuery: HISTORY_DELIVERIES_CORE,
+            fullQuery: subUuid ? HISTORY_DELIVERIES_FULL_SUB : HISTORY_DELIVERIES_FULL,
+            coreQuery: subUuid ? HISTORY_DELIVERIES_CORE_SUB : HISTORY_DELIVERIES_CORE,
             variables: {
                 orgUuid: orgUuid.value,
                 channelUuid: historyFilters.value.channelUuid,
@@ -221,6 +258,7 @@ async function loadDeliveries (): Promise<void> {
                 origin: historyFilters.value.origin,
                 limit: historyPageSize.value,
                 offset,
+                ...(subUuid ? { subscriptionUuid: subUuid } : {}),
             },
             extractPath: (d: any) => d?.notificationDeliveries,
         })
@@ -306,6 +344,7 @@ onMounted(async () => {
     // query is already scoped (no flash of the full list, no extra fetch).
     if (props.initialChannelUuid) historyFilters.value.channelUuid = props.initialChannelUuid
     if (props.initialStatus) historyFilters.value.status = props.initialStatus
+    if (props.initialSubscriptionUuid) historyFilters.value.subscriptionUuid = props.initialSubscriptionUuid
     // Channels + subscriptions feed the name-resolution maps; deliveries
     // is the actual table. Load all three in parallel.
     await Promise.all([loadChannels(), loadSubscriptions(), loadDeliveries()])

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -127,6 +127,7 @@
                                                 :title="testingChannels.has(ch.uuid) ? 'Sending test...' : 'Send test notification'"
                                                 @click="!testingChannels.has(ch.uuid) && sendChannelTest(ch)"
                                             ><Refresh v-if="testingChannels.has(ch.uuid)" /><Send v-else /></n-icon>
+                                            <n-icon class="instance-icon" size="20" title="View delivery history for this channel" @click="viewChannelDeliveries(ch.uuid)"><History /></n-icon>
                                             <n-icon class="instance-icon" size="20" :title="`Edit ${card.name} channel`" @click="openEditChannelForCard(card, ch)"><EditIcon /></n-icon>
                                             <n-icon class="instance-icon danger" size="20" :title="`Delete ${card.name} channel`" @click="onDeleteChannel(card, ch)"><Trash /></n-icon>
                                         </div>
@@ -151,6 +152,8 @@
                                             </template>
                                             <n-icon v-if="card.id === 'BEAR'" class="instance-icon" size="20" title="Edit BEAR Integration" @click="openBearEditModal"><EditIcon /></n-icon>
                                             <n-icon v-if="card.id === 'VULNCHECK_KEV'" class="instance-icon" size="20" title="Replace VulnCheck API token" @click="openVulncheckModal"><EditIcon /></n-icon>
+                                            <!-- Notification channel (Slack/Teams): jump to this channel's delivery log. -->
+                                            <n-icon v-if="isChannelCard(card)" class="instance-icon" size="20" title="View delivery history for this channel" @click="viewChannelDeliveries(channelRowsForCard(card)[0]?.uuid)"><History /></n-icon>
                                             <n-icon
                                                 class="instance-icon danger"
                                                 size="20"
@@ -842,7 +845,7 @@ import {
 import {
     Edit as EditIcon, Trash, Refresh, CirclePlus, CloudUpload,
     BrandGithub, BrandGitlab, BrandSlack, Mail, PlayerPlay, PlayerPause,
-    PlugConnected, ShieldCheck, LayoutGrid, Bell, Users, Send
+    PlugConnected, ShieldCheck, LayoutGrid, Bell, Users, Send, History
 } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import { FetchPolicy } from '@apollo/client'
@@ -867,6 +870,19 @@ const props = defineProps<{
 
 const route = useRoute()
 const router = useRouter()
+
+// Deep-link from a channel card into the Delivery History audit surface,
+// pre-filtered to that channel -- the "is this channel actually delivering?"
+// entry point. Mirrors the inbox/subscription "View delivery log" deep-links.
+function viewChannelDeliveries (channelUuid: string | undefined): void {
+    if (!channelUuid) return
+    router.push({
+        name: 'OrgSettings',
+        params: { orguuid: props.orguuid },
+        query: { tab: 'audit', auditTab: 'deliveryHistory', historyChannel: channelUuid },
+    })
+}
+
 const notification = useNotification()
 const notify = (type: NotificationType, title: string, content: string) => {
     notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1075,7 +1075,8 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
                             :orguuid="orgResolved"
                             :initial-channel-uuid="(route.query.historyChannel as string) || null"
                             :initial-status="(route.query.historyStatus as string) || null"
-                            :key="`hist-${route.query.historyChannel || ''}-${route.query.historyStatus || ''}`"
+                            :initial-subscription-uuid="(route.query.historySubscription as string) || null"
+                            :key="`hist-${route.query.historyChannel || ''}-${route.query.historyStatus || ''}-${route.query.historySubscription || ''}`"
                         />
                     </n-tab-pane>
                 </n-tabs>

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -244,7 +244,8 @@ import {
     NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag, NDropdown, NTooltip,
     NRadioGroup, NRadioButton, useDialog, useMessage
 } from 'naive-ui'
-import { CirclePlus, Trash, Edit as EditIcon, Send } from '@vicons/tabler'
+import { CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabler'
+import { useRouter } from 'vue-router'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import {
@@ -264,6 +265,19 @@ const props = defineProps<{
 const dialog = useDialog()
 const message = useMessage()
 const store = useStore()
+const router = useRouter()
+
+// Deep-link into the Delivery History audit surface, pre-filtered to this
+// subscription, so a user can go from "this subscription" straight to "what did
+// it actually deliver (and why did some fail)". Mirrors the inbox/channel
+// "View delivery log" deep-links.
+function viewSubscriptionDeliveries (row: SubscriptionRow): void {
+    router.push({
+        name: 'OrgSettings',
+        params: { orguuid: orgUuid.value },
+        query: { tab: 'audit', auditTab: 'deliveryHistory', historySubscription: row.uuid },
+    })
+}
 
 const orgUuid = computed<string>(() => props.orguuid)
 const canWrite = computed<boolean>(() => props.isWritable)
@@ -811,6 +825,14 @@ const subscriptionColumns = computed(() => [
                     h(NTooltip, { trigger: 'hover' }, {
                         trigger: () => testButton,
                         default: () => disabledReason || "Send a synthetic test event through this subscription's matching path (also exercises other subscriptions on the same event type -- asks for confirmation first).",
+                    }),
+                    h(NTooltip, { trigger: 'hover' }, {
+                        trigger: () => h(NButton, {
+                            size: 'tiny', secondary: true,
+                            onClick: () => viewSubscriptionDeliveries(row),
+                            'data-testid': 'view-subscription-deliveries',
+                        }, { icon: () => h(NIcon, null, { default: () => h(History) }) }),
+                        default: () => 'View delivery history for this subscription',
                     }),
                     h(NButton, {
                         size: 'tiny', secondary: true, type: 'error',


### PR DESCRIPTION
## What

Frontend for the notifications failure-diagnosis follow-up (`-26317`). Completes
the "View delivery log" deep-link set started in #173 and adds a subscription
filter to Delivery History. Pairs with backend **rearm-saas #275** (the
`subscriptionUuid` filter arg).

### Changes
- **"View deliveries" from subscription rows** (`SubscriptionsOfOrg.vue`): a
  History-icon row action -> `OrgSettings -> Audit -> Delivery History` filtered
  to that subscription (`historySubscription=<uuid>`).
- **"View deliveries" from channel cards** (`OrgIntegrations.vue`): a History
  icon on each channel instance -> Delivery History filtered to that channel
  (`historyChannel=<uuid>`). Works for both card layouts (multi-instance
  `ch.uuid`; single-instance Slack/Teams via `channelRowsForCard(card)[0]?.uuid`,
  guarded against undefined).
- **Subscription filter in Delivery History** (`NotificationHistory.vue`): a 4th
  filter (Status | Origin | Channel | Subscription).
- `OrgSettings.vue`: passes `historySubscription` route query -> the new
  `initial-subscription-uuid` prop (+ remount `:key`), mirroring the #173
  channel/status seeding.

### Drift-safety (important)
The `subscriptionUuid` GraphQL **argument** is included in the History query
**only when the subscription filter is active** (`buildHistoryQuery(fields,
withSub)` -> 4 variants). Default History never sends the arg, so on a backend
that lacks it (a CE mirror lagging #275) the table still loads normally -- an
unknown *argument* rejects the whole document and can't degrade to core, so it
must not be sent unconditionally.

## Verification (sandbox)
- Channel-card + subscription-row "View deliveries" navigate correctly; History
  renders all 4 filters with the subscription dropdown populated; **no
  regression** on default History (25 rows).
- Subscription-filter SQL confirmed directly against the sandbox DB: `subscription_uuid = <sub>`
  returns a proper subset (12/43), and the null-tolerant clause returns all 43;
  the resolver->repo plumbing is covered by #275's propagation test.
- The full subscription-filter UI round-trip requires #275 deployed (the arg
  needs the backend); merge #275 first.
- Two-layer review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
