### PR TITLE
Show the branch on over-time timeline drawer rows (F7b)

### DIFF
--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -136,16 +136,18 @@ function recordFindingKey(rec: MetricsRevisionFindingChange): string | null {
     return findingChangeRecordKey(rec)
 }
 
-// Per-release attribution line for a normalized over-time finding (closes #41):
-// two identical CVE rows from different releases are now distinguishable.
-function releaseLabel(finding: { componentName?: string, version?: string }): string {
+// Per-row attribution line for a normalized over-time finding: component@version plus the branch
+// (F7b) so the many drawer rows that share one component@version -- the same finding fanned out across
+// a component's branches -- are distinguishable, not an undifferentiated wall.
+function releaseLabel(finding: { componentName?: string, version?: string, branchName?: string | null }): string {
     const parts: string[] = []
     if (finding.componentName) parts.push(finding.componentName)
     if (finding.version) parts.push(finding.version)
-    if (parts.length === 0) return ''
-    return finding.componentName && finding.version
+    let label = finding.componentName && finding.version
         ? `${finding.componentName}@${finding.version}`
         : parts.join(' ')
+    if (finding.branchName) label = label ? `${label} (${finding.branchName})` : finding.branchName
+    return label
 }
 
 const showKevModal = ref(false)
@@ -161,6 +163,7 @@ type OverTimeFinding = NormalizedReleaseFinding & {
     componentName: string
     version: string
     releaseUuid: string
+    branchName?: string | null
     previousSeverity?: string | null
 }
 
@@ -196,6 +199,7 @@ function toOverTimeFinding(rec: MetricsRevisionFindingChange): OverTimeFinding |
         componentName: rec.componentName,
         version: rec.version,
         releaseUuid: rec.releaseUuid,
+        branchName: rec.branchName ?? null,
         previousSeverity: rec.previousSeverity ?? null
     }
 }

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -104,6 +104,9 @@ export interface MetricsRevisionFindingChange {
     version: string
     componentUuid: string
     componentName: string
+    // F7b: producing branch, so the timeline drawer can distinguish rows sharing one component@version.
+    branchUuid?: string | null
+    branchName?: string | null
     vulnerability?: ReleaseVulnerabilityInfo | null
     violation?: ReleaseViolationInfo | null
     weakness?: ReleaseWeaknessInfo | null

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -102,6 +102,8 @@ const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
     version
     componentUuid
     componentName
+    branchUuid
+    branchName
     previousSeverity
     vulnerability {
         vulnId


### PR DESCRIPTION
The changelog **timeline drill-down drawer** collapsed every branch of a component to an identical `component@version` row (up to ~170 indistinguishable rows for one finding). Thread `branchName` (now on the changelog GraphQL payload) into the row label so they're distinguishable: **`component@version (branch)`**.

- Selects `branchUuid`/`branchName` on the over-time fragment; adds them to the `MetricsRevisionFindingChange` TS type + `OverTimeFinding`; `releaseLabel` appends the branch when present (null-safe, unchanged for branchless rows).
- `npm run build` clean; GraphQL validator 0 Pro failures.

Pairs with the **rearm-saas** PR (backend DTO/schema + branch-name resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)