### PR TITLE
chore(deps): netty 4.2.15.Final — fix netty-resolver-dns DNS poisoning CVEs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,7 +31,7 @@
          patch releases that carry CVE fixes vs the BOM-pinned defaults.
          Refresh on each Spring Boot bump and re-check against the
          scanner so we don't silently regress past a future BOM. -->
-    <netty.version>4.2.14.Final</netty.version>
+    <netty.version>4.2.15.Final</netty.version>
     <tomcat.version>11.0.22</tomcat.version>
     <postgresql.version>42.7.13</postgresql.version>
   </properties>


### PR DESCRIPTION
One-line bump of the `netty.version` Spring Boot override: 4.2.14.Final → 4.2.15.Final.

Clears the two CRITICAL findings on the backend source-code BOM — CVE-2026-45674 / CVE-2026-47691 (netty-resolver-dns DNS cache poisoning, missing bailiwick checks on CNAME/NS records), both first patched in 4.2.15.Final. 4.2.16.Final (July 7) held for cooldown; can follow later.

test-compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)