### PR TITLE
feat(ui): help tooltips on every permission function

### DIFF
--- a/ui/src/components/PermissionFunctionLabel.vue
+++ b/ui/src/components/PermissionFunctionLabel.vue
@@ -1,0 +1,29 @@
+<template>
+    <span style="display: inline-flex; align-items: center;">
+        {{ label }}
+        <n-tooltip v-if="description" trigger="hover">
+            <template #trigger>
+                <n-icon size="16" style="margin-left: 4px;">
+                    <QuestionCircle20Regular />
+                </n-icon>
+            </template>
+            <div style="max-width: 480px; white-space: pre-line;">{{ description }}</div>
+        </n-tooltip>
+    </span>
+</template>
+
+<script lang="ts" setup>
+// Label for a single permission function: its display name plus, when one
+// exists, a help icon with the function's description tooltip. Replaces the
+// per-function v-if chains that were duplicated across the org-wide and
+// per-scope function checkbox groups in ScopedPermissions.
+import { computed } from 'vue'
+import { NTooltip, NIcon } from 'naive-ui'
+import { QuestionCircle20Regular } from '@vicons/fluent'
+import commonFunctions from '@/utils/commonFunctions'
+
+const props = defineProps<{ f: string }>()
+
+const label = computed(() => commonFunctions.translateFunctionName(props.f))
+const description = computed(() => commonFunctions.translateFunctionDescription(props.f))
+</script>

--- a/ui/src/components/ScopedPermissions.vue
+++ b/ui/src/components/ScopedPermissions.vue
@@ -41,46 +41,7 @@
             </n-h5>
             <n-checkbox-group v-model:value="orgPermission.functions" @update:value="onOrgFunctionsUpdate">
                 <n-checkbox v-for="f in orgPermissionFunctions" :key="f" :value="f" :title="translateFunctionName(f)">
-                    <span v-if="f === 'FINDING_ANALYSIS_WRITE'" style="display: inline-flex; align-items: center;">
-                        {{ translateFunctionName(f) }}
-                        <n-tooltip trigger="hover">
-                            <template #trigger>
-                                <n-icon size="16" style="margin-left: 4px;">
-                                    <QuestionCircle20Regular />
-                                </n-icon>
-                            </template>
-                            Requires "Finding Analysis Read" function to be able to view existing finding records.
-                        </n-tooltip>
-                    </span>
-                    <span v-else-if="f === 'LIFECYCLE_UPDATE'" style="display: inline-flex; align-items: center;">
-                        {{ translateFunctionName(f) }}
-                        <n-tooltip trigger="hover">
-                            <template #trigger>
-                                <n-icon size="16" style="margin-left: 4px;">
-                                    <QuestionCircle20Regular />
-                                </n-icon>
-                            </template>
-                            Requires Read &amp; Write permission to take effect - granting this function to a Read Only user will not allow them to change lifecycle.
-                        </n-tooltip>
-                    </span>
-                    <span v-else-if="f === 'AGENT'" style="display: inline-flex; align-items: center;">
-                        {{ translateFunctionName(f) }}
-                        <n-tooltip trigger="hover">
-                            <template #trigger>
-                                <n-icon size="16" style="margin-left: 4px;">
-                                    <QuestionCircle20Regular />
-                                </n-icon>
-                            </template>
-                            <div style="max-width: 480px;">
-                                The I-am-an-agent marker — grants a key the right to act as an AI agent: register itself on first call, open / touch / close sessions, attach artifacts, spawn sub-agents. Not needed for human users browsing the AI Agents dashboard or admining agent policies.
-                                <br/><br/>
-                                <strong>Carve-out:</strong> a key with this function (even at <code>READ_ONLY</code>) can also enrol its <em>own</em> SSH/GPG public signing key via <code>rearm agent enrollkey</code> — needed so an agent can sign its first commit without operator intervention. The backend enforces that the key being enrolled targets the calling key's own agent identity; cross-agent enrolment is rejected.
-                            </div>
-                        </n-tooltip>
-                    </span>
-                    <span v-else>
-                        {{ translateFunctionName(f) }}
-                    </span>
+                    <permission-function-label :f="f" />
                 </n-checkbox>
             </n-checkbox-group>
         </n-space>
@@ -122,18 +83,7 @@
                         <n-text depth="3" style="font-size: 12px;">Functions:</n-text>
                         <n-checkbox-group v-model:value="sp.functions" @update:value="onFunctionsUpdate($event, sp)">
                             <n-checkbox v-for="f in scopedPermissionFunctions" :key="f" :value="f" :title="translateFunctionName(f)">
-                                    <span v-if="f === 'LIFECYCLE_UPDATE'" style="display: inline-flex; align-items: center;">
-                                        {{ translateFunctionName(f) }}
-                                        <n-tooltip trigger="hover">
-                                            <template #trigger>
-                                                <n-icon size="16" style="margin-left: 4px;">
-                                                    <QuestionCircle20Regular />
-                                                </n-icon>
-                                            </template>
-                                            Requires Read &amp; Write permission to take effect - granting this function to a Read Only user will not allow them to change lifecycle.
-                                        </n-tooltip>
-                                    </span>
-                                    <span v-else>{{ translateFunctionName(f) }}</span>
+                                    <permission-function-label :f="f" />
                                 </n-checkbox>
                         </n-checkbox-group>
                     </n-space>
@@ -182,18 +132,7 @@
                         <n-text depth="3" style="font-size: 12px;">Functions:</n-text>
                         <n-checkbox-group v-model:value="sp.functions" @update:value="onFunctionsUpdate($event, sp)">
                             <n-checkbox v-for="f in scopedPermissionFunctions" :key="f" :value="f" :title="translateFunctionName(f)">
-                                    <span v-if="f === 'LIFECYCLE_UPDATE'" style="display: inline-flex; align-items: center;">
-                                        {{ translateFunctionName(f) }}
-                                        <n-tooltip trigger="hover">
-                                            <template #trigger>
-                                                <n-icon size="16" style="margin-left: 4px;">
-                                                    <QuestionCircle20Regular />
-                                                </n-icon>
-                                            </template>
-                                            Requires Read &amp; Write permission to take effect - granting this function to a Read Only user will not allow them to change lifecycle.
-                                        </n-tooltip>
-                                    </span>
-                                    <span v-else>{{ translateFunctionName(f) }}</span>
+                                    <permission-function-label :f="f" />
                                 </n-checkbox>
                         </n-checkbox-group>
                     </n-space>
@@ -243,18 +182,7 @@
                         <n-text depth="3" style="font-size: 12px;">Functions:</n-text>
                         <n-checkbox-group v-model:value="sp.functions" @update:value="onFunctionsUpdate($event, sp)">
                             <n-checkbox v-for="f in scopedPermissionFunctions" :key="f" :value="f" :title="translateFunctionName(f)">
-                                    <span v-if="f === 'LIFECYCLE_UPDATE'" style="display: inline-flex; align-items: center;">
-                                        {{ translateFunctionName(f) }}
-                                        <n-tooltip trigger="hover">
-                                            <template #trigger>
-                                                <n-icon size="16" style="margin-left: 4px;">
-                                                    <QuestionCircle20Regular />
-                                                </n-icon>
-                                            </template>
-                                            Requires Read &amp; Write permission to take effect - granting this function to a Read Only user will not allow them to change lifecycle.
-                                        </n-tooltip>
-                                    </span>
-                                    <span v-else>{{ translateFunctionName(f) }}</span>
+                                    <permission-function-label :f="f" />
                                 </n-checkbox>
                         </n-checkbox-group>
                     </n-space>
@@ -383,6 +311,7 @@ import { X as CloseIcon } from '@vicons/tabler'
 import { QuestionCircle20Regular } from '@vicons/fluent'
 import constants from '@/utils/constants'
 import commonFunctions from '@/utils/commonFunctions'
+import PermissionFunctionLabel from '@/components/PermissionFunctionLabel.vue'
 
 interface ApprovalRole {
     id: string

--- a/ui/src/utils/commonFunctions.ts
+++ b/ui/src/utils/commonFunctions.ts
@@ -31,6 +31,39 @@ function translateFunctionName(fn: string): string {
     }
 }
 
+// Help-tooltip text for each permission function, keyed by the backend
+// PermissionFunction enum value. Rendered by PermissionFunctionLabel next to
+// the function's checkbox. Plain text; blank lines become paragraph breaks
+// (the label renders with white-space: pre-line). Keep in sync with the
+// PermissionFunction enum in the backend (model/UserPermission.java).
+const PERMISSION_FUNCTION_DESCRIPTIONS: Record<string, string> = {
+    FINDING_ANALYSIS_READ:
+        'View existing finding analysis records - VEX statements, suppressions, and justifications on vulnerabilities and policy violations.',
+    FINDING_ANALYSIS_WRITE:
+        'Create and edit finding analysis (VEX / suppression / justification). Requires "Finding Analysis Read" to also view existing finding records.',
+    ARTIFACT_DOWNLOAD:
+        'Download release artifacts - SBOMs, attestations, and other stored files.',
+    LIFECYCLE_UPDATE:
+        'Advance a release through its lifecycle (e.g. Draft to Assembled to Rejected). Requires Read & Write permission to take effect - granting this function to a Read Only user will not allow them to change lifecycle.',
+    SBOM_PROBING:
+        'Upload a temporary SBOM to get vulnerability and policy stats on it, without creating a persistent Dependency-Track project or a release.',
+    DEVOPS_READ:
+        'View the DevOps surface - instances, clusters, and their current deployment state.',
+    DEVOPS_WRITE:
+        'Modify the DevOps surface - register instances and clusters and submit deployment state. Requires Read & Write permission to take effect.',
+    VERSION_FEATURESET:
+        'Create a new product feature set with selected dependency-branch overrides applied on top of the base feature set. Typically granted to a CI/CD (FREEFORM) key on the product.',
+    AGENT:
+        'The "I am an agent" marker - grants a key the right to act as an AI agent: register itself on first call, open / touch / close sessions, attach artifacts, and spawn sub-agents. Not needed for human users browsing the AI Agents dashboard or managing agent policies.\n\n' +
+        'Carve-out: a key with this function (even Read Only) can also enrol its own SSH/GPG public signing key via "rearm agent enrollkey" - needed so an agent can sign its first commit without operator intervention. The backend enforces that the key being enrolled targets the calling key\'s own agent identity; cross-agent enrolment is rejected.',
+    DISTRIBUTION:
+        'Access the Distribution module - clients, sites, shipments, devices, and device events. Organization admins have this implicitly.',
+}
+
+function translateFunctionDescription(fn: string): string | null {
+    return PERMISSION_FUNCTION_DESCRIPTIONS[fn] ?? null
+}
+
 function getUserPermission (org : string, myUser: any) {
     let userPermission = {
         org: '',
@@ -345,6 +378,7 @@ export default {
     getUserPermission,
     translatePermissionName,
     translateFunctionName,
+    translateFunctionDescription,
     deepCopy,
     isAdmin,
     isWritable,


### PR DESCRIPTION
## What

Adds a help icon + tooltip to **every** org-wide and per-scope permission function in the permission editor (`ScopedPermissions`). Previously only *Finding Analysis Write*, *Lifecycle Update*, and *AI Agent* had them.

Now covered: Finding Analysis Read, Finding Analysis Write, Artifact Download, Lifecycle Update, SBOM Probing, DevOps Read, DevOps Write, Version Feature Set, AI Agent, Distribution.

## How

The old approach was a hand-written `v-if / v-else-if` chain per function, **duplicated four times** (org-wide + per-perspective + per-product + per-component checkbox groups). This generalizes it:

- **One description map** — `translateFunctionDescription(fn)` in `commonFunctions.ts`, keyed by the backend `PermissionFunction` enum value. Adding/editing a tooltip is a one-line change in one place.
- **One reusable component** — `PermissionFunctionLabel.vue` renders the function's display name plus, when a description exists, the help icon + tooltip.
- The four duplicated blocks collapse to `<permission-function-label :f="f" />`.

Net: `ScopedPermissions.vue` loses ~76 lines of duplicated markup; the tooltip copy is centralized and enum-keyed so it stays in sync with the backend.

## Validation

- `npm run build` clean.
- Verified live on the sandbox via Playwright (Free Form Key -> Permissions -> Read & Write): all 9 org-wide functions show a `?` help icon; hovering a previously-untooltipped one (Distribution) renders its description. Screenshots below.

Descriptions are sourced from the authoritative `PermissionFunction` enum comments in the backend (`model/UserPermission.java`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)