### PR TITLE
fix(ui): show commit-scoped SCE artifacts on every release sharing the commit

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -3573,9 +3573,19 @@ const artifacts: ComputedRef<any> = computed((): any => {
         }
         if(updatedRelease.value.sourceCodeEntryDetails && updatedRelease.value.sourceCodeEntryDetails.artifactDetails && updatedRelease.value.sourceCodeEntryDetails.artifactDetails.length) {
             const cursce = updatedRelease.value.sourceCodeEntryDetails
+            // SCEs are canonical per (vcs, commit) and can be shared by several
+            // components; per-component artifacts are tagged with the attaching
+            // component's uuid. Commit-scoped artifacts (signatures / signed
+            // payloads -- properties of the commit, not of any one component)
+            // are shown on every release referencing the SCE: new backend data
+            // tags them with a null componentUuid, and the type check covers
+            // rows written before that convention existed.
+            const commitScopedTypes = ['SIGNATURE', 'SIGNED_PAYLOAD']
             artifacts.push.apply(artifacts,
                 updatedRelease.value.sourceCodeEntryDetails.artifactDetails
-                    .filter((ad: any) => ad.componentUuid === updatedRelease.value.componentDetails.uuid)
+                    .filter((ad: any) => !ad.componentUuid
+                        || ad.componentUuid === updatedRelease.value.componentDetails.uuid
+                        || commitScopedTypes.includes(ad.type))
                     .map((ad: any) => setArtifactBelongsTo(ad, 'Source Code Entry', '', cursce.uuid)))
         }
         


### PR DESCRIPTION
## What

Companion to the backend null-means-commit-scoped change. The release view filtered SCE artifacts to `componentUuid === release.component`, which hid commit signatures / signed payloads from all but one release when several components share a HEAD commit (the canonical-per-commit SCE keeps a single semantically-deduped copy, tagged with whichever build landed first).

The filter now passes an SCE artifact when any of:
- `componentUuid` is null (new backend convention: commit-scoped),
- it matches the release's component (unchanged monorepo behavior),
- the type is SIGNATURE / SIGNED_PAYLOAD (covers rows written before the null convention -- this is why no data migration is needed).

## Validation

Live on the sandbox: a pre-fix shared-commit SCE whose artifacts are tagged with component A's uuid now renders SIGNATURE + SIGNED_PAYLOAD rows on component B's release (screenshot-verified via Playwright), and a post-fix null-tagged SCE shows them on both releases. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)