### PR TITLE
feat(ui): show Dependency-Track version badge on the integration card

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -139,7 +139,12 @@
                                     <div class="instance-row">
                                         <div class="instance-status"><span class="ddot ok" /></div>
                                         <div class="instance-body">
-                                            <div class="instance-name">{{ singleInstanceLabel(card) }}</div>
+                                            <div class="instance-name">
+                                                {{ singleInstanceLabel(card) }}
+                                                <n-tag v-if="card.id === 'DEPENDENCYTRACK' && dtrackVersion" size="small" :bordered="false" :type="dtrackVersion === 'V5' ? 'info' : 'default'" style="margin-left: 6px;">
+                                                    {{ dtrackVersion === 'V5' ? 'v5' : 'v4' }}
+                                                </n-tag>
+                                            </div>
                                             <div v-if="card.id === 'BEAR' && bearIntegration?.uri" class="instance-meta">
                                                 <span class="instance-scope">{{ bearIntegration.uri }}</span>
                                             </div>
@@ -840,7 +845,7 @@ import { useRoute, useRouter } from 'vue-router'
 import {
     NIcon, NButton, NCard, NModal, NForm, NFormItem, NInput, NCheckbox, NCheckboxGroup,
     NRadioGroup, NRadioButton, NRadio, NSelect, NAlert, NSpace, NText, NDynamicInput,
-    NUpload, NUploadTrigger, NTooltip
+    NUpload, NUploadTrigger, NTooltip, NTag
 } from 'naive-ui'
 import {
     Edit as EditIcon, Trash, Refresh, CirclePlus, CloudUpload,
@@ -2344,8 +2349,35 @@ async function loadConfiguredIntegrations(useCache: boolean) {
         if (resp.data?.configuredBaseIntegrations) {
             configuredIntegrations.value = resp.data.configuredBaseIntegrations
         }
+        if (configuredIntegrations.value.includes('DEPENDENCYTRACK')) {
+            await loadDtrackVersion(cachePolicy)
+        } else {
+            dtrackVersion.value = null
+        }
     } catch (err) {
         console.error(err)
+    }
+}
+
+// Detected Dependency-Track generation ("V4"/"V5") for the version badge on
+// the Dependency-Track card. Auto-detected server-side from the instance's
+// /api/version at integration-create time.
+const dtrackVersion: Ref<string | null> = ref(null)
+
+async function loadDtrackVersion(cachePolicy: FetchPolicy) {
+    try {
+        const resp = await graphqlClient.query({
+            query: gql`
+                query dependencyTrackVersion($org: ID!) {
+                    dependencyTrackVersion(org: $org)
+                }`,
+            variables: { org: orguuid.value },
+            fetchPolicy: cachePolicy
+        })
+        dtrackVersion.value = resp.data?.dependencyTrackVersion ?? null
+    } catch (err) {
+        // Older backends without the query: leave the badge off rather than error.
+        dtrackVersion.value = null
     }
 }
 


### PR DESCRIPTION
## What

Surfaces the auto-detected Dependency-Track generation (**v4** / **v5**) as a small tag on the Dependency-Track integration card in Org Settings → Integrations. v5 is tinted (info) so a v5-linked instance is visible at a glance.

Companion to the rearm-saas backend PR that adds Dependency-Track 5 support via an integration version field. The badge reads the new `dependencyTrackVersion(org)` query — loaded only when a DTrack integration is configured, and degrading silently (no badge) against older backends that lack the query.

## Live result on the sandbox

Against the DT5 instance deployed on the sandbox, the card auto-detects and shows the `v5` badge:

- Dependency-Track card, "Configured" state, blue `v5` tag next to it.

(Detection is entirely server-side from the DT instance's `/api/version` at integration-create time; the UI just displays it.)

## Validation

- `npm run build` clean.
- Verified live via Playwright against the sandbox: created a DTrack integration pointing at DT5, badge renders `v5` on the card (auto-detected end-to-end through the deployed backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)