### PR TITLE
Notifications: show disabled/misconfigured channel distinctly

### DIFF
--- a/ui/src/components/NotificationHistory.vue
+++ b/ui/src/components/NotificationHistory.vue
@@ -160,6 +160,14 @@ const subscriptionFilterOptions = computed(() =>
 // the loaded channels + subscriptions lists.
 const channelNameById = computed<Record<string, string>>(() => buildNameMap(channels.value))
 const subscriptionNameById = computed<Record<string, string>>(() => buildNameMap(subscriptions.value))
+// Channel status (from the channels list) so a delivery to a disabled channel
+// reads "name (disabled)" instead of looking healthy -- the audit-log analogue
+// of the inbox's disabled-channel label.
+const channelStatusById = computed<Record<string, string>>(() => {
+    const m: Record<string, string> = {}
+    for (const c of channels.value) m[c.uuid] = c.status
+    return m
+})
 
 // CORE = identity + status + time needed to render a delivery row.
 // ENRICHMENT = retry/error detail; if a backend lacks one of these (CE mirror
@@ -308,10 +316,18 @@ const deliveryColumns = computed(() => [
         title: 'Channel', key: 'channelUuid',
         // Null channel = Phase 4a targeted delivery (personal inbox copy,
         // no transmission channel) — not a deleted channel.
-        render: (row: DeliveryRow) => (row.channelUuid
-            ? (channelNameById.value[row.channelUuid]
-                || h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)'))
-            : h('span', { class: 'muted-12' }, 'Direct')),
+        render: (row: DeliveryRow) => {
+            if (!row.channelUuid) return h('span', { class: 'muted-12' }, 'Direct')
+            const name = channelNameById.value[row.channelUuid]
+            if (!name) return h('span', { class: 'muted-12', title: row.channelUuid }, '(deleted channel)')
+            const status = channelStatusById.value[row.channelUuid]
+            return status && status !== 'ENABLED'
+                ? h('span', {}, [name, h('span', {
+                    class: 'hist-chan-disabled',
+                    title: 'This channel is disabled; deliveries to it are paused.',
+                }, ' (disabled)')])
+                : name
+        },
     },
     {
         title: 'Subscription', key: 'subscriptionUuid',
@@ -361,6 +377,7 @@ onMounted(async () => {
 }
 .tab-toolbar-info { font-size: 12.5px; color: var(--n-text-color-3, #888); }
 .muted-12 { font-size: 12px; color: var(--n-text-color-3, #888); }
+.hist-chan-disabled { color: #f0a020; font-weight: 600; }
 .history-filters { margin-bottom: 12px; }
 .history-pagination { margin-top: 12px; display: flex; justify-content: flex-end; }
 </style>

--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -166,7 +166,11 @@
                                         data-testid="inbox-cell-channel"
                                         :class="['inbox-chan', { fail: c.failed, 'muted-12': !c.failed && c.channel.muted }]"
                                         :title="c.channel.title"
-                                    >{{ c.channel.text }}</span>
+                                    >{{ c.channel.text }}<span
+                                        v-if="c.channel.disabled"
+                                        class="inbox-chan-disabled"
+                                        data-testid="inbox-cell-channel-disabled"
+                                    > (disabled)</span></span>
                                     <span v-if="c.failed" class="inbox-fail-note">&mdash; message was not delivered</span>
                                 </div>
                             </div>
@@ -285,7 +289,7 @@
                             <n-tag :type="deliveryStatusTagType(inboxDrawerRow.status)" size="small">{{ inboxDrawerRow.status }}</n-tag>
                         </n-descriptions-item>
                         <n-descriptions-item label="Channel">
-                            <span :class="{ 'muted-12': drawerChannel.muted }" :title="drawerChannel.title">{{ drawerChannel.text }}</span>
+                            <span :class="{ 'muted-12': drawerChannel.muted }" :title="drawerChannel.title">{{ drawerChannel.text }}<span v-if="drawerChannel.disabled" class="inbox-chan-disabled"> (disabled)</span></span>
                         </n-descriptions-item>
                         <n-descriptions-item label="Delivered">
                             {{ formatHistoryTimestamp(inboxDrawerRow.sentAt || inboxDrawerRow.createdDate) }}
@@ -934,9 +938,23 @@ async function loadInboxUnreadCount (): Promise<void> {
 // useful. States: no channelUuid => Direct; channelName present => the name;
 // channelName selected-but-null => the channel was deleted; channelName ABSENT
 // from the row (degraded fallback) => a neutral label, NOT a false "deleted".
-function channelLabel (row: InboxRow | null): { text: string, muted: boolean, title?: string } {
+function channelLabel (row: InboxRow | null): { text: string, muted: boolean, title?: string, disabled?: boolean } {
     if (!row || !row.channelUuid) return { text: 'Direct', muted: true }
-    if (row.channelName) return { text: row.channelName, muted: false }
+    if (row.channelName) {
+        // The channel exists. Surface a disabled/auto-disabled state (Pro-ahead
+        // enrichment; absent on a degraded load) so a failed delivery explains
+        // itself -- a disabled channel is why nothing lands, distinct from a
+        // deleted one. channelDisabledReason (when present) rides the hover.
+        const disabled = row.channelEnabled === false
+        return {
+            text: row.channelName,
+            muted: false,
+            disabled,
+            title: disabled
+                ? (row.channelDisabledReason || 'This channel is disabled; deliveries to it are paused.')
+                : undefined,
+        }
+    }
     return { text: ('channelName' in row) ? '(deleted channel)' : 'Channel', muted: true, title: row.channelUuid }
 }
 
@@ -1202,6 +1220,8 @@ onUnmounted(() => {
 .inbox-card-sub { display: flex; align-items: center; gap: 6px; margin-top: 6px; flex-wrap: wrap; }
 .inbox-meta-sep { opacity: 0.5; }
 .inbox-chan.fail { color: #d03050; font-weight: 600; }
+/* Disabled-channel suffix on the channel label: amber, hover shows the reason. */
+.inbox-chan-disabled { color: #f0a020; font-weight: 600; }
 .inbox-fail-note { color: #d03050; font-size: 12px; }
 
 /* Right column: timestamp over the per-row read/unread action. */

--- a/ui/src/utils/notificationInboxQuery.ts
+++ b/ui/src/utils/notificationInboxQuery.ts
@@ -31,6 +31,10 @@ export const INBOX_CORE_ITEM_FIELDS: string[] = [
 // behind a presence guard (`'field' in row`) so a degraded row can't throw.
 export const INBOX_ENRICHMENT_ITEM_FIELDS: string[] = [
     'channelName',
+    // Channel enabled/auto-disable state so the label can distinguish a
+    // disabled/misconfigured channel from a deleted one (see channelLabel).
+    'channelEnabled',
+    'channelDisabledReason',
 ]
 
 function buildInboxQuery (itemFields: string[]): DocumentNode {

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -79,6 +79,11 @@ export interface InboxRow {
     // inbox doesn't need an admin-only channel-list fetch to render the name).
     // Null when the channel has been deleted or for channel-less targeted rows.
     channelName: string | null
+    // Channel enabled/auto-disable state (Pro-ahead enrichment; optional since a
+    // degraded/CE-lagging load may omit it). channelEnabled === false = disabled;
+    // channelDisabledReason carries the auto-disable reason when present.
+    channelEnabled?: boolean | null
+    channelDisabledReason?: string | null
     status: string
     origin: string
     dedupKey: string | null


### PR DESCRIPTION
## What

Final piece of the failure-diagnosis follow-up (`-26317`). Surfaces a
**disabled / auto-disabled (misconfigured)** channel distinctly from a **deleted**
one, so a failed delivery explains itself instead of dead-ending at
*"(deleted channel)"*. Consumes the `channelEnabled` / `channelDisabledReason`
fields added in backend **rearm-saas #276**.

### Changes
- `notificationInboxQuery.ts`: `channelEnabled` + `channelDisabledReason` added
  to `INBOX_ENRICHMENT_ITEM_FIELDS` (Pro-ahead, drift-tolerant).
- `notificationsCommon.ts` `InboxRow`: two optional fields.
- `NotificationInbox.vue`: `channelLabel` flags `disabled` when the channel
  exists and `channelEnabled === false`; the card cell + drawer render a
  " (disabled)" suffix with the reason on hover. A deleted channel still shows
  "(deleted channel)"; a Direct row still shows "Direct".
- `NotificationHistory.vue`: a `channelStatusById` map (from the channels list's
  `status`) appends " (disabled)" to the Channel column for a disabled channel
  (the audit-log analogue; no reason there, just the state).

## Drift-safety / merge order
The new fields are **enrichment** — on a backend lacking them (a CE mirror
lagging #276), the inbox degrades to core rows + the existing banner rather than
blanking. **Verified live on the current sandbox backend** (which lacks the
fields): inbox loads 25 rows + banner, no blank. To avoid a transient
channel-name degrade, **merge #276 (and let it deploy) before this PR.**

## Verification
- `vite build` clean; 37 util tests green (incl. the schema-drift spec, which
  validates the FULL query against the co-located #276 schema).
- Graceful degrade confirmed live on the current backend.
- The disabled-label DISPLAY is a straight render of `channelEnabled === false`;
  the backend resolution is unit-tested in #276 (a disabled channel carries
  `channelEnabled=false` + reason). It shows live once #276 deploys.
- Two-layer review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
