### PR TITLE
fix(changelog): render SEVERITY_DECREASED + KEV_REMOVED in the over-time view

### DIFF
--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -52,11 +52,43 @@
                     </template>
                 </FindingListSection>
                 <FindingListSection
+                    title="Severity decreased"
+                    title-class="finding-resolved"
+                    :key-prefix="`ot-severity-down-${bucket.dateKey}`"
+                    :findings="bucket.severityDecreased"
+                    description="Findings whose severity was lowered on this date."
+                    @kev-click="openKevModal"
+                >
+                    <template #attribution="{ finding }">
+                        <div class="release-attribution">
+                            {{ releaseLabel(finding) }}
+                            <template v-if="finding.previousSeverity">
+                                <span class="severity-change">Severity: <strong>{{ finding.previousSeverity }}</strong>
+                                    <span class="severity-arrow">→</span>
+                                    <strong>{{ finding.severity || 'UNASSIGNED' }}</strong>
+                                </span>
+                            </template>
+                        </div>
+                    </template>
+                </FindingListSection>
+                <FindingListSection
                     title="KEV listed"
                     title-class="finding-inherited"
                     :key-prefix="`ot-kev-${bucket.dateKey}`"
                     :findings="bucket.kevAdded"
                     description="Findings newly flagged as a CISA Known Exploited Vulnerability on this date."
+                    @kev-click="openKevModal"
+                >
+                    <template #attribution="{ finding }">
+                        <div class="release-attribution">{{ releaseLabel(finding) }}</div>
+                    </template>
+                </FindingListSection>
+                <FindingListSection
+                    title="KEV removed"
+                    title-class="finding-resolved"
+                    :key-prefix="`ot-kev-removed-${bucket.dateKey}`"
+                    :findings="bucket.kevRemoved"
+                    description="Findings no longer flagged as a CISA Known Exploited Vulnerability on this date."
                     @kev-click="openKevModal"
                 >
                     <template #attribution="{ finding }">
@@ -138,7 +170,9 @@ interface DateBucket {
     appeared: OverTimeFinding[]
     resolved: OverTimeFinding[]
     severityIncreased: OverTimeFinding[]
+    severityDecreased: OverTimeFinding[]
     kevAdded: OverTimeFinding[]
+    kevRemoved: OverTimeFinding[]
 }
 
 function dayKey(changeDate: string): string {
@@ -190,7 +224,9 @@ const dateBuckets = computed<DateBucket[]>(() => {
         const appeared: OverTimeFinding[] = []
         const resolved: OverTimeFinding[] = []
         const severityIncreased: OverTimeFinding[] = []
+        const severityDecreased: OverTimeFinding[] = []
         const kevAdded: OverTimeFinding[] = []
+        const kevRemoved: OverTimeFinding[] = []
 
         for (const rec of dayRecords) {
             const f = toOverTimeFinding(rec)
@@ -199,7 +235,9 @@ const dateBuckets = computed<DateBucket[]>(() => {
                 case 'APPEARED': appeared.push(f); break
                 case 'RESOLVED': resolved.push(f); break
                 case 'SEVERITY_INCREASED': severityIncreased.push(f); break
+                case 'SEVERITY_DECREASED': severityDecreased.push(f); break
                 case 'KEV_ADDED': kevAdded.push(f); break
+                case 'KEV_REMOVED': kevRemoved.push(f); break
             }
         }
 
@@ -209,7 +247,9 @@ const dateBuckets = computed<DateBucket[]>(() => {
             appeared: sortBySeverityThenId(appeared) as OverTimeFinding[],
             resolved: sortBySeverityThenId(resolved) as OverTimeFinding[],
             severityIncreased: sortBySeverityThenId(severityIncreased) as OverTimeFinding[],
-            kevAdded: sortBySeverityThenId(kevAdded) as OverTimeFinding[]
+            severityDecreased: sortBySeverityThenId(severityDecreased) as OverTimeFinding[],
+            kevAdded: sortBySeverityThenId(kevAdded) as OverTimeFinding[],
+            kevRemoved: sortBySeverityThenId(kevRemoved) as OverTimeFinding[]
         }
     })
 })

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -89,12 +89,13 @@ export interface ReleaseFindingChanges {
 /**
  * Kind of finding change surfaced by a metrics re-scan over time.
  */
-export type FindingChangeKind = 'APPEARED' | 'RESOLVED' | 'SEVERITY_INCREASED' | 'KEV_ADDED'
+export type FindingChangeKind =
+    'APPEARED' | 'RESOLVED' | 'SEVERITY_INCREASED' | 'SEVERITY_DECREASED' | 'KEV_ADDED' | 'KEV_REMOVED'
 
 /**
  * A single re-scan-driven finding change observed at a point in time.
  * Exactly one of vulnerability / violation / weakness is non-null per record;
- * previousSeverity is set only for SEVERITY_INCREASED.
+ * previousSeverity is set for SEVERITY_INCREASED and SEVERITY_DECREASED (the pre-change severity).
  */
 export interface MetricsRevisionFindingChange {
     changeDate: string

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -92,7 +92,7 @@ const RELEASE_FINDING_CHANGES_FRAGMENT = `
 
 // Over-time finding changes: flat list of re-scan-driven MetricsRevisionFindingChange
 // records. Exactly one of vulnerability/violation/weakness is non-null per record;
-// previousSeverity is set only for SEVERITY_INCREASED. Selects analysisState on each
+// previousSeverity is set for SEVERITY_INCREASED and SEVERITY_DECREASED. Selects analysisState on each
 // nested finding for parity with the per-release finding-change fragments (so
 // suppressed/FALSE_POSITIVE findings render correctly in the drill-down drawer).
 const OVER_TIME_FINDING_CHANGES_FRAGMENT = `


### PR DESCRIPTION
## Problem (audit finding F6)
The changelog over-time "Finding changes" view **silently dropped** `SEVERITY_DECREASED` and `KEV_REMOVED` events. `OverTimeFindingChanges.vue`'s render switch only handled `APPEARED` / `RESOLVED` / `SEVERITY_INCREASED` / `KEV_ADDED`, so:
- **severity was only ever shown going up** (a finding that escalated then de-escalated showed only the escalation), and
- a KEV that was later de-listed never appeared.

On the demo dataset that's **~1,900 `SEVERITY_DECREASED` events hidden in a 30-day window** (16 findings show an increase but not their later decrease).

## Fix (pure UI — no backend change)
The backend already emits and sends both kinds, and the GraphQL fragment selects `changeKind` as an unrestricted scalar, so the data was reaching the client and being discarded at render.
- Add **"Severity decreased"** (mirrors "Severity increased", shows `previousSeverity → severity`) and **"KEV removed"** sections; both use the positive/green `finding-resolved` heading class.
- Extend the `FindingChangeKind` TS union with `SEVERITY_DECREASED` / `KEV_REMOVED`.
- Add the two `switch` cases + `DateBucket` fields; both sort via `sortBySeverityThenId`.
- Sync two stale `// previousSeverity only for SEVERITY_INCREASED` comments.

The per-finding **timeline drill-down drawer** renders the same component, so it gets the fix automatically.

## Validation
- `npm run build` (type-check) passes.
- Two-layer review (correctness + Vue/ReARM conventions): **clean, no blockers**.
- Repo-wide `npm run lint` is broken by a pre-existing eslint flat-config migration issue (separate board task), unrelated to this change.
- **Recommend a quick visual check** on an org with severity-downgrade history before merge (the sections only appear when such events exist in the window).

Part of the changelog design-audit backlog (findings register: `changelog-audit-findings.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)