### PR TITLE
fix(ui): suspend route swaps at their own boundary to stop intermittent stacked layout

### DIFF
--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -21,11 +21,27 @@
             />
                 </n-layout-sider>
                 <n-layout>
-                    <router-view style="margin-left: 5px; margin-right: 5px;"
-                        class="nofloat viewWrapper"
-                        @routerViewEvent="routerViewEventHandle"
-                        :key="$route.fullPath"
-                    />
+                    <!-- Route components use top-level await (async setup), so each
+                         navigation must suspend at its own boundary. Without this
+                         nested Suspense, the keyed remount re-suspends the app-root
+                         Suspense, and a patch landing mid-resolution (menu active
+                         item, store updates) intermittently leaves both the old and
+                         new route subtrees stacked in the DOM until a full reload.
+                         RouteComponent is renamed from the slot's Component prop to
+                         avoid shadowing the Component type imported from vue. -->
+                    <router-view v-slot="{ Component: RouteComponent }">
+                        <template v-if="RouteComponent">
+                            <Suspense>
+                                <component
+                                    :is="RouteComponent"
+                                    style="margin-left: 5px; margin-right: 5px;"
+                                    class="nofloat viewWrapper"
+                                    @routerViewEvent="routerViewEventHandle"
+                                    :key="$route.fullPath"
+                                />
+                            </Suspense>
+                        </template>
+                    </router-view>
                 </n-layout>
             </n-layout>
         </n-space>


### PR DESCRIPTION
## Problem

Intermittently, opening the instance page or browsing between instances leaves the layout corrupted — the instances/clusters lists render stacked and duplicated, with the instance detail pushed below instead of beside them. Only a full page reload (F5) fixes it. A browser console warning about layout forced before stylesheets loaded typically accompanies it.

## Root cause

- Every route component is an async setup component (top-level `await` in `<script setup>`).
- `LeftNavBar`'s `<router-view :key="$route.fullPath">` fully remounts the routed component on **every** navigation — including each instance click, which pushes a new route.
- The only `<Suspense>` boundary was at the app root (`App.vue`). A keyed remount of an async component under an **already-resolved** Suspense re-enters pending while keeping the old subtree visible; a patch landing in that window (the sidebar menu's active item updates from the route immediately, store updates arrive from resolving queries) hits the known Vue Suspense re-entry behavior and leaves **both** the old and new route subtrees in the DOM, stacked. Timing-dependent → intermittent; clean mount on F5 → "fixed".

## Fix

The documented vue-router pattern for async setup route components — suspend each swap at its own boundary:

```vue
<router-view v-slot="{ Component: RouteComponent }">
    <template v-if="RouteComponent">
        <Suspense>
            <component :is="RouteComponent" ... :key="$route.fullPath" />
        </Suspense>
    </template>
</router-view>
```

The root Suspense never re-enters pending on navigation; each route swap resolves in its own nested boundary (old content stays until the new resolves — same UX as before, minus the corruption).

## Validation

- `npm run build` green (`npm run lint` is broken on eslint 9 independently of this change — `--ignore-path` was removed; pre-existing on main).
- Deployed to a live sandbox: instances page and other routes render correctly (screenshot-verified via the playwright probe harness).
- Navigation stress probe: 120 rapid sidebar navigations across async routes (plain + with 600ms-throttled GraphQL responses to widen the suspension window) — exactly one route subtree in the DOM after every navigation.
- Honest caveat: the original race could not be reproduced synthetically on the unfixed build either (it needs real-world timing), so the fix rests on the documented mechanism + regression-free stress, not on a red/green repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
