### PR TITLE
feat(ui): report attestation-deferred VEX statements; document conditional claims in skill

### DIFF
--- a/skills/vex-authoring/SKILL.md
+++ b/skills/vex-authoring/SKILL.md
@@ -172,6 +172,27 @@ statement message; the rest of the document still imports. Note OpenVEX has
 no severity field, so the fallback chain above always applies -- expect
 SEVERITY_MISSING demotions for CVEs the org has never seen.
 
+## Conditional justifications defer to attestation
+
+Not every accepted statement applies immediately. ReARM distinguishes
+**code properties** (true regardless of deployment) from **conditional
+claims** (true only while some consumer-side control is in place):
+
+- `not_affected` with one of `requires_configuration`,
+  `requires_environment`, `protected_by_compiler`, `protected_at_runtime`,
+  `protected_at_perimeter`, `protected_by_mitigating_control`
+- `exploitable` with a `workaround` (text or a `workaround_available`
+  response)
+
+These are accepted but their Finding Analysis write is **deferred behind a
+PENDING Mitigation Attestation**: someone must attest that the environmental
+control / workaround is actually in place (Mitigation Attestations inbox)
+before the analysis applies and finding counts change. This is by design,
+not a dropped statement -- do not "fix" it by swapping the justification to
+`code_not_reachable` or `code_not_present`; use those only when they are the
+true assessment. `not_affected` with `code_not_present` /
+`code_not_reachable` applies immediately.
+
 ## Interpreting the import outcome
 
 The upload response (and the VEX artifact record) carries the outcome
@@ -185,6 +206,7 @@ summary. Symptom-to-fix table:
 | "doc parse failed: ..." | Malformed JSON or wrong schema | Validate the JSON; check `bomFormat` / OpenVEX `@context` |
 | "Cannot import VEX: release has no SBOM components yet" | Upload order | Upload and reconcile the SBOM first, then the VEX |
 | Statement staged despite Auto-accept | Trust gate (issuer class) or missing severity demoted it | Expected; supply `ratings[]` and review the proposal, or adjust issuer class if you authored the VEX yourself |
+| Statement accepted but finding state / counts unchanged | Conditional claim (environmental justification or workaround) -- analysis write deferred behind a PENDING Mitigation Attestation | By design; attest the control in the Mitigation Attestations inbox and the analysis applies. See "Conditional justifications defer to attestation" |
 
 Do not invent an `analysis` state to force an import: `state` is an
 assertion about exploitability. If no assessment exists yet, use

--- a/ui/src/components/CreateArtifact.vue
+++ b/ui/src/components/CreateArtifact.vue
@@ -375,7 +375,7 @@ const onSubmit = async () => {
     // For a VEX upload, ask the mutation for the resulting artifacts + their
     // import summary so we can report matched / unmatched counts.
     const releaseBody = isVex
-        ? `uuid artifactDetails { uuid displayIdentifier type vexImportSummary { statementsTotal proposalsCreated proposalsAutoAccepted proposalsAutoRejected statementsUnmatched statementsErrored errorMessages } }`
+        ? `uuid artifactDetails { uuid displayIdentifier type vexImportSummary { statementsTotal proposalsCreated proposalsAutoAccepted proposalsAutoRejected attestationsDeferred statementsUnmatched statementsErrored errorMessages } }`
         : `uuid`
 
     isUploading.value = true
@@ -452,6 +452,7 @@ function showVexOutcome(release: any, displayId: string) {
     const staged = s.proposalsCreated ?? 0
     const accepted = s.proposalsAutoAccepted ?? 0
     const rejected = s.proposalsAutoRejected ?? 0
+    const deferred = s.attestationsDeferred ?? 0
     const unmatched = s.statementsUnmatched ?? 0
     const errored = s.statementsErrored ?? 0
     const matched = staged + accepted + rejected
@@ -480,16 +481,24 @@ function showVexOutcome(release: any, displayId: string) {
 
     const parts = []
     if (staged > 0) parts.push(`${staged} staged for review`)
-    if (accepted > 0) parts.push(`${accepted} auto-accepted`)
+    // Deferred statements are accepted but their analysis write waits on a
+    // mitigation attestation -- report them separately so a conditional claim
+    // (e.g. not_affected / requires_environment) doesn't look silently ignored.
+    const applied = accepted - deferred
+    if (applied > 0) parts.push(`${applied} auto-accepted`)
+    if (deferred > 0) parts.push(`${deferred} deferred pending mitigation attestation`)
     if (rejected > 0) parts.push(`${rejected} auto-rejected`)
     if (unmatched > 0) parts.push(`${unmatched} unmatched`)
     if (errored > 0) parts.push(`${errored} could not be processed`)
     const breakdown = parts.length ? `: ${parts.join(', ')}` : ' processed'
+    const deferredHint = deferred > 0
+        ? ' Conditional claims apply after their control is attested in the Mitigation Attestations inbox.'
+        : ''
     const suffix = details && errored > 0 ? ` ${details}` : ''
     Swal.fire({
         icon: 'success', title: 'VEX processed',
-        text: `${total} statement${total === 1 ? '' : 's'}${breakdown}. Open the VEX tab to review.${suffix}`,
-        timer: 7000, showConfirmButton: true,
+        text: `${total} statement${total === 1 ? '' : 's'}${breakdown}. Open the VEX tab to review.${deferredHint}${suffix}`,
+        timer: deferred > 0 ? 10000 : 7000, showConfirmButton: true,
     })
 }
 


### PR DESCRIPTION
## What

Companion to the rearm-saas PR adding `attestationsDeferred` to the VEX import summary.

**Toast (`CreateArtifact.vue`):** auto-accepted statements are split into applied vs deferred, e.g.:

> 2 statements: 1 auto-accepted, 1 deferred pending mitigation attestation. Open the VEX tab to review. Conditional claims apply after their control is attested in the Mitigation Attestations inbox.

Falls back gracefully (`?? 0`) on backends without the field. Longer toast timer when deferrals are present.

**Skill (`skills/vex-authoring/SKILL.md`):** new "Conditional justifications defer to attestation" section listing the six environmental justifications (`requires_configuration`, `requires_environment`, `protected_by_compiler`, `protected_at_runtime`, `protected_at_perimeter`, `protected_by_mitigating_control`) plus the exploitable-with-workaround case, a troubleshooting-table row ("accepted but finding counts unchanged"), and explicit guidance not to swap justifications to `code_not_reachable` to force an immediate apply -- the exact mis-diagnosis a VEX-producing agent made in the field ("requires_environment is silently dropped").

## Validation

Backend side live-verified on the sandbox (`{statementsTotal: 2, proposalsAutoAccepted: 2, attestationsDeferred: 1}` for a code_not_reachable + requires_environment pair); `npm run build` clean; toast logic verified present in the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)