### PR TITLE
feat(ui): report VEX import outcome instead of a misleading 'processing' toast

### DIFF
--- a/ui/src/components/CreateArtifact.vue
+++ b/ui/src/components/CreateArtifact.vue
@@ -368,14 +368,25 @@ const onSubmit = async () => {
         createArtifactInput.sce = props.inputSce
     }
 
+    // Capture the display id we submitted so we can locate the resulting VEX
+    // artifact (and its import summary) in the mutation response below.
+    const submittedDisplayId = artifact.value.displayIdentifier
+    const isVex = artifact.value.type === 'VEX'
+    // For a VEX upload, ask the mutation for the resulting artifacts + their
+    // import summary so we can report matched / unmatched counts.
+    const releaseBody = isVex
+        ? `uuid artifactDetails { uuid displayIdentifier type vexImportSummary { statementsTotal proposalsCreated proposalsAutoAccepted proposalsAutoRejected statementsUnmatched statementsErrored } }`
+        : `uuid`
+
     isUploading.value = true
     try{
+        let mutationResult: any
         if(props.isUpdateExistingBom){
-            const response = await graphqlClient.mutate({
+            mutationResult = await graphqlClient.mutate({
                 mutation: gql`
                     mutation addArtifactManual($artifactInput: CreateArtifactInput, $artifactUuid: ID!) {
                         addArtifactManual(artifactInput: $artifactInput, artifactUuid: $artifactUuid) {
-                            uuid
+                            ${releaseBody}
                         }
                     }`,
                 variables: {
@@ -386,11 +397,11 @@ const onSubmit = async () => {
             })
             emit('addArtifact')
         }else {
-            const response = await graphqlClient.mutate({
+            mutationResult = await graphqlClient.mutate({
                 mutation: gql`
                     mutation addArtifactManual($artifactInput: CreateArtifactInput) {
                         addArtifactManual(artifactInput: $artifactInput) {
-                            uuid
+                            ${releaseBody}
                         }
                     }`,
                 variables: {
@@ -401,14 +412,8 @@ const onSubmit = async () => {
             emit('addArtifact')
         }
 
-        if (artifact.value.type === 'VEX') {
-            Swal.fire({
-                icon: 'success',
-                title: 'VEX uploaded',
-                text: 'Statements are being processed in the background. Open the VEX tab on this release (or the org-wide VEX Proposals inbox) to review proposals.',
-                timer: 6000,
-                showConfirmButton: true,
-            })
+        if (isVex) {
+            showVexOutcome(mutationResult?.data?.addArtifactManual, submittedDisplayId)
         }
 
     }   catch (err: any) {
@@ -421,6 +426,58 @@ const onSubmit = async () => {
         isUploading.value = false
     }
 };
+
+// Report the VEX import outcome. VEX import is synchronous, so the counts are
+// final by the time the mutation returns -- if nothing matched the release's
+// SBOM inventory, say so instead of pointing the user at an empty VEX tab.
+function showVexOutcome(release: any, displayId: string) {
+    const artifacts = release?.artifactDetails ?? []
+    const vexArtifact = artifacts
+        .filter((a: any) => a?.type === 'VEX' && a?.displayIdentifier === displayId)
+        .find((a: any) => a?.vexImportSummary)
+    const s = vexArtifact?.vexImportSummary
+
+    if (!s) {
+        // No summary available (older backend, or nothing to summarize): keep it
+        // truthful -- processing is already done, direct the user to the tab.
+        Swal.fire({
+            icon: 'success', title: 'VEX uploaded',
+            text: 'Open the VEX tab on this release (or the org-wide VEX Proposals inbox) to review proposals.',
+            timer: 6000, showConfirmButton: true,
+        })
+        return
+    }
+
+    const total = s.statementsTotal ?? 0
+    const staged = s.proposalsCreated ?? 0
+    const accepted = s.proposalsAutoAccepted ?? 0
+    const rejected = s.proposalsAutoRejected ?? 0
+    const unmatched = s.statementsUnmatched ?? 0
+    const errored = s.statementsErrored ?? 0
+    const matched = staged + accepted + rejected
+
+    if (total > 0 && matched === 0) {
+        const parts = [`${total} VEX statement${total === 1 ? '' : 's'} uploaded, but none matched components in this release's SBOM inventory, so nothing was added to the VEX tab.`]
+        if (unmatched > 0) parts.push(`${unmatched} unmatched (the VEX product PURLs / versions do not correspond to any component in the release's SBOM).`)
+        if (errored > 0) parts.push(`${errored} could not be parsed.`)
+        parts.push('Check that the VEX targets the same component PURLs (including version) that appear in this release\'s SBOM.')
+        Swal.fire({ icon: 'warning', title: 'No VEX statements matched', text: parts.join(' '), showConfirmButton: true })
+        return
+    }
+
+    const parts = []
+    if (staged > 0) parts.push(`${staged} staged for review`)
+    if (accepted > 0) parts.push(`${accepted} auto-accepted`)
+    if (rejected > 0) parts.push(`${rejected} auto-rejected`)
+    if (unmatched > 0) parts.push(`${unmatched} unmatched`)
+    if (errored > 0) parts.push(`${errored} errored`)
+    Swal.fire({
+        icon: 'success', title: 'VEX processed',
+        text: `${total} statement${total === 1 ? '' : 's'}: ${parts.join(', ')}. Open the VEX tab to review.`,
+        timer: 7000, showConfirmButton: true,
+    })
+}
+
 const onCreateDownloadLinks = () => {
     return {
         uri: '',


### PR DESCRIPTION
## Problem

VEX import is **synchronous**, but the upload toast said statements were *"being processed in the background"* and pointed at the VEX tab — which stays empty when nothing matched the release's SBOM inventory. So a user whose VEX didn't match (e.g. PURL version mismatch, or `affects[].ref` bom-refs that don't resolve) waits on a job that already finished, staring at an empty tab with no explanation. (Operator-reported; root cause diagnosed on the sandbox.)

## Change

Companion to the rearm-saas backend PR that adds `Artifact.vexImportSummary`. On VEX upload, request the summary in the `addArtifactManual` response and report the actual outcome:

- **Nothing matched** → warning: *"N VEX statements uploaded, but none matched components in this release's SBOM inventory, so nothing was added to the VEX tab. … Check that the VEX targets the same component PURLs (including version) that appear in this release's SBOM."*
- **Matched** → success summary: *"N statements: X staged for review, Y auto-accepted, Z unmatched. Open the VEX tab to review."*
- Falls back to a truthful generic message (no "background" wording) on older backends that don't return the summary.

## Validation

- `npm run build` clean.
- Deployed to the sandbox (latest main); confirmed the toast logic is live in the served bundle, and the backend returns the matched/unmatched summary the toast consumes (verified end-to-end via the real `addArtifactManual` multipart path). The `@vex` integration suite passes 7/7 against the deployed backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)