### PR TITLE
Clarify Newly-KEV / Severity-up badge tooltips as open-findings-only (F9)

### DIFF
--- a/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
+++ b/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
@@ -47,13 +47,13 @@
                     <template #trigger>
                         <n-tag type="error" size="small" :bordered="false" class="tag-spacing worsened-tag">Newly KEV ({{ newlyKevCount }})</n-tag>
                     </template>
-                    <span>Findings newly flagged as a CISA Known Exploited Vulnerability within this period.</span>
+                    <span>Open findings (still present at the end of the period) that became a CISA Known Exploited Vulnerability during it. A finding that became KEV but was resolved before the period ended is not counted here — see the over-time tab for every KEV event.</span>
                 </n-tooltip>
                 <n-tooltip v-if="severityIncreasedCount > 0" trigger="hover" placement="bottom">
                     <template #trigger>
                         <n-tag type="warning" size="small" :bordered="false" class="tag-spacing worsened-tag">Severity ↑ ({{ severityIncreasedCount }})</n-tag>
                     </template>
-                    <span>Findings whose severity was raised within this period.</span>
+                    <span>Open findings (still present at the end of the period) whose severity was raised during it. A finding raised then resolved before the period ended is not counted here — see the over-time tab for every severity change.</span>
                 </n-tooltip>
             </div>
             


### PR DESCRIPTION
The changelog **"Newly KEV"** / **"Severity ↑"** summary badges count **open** findings that worsened in the period (present at both endpoints), not every escalation event — an escalation on a finding that was resolved before the period ended nets out and appears only in the over-time tab. That made the badge count look inconsistent with the raw event stream.

Updated the two summary-tag tooltips to clarify: "Open findings (still present at the end of the period) that became KEV / whose severity was raised during it … see the over-time tab for every event."

Pairs with the **rearm-saas** PR (backend `WorsenedOverlay` javadoc + the F10 fix that stops a brand-new already-KEV finding from badging "Newly-KEV"). Labeling-only; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)