### PR TITLE
backend: sync shared source tree from ReARM Pro backend

### DIFF
--- a/backend/src/main/java/io/reliza/model/ArtifactData.java
+++ b/backend/src/main/java/io/reliza/model/ArtifactData.java
@@ -22,6 +22,7 @@ import io.reliza.common.CommonVariables.TagRecord;
 import io.reliza.common.Utils;
 import io.reliza.model.dto.ArtifactDto;
 import io.reliza.model.dto.ReleaseMetricsDto;
+import io.reliza.model.dto.VexImportSummary;
 import io.reliza.model.tea.Link;
 import io.reliza.model.tea.Rebom.InternalBom;
 import io.reliza.model.tea.TeaChecksumType;
@@ -329,6 +330,10 @@ public class ArtifactData extends RelizaDataParent implements RelizaObject {
 	private String version; // FIGURE OUT VERSIONING 
 	@JsonIgnore
 	private DependencyTrackIntegration metrics = new DependencyTrackIntegration();
+	// Outcome of the VEX import this artifact triggered (VEX artifacts only;
+	// null otherwise). Persisted so the upload UI can report matched / unmatched
+	// counts instead of leaving the user with a silently empty VEX tab.
+	private VexImportSummary vexImportSummary;
 	/**
 	 * Artifact may have its own artifacts - this is for signature related artifacts, maybe there will be more use cases discovered later
 	 */

--- a/backend/src/main/java/io/reliza/model/dto/VexImportSummary.java
+++ b/backend/src/main/java/io/reliza/model/dto/VexImportSummary.java
@@ -1,0 +1,56 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+/**
+ * Compact, durable outcome of a VEX import, persisted on the VEX
+ * {@link io.reliza.model.ArtifactData} that produced it and surfaced to the UI
+ * (see the {@code Artifact.vexImportSummary} GraphQL field). Unlike
+ * {@link VexImportResult} -- the transient, per-dispatch working object that
+ * also carries the created proposal UUIDs -- this holds only the counts a user
+ * needs to understand what happened, so an upload that matched nothing shows
+ * "N statements, 0 matched" instead of a silently empty VEX tab.
+ *
+ * <p>{@code proposalsCreated} counts statements staged for review (PENDING);
+ * {@code proposalsAutoAccepted} counts statements applied immediately. A
+ * statement that matched no component in the release's SBOM inventory is
+ * counted in {@code statementsUnmatched} and produces no proposal.
+ */
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VexImportSummary {
+    private int statementsTotal;
+    private int proposalsCreated;
+    private int proposalsAutoAccepted;
+    private int proposalsAutoRejected;
+    private int statementsUnmatched;
+    private int statementsErrored;
+    // Capped at MAX_ERROR_MESSAGES so a pathological VEX can't bloat the artifact record.
+    private List<String> errorMessages;
+
+    public static final int MAX_ERROR_MESSAGES = 20;
+
+    public static VexImportSummary fromResult(VexImportResult r) {
+        VexImportSummary s = new VexImportSummary();
+        s.setStatementsTotal(r.getStatementsTotal());
+        s.setProposalsCreated(r.getProposalsCreated());
+        s.setProposalsAutoAccepted(r.getProposalsAutoAccepted());
+        s.setProposalsAutoRejected(r.getProposalsAutoRejected());
+        s.setStatementsUnmatched(r.getStatementsUnmatched());
+        s.setStatementsErrored(r.getStatementsErrored());
+        List<String> errors = r.getErrorMessages();
+        if (errors != null && !errors.isEmpty()) {
+            s.setErrorMessages(errors.size() > MAX_ERROR_MESSAGES
+                ? List.copyOf(errors.subList(0, MAX_ERROR_MESSAGES))
+                : List.copyOf(errors));
+        }
+        return s;
+    }
+}

--- a/backend/src/main/java/io/reliza/service/ArtifactService.java
+++ b/backend/src/main/java/io/reliza/service/ArtifactService.java
@@ -60,6 +60,7 @@ import io.reliza.model.WhoUpdated;
 import io.reliza.model.dto.ArtifactDto;
 import io.reliza.model.dto.OASResponseDto;
 import io.reliza.model.dto.ReleaseMetricsDto;
+import io.reliza.model.dto.VexImportSummary;
 import io.reliza.model.tea.TeaChecksumType;
 import io.reliza.model.tea.Rebom.InternalBom;
 import io.reliza.model.tea.Rebom.RebomOptions;
@@ -297,6 +298,25 @@ public class ArtifactService {
 	 * @return updated Artifact
 	 * @throws RelizaException if artifact not found or validation fails
 	 */
+	/**
+	 * Persist the VEX import outcome onto the artifact that triggered it, so the
+	 * upload UI can report matched / unmatched counts (see the
+	 * {@code Artifact.vexImportSummary} GraphQL field). Best-effort at the call
+	 * site: a failure here must not fail the artifact upload -- the proposals
+	 * (if any) are already committed by the REQUIRES_NEW import.
+	 */
+	@Transactional
+	public void saveArtifactVexImportSummary(UUID artifactUuid, VexImportSummary summary, WhoUpdated wu) throws RelizaException {
+		Optional<Artifact> oa = sharedArtifactService.getArtifact(artifactUuid);
+		if (oa.isEmpty()) {
+			throw new RelizaException("Artifact not found: " + artifactUuid);
+		}
+		Artifact a = oa.get();
+		ArtifactData ad = ArtifactData.dataFromRecord(a);
+		ad.setVexImportSummary(summary);
+		sharedArtifactService.saveArtifact(a, ad, wu);
+	}
+
 	@Transactional
 	public Artifact updateArtifactTags(UUID artifactUuid, List<TagRecord> newTags, WhoUpdated wu) throws RelizaException {
 		Optional<Artifact> oa = sharedArtifactService.getArtifact(artifactUuid);

--- a/backend/src/main/java/io/reliza/service/ReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseService.java
@@ -72,6 +72,8 @@ import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilityReferenceDto;
 import io.reliza.model.VulnerabilityRecordData;
 import io.reliza.model.VulnerabilityRecordData.CvssScore;
 import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilitySeverity;
+import io.reliza.model.dto.VexImportResult;
+import io.reliza.model.dto.VexImportSummary;
 import io.reliza.common.SidPurlUtils;
 import io.reliza.common.Utils;
 import io.reliza.common.Utils.ArtifactBelongsTo;
@@ -1418,8 +1420,11 @@ public class ReleaseService {
 			dispatchDto.setVexImportMode(vu.inputDto().getVexImportMode());
 			dispatchDto.setUserIssuerClassOverride(vu.inputDto().getUserIssuerClassOverride());
 			try {
-				vexImportService.dispatchFromArtifact(
+				VexImportResult vexResult = vexImportService.dispatchFromArtifact(
 					artId, dispatchDto, rd, belongsTo, vu.content(), wu);
+				// Stamp the outcome on the artifact so consumers can report
+				// matched / unmatched counts (mirrors the manual upload path).
+				artifactService.saveArtifactVexImportSummary(artId, VexImportSummary.fromResult(vexResult), wu);
 			} catch (Exception e) {
 				log.warn("VEX import dispatch failed for artifact {} on release {}: {}",
 					artId, rd.getUuid(), e.getMessage());

--- a/backend/src/main/java/io/reliza/service/kev/CisaKevConnector.java
+++ b/backend/src/main/java/io/reliza/service/kev/CisaKevConnector.java
@@ -46,6 +46,7 @@ public class CisaKevConnector implements KevSourceConnector {
 	private static final String KEV_USER_AGENT = "ReARM-KEV-Sync/1.0 (+https://reliza.io)";
 
 	private final String feedUrl;
+	private final String backupFeedUrl;
 	// Non-final so tests can substitute an ExchangeFunction-stubbed client.
 	private WebClient webClient;
 	// First backoff step; exponential from here. Package-private and non-final
@@ -54,8 +55,15 @@ public class CisaKevConnector implements KevSourceConnector {
 
 	public CisaKevConnector(
 			@Value("${relizaprops.kevFeedUrl:https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json}")
-			String feedUrl) {
+			String feedUrl,
+			// CISA's own first-party mirror (cisagov org) of the same feed —
+			// byte-identical output of the same publishing pipeline. Used only
+			// when the primary fails (e.g. Akamai WAF cooldown on our egress
+			// IP); GitHub's CDN has an independent failure domain.
+			@Value("${relizaprops.kevFeedBackupUrl:https://raw.githubusercontent.com/cisagov/kev-data/refs/heads/develop/known_exploited_vulnerabilities.json}")
+			String backupFeedUrl) {
 		this.feedUrl = feedUrl;
+		this.backupFeedUrl = backupFeedUrl;
 		// Feed is ~4 MB and growing; default 256 KB codec buffer would reject it.
 		ExchangeStrategies strategies = ExchangeStrategies.builder()
 				.codecs(codecs -> codecs.defaultCodecs().maxInMemorySize(32 * 1024 * 1024))
@@ -82,39 +90,52 @@ public class CisaKevConnector implements KevSourceConnector {
 
 	@Override
 	public List<KevAssertionData> fetchCatalog(String credential) {
-		// Public feed — no auth, credential is ignored.
+		// Public feed — no auth, credential is ignored. Primary first; on any
+		// failure (fetch, parse, or empty catalog) fall back to the backup
+		// mirror. Only when BOTH fail is an error logged — a primary blip with
+		// a healthy backup is a warning-grade event, not an incident.
 		try {
-			String body = webClient.get()
-					// URI.create: pass the configured URL byte-for-byte, no template re-encoding
-					.uri(URI.create(feedUrl))
-					.header(HttpHeaders.USER_AGENT, KEV_USER_AGENT)
-					.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-					.retrieve()
-					.bodyToMono(String.class)
-					// Back off on transient Akamai throttling (429/5xx). NOT 403:
-					// once CISA's WAF 403s the egress IP the penalty persists for
-					// a cooldown far longer than this bounded backoff, so retrying
-					// only adds load to an already-blocked IP -- fail closed and let
-					// the next scheduled pass retry. (The dedup upstream is what
-					// keeps us from tripping the WAF in the first place.)
-					.retryWhen(Retry.backoff(3, retryFirstBackoff)
-							.maxBackoff(Duration.ofSeconds(30))
-							.filter(CisaKevConnector::isTransient))
-					.block(Duration.ofSeconds(120));
-			CisaKevCatalog catalog = Utils.OM.readValue(body, CisaKevCatalog.class);
-			if (catalog == null || catalog.vulnerabilities() == null || catalog.vulnerabilities().isEmpty()) {
-				log.error("CISA KEV fetch aborted: feed at {} parsed to an empty catalog", feedUrl);
-				return List.of();
-			}
-			List<KevAssertionData> entries = new ArrayList<>(catalog.vulnerabilities().size());
-			for (CisaKevEntry e : catalog.vulnerabilities()) {
-				entries.add(toAssertionData(e));
-			}
-			return entries;
-		} catch (Exception e) {
-			log.error("CISA KEV fetch aborted: failed to fetch or parse feed at {}", feedUrl, e);
+			return fetchAndParse(feedUrl);
+		} catch (Exception primaryFailure) {
+			log.warn("CISA KEV primary feed fetch failed ({}), trying backup feed", primaryFailure.getMessage());
+		}
+		try {
+			return fetchAndParse(backupFeedUrl);
+		} catch (Exception backupFailure) {
+			log.error("CISA KEV fetch aborted: primary {} and backup {} both failed", feedUrl, backupFeedUrl,
+					backupFailure);
 			return List.of();
 		}
+	}
+
+	/** Fetch one feed URL and parse it; throws on any failure incl. an empty catalog. */
+	private List<KevAssertionData> fetchAndParse(String url) throws Exception {
+		String body = webClient.get()
+				// URI.create: pass the configured URL byte-for-byte, no template re-encoding
+				.uri(URI.create(url))
+				.header(HttpHeaders.USER_AGENT, KEV_USER_AGENT)
+				.header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+				.retrieve()
+				.bodyToMono(String.class)
+				// Back off on transient Akamai throttling (429/5xx). NOT 403:
+				// once CISA's WAF 403s the egress IP the penalty persists for
+				// a cooldown far longer than this bounded backoff, so retrying
+				// only adds load to an already-blocked IP -- fall through to
+				// the backup feed instead. (The dedup upstream is what keeps
+				// us from tripping the WAF in the first place.)
+				.retryWhen(Retry.backoff(3, retryFirstBackoff)
+						.maxBackoff(Duration.ofSeconds(30))
+						.filter(CisaKevConnector::isTransient))
+				.block(Duration.ofSeconds(120));
+		CisaKevCatalog catalog = Utils.OM.readValue(body, CisaKevCatalog.class);
+		if (catalog == null || catalog.vulnerabilities() == null || catalog.vulnerabilities().isEmpty()) {
+			throw new IllegalStateException("feed at " + url + " parsed to an empty catalog");
+		}
+		List<KevAssertionData> entries = new ArrayList<>(catalog.vulnerabilities().size());
+		for (CisaKevEntry e : catalog.vulnerabilities()) {
+			entries.add(toAssertionData(e));
+		}
+		return entries;
 	}
 
 	private static KevAssertionData toAssertionData(CisaKevEntry e) {

--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -125,6 +125,8 @@ import io.reliza.service.SharedReleaseService;
 import io.reliza.service.SourceCodeEntryService;
 import io.reliza.service.UserService;
 import io.reliza.service.VariantService;
+import io.reliza.model.dto.VexImportResult;
+import io.reliza.model.dto.VexImportSummary;
 import io.reliza.service.VexImportService;
 import io.reliza.service.oss.OssPerspectiveService;
 import io.reliza.service.oss.OssReleaseService;
@@ -1524,9 +1526,12 @@ public class ReleaseDatafetcher {
 
 			if (ArtifactType.VEX.equals(artDto.getType()) && multipartFile != null) {
 				try {
-					vexImportService.dispatchFromArtifact(
+					VexImportResult vexResult = vexImportService.dispatchFromArtifact(
 						artId, artDto, rd, belongsTo,
 						multipartFile.getBytes(), wu);
+					// Stamp the outcome on the artifact so the UI can report
+					// matched / unmatched counts instead of a silently empty VEX tab.
+					artifactService.saveArtifactVexImportSummary(artId, VexImportSummary.fromResult(vexResult), wu);
 				} catch (Exception e) {
 					log.warn("VEX import dispatch failed for artifact {} on release {}: {}",
 						artId, rd.getUuid(), e.getMessage());

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -3155,6 +3155,25 @@ type Artifact {
 	# rebom). The UI uses this to render PENDING / COMPLETED / FAILED / SKIPPED
 	# pills next to the artifact row.
 	enrichmentStatus: EnrichmentStatus
+	# Outcome of the VEX import this artifact triggered (VEX artifacts only;
+	# null otherwise). Lets the UI report matched / unmatched statement counts
+	# instead of leaving the user with a silently empty VEX tab.
+	vexImportSummary: VexImportSummary
+}
+
+# Counts from a single VEX import, persisted on the VEX artifact that produced
+# it. proposalsCreated = statements staged for review (PENDING);
+# proposalsAutoAccepted = statements applied immediately; statementsUnmatched =
+# statements whose product did not match any component in the release's SBOM
+# inventory (these produce no proposal).
+type VexImportSummary {
+	statementsTotal: Int
+	proposalsCreated: Int
+	proposalsAutoAccepted: Int
+	proposalsAutoRejected: Int
+	statementsUnmatched: Int
+	statementsErrored: Int
+	errorMessages: [String]
 }
 
 enum EnrichmentStatus {

--- a/backend/src/test/java/io/reliza/service/kev/CisaKevConnectorTest.java
+++ b/backend/src/test/java/io/reliza/service/kev/CisaKevConnectorTest.java
@@ -83,8 +83,11 @@ class CisaKevConnectorTest {
 			}
 			""";
 
+	private static final String PRIMARY_URL = "https://kev.test/feed.json";
+	private static final String BACKUP_URL = "https://kev-backup.test/feed.json";
+
 	private CisaKevConnector newConnector(ExchangeFunction exchange) throws Exception {
-		CisaKevConnector connector = new CisaKevConnector("https://kev.test/feed.json");
+		CisaKevConnector connector = new CisaKevConnector(PRIMARY_URL, BACKUP_URL);
 		WebClient stub = WebClient.builder().exchangeFunction(exchange).build();
 		Field f = CisaKevConnector.class.getDeclaredField("webClient");
 		f.setAccessible(true);
@@ -186,7 +189,8 @@ class CisaKevConnectorTest {
 	void doesNotRetryForbiddenAndFailsClosedImmediately() throws Exception {
 		// CISA's WAF 403 is a sticky IP cooldown, not transient -- retrying it
 		// in-pass never recovers and only loads an already-blocked IP. So a 403
-		// must fail closed on the first attempt (no retries).
+		// must not be retried on either feed: one attempt on the primary, then
+		// straight to the backup's single attempt.
 		AtomicInteger attempts = new AtomicInteger();
 		CisaKevConnector connector = newConnector(req -> {
 			attempts.incrementAndGet();
@@ -195,7 +199,7 @@ class CisaKevConnectorTest {
 		connector.retryFirstBackoff = Duration.ofMillis(1);
 
 		assertTrue(connector.fetchCatalog(null).isEmpty());
-		assertEquals(1, attempts.get(), "403 must not be retried");
+		assertEquals(2, attempts.get(), "403 must not be retried: one attempt per feed");
 	}
 
 	@Test
@@ -209,6 +213,69 @@ class CisaKevConnectorTest {
 
 		// Fail-closed: exhausted retries return an empty list, never throw.
 		assertTrue(connector.fetchCatalog(null).isEmpty());
-		assertEquals(4, attempts.get()); // initial + 3 backoff retries
+		assertEquals(8, attempts.get()); // (initial + 3 backoff retries) per feed
+	}
+
+	// ---------- backup feed fallback ----------
+
+	@Test
+	void backupFeedIsUsedWhenPrimaryFails() throws Exception {
+		// Primary 403s (WAF cooldown); the backup mirror serves the catalog.
+		// The result must come from the backup with no error-grade outcome.
+		AtomicInteger primaryAttempts = new AtomicInteger();
+		AtomicInteger backupAttempts = new AtomicInteger();
+		CisaKevConnector connector = newConnector(req -> {
+			if (req.url().toString().equals(PRIMARY_URL)) {
+				primaryAttempts.incrementAndGet();
+				return Mono.just(ClientResponse.create(HttpStatus.FORBIDDEN).build());
+			}
+			backupAttempts.incrementAndGet();
+			return Mono.just(ClientResponse.create(HttpStatus.OK)
+					.headers(h -> h.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+					.body(FEED_JSON)
+					.build());
+		});
+		connector.retryFirstBackoff = Duration.ofMillis(1);
+
+		List<KevAssertionData> entries = connector.fetchCatalog(null);
+
+		assertEquals(3, entries.size(), "catalog must be served from the backup feed");
+		assertEquals(1, primaryAttempts.get());
+		assertEquals(1, backupAttempts.get());
+	}
+
+	@Test
+	void backupFeedIsUsedWhenPrimaryParsesEmpty() throws Exception {
+		// An empty/degenerate primary catalog is a failure mode too (a bad
+		// publish would otherwise wipe enrichment downstream) -- it must fall
+		// through to the backup rather than being accepted.
+		CisaKevConnector connector = newConnector(req -> {
+			String body = req.url().toString().equals(PRIMARY_URL)
+					? "{\"catalogVersion\":\"x\",\"vulnerabilities\":[]}"
+					: FEED_JSON;
+			return Mono.just(ClientResponse.create(HttpStatus.OK)
+					.headers(h -> h.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+					.body(body)
+					.build());
+		});
+
+		assertEquals(3, connector.fetchCatalog(null).size());
+	}
+
+	@Test
+	void primarySuccessNeverTouchesBackup() throws Exception {
+		AtomicInteger backupAttempts = new AtomicInteger();
+		CisaKevConnector connector = newConnector(req -> {
+			if (!req.url().toString().equals(PRIMARY_URL)) {
+				backupAttempts.incrementAndGet();
+			}
+			return Mono.just(ClientResponse.create(HttpStatus.OK)
+					.headers(h -> h.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+					.body(FEED_JSON)
+					.build());
+		});
+
+		assertEquals(3, connector.fetchCatalog(null).size());
+		assertEquals(0, backupAttempts.get(), "healthy primary must not fan out to the backup");
 	}
 }


### PR DESCRIPTION
Clean scripted sync of the shared backend source tree from the ReARM Pro backend — **no CE-side reconciliation needed** (`mvn test-compile` green against the existing oss tree, sync-script exclusions honored).

Brings:
- **KEV catalog backup-feed fallback** — a primary CISA feed failure (fetch, parse, or empty catalog) logs a short warning and falls through to CISA's first-party GitHub mirror (`cisagov/kev-data`); an error is logged only when both feeds fail. Backup URL configurable via `relizaprops.kevFeedBackupUrl`.
- **Per-artifact VEX import outcome** — persisted import summary exposed on the artifact (new `VexImportSummary` DTO + schema fields), backing the UI's outcome reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)