### PR TITLE
backend: sync shared source tree from ReARM Pro backend

### DIFF
--- a/backend/src/main/java/io/reliza/model/dto/CdxVexParseResult.java
+++ b/backend/src/main/java/io/reliza/model/dto/CdxVexParseResult.java
@@ -6,4 +6,11 @@ package io.reliza.model.dto;
 
 import java.util.List;
 
-public record CdxVexParseResult(List<CdxVexStatement> statements, String docError) {}
+/**
+ * Raw CDX-VEX parse output. {@code skippedNoAnalysis} counts vulnerabilities[]
+ * entries dropped because they carry no analysis block (a CycloneDX
+ * vulnerability without analysis is a plain vulnerability report, not a VEX
+ * statement) -- surfaced so an upload that yields zero statements can tell the
+ * user why instead of reporting a bare "0 statements".
+ */
+public record CdxVexParseResult(List<CdxVexStatement> statements, String docError, int skippedNoAnalysis) {}

--- a/backend/src/main/java/io/reliza/service/CdxVexParser.java
+++ b/backend/src/main/java/io/reliza/service/CdxVexParser.java
@@ -54,7 +54,15 @@ public class CdxVexParser implements VexFormatParser {
         java.util.List<VexParseEntry> entries = raw.statements().stream()
             .map(s -> new VexParseEntry(s, java.util.List.of()))
             .toList();
-        return new VexParseResult(entries, null, 0, java.util.List.of());
+        // Report no-analysis entries as invalid statements so the import summary
+        // reflects them ("N could not be processed") instead of a bare 0 total.
+        java.util.List<String> errors = raw.skippedNoAnalysis() > 0
+            ? java.util.List.of(raw.skippedNoAnalysis()
+                + " vulnerability entr" + (raw.skippedNoAnalysis() == 1 ? "y" : "ies")
+                + " skipped: no analysis block (a CycloneDX vulnerability without an analysis"
+                + " section carries no exploitability statement to import)")
+            : java.util.List.of();
+        return new VexParseResult(entries, null, raw.skippedNoAnalysis(), errors);
     }
 
     public CdxVexParseResult parseRaw(String json) {
@@ -62,7 +70,7 @@ public class CdxVexParser implements VexFormatParser {
         try {
             bom = new JsonParser().parse(json.getBytes(StandardCharsets.UTF_8));
         } catch (ParseException e) {
-            return new CdxVexParseResult(List.of(), "doc parse failed: " + e.getMessage());
+            return new CdxVexParseResult(List.of(), "doc parse failed: " + e.getMessage(), 0);
         }
 
         Map<String, String> bomRefToPurl = new HashMap<>();
@@ -75,13 +83,18 @@ public class CdxVexParser implements VexFormatParser {
         }
 
         List<CdxVexStatement> statements = new LinkedList<>();
+        int skippedNoAnalysis = 0;
         if (bom.getVulnerabilities() != null) {
             for (Vulnerability v : bom.getVulnerabilities()) {
-                if (v.getAnalysis() == null) continue;
+                if (v.getAnalysis() == null) {
+                    log.warn("CDX-VEX: vulnerability {} has no analysis block, skipping", v.getId());
+                    skippedNoAnalysis++;
+                    continue;
+                }
                 statements.add(buildStatement(v, bomRefToPurl));
             }
         }
-        return new CdxVexParseResult(statements, null);
+        return new CdxVexParseResult(statements, null, skippedNoAnalysis);
     }
 
     private CdxVexStatement buildStatement(Vulnerability v, Map<String, String> bomRefToPurl) {

--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -1579,11 +1579,21 @@ public class ReleaseDatafetcher {
 
 		// Authorization
 		if (null == componentId) componentId = ord.get().getComponent();
-		List<ApiTypeEnum> supportedApiTypes = Arrays.asList(ApiTypeEnum.COMPONENT, ApiTypeEnum.ORGANIZATION_RW);
 		Optional<ComponentData> ocd = (componentId != null) ? getComponentService.getComponentData(componentId) : Optional.empty();
 		RelizaObject ro = ocd.isPresent() ? ocd.get() : null;
 		AuthorizationResponse ar = AuthorizationResponse.initialize(InitType.FORBID);
-		if (null != ro) {
+		if (null != ro && ahp.getType() == ApiTypeEnum.FREEFORM) {
+			// FREEFORM keys carry scope/function permission tuples; authorize a
+			// WRITE on the resolved component the same way PR upsert does --
+			// COMPONENT-scoped READ_WRITE on this component, a PERSPECTIVE
+			// permission containing it, or org-wide READ_WRITE all match.
+			FreeformKeyVerification fkv = authorizationService.isFreeformKeyAuthorizedForObjectGraphQL(ahp,
+					PermissionFunction.RESOURCE, PermissionScope.COMPONENT, ro.getUuid(),
+					List.of(ro), CallType.WRITE);
+			ar = AuthorizationResponse.initialize(InitType.ALLOW);
+			ar.setWhoUpdated(fkv.whoUpdated());
+		} else if (null != ro) {
+			List<ApiTypeEnum> supportedApiTypes = Arrays.asList(ApiTypeEnum.COMPONENT, ApiTypeEnum.ORGANIZATION_RW);
 			ar = authorizationService.isApiKeyAuthorized(ahp, supportedApiTypes, ro.getOrg(), CallType.WRITE, ro);
 		} else {
 			authorizationService.gqlValidateAuthorizationResponse(ar);

--- a/backend/src/test/java/io/reliza/service/CdxVexParserTest.java
+++ b/backend/src/test/java/io/reliza/service/CdxVexParserTest.java
@@ -111,6 +111,29 @@ class CdxVexParserTest {
     }
 
     @Test
+    void vulnerabilityWithoutAnalysisIsCountedAsSkipped() {
+        String doc = """
+        {"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1,
+         "vulnerabilities": [
+            {"id": "CVE-2024-0001",
+             "affects": [{"ref": "pkg:npm/left-pad@1.3.0"}]},
+            {"id": "CVE-2024-0002",
+             "affects": [{"ref": "pkg:npm/left-pad@1.3.0"}],
+             "analysis": {"state": "not_affected", "justification": "code_not_reachable"}}
+         ]}
+        """;
+        CdxVexParseResult r = p.parseRaw(doc);
+        assertEquals(1, r.statements().size());
+        assertEquals(1, r.skippedNoAnalysis());
+        // and the format-level parse() surfaces them as invalid statements with a message
+        var parsed = p.parse(doc);
+        assertEquals(1, parsed.entries().size());
+        assertEquals(1, parsed.invalidStatements());
+        assertEquals(1, parsed.errorMessages().size());
+        assertTrue(parsed.errorMessages().get(0).contains("no analysis block"));
+    }
+
+    @Test
     void capturesSeverityFromSingleRating() {
         String doc = """
         {


### PR DESCRIPTION
Clean scripted sync of the shared backend source tree from the ReARM Pro backend — **no CE-side reconciliation needed** (`mvn test-compile` green against the existing oss tree, sync-script exclusions honored, no private-reference leaks in the added lines).

Brings:
- **CycloneDX VEX parser refinements** (`CdxVexParser`, `CdxVexParseResult` + test updates).
- **FREEFORM API-key support on `addArtifactProgrammatic`** (`ReleaseDatafetcher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)