### PR TITLE
rebom: preserve distro and epoch qualifiers in canonical purls

### DIFF
--- a/rebom-backend/src/services/bom/bomComponentExtractor.ts
+++ b/rebom-backend/src/services/bom/bomComponentExtractor.ts
@@ -68,32 +68,46 @@ export interface ParsedBom {
 }
 
 /**
- * purl types whose identity is incomplete without a specific qualifier — the
+ * purl types whose identity is incomplete without specific qualifiers — the
  * purl-spec marks these `requirement: "required"` (julia/swid), plus oci where
- * the registry must be preserved to disambiguate the image. Canonicalization
- * keeps ONLY the listed qualifier for these types and strips everything else.
+ * the registry must be preserved to disambiguate the image, plus Linux distro
+ * packages (apk/deb/rpm/bitnami) where `distro` scopes advisory matching to a
+ * release branch (Alpine secdb / OSV `Alpine:v3.NN` ecosystems — without it a
+ * matcher can only match across all branches, surfacing long-fixed CVEs) and
+ * rpm `epoch` which is part of RPM version identity. Canonicalization keeps
+ * ONLY the listed qualifiers for these types and strips everything else.
  */
-const PRESERVED_QUALIFIERS: Record<string, string> = {
-	julia: 'uuid',
-	swid: 'tag_id',
-	oci: 'repository_url',
+const PRESERVED_QUALIFIERS: Record<string, string[]> = {
+	julia: ['uuid'],
+	swid: ['tag_id'],
+	oci: ['repository_url'],
+	apk: ['distro'],
+	deb: ['distro'],
+	rpm: ['distro', 'epoch'],
+	bitnami: ['distro'],
 };
 
 /**
  * Strip qualifiers and subpath from a purl, leaving the canonical
  * identity part: pkg:<type>/<namespace>/<name>@<version>. For purl types in
- * {@link PRESERVED_QUALIFIERS} the one required qualifier is retained (DTrack
- * and OSV match on the qualifier-stripped purl, but these types lose identity
- * without it). Returns null if the input is missing or unparseable.
+ * {@link PRESERVED_QUALIFIERS} the listed identity-bearing qualifiers are
+ * retained (DTrack and OSV match on the qualifier-stripped purl, but these
+ * types lose identity or advisory-matching precision without them). Returns
+ * null if the input is missing or unparseable.
  */
 export function canonicalizePurl(rawPurl: string | undefined | null): string | null {
 	if (!rawPurl) return null;
 	try {
 		const parsed = PackageURL.fromString(rawPurl);
-		const preserveKey = PRESERVED_QUALIFIERS[parsed.type];
+		const preserveKeys = PRESERVED_QUALIFIERS[parsed.type];
 		let qualifiers: { [k: string]: string } | undefined = undefined;
-		if (preserveKey && parsed.qualifiers && (parsed.qualifiers as any)[preserveKey] != null) {
-			qualifiers = { [preserveKey]: String((parsed.qualifiers as any)[preserveKey]) };
+		if (preserveKeys && parsed.qualifiers) {
+			for (const key of preserveKeys) {
+				if ((parsed.qualifiers as any)[key] != null) {
+					qualifiers = qualifiers ?? {};
+					qualifiers[key] = String((parsed.qualifiers as any)[key]);
+				}
+			}
 		}
 		const canonical = new PackageURL(
 			parsed.type,

--- a/rebom-backend/test/unit/bomComponentExtractor.test.ts
+++ b/rebom-backend/test/unit/bomComponentExtractor.test.ts
@@ -28,6 +28,19 @@ describe('bomComponentExtractor.canonicalizePurl', () => {
 		expect(canonicalizePurl(raw)).toBe('pkg:apk/alpine/openssl@3.5.7-r0');
 	});
 
+	it('produces the same canonical regardless of input qualifier order', () => {
+		expect(canonicalizePurl('pkg:apk/alpine/openssl@3.5.7-r0?arch=x86_64&distro=alpine-3.24.1'))
+			.toBe(canonicalizePurl('pkg:apk/alpine/openssl@3.5.7-r0?distro=alpine-3.24.1&arch=x86_64'));
+		const rpmPermutations = [
+			'pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25&epoch=1',
+			'pkg:rpm/fedora/curl@7.50.3-1.fc25?epoch=1&arch=i386&distro=fedora-25',
+			'pkg:rpm/fedora/curl@7.50.3-1.fc25?epoch=1&distro=fedora-25&arch=i386',
+			'pkg:rpm/fedora/curl@7.50.3-1.fc25?distro=fedora-25&epoch=1&arch=i386',
+		].map(canonicalizePurl);
+		expect(new Set(rpmPermutations).size).toBe(1);
+		expect(rpmPermutations[0]).toBe('pkg:rpm/fedora/curl@7.50.3-1.fc25?distro=fedora-25&epoch=1');
+	});
+
 	it('strips subpath from a purl', () => {
 		const raw = 'pkg:golang/github.com/foo/bar@v1.2.3?go-version=1.22#pkg/util';
 		expect(canonicalizePurl(raw)).toBe('pkg:golang/github.com/foo/bar@v1.2.3');

--- a/rebom-backend/test/unit/bomComponentExtractor.test.ts
+++ b/rebom-backend/test/unit/bomComponentExtractor.test.ts
@@ -6,9 +6,26 @@ import {
 } from '../../src/services/bom/bomComponentExtractor';
 
 describe('bomComponentExtractor.canonicalizePurl', () => {
-	it('strips qualifiers from a purl', () => {
+	it('preserves distro but strips arch for apk', () => {
 		const raw = 'pkg:apk/alpine/alpine-baselayout-data@3.6.5-r0?arch=x86_64&distro=alpine-3.20.5';
-		expect(canonicalizePurl(raw)).toBe('pkg:apk/alpine/alpine-baselayout-data@3.6.5-r0');
+		expect(canonicalizePurl(raw)).toBe(
+			'pkg:apk/alpine/alpine-baselayout-data@3.6.5-r0?distro=alpine-3.20.5');
+	});
+
+	it('preserves distro but strips arch for deb', () => {
+		const raw = 'pkg:deb/debian/curl@7.50.3-1?arch=i386&distro=debian-9';
+		expect(canonicalizePurl(raw)).toBe('pkg:deb/debian/curl@7.50.3-1?distro=debian-9');
+	});
+
+	it('preserves distro and epoch for rpm, strips arch', () => {
+		const raw = 'pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25&epoch=1';
+		expect(canonicalizePurl(raw)).toBe(
+			'pkg:rpm/fedora/curl@7.50.3-1.fc25?distro=fedora-25&epoch=1');
+	});
+
+	it('canonicalizes an apk purl without distro into its bare form', () => {
+		const raw = 'pkg:apk/alpine/openssl@3.5.7-r0?arch=x86_64';
+		expect(canonicalizePurl(raw)).toBe('pkg:apk/alpine/openssl@3.5.7-r0');
 	});
 
 	it('strips subpath from a purl', () => {


### PR DESCRIPTION
## Why

A prod VDR reported 9 false-positive Alpine CVEs (2018-2023 vintage) against current alpine 3.24.1 packages (openssl 3.5.7-r0, busybox 1.37.0-r31, apk-tools 3.0.6-r0). Root-caused to two interacting issues:

1. **Alpine OSV data bugs** - secdb never-affected markers exported as literal fixed-0 range events (matches everything, even branch-scoped), plus inverted ranges (fixed < introduced) in EOL branch ecosystems.
2. **Our canonicalization strips the distro qualifier** - so any OSV-style matcher receives a bare purl and can only match across ALL Alpine:vX.Y branch ecosystems, picking up the EOL-branch garbage. 4 of the 9 FPs exist only in old-branch entries that a distro-scoped match would never consult.

Verified end-to-end on the psclaude sandbox: an SBOM uploaded with pkg:apk/alpine/openssl@3.5.7-r0?arch=x86_64&distro=alpine-3.24.1 reaches Dependency-Track as the bare purl (sbom_components.canonical_purl, identities, and the synthetic bucket ref_map all carry qualifier-free forms).

## What

`PRESERVED_QUALIFIERS` in `bomComponentExtractor.ts` becomes a per-type **list**:

| type | preserved | rationale |
|---|---|---|
| apk / deb / bitnami | `distro` | scopes advisory matching to the release branch |
| rpm | `distro`, `epoch` | epoch is part of RPM version identity |
| julia / swid / oci | unchanged | spec-required / registry disambiguation |

`arch` stays stripped deliberately - advisories are arch-independent and stripping it dedups the same package across image architectures.

Companion PR mirrors the map in rearm-core `Utils.canonicalizePurl` (must produce the identical canonical string for external lookups).

## Data migration

None in this PR - existing `sbom_components` rows keep bare canonicals until reconcile is re-run; the operator triggers that manually (truncate derived tables + re-enqueue via `flow_control`, V37 tail pattern).

## Testing

- 29/29 vitest unit tests pass (4 new: apk/deb/rpm preservation + apk-without-distro stays bare); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)