### PR TITLE
ui: show Release rejected instead of eternal Scan pending

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -476,7 +476,7 @@ const dtrackConfigured: Ref<boolean> = ref(false)
 isDtrackConfiguredForOrg(orguuid).then((c) => { dtrackConfigured.value = c })
 
 function renderPendingBadge (status: { label: string, title: string, kind: string }) {
-    const bg = status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
+    const bg = status.kind === 'rejected' ? '#d03050' : status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
     return h('span', {
         title: status.title,
         style: `display: inline-block; padding: 2px 10px; border-radius: 12px; background: ${bg}; color: white; font-size: 0.8em; white-space: nowrap;`

--- a/ui/src/components/MostRecentReleasesWidget.vue
+++ b/ui/src/components/MostRecentReleasesWidget.vue
@@ -66,7 +66,7 @@
                         <span
                             v-if="getPendingStatus(rel).kind !== 'ready'"
                             :title="getPendingStatus(rel).title"
-                            :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', flexShrink: 0, background: getPendingStatus(rel).kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
+                            :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', flexShrink: 0, background: getPendingStatus(rel).kind === 'rejected' ? '#d03050' : getPendingStatus(rel).kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
                         >{{ getPendingStatus(rel).label }}</span>
                         <n-space :size="1" v-else-if="rel.metrics?.lastScanned" style="flex-shrink: 0;">
                             <span title="Critical Severity Vulnerabilities" class="circle" :style="{ background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer' }" @click="openVulnModal(rel, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ rel.metrics.critical }}</span>

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -646,7 +646,7 @@
                         <span
                             v-if="releaseScanStatus.kind !== 'ready'"
                             :title="releaseScanStatus.title"
-                            :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', background: releaseScanStatus.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
+                            :style="{ display: 'inline-block', padding: '2px 10px', borderRadius: '12px', color: 'white', fontSize: '0.8em', whiteSpace: 'nowrap', background: releaseScanStatus.kind === 'rejected' ? '#d03050' : releaseScanStatus.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107' }"
                         >{{ releaseScanStatus.label }}</span>
                         <n-space :size="1" v-else>
                             <span title="Criticial Severity Vulnerabilities" class="circle" :style="{background: constants.VulnerabilityColors.CRITICAL, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, 'CRITICAL', ['Vulnerability', 'Weakness'])">{{ updatedRelease.metrics.critical }}</span>
@@ -5354,11 +5354,12 @@ function renderEnrichmentPill (row: any): any {
 }
 
 function renderChildScanStatusBadge (status: { label: string, title: string, kind: string }): any {
-    // Same color rule as the home-page widgets and BranchView: orange for the
+    // Same color rule as the home-page widgets and BranchView: red for a
+    // rejected release whose scan will never run, orange for the
     // BOM-enrichment stage, yellow for everything else (DTrack-pending,
     // scan-pending). Keeps the parent-release table's pre-scan child rows in
     // sync with the rest of the UI instead of falling back to zeroed circles.
-    const bg = status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
+    const bg = status.kind === 'rejected' ? '#d03050' : status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
     return h('span', {
         title: status.title,
         style: `display: inline-block; padding: 2px 10px; border-radius: 12px; background: ${bg}; color: white; font-size: 0.8em; white-space: nowrap;`
@@ -5399,6 +5400,11 @@ function renderDtrackPill (row: any): any {
     }
     if (m.dependencyTrackFullUri) {
         return h(NTag, { type: 'warning', size: 'small', round: true, title: 'Submitted to Dependency-Track, awaiting scan results' }, () => 'Scanning…')
+    }
+    // A rejected release's artifacts are never submitted — a "pending" pill
+    // would wait forever, so say what actually happened.
+    if (updatedRelease.value?.lifecycle === 'REJECTED') {
+        return h(NTag, { type: 'error', size: 'small', round: true, title: 'Release was rejected — the scan will not run for this release' }, () => 'Release rejected')
     }
     return h(NTag, { type: 'warning', size: 'small', round: true, title: 'Awaiting Dependency-Track submission' }, () => 'Scan pending')
 }

--- a/ui/src/utils/releaseScanStatus.ts
+++ b/ui/src/utils/releaseScanStatus.ts
@@ -34,7 +34,7 @@ export async function isDtrackConfiguredForOrg (orgUuid: string): Promise<boolea
     }
 }
 
-export type ReleaseScanStatusKind = 'enrichment-pending' | 'dtrack-pending' | 'scan-pending' | 'ready'
+export type ReleaseScanStatusKind = 'enrichment-pending' | 'dtrack-pending' | 'scan-pending' | 'rejected' | 'ready'
 
 export interface ReleaseScanStatus {
     kind: ReleaseScanStatusKind
@@ -53,6 +53,11 @@ export interface ReleaseScanStatus {
  *                      not completed across all scannable inputs (artifacts +
  *                      child releases for products). Catches PENDING-lifecycle
  *                      releases and product releases waiting on a child.
+ *  rejected            the release is REJECTED and its scan never completed —
+ *                      the scan will not run for a rejected release, so a
+ *                      "pending" badge would wait forever. Enrichment-pending
+ *                      is NOT remapped: rebom enrichment is artifact-level and
+ *                      still finishes regardless of release lifecycle.
  *  ready               firstScanned is set — caller renders the existing circles
  */
 export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): ReleaseScanStatus {
@@ -65,9 +70,11 @@ export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): 
             title: 'BOM enrichment in progress for at least one artifact'
         }
     }
+    const rejected = release?.lifecycle === 'REJECTED'
     if (dtrackConfigured) {
         const hasDtrackPending = artifacts.some((a) => isBomDtrackPending(a))
         if (hasDtrackPending) {
+            if (rejected) return rejectedStatus()
             return {
                 kind: 'dtrack-pending',
                 label: 'DTrack pending',
@@ -76,6 +83,7 @@ export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): 
         }
     }
     if (!release?.metrics?.firstScanned) {
+        if (rejected) return rejectedStatus()
         return {
             kind: 'scan-pending',
             label: 'Scan pending',
@@ -83,6 +91,14 @@ export function getReleaseScanStatus (release: any, dtrackConfigured: boolean): 
         }
     }
     return { kind: 'ready', label: '', title: '' }
+}
+
+function rejectedStatus (): ReleaseScanStatus {
+    return {
+        kind: 'rejected',
+        label: 'Release rejected',
+        title: 'Release was rejected — the scan will not run for this release'
+    }
 }
 
 function collectArtifactsForStatus (release: any): any[] {


### PR DESCRIPTION
## Why

A REJECTED release whose initial scan never completed shows a yellow **Scan pending** badge forever — but the scan will never run for a rejected release, so the badge promises something that won't happen.

## What

- `releaseScanStatus.ts`: new `rejected` kind — when `release.lifecycle === 'REJECTED'` and the status would otherwise be `scan-pending` or `dtrack-pending`, return **"Release rejected"** instead. Two deliberate non-remaps:
  - `enrichment-pending` stays as-is — rebom enrichment is artifact-level and completes regardless of release lifecycle, so "Enriching…" remains truthful.
  - Releases that *were* scanned before rejection still show their normal metric circles (`ready` path unchanged).
- Red badge color (`#d03050`, naive-ui error red) wired at all four render sites: release page header, product child-release rows, branch list, home-page recent-releases widget.
- The artifact-level DTrack pill on the release page gets the same treatment for its terminal "Scan pending" state.

## Testing

- `vite build` green; bundle contains the new label at both logic sites.
- On-sandbox visual verification was attempted but blocked: the psclaude backend currently runs a June feature build (`v2026-06-autointegrate-async-retry.59`), and a main-built UI 400s on `FetchRelease` against it (pre-existing schema drift, unrelated to this change). Sandbox UI restored to 26.07.12 afterwards. The change is pure client-side presentation logic on fields (`lifecycle`, `metrics.firstScanned`) that all affected views already fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)