### PR TITLE
changelog UI: capped inline attribution + "+N more" drill-down drawer

### DIFF
--- a/ui/src/components/OrganizationChangelogView.vue
+++ b/ui/src/components/OrganizationChangelogView.vue
@@ -70,7 +70,7 @@
                         
                         <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedOrganizationChangelog'">
                             <p class="aggregation-note">Aggregated across all components</p>
-                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" />
+                            <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" :date-from="dateFrom" :date-to="dateTo" :perspective-uuid="perspectiveUuid" />
                         </div>
                     </n-tab-pane>
                 </n-tabs>
@@ -129,17 +129,22 @@ const aggregationType: Ref<'NONE' | 'AGGREGATED'> = ref('AGGREGATED')
 const loading: Ref<boolean> = ref(false)
 const changelog: Ref<OrganizationChangelog | null> = ref(null)
 
+// Drill-down window bound to the currently-loaded changelog (updated on fetch so
+// the "+N more" / timeline drawers query the same range that was displayed).
+const dateFrom = ref('')
+const dateTo = ref('')
+
 const fetchChangelog = async () => {
     loading.value = true
     try {
-        const dateFrom = new Date(dateRange.value[0]).toISOString()
-        const dateTo = new Date(dateRange.value[1]).toISOString()
-        
+        dateFrom.value = new Date(dateRange.value[0]).toISOString()
+        dateTo.value = new Date(dateRange.value[1]).toISOString()
+
         const params = {
             orgUuid: props.orgUuid,
             perspectiveUuid: props.perspectiveUuid,
-            dateFrom,
-            dateTo,
+            dateFrom: dateFrom.value,
+            dateTo: dateTo.value,
             aggregated: aggregationType.value as 'NONE' | 'AGGREGATED',
             timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
         }

--- a/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
+++ b/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
@@ -63,6 +63,8 @@
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getAppearedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.appearedInCount, finding.appearedIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'APPEARED')">+{{ moreCount(finding.appearedInCount, finding.appearedIn) }} more</a>
+                        <span v-else-if="moreCount(finding.appearedInCount, finding.appearedIn) > 0" class="more-text">+{{ moreCount(finding.appearedInCount, finding.appearedIn) }} more</span>
                         <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
                         <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
@@ -78,6 +80,8 @@
                         <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
                         <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getStillPresentContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.presentInCount, finding.presentIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'PRESENT')">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</a>
+                        <span v-else-if="moreCount(finding.presentInCount, finding.presentIn) > 0" class="more-text">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
@@ -88,7 +92,11 @@
                 @kev-click="openKevModal">
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
+                        <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
+                        <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.resolvedInCount, finding.resolvedIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'RESOLVED')">+{{ moreCount(finding.resolvedInCount, finding.resolvedIn) }} more</a>
+                        <span v-else-if="moreCount(finding.resolvedInCount, finding.resolvedIn) > 0" class="more-text">+{{ moreCount(finding.resolvedInCount, finding.resolvedIn) }} more</span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
@@ -102,6 +110,8 @@
                         <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
                         <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getInheritedDebtContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.presentInCount, finding.presentIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'PRESENT')">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</a>
+                        <span v-else-if="moreCount(finding.presentInCount, finding.presentIn) > 0" class="more-text">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
@@ -115,6 +125,8 @@
                         <span v-if="finding.orgContext?.isNewlyKev" class="worsened-badge worsened-badge-kev" title="Newly flagged as a CISA Known Exploited Vulnerability in this period">KEV added</span>
                         <span v-if="finding.orgContext?.isSeverityIncreased" class="worsened-badge worsened-badge-sev" title="Severity was raised in this period">Severity ↑<template v-if="finding.orgContext?.previousSeverity"> ({{ finding.orgContext.previousSeverity }} → {{ finding.severity || 'UNASSIGNED' }})</template></span>
                         <span v-for="(seg, i) in getStillPresentContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.presentInCount, finding.presentIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'PRESENT')">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</a>
+                        <span v-else-if="moreCount(finding.presentInCount, finding.presentIn) > 0" class="more-text">+{{ moreCount(finding.presentInCount, finding.presentIn) }} more</span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
@@ -126,6 +138,8 @@
                 <template #attribution="{ finding }">
                     <div v-if="showAttribution" class="attribution">
                         <span v-for="(seg, i) in getResolvedContextSegments(finding)" :key="i" class="attribution-context"><router-link v-if="seg.releaseUuid" :to="{ name: 'ReleaseView', params: { uuid: seg.releaseUuid } }" class="release-link">{{ seg.text }}</router-link><span v-else>{{ seg.text }}</span></span>
+                        <a v-if="moreCount(finding.resolvedInCount, finding.resolvedIn) > 0 && canDrillDown" class="more-link" @click.prevent="openAttributionDrawer(finding, 'RESOLVED')">+{{ moreCount(finding.resolvedInCount, finding.resolvedIn) }} more</a>
+                        <span v-else-if="moreCount(finding.resolvedInCount, finding.resolvedIn) > 0" class="more-text">+{{ moreCount(finding.resolvedInCount, finding.resolvedIn) }} more</span>
                         <a v-if="canViewTimeline(finding)" class="timeline-link" @click.prevent="openTimeline(finding)">View timeline</a>
                     </div>
                 </template>
@@ -135,11 +149,33 @@
 
             <n-drawer v-model:show="showTimeline" :width="560" placement="right">
                 <n-drawer-content :title="timelineTitle" closable>
-                    <OverTimeFindingChanges
-                        :over-time-finding-changes="overTimeFindingChanges"
-                        :finding-key-filter="timelineFilterKey"
-                        :org-uuid="orgUuid"
-                    />
+                    <n-spin :show="timelineLoading">
+                        <OverTimeFindingChanges
+                            :over-time-finding-changes="timelineItems"
+                            :finding-key-filter="''"
+                            :org-uuid="orgUuid"
+                        />
+                        <div v-if="timelineItems.length < timelineTotal" class="drawer-load-more">
+                            <n-button size="small" :loading="timelineLoading" @click="loadMoreTimeline">Load more ({{ timelineItems.length }} of {{ timelineTotal }})</n-button>
+                        </div>
+                    </n-spin>
+                </n-drawer-content>
+            </n-drawer>
+
+            <n-drawer v-model:show="showAttributionDrawer" :width="560" placement="right">
+                <n-drawer-content :title="attributionTitle" closable>
+                    <n-spin :show="attributionLoading">
+                        <p class="drawer-total">{{ attributionTotal }} total</p>
+                        <ul class="attribution-list">
+                            <li v-for="item in attributionItems" :key="`${item.releaseUuid}-${item.componentUuid}`">
+                                <router-link :to="{ name: 'ReleaseView', params: { uuid: item.releaseUuid } }" class="release-link">{{ attributionLabel(item) }}</router-link>
+                            </li>
+                        </ul>
+                        <div v-if="attributionItems.length === 0 && !attributionLoading" class="drawer-empty">No entries.</div>
+                        <div v-if="attributionItems.length < attributionTotal" class="drawer-load-more">
+                            <n-button size="small" :loading="attributionLoading" @click="loadMoreAttribution">Load more ({{ attributionItems.length }} of {{ attributionTotal }})</n-button>
+                        </div>
+                    </n-spin>
                 </n-drawer-content>
             </n-drawer>
         </div>
@@ -155,12 +191,17 @@
 
 <script lang="ts" setup>
 import { computed, ref } from 'vue'
-import { NTag, NTooltip, NDrawer, NDrawerContent } from 'naive-ui'
+import { NTag, NTooltip, NDrawer, NDrawerContent, NSpin, NButton } from 'naive-ui'
 import FindingListSection from './FindingListSection.vue'
 import OverTimeFindingChanges from './OverTimeFindingChanges.vue'
 import KevDetailsModal from '../KevDetailsModal.vue'
 import { getSeverityIndex } from '../../utils/findingUtils'
 import { resolveKevCveId } from '../../utils/kevService'
+import {
+    fetchFindingAttribution,
+    fetchFindingChangeTimeline,
+    type ComponentAttributionEntry
+} from '../../utils/changelogQueries'
 import type {
     FindingChangesWithAttribution,
     VulnerabilityWithAttribution,
@@ -170,18 +211,36 @@ import type {
 } from '../../types/changelog-attribution'
 import type { MetricsRevisionFindingChange } from '../../types/changelog-sealed'
 
+type AttributionBucket = 'APPEARED' | 'PRESENT' | 'RESOLVED'
+
 interface Props {
     findingChanges?: FindingChangesWithAttribution
     showAttribution?: boolean
     orgUuid?: string
-    // Flat re-scan timeline (same GraphQL payload) — filtered client-side by
-    // finding key for the per-finding drill-down drawer. Optional/nullable.
+    // Flat re-scan timeline (same GraphQL payload) - retained for backward compat
+    // but no longer used to gate/populate the timeline drawer (which now fetches
+    // server-side; the inline payload is capped and can miss older events).
     overTimeFindingChanges?: MetricsRevisionFindingChange[]
+    // Scope of the "first occurrence in ..." attribution text. Defaults to
+    // 'organization' so the org changelog view renders unchanged; the
+    // component/product posture rollup passes 'component' / 'product'.
+    scopeLabel?: 'organization' | 'component' | 'product'
+    // Drill-down context: date window + scope for the "+N more" attribution
+    // drawer and the per-finding timeline drawer (both fetched server-side).
+    dateFrom?: string
+    dateTo?: string
+    componentUuid?: string
+    branchUuid?: string
+    perspectiveUuid?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
-    showAttribution: true
+    showAttribution: true,
+    scopeLabel: 'organization'
 })
+
+// Drill-down is available only when we have the org + date window to scope a query.
+const canDrillDown = computed(() => !!(props.orgUuid && props.dateFrom && props.dateTo))
 
 const showKevModal = ref(false)
 const kevModalCveId = ref('')
@@ -191,36 +250,152 @@ function openKevModal(finding: any) {
     showKevModal.value = true
 }
 
-// ---- Per-finding timeline drill-down (drawer) ----
+// ---- Per-finding timeline drill-down (drawer, fetched server-side) ----
+// The inline overTimeFindingChanges payload is capped to the newest 1000 events
+// so a client-side per-finding filter can MISS older events. The drawer instead
+// pages the finding's full timeline via fetchFindingChangeTimeline.
 const showTimeline = ref(false)
-const timelineFilterKey = ref('')
 const timelineTitle = ref('')
+const timelineItems = ref<MetricsRevisionFindingChange[]>([])
+const timelineTotal = ref(0)
+const timelinePage = ref(0)
+const timelineLoading = ref(false)
+const timelineFindingKey = ref('')
+const TIMELINE_PAGE_SIZE = 50
 
-// Type-scoped id key matching recordFindingKey() in OverTimeFindingChanges.vue:
-// deliberately excludes the per-release component so a CVE's whole cross-release
-// timeline is shown (this is the #41 case — same CVE, different releases).
-function findingKeyForFilter(finding: NormalizedFinding): string {
-    return `${finding.type}-${finding.findingId}`
+// A timeline link is offered whenever drill-down context is present - the events
+// live in a separate store that the changelog payload no longer carries, so we
+// gate on scope availability rather than the (capped/absent) inline array.
+function canViewTimeline(finding: NormalizedFinding): boolean {
+    return canDrillDown.value && !!finding.findingKey
 }
 
-// A timeline is available only when the payload actually carries at least one
-// matching over-time record for this finding (flag-off / legacy => no link).
-function canViewTimeline(finding: NormalizedFinding): boolean {
-    const records = props.overTimeFindingChanges
-    if (!records || records.length === 0) return false
-    const key = findingKeyForFilter(finding)
-    return records.some(rec => {
-        if (rec.vulnerability) return `VULN-${rec.vulnerability.vulnId}` === key
-        if (rec.violation) return `VIOLATION-${rec.violation.type}` === key
-        if (rec.weakness) return `WEAKNESS-${rec.weakness.cweId || rec.weakness.ruleId || ''}` === key
-        return false
-    })
+async function loadTimelinePage(page: number) {
+    if (!props.orgUuid || !props.dateFrom || !props.dateTo) return
+    timelineLoading.value = true
+    try {
+        const res = await fetchFindingChangeTimeline({
+            orgUuid: props.orgUuid,
+            componentUuid: props.componentUuid,
+            branchUuid: props.branchUuid,
+            perspectiveUuid: props.perspectiveUuid,
+            dateFrom: props.dateFrom,
+            dateTo: props.dateTo,
+            findingKey: timelineFindingKey.value,
+            page,
+            pageSize: TIMELINE_PAGE_SIZE
+        })
+        if (page === 0) {
+            timelineItems.value = res.items as MetricsRevisionFindingChange[]
+        } else {
+            timelineItems.value = [...timelineItems.value, ...(res.items as MetricsRevisionFindingChange[])]
+        }
+        timelineTotal.value = res.total
+        timelinePage.value = res.page
+    } catch (error) {
+        console.error('Error fetching finding change timeline:', error)
+    } finally {
+        timelineLoading.value = false
+    }
 }
 
 function openTimeline(finding: NormalizedFinding) {
-    timelineFilterKey.value = findingKeyForFilter(finding)
+    timelineFindingKey.value = finding.findingKey
     timelineTitle.value = `Timeline — ${finding.findingId}`
+    timelineItems.value = []
+    timelineTotal.value = 0
+    timelinePage.value = 0
     showTimeline.value = true
+    loadTimelinePage(0)
+}
+
+function loadMoreTimeline() {
+    loadTimelinePage(timelinePage.value + 1)
+}
+
+// ---- "+N more" attribution drill-down (drawer, fetched server-side) ----
+const showAttributionDrawer = ref(false)
+const attributionTitle = ref('')
+const attributionItems = ref<ComponentAttributionEntry[]>([])
+const attributionTotal = ref(0)
+const attributionPage = ref(0)
+const attributionLoading = ref(false)
+const attributionFindingKey = ref('')
+const attributionFindingKind = ref<'VULNERABILITY' | 'VIOLATION' | 'WEAKNESS'>('VULNERABILITY')
+const attributionBucket = ref<AttributionBucket>('APPEARED')
+const ATTRIBUTION_PAGE_SIZE = 50
+
+const BUCKET_LABELS: Record<AttributionBucket, string> = {
+    APPEARED: 'Appeared in',
+    PRESENT: 'Present in',
+    RESOLVED: 'Resolved in'
+}
+
+function findingKindOf(finding: NormalizedFinding): 'VULNERABILITY' | 'VIOLATION' | 'WEAKNESS' {
+    switch (finding.type) {
+        case 'VULN': return 'VULNERABILITY'
+        case 'VIOLATION': return 'VIOLATION'
+        default: return 'WEAKNESS'
+    }
+}
+
+function attributionLabel(item: ComponentAttributionEntry): string {
+    if (item.componentName) return `${item.componentName}@${item.releaseVersion}`
+    if (item.branchName) return `${item.branchName} ${item.releaseVersion}`
+    return item.releaseVersion
+}
+
+async function loadAttributionPage(page: number) {
+    if (!props.orgUuid || !props.dateFrom || !props.dateTo) return
+    attributionLoading.value = true
+    try {
+        const res = await fetchFindingAttribution({
+            orgUuid: props.orgUuid,
+            componentUuid: props.componentUuid,
+            branchUuid: props.branchUuid,
+            perspectiveUuid: props.perspectiveUuid,
+            dateFrom: props.dateFrom,
+            dateTo: props.dateTo,
+            findingKind: attributionFindingKind.value,
+            findingKey: attributionFindingKey.value,
+            bucket: attributionBucket.value,
+            page,
+            pageSize: ATTRIBUTION_PAGE_SIZE
+        })
+        if (page === 0) {
+            attributionItems.value = res.items
+        } else {
+            attributionItems.value = [...attributionItems.value, ...res.items]
+        }
+        attributionTotal.value = res.total
+        attributionPage.value = res.page
+    } catch (error) {
+        console.error('Error fetching finding attribution:', error)
+    } finally {
+        attributionLoading.value = false
+    }
+}
+
+function openAttributionDrawer(finding: NormalizedFinding, bucket: AttributionBucket) {
+    attributionFindingKey.value = finding.findingKey
+    attributionFindingKind.value = findingKindOf(finding)
+    attributionBucket.value = bucket
+    attributionTitle.value = `${BUCKET_LABELS[bucket]} — ${finding.findingId}`
+    attributionItems.value = []
+    attributionTotal.value = 0
+    attributionPage.value = 0
+    showAttributionDrawer.value = true
+    loadAttributionPage(0)
+}
+
+function loadMoreAttribution() {
+    loadAttributionPage(attributionPage.value + 1)
+}
+
+// "+N more" count for a bucket: total (from *InCount) minus the inline preview
+// entries already shown. Returns 0 when nothing is hidden.
+function moreCount(count: number, shown: unknown[]): number {
+    return Math.max(0, (count || 0) - (shown ? shown.length : 0))
 }
 
 type AttributionSegment = {
@@ -230,6 +405,7 @@ type AttributionSegment = {
 
 type NormalizedFinding = {
     findingId: string
+    findingKey: string
     affectedComponent: string
     severity?: string
     aliases?: Array<{ aliasId: string }>
@@ -239,6 +415,9 @@ type NormalizedFinding = {
     appearedIn: any[]
     resolvedIn: any[]
     presentIn: any[]
+    appearedInCount: number
+    resolvedInCount: number
+    presentInCount: number
     isNetAppeared: boolean
     isNetResolved: boolean
     isStillPresent: boolean
@@ -256,6 +435,7 @@ const sortBySeverity = (findings: NormalizedFinding[]) => {
 
 const normalizeVulnerability = (vuln: VulnerabilityWithAttribution): NormalizedFinding => ({
     findingId: vuln.vulnId,
+    findingKey: vuln.findingKey,
     affectedComponent: vuln.purl,
     severity: vuln.severity,
     aliases: vuln.aliases,
@@ -265,6 +445,9 @@ const normalizeVulnerability = (vuln: VulnerabilityWithAttribution): NormalizedF
     appearedIn: vuln.appearedIn,
     resolvedIn: vuln.resolvedIn,
     presentIn: vuln.presentIn,
+    appearedInCount: vuln.appearedInCount,
+    resolvedInCount: vuln.resolvedInCount,
+    presentInCount: vuln.presentInCount,
     isNetAppeared: vuln.isNetAppeared,
     isNetResolved: vuln.isNetResolved,
     isStillPresent: vuln.isStillPresent,
@@ -274,12 +457,16 @@ const normalizeVulnerability = (vuln: VulnerabilityWithAttribution): NormalizedF
 
 const normalizeViolation = (violation: ViolationWithAttribution): NormalizedFinding => ({
     findingId: violation.type,
+    findingKey: violation.findingKey,
     affectedComponent: violation.purl,
     type: 'VIOLATION',
     typeLabel: 'VIOLATION',
     appearedIn: violation.appearedIn,
     resolvedIn: violation.resolvedIn,
     presentIn: violation.presentIn,
+    appearedInCount: violation.appearedInCount,
+    resolvedInCount: violation.resolvedInCount,
+    presentInCount: violation.presentInCount,
     isNetAppeared: violation.isNetAppeared,
     isNetResolved: violation.isNetResolved,
     isStillPresent: violation.isStillPresent,
@@ -289,6 +476,7 @@ const normalizeViolation = (violation: ViolationWithAttribution): NormalizedFind
 
 const normalizeWeakness = (weakness: WeaknessWithAttribution): NormalizedFinding => ({
     findingId: weakness.cweId || weakness.ruleId || '',
+    findingKey: weakness.findingKey,
     affectedComponent: weakness.location,
     severity: weakness.severity || undefined,
     type: 'WEAKNESS',
@@ -296,6 +484,9 @@ const normalizeWeakness = (weakness: WeaknessWithAttribution): NormalizedFinding
     appearedIn: weakness.appearedIn,
     resolvedIn: weakness.resolvedIn,
     presentIn: weakness.presentIn,
+    appearedInCount: weakness.appearedInCount,
+    resolvedInCount: weakness.resolvedInCount,
+    presentInCount: weakness.presentInCount,
     isNetAppeared: weakness.isNetAppeared,
     isNetResolved: weakness.isNetResolved,
     isStillPresent: weakness.isStillPresent,
@@ -351,7 +542,7 @@ function isWorsened(f: NormalizedFinding): boolean {
 }
 
 // Worsened section lists worsened findings that are NOT already surfaced under
-// New Findings — a KEV/severity-worsened finding that is also brand-new is
+// New Findings - a KEV/severity-worsened finding that is also brand-new is
 // badge-only in New (signed-off decision: no double-listing).
 const worsenedFindings = computed(() =>
     sortBySeverity(allFindings.value.filter(f => isWorsened(f) && !f.orgContext?.isNewToOrganization))
@@ -359,7 +550,7 @@ const worsenedFindings = computed(() =>
 
 // Headline counts. Prefer the backend rollup totals; fall back to a client-side
 // count of the org-context flags when the rollup fields are absent (both are
-// nullable — 0 when the backend feature flag is off, hiding the tags).
+// nullable - 0 when the backend feature flag is off, hiding the tags).
 const newlyKevCount = computed(() => {
     const total = props.findingChanges?.totalNewlyKev
     if (total != null) return total
@@ -438,7 +629,7 @@ function getAppearedContextSegments(finding: NormalizedFinding): AttributionSegm
             segments.push({ text: `${a.componentName}@${a.releaseVersion}`, releaseUuid: a.releaseUuid })
         })
         if (finding.orgContext.isNewToOrganization) {
-            segments.push({ text: ' (first occurrence in organization)' })
+            segments.push({ text: ` (first occurrence in ${props.scopeLabel})` })
         } else if (finding.orgContext.wasPreviouslyReported) {
             segments.push({ text: ' (was previously reported in other components)' })
         }
@@ -591,5 +782,64 @@ function getInheritedDebtContextSegments(finding: NormalizedFinding): Attributio
             text-decoration: underline;
         }
     }
+
+    .more-link {
+        margin-left: 6px;
+        color: #2080f0;
+        font-style: normal;
+        cursor: pointer;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .more-text {
+        margin-left: 6px;
+        color: #888;
+        font-style: italic;
+    }
+}
+
+.drawer-total {
+    margin-bottom: 10px;
+    color: #666;
+    font-style: italic;
+}
+
+.attribution-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+
+    li {
+        padding: 4px 0;
+        border-bottom: 1px solid #f0f0f0;
+
+        &:last-child {
+            border-bottom: none;
+        }
+    }
+
+    .release-link {
+        color: #2080f0;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+.drawer-empty {
+    padding: 12px 0;
+    color: #999;
+    font-style: italic;
+}
+
+.drawer-load-more {
+    margin-top: 12px;
+    text-align: center;
 }
 </style>

--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -79,6 +79,7 @@ import KevDetailsModal from '../KevDetailsModal.vue'
 import {
     normalizeFindingChangeRecord,
     sortBySeverityThenId,
+    findingChangeRecordKey,
     type NormalizedReleaseFinding
 } from '../../utils/findingUtils'
 import { resolveKevCveId } from '../../utils/kevService'
@@ -95,14 +96,12 @@ interface Props {
 const props = defineProps<Props>()
 
 // Type-scoped id key for a raw over-time record: identifies a single logical
-// finding (e.g. a CVE) across releases/components — deliberately excludes the
-// per-release purl/location so #41's "same CVE in two releases" collapses to one
-// timeline. Mirrors findingKeyForFilter() in FindingChangesDisplayWithAttribution.
+// finding (e.g. a CVE) across releases/components - deliberately excludes the
+// per-release purl/location so "same CVE in two releases" collapses to one
+// timeline. Client-side grouping key only (findingChangeRecordKey in findingUtils);
+// NOT the backend findingKey used by the server-side timeline drill-down.
 function recordFindingKey(rec: MetricsRevisionFindingChange): string | null {
-    if (rec.vulnerability) return `VULN-${rec.vulnerability.vulnId}`
-    if (rec.violation) return `VIOLATION-${rec.violation.type}`
-    if (rec.weakness) return `WEAKNESS-${rec.weakness.cweId || rec.weakness.ruleId || ''}`
-    return null
+    return findingChangeRecordKey(rec)
 }
 
 // Per-release attribution line for a normalized over-time finding (closes #41):

--- a/ui/src/components/changelog/SbomChangesDisplay.vue
+++ b/ui/src/components/changelog/SbomChangesDisplay.vue
@@ -20,12 +20,12 @@
                             <code class="purl">{{ artifact.purl }}</code>
                         </span>
                         <div v-if="showAttribution && artifact.addedIn.length > 0" class="attribution">
-                            <span class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).addedInCount, artifact.addedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).addedInCount, artifact.addedIn) }} more</span></span>
                         </div>
                     </li>
                 </ul>
             </div>
-            
+
             <!-- Net Removed Artifacts -->
             <div v-if="netRemovedArtifacts.length > 0">
                 <h5 class="sbom-removed">Removed ({{ netRemovedArtifacts.length }})</h5>
@@ -38,7 +38,7 @@
                             <code class="purl">{{ artifact.purl }}</code>
                         </span>
                         <div v-if="showAttribution && artifact.removedIn.length > 0" class="attribution">
-                            <span class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).removedInCount, artifact.removedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).removedInCount, artifact.removedIn) }} more</span></span>
                         </div>
                     </li>
                 </ul>
@@ -59,9 +59,9 @@
                             <code class="purl">{{ artifact.purl }}</code>
                         </span>
                         <div v-if="showAttribution" class="attribution">
-                            <span v-if="artifact.addedIn.length > 0" class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span v-if="artifact.addedIn.length > 0" class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).addedInCount, artifact.addedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).addedInCount, artifact.addedIn) }} more</span></span>
                             <span v-if="artifact.addedIn.length > 0 && artifact.removedIn.length > 0" class="attribution-context"> · </span>
-                            <span v-if="artifact.removedIn.length > 0" class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span v-if="artifact.removedIn.length > 0" class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).removedInCount, artifact.removedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).removedInCount, artifact.removedIn) }} more</span></span>
                         </div>
                     </li>
                 </ul>
@@ -82,9 +82,9 @@
                             <code class="purl">{{ artifact.purl }}</code>
                         </span>
                         <div v-if="showAttribution" class="attribution">
-                            <span v-if="artifact.addedIn.length > 0" class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span v-if="artifact.addedIn.length > 0" class="attribution-context">Added in <template v-for="(attr, i) in artifact.addedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).addedInCount, artifact.addedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).addedInCount, artifact.addedIn) }} more</span></span>
                             <span v-if="artifact.addedIn.length > 0 && artifact.removedIn.length > 0" class="attribution-context"> · </span>
-                            <span v-if="artifact.removedIn.length > 0" class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template></span>
+                            <span v-if="artifact.removedIn.length > 0" class="attribution-context">Removed in <template v-for="(attr, i) in artifact.removedIn" :key="attr.releaseUuid"><span v-if="i > 0">, </span><router-link :to="{ name: 'ReleaseView', params: { uuid: attr.releaseUuid } }" class="release-link">{{ attr.componentName }}@{{ attr.releaseVersion }}</router-link><span v-if="attr.branchName" class="branch-hint"> ({{ attr.branchName }})</span></template><span v-if="moreCount((artifact as any).removedInCount, artifact.removedIn) > 0" class="more-text"> +{{ moreCount((artifact as any).removedInCount, artifact.removedIn) }} more</span></span>
                         </div>
                     </li>
                 </ul>
@@ -223,6 +223,14 @@ const hasChanges = computed(() => {
            redistributedArtifacts.value.length > 0 ||
            transientArtifacts.value.length > 0
 })
+
+// "+N more" for the (preview-capped) addedIn/removedIn inline lists. The true
+// total lives in addedInCount/removedInCount (present only on AGGREGATED
+// artifacts; NONE-mode synthetic rows omit them -> returns 0, nothing shown).
+// No drill-down query exists for SBOM, so this is plain text only.
+function moreCount(count: number | undefined, shown: unknown[] | undefined): number {
+    return Math.max(0, (count || 0) - (shown ? shown.length : 0))
+}
 </script>
 
 <style scoped lang="scss">
@@ -326,6 +334,11 @@ const hasChanges = computed(() => {
     }
     
     .attribution-context {
+        color: #888;
+        font-style: italic;
+    }
+
+    .more-text {
         color: #888;
         font-style: italic;
     }

--- a/ui/src/types/changelog-attribution.ts
+++ b/ui/src/types/changelog-attribution.ts
@@ -28,7 +28,7 @@ export interface OrgLevelContext {
     componentCount: number              // Number of components currently affected
     affectedComponentNames: string[]    // Names of components currently affected
     // Posture-worsening context (additive; populated only when the backend feature
-    // flag is on — null/undefined on legacy payloads, render nothing when absent).
+    // flag is on - null/undefined on legacy payloads, render nothing when absent).
     isNewlyKev?: boolean | null         // Finding became a CISA Known Exploited Vulnerability within this period
     isSeverityIncreased?: boolean | null // Finding's severity was raised within this period
     previousSeverity?: string | null    // Prior severity when isSeverityIncreased (for "prev -> current")
@@ -43,6 +43,8 @@ export interface ArtifactWithAttribution {
     version: string
     addedIn: ComponentAttribution[]
     removedIn: ComponentAttribution[]
+    addedInCount: number
+    removedInCount: number
     isNetAdded: boolean      // Org-wide: net added across all components
     isNetRemoved: boolean    // Org-wide: net removed across all components
 }
@@ -60,14 +62,19 @@ export interface SbomChangesWithAttribution {
  * Vulnerability with attribution showing which releases introduced/resolved it
  */
 export interface VulnerabilityWithAttribution {
+    findingKey: string  // opaque handle for the findingAttributionByDate drill-down
     vulnId: string
     purl: string
     severity: string
     aliases: Array<{ aliasId: string }>
     knownExploited?: boolean
+    // *In are PREVIEW-capped (first ATTRIBUTION_PREVIEW_CAP); *InCount is the true total ("+N more").
     resolvedIn: ComponentAttribution[]
     appearedIn: ComponentAttribution[]
     presentIn: ComponentAttribution[]
+    resolvedInCount: number
+    appearedInCount: number
+    presentInCount: number
     isNetResolved: boolean   // Org-wide: net resolved across all components
     isNetAppeared: boolean   // Org-wide: net appeared across all components
     isStillPresent: boolean  // Org-wide: still present in some releases
@@ -79,11 +86,15 @@ export interface VulnerabilityWithAttribution {
  * Violation with attribution
  */
 export interface ViolationWithAttribution {
+    findingKey: string
     type: string
     purl: string
     resolvedIn: ComponentAttribution[]
     appearedIn: ComponentAttribution[]
     presentIn: ComponentAttribution[]
+    resolvedInCount: number
+    appearedInCount: number
+    presentInCount: number
     isNetResolved: boolean
     isNetAppeared: boolean
     isStillPresent: boolean
@@ -95,6 +106,7 @@ export interface ViolationWithAttribution {
  * Weakness with attribution
  */
 export interface WeaknessWithAttribution {
+    findingKey: string
     cweId: string
     severity: string | null
     ruleId: string | null
@@ -102,6 +114,9 @@ export interface WeaknessWithAttribution {
     resolvedIn: ComponentAttribution[]
     appearedIn: ComponentAttribution[]
     presentIn: ComponentAttribution[]
+    resolvedInCount: number
+    appearedInCount: number
+    presentInCount: number
     isNetResolved: boolean
     isNetAppeared: boolean
     isStillPresent: boolean
@@ -119,7 +134,7 @@ export interface FindingChangesWithAttribution {
     totalAppeared: number
     totalResolved: number
     // Posture-worsening rollup counts (additive; null/undefined when the
-    // backend feature flag is off — render the tag only when > 0).
+    // backend feature flag is off - render the tag only when > 0).
     totalNewlyKev?: number | null
     totalSeverityIncreased?: number | null
 }

--- a/ui/src/utils/changelogPdfExport.ts
+++ b/ui/src/utils/changelogPdfExport.ts
@@ -255,7 +255,7 @@ function buildSbomAggregatedTable(changelog: any): { headers: string[]; rows: Pd
     for (const art of sorted) {
         const status = art.isNetAdded ? 'Added' : art.isNetRemoved ? 'Removed' : 'Changed'
         const statusColor = art.isNetAdded ? '#18a058' : art.isNetRemoved ? '#d03050' : '#f0a020'
-        const attribution = formatAttribution(art.addedIn, art.removedIn)
+        const attribution = formatAttribution(art.addedIn, art.removedIn, art.addedInCount, art.removedInCount)
 
         rows.push({ cells: [
             { text: status, color: statusColor },
@@ -423,13 +423,20 @@ function buildFindingAggregatedTable(changelog: any): { headers: string[]; rows:
 
 // ==================== Attribution Helpers ====================
 
-function formatAttribution(addedIn: any[], removedIn: any[]): string {
+// Inline attribution arrays are preview-capped; the true total lives in *InCount.
+// A static PDF cannot lazy-fetch, so append " +N more" to signal truncation.
+function moreSuffix(count: number | undefined, shown: any[]): string {
+    const more = Math.max(0, (count || 0) - (shown ? shown.length : 0))
+    return more > 0 ? ` +${more} more` : ''
+}
+
+function formatAttribution(addedIn: any[], removedIn: any[], addedInCount?: number, removedInCount?: number): string {
     const parts: string[] = []
     if (addedIn && addedIn.length > 0) {
-        parts.push('Added in: ' + addedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', '))
+        parts.push('Added in: ' + addedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', ') + moreSuffix(addedInCount, addedIn))
     }
     if (removedIn && removedIn.length > 0) {
-        parts.push('Removed in: ' + removedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', '))
+        parts.push('Removed in: ' + removedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', ') + moreSuffix(removedInCount, removedIn))
     }
     return parts.join('; ')
 }
@@ -437,10 +444,10 @@ function formatAttribution(addedIn: any[], removedIn: any[]): string {
 function formatFindingAttribution(finding: any): string {
     const parts: string[] = []
     if (finding.appearedIn && finding.appearedIn.length > 0) {
-        parts.push(finding.appearedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', '))
+        parts.push(finding.appearedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', ') + moreSuffix(finding.appearedInCount, finding.appearedIn))
     }
     if (finding.resolvedIn && finding.resolvedIn.length > 0) {
-        parts.push('Resolved: ' + finding.resolvedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', '))
+        parts.push('Resolved: ' + finding.resolvedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', ') + moreSuffix(finding.resolvedInCount, finding.resolvedIn))
     }
     return parts.join('; ')
 }

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -92,8 +92,9 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
 
 // Over-time finding changes: flat list of re-scan-driven MetricsRevisionFindingChange
 // records. Exactly one of vulnerability/violation/weakness is non-null per record;
-// previousSeverity is set only for SEVERITY_INCREASED. Reuses the same lightweight
-// nested selections as the per-release finding-change fragments.
+// previousSeverity is set only for SEVERITY_INCREASED. Selects analysisState on each
+// nested finding for parity with the per-release finding-change fragments (so
+// suppressed/FALSE_POSITIVE findings render correctly in the drill-down drawer).
 const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
     changeDate
     changeKind
@@ -109,17 +110,20 @@ const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
         aliases {
             aliasId
         }
+        analysisState
         knownExploited
     }
     violation {
         type
         purl
+        analysisState
     }
     weakness {
         cweId
         severity
         ruleId
         location
+        analysisState
     }
 `
 
@@ -177,6 +181,8 @@ const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         version
         isNetAdded
         isNetRemoved
+        addedInCount
+        removedInCount
         addedIn {
             ${COMPONENT_ATTRIBUTION_FRAGMENT}
         }
@@ -192,6 +198,7 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
     totalNewlyKev
     totalSeverityIncreased
     vulnerabilities {
+        findingKey
         vulnId
         purl
         severity
@@ -202,6 +209,9 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         isNetAppeared
         isNetResolved
         isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
         appearedIn {
             ${COMPONENT_ATTRIBUTION_FRAGMENT}
         }
@@ -217,11 +227,15 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         analysisState
     }
     violations {
+        findingKey
         type
         purl
         isNetAppeared
         isNetResolved
         isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
         appearedIn {
             ${COMPONENT_ATTRIBUTION_FRAGMENT}
         }
@@ -237,6 +251,7 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         analysisState
     }
     weaknesses {
+        findingKey
         cweId
         severity
         ruleId
@@ -244,6 +259,9 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
         isNetAppeared
         isNetResolved
         isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
         appearedIn {
             ${COMPONENT_ATTRIBUTION_FRAGMENT}
         }
@@ -340,6 +358,9 @@ const AGGREGATED_CHANGELOG_FIELDS = `
         ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
     }
     findingChanges {
+        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+    }
+    postureFindingChanges {
         ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
     }
     overTimeFindingChanges {
@@ -540,4 +561,168 @@ export async function fetchOrganizationChangelogByDate(params: {
     })
 
     return (response.data as any).organizationChangelogByDate as OrganizationChangelog
+}
+
+// ========== Drill-down: full attribution / timeline behind the capped inline previews ==========
+
+export interface ComponentAttributionEntry {
+    componentUuid: string
+    componentName: string
+    releaseUuid: string
+    releaseVersion: string
+    branchUuid?: string
+    branchName?: string
+}
+
+export interface ComponentAttributionPage {
+    items: ComponentAttributionEntry[]
+    total: number
+    page: number
+    pageSize: number
+}
+
+/**
+ * Pages one finding's FULL attribution for a bucket (the "+N more" behind the capped inline list).
+ * `total` equals the *InCount shown inline. Scope: org (only orgUuid) / component (+componentUuid) /
+ * branch (+componentUuid+branchUuid).
+ */
+export async function fetchFindingAttribution(params: {
+    orgUuid: string
+    componentUuid?: string
+    branchUuid?: string
+    perspectiveUuid?: string
+    dateFrom: string
+    dateTo: string
+    findingKind: 'VULNERABILITY' | 'VIOLATION' | 'WEAKNESS'
+    findingKey: string
+    bucket: 'APPEARED' | 'PRESENT' | 'RESOLVED'
+    page?: number
+    pageSize?: number
+}): Promise<ComponentAttributionPage> {
+    const response = await graphqlClient.query({
+        query: gql`
+            query FetchFindingAttribution(
+                $orgUuid: ID!
+                $componentUuid: ID
+                $branchUuid: ID
+                $perspectiveUuid: ID
+                $dateFrom: DateTime!
+                $dateTo: DateTime!
+                $findingKind: ChangelogFindingKind!
+                $findingKey: String!
+                $bucket: FindingAttributionBucket!
+                $page: Int
+                $pageSize: Int
+            ) {
+                findingAttributionByDate(
+                    orgUuid: $orgUuid
+                    componentUuid: $componentUuid
+                    branchUuid: $branchUuid
+                    perspectiveUuid: $perspectiveUuid
+                    dateFrom: $dateFrom
+                    dateTo: $dateTo
+                    findingKind: $findingKind
+                    findingKey: $findingKey
+                    bucket: $bucket
+                    page: $page
+                    pageSize: $pageSize
+                ) {
+                    total
+                    page
+                    pageSize
+                    items {
+                        ${COMPONENT_ATTRIBUTION_FRAGMENT}
+                    }
+                }
+            }
+        `,
+        variables: {
+            orgUuid: params.orgUuid,
+            componentUuid: params.componentUuid || null,
+            branchUuid: params.branchUuid || null,
+            perspectiveUuid: params.perspectiveUuid || null,
+            dateFrom: params.dateFrom,
+            dateTo: params.dateTo,
+            findingKind: params.findingKind,
+            findingKey: params.findingKey,
+            bucket: params.bucket,
+            page: params.page ?? 0,
+            pageSize: params.pageSize ?? 50
+        },
+        fetchPolicy: 'no-cache'
+    })
+    return (response.data as any).findingAttributionByDate as ComponentAttributionPage
+}
+
+export interface MetricsRevisionFindingChangePage {
+    items: any[]
+    total: number
+    page: number
+    pageSize: number
+    since?: string
+}
+
+/**
+ * Pages the over-time finding-change timeline behind the capped inline overTimeFindingChanges. Optional
+ * findingKey narrows to one finding's timeline (drawer). Newest-first.
+ */
+export async function fetchFindingChangeTimeline(params: {
+    orgUuid: string
+    componentUuid?: string
+    branchUuid?: string
+    perspectiveUuid?: string
+    dateFrom: string
+    dateTo: string
+    findingKey?: string
+    page?: number
+    pageSize?: number
+}): Promise<MetricsRevisionFindingChangePage> {
+    const response = await graphqlClient.query({
+        query: gql`
+            query FetchFindingChangeTimeline(
+                $orgUuid: ID!
+                $componentUuid: ID
+                $branchUuid: ID
+                $perspectiveUuid: ID
+                $dateFrom: DateTime!
+                $dateTo: DateTime!
+                $findingKey: String
+                $page: Int
+                $pageSize: Int
+            ) {
+                findingChangeTimelineByDate(
+                    orgUuid: $orgUuid
+                    componentUuid: $componentUuid
+                    branchUuid: $branchUuid
+                    perspectiveUuid: $perspectiveUuid
+                    dateFrom: $dateFrom
+                    dateTo: $dateTo
+                    findingKey: $findingKey
+                    page: $page
+                    pageSize: $pageSize
+                ) {
+                    total
+                    page
+                    pageSize
+                    since
+                    items {
+                        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+                    }
+                }
+            }
+        `,
+        variables: {
+            orgUuid: params.orgUuid,
+            componentUuid: params.componentUuid || null,
+            branchUuid: params.branchUuid || null,
+            perspectiveUuid: params.perspectiveUuid || null,
+            dateFrom: params.dateFrom,
+            dateTo: params.dateTo,
+            findingKey: params.findingKey || null,
+            page: params.page ?? 0,
+            pageSize: params.pageSize ?? 50
+        },
+        fetchPolicy: 'no-cache'
+    })
+    return (response.data as any).findingChangeTimelineByDate as MetricsRevisionFindingChangePage
 }

--- a/ui/src/utils/findingUtils.ts
+++ b/ui/src/utils/findingUtils.ts
@@ -128,6 +128,25 @@ export function normalizeFindingChangeRecord(rec: {
     return null
 }
 
+/**
+ * Type-scoped id key identifying a single logical finding (e.g. a CVE) across
+ * releases/components, used for CLIENT-SIDE grouping of the over-time timeline.
+ * Deliberately excludes the per-release purl/location so a "same CVE in two
+ * releases" case collapses to one group. NOTE: this is a UI grouping key, NOT
+ * the backend `findingKey` (`vulnId|purl`) used by the findingAttributionByDate /
+ * findingChangeTimelineByDate drill-down -- those pass the DTO's `findingKey`.
+ */
+export function findingChangeRecordKey(rec: {
+    vulnerability?: any
+    violation?: any
+    weakness?: any
+}): string | null {
+    if (rec.vulnerability) return `VULN-${rec.vulnerability.vulnId}`
+    if (rec.violation) return `VIOLATION-${rec.violation.type}`
+    if (rec.weakness) return `WEAKNESS-${rec.weakness.cweId || rec.weakness.ruleId || ''}`
+    return null
+}
+
 export function sortBySeverityThenId(findings: NormalizedReleaseFinding[]): NormalizedReleaseFinding[] {
     return [...findings].sort((a, b) => {
         const severityDiff = getSeverityIndex(a.severity) - getSeverityIndex(b.severity)


### PR DESCRIPTION
Companion to **relizaio/rearm-saas#278** (merged): backend caps the changelog attribution lists (`appearedIn`/`presentIn`/`resolvedIn`) at 1 entry with exact `*InCount` totals + a `findingAttributionByDate` paginated drill-down.

## UI
- Renders **1 inline release per bucket + "+N more"**; clicking it opens a drawer that **pages `findingAttributionByDate`** (drawer `total` == the inline count).
- Switches the per-finding **timeline drawer to server-side `findingChangeTimelineByDate`** (inline `overTimeFindingChanges` is now capped to the newest 1000).
- SBOM shows a non-clickable "+N more"; the PDF export appends " +N more" from the counts.
- `OrganizationChangelogView` threads the date/perspective props for the org-changelog drill-down.

## Scope
This is the **organization changelog** drill-down (8 files). The component/product changelog prop-threading is coupled to the board #42 `postureFindingChanges` rollup and lands with that work; there "+N more" degrades gracefully to non-clickable text (counts still shown). Re-cut clean off current `main` (supersedes the earlier entangled PR #179).

## Validation
- `npm run build` passes. (Repo `npm run lint` is independently broken — eslint v10 vs the legacy `.eslintrc` — unrelated to this diff.)
- Live browser smoke on the perf rig org (same org-path code): 6000 "+N more" links render; a finding shown as "1 + **+499 more**" opens the drawer and `findingAttributionByDate` returns **total=500** (exact match), first page of 50.

Requires backend **#278** (merged): new schema fields + `findingAttributionByDate` / `findingChangeTimelineByDate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)