### PR TITLE
build(ui): validate-graphql skips test files

### DIFF
--- a/ui/scripts/validate-graphql.mjs
+++ b/ui/scripts/validate-graphql.mjs
@@ -62,7 +62,10 @@ function walk (dir) {
         const p = join(dir, name)
         const st = statSync(p)
         if (st.isDirectory()) out.push(...walk(p))
-        else if (/\.(ts|vue|js|mjs)$/.test(name)) out.push(p)
+        // Skip test files: their gql documents are deliberately-invalid fixtures
+        // (e.g. a bogus `thing` query used to exercise the drift fallback), not
+        // real UI operations to validate against the prod schema.
+        else if (/\.(ts|vue|js|mjs)$/.test(name) && !/\.(spec|test)\.[tj]s$/.test(name)) out.push(p)
     }
     return out
 }


### PR DESCRIPTION
`ui/scripts/validate-graphql.mjs` walked every `.ts/.vue/.js/.mjs` under `src`, including `*.spec.ts` / `*.test.ts`. Test files carry **deliberately-invalid** `gql` fixtures (e.g. a bogus `thing` query that exercises the schema-drift fallback in `notificationInboxSchemaDrift.spec.ts`), which the validator flags as Pro-schema failures — noise, not real UI operations.

Excludes `*.spec` / `*.test` `.ts`/`.js` files from the walk (added negative lookahead in `walk()`). Validator still runs report-only and exits 0; the remaining Pro failures are the pre-existing dead-UI-GraphQL paths tracked separately (board `t20260706-103640-8807`).

This was an uncommitted change lingering on `main`'s working tree; landing it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)