### PR TITLE
backend: sync shared source tree from ReARM Pro backend

### DIFF
--- a/backend/src/main/java/io/reliza/model/SourceCodeEntryData.java
+++ b/backend/src/main/java/io/reliza/model/SourceCodeEntryData.java
@@ -151,7 +151,30 @@ public class SourceCodeEntryData extends RelizaDataParent implements RelizaObjec
 
 	private SourceCodeEntryData () {}
 	
+	/**
+	 * componentUuid semantics: a concrete uuid means the artifact was attached in
+	 * the context of that component (monorepo case -- each component tags its own
+	 * SCE artifacts); null means the artifact is commit-scoped and applies to
+	 * every release referencing this SCE (signatures / signed payloads -- the
+	 * content is a property of the commit, not of any one component).
+	 */
 	public record SCEArtifact (UUID artifactUuid, UUID componentUuid) {}
+
+	/**
+	 * Artifact types whose content is a property of the commit itself, so one
+	 * copy on the canonical (vcs, commit) SCE serves every component sharing
+	 * that commit. Kept in sync with the semantic dedupe in
+	 * SourceCodeEntryService, which collapses byte-identical copies of these
+	 * across components.
+	 */
+	public static final java.util.Set<ArtifactData.ArtifactType> COMMIT_SCOPED_ARTIFACT_TYPES =
+			java.util.Set.of(ArtifactData.ArtifactType.SIGNATURE, ArtifactData.ArtifactType.SIGNED_PAYLOAD);
+
+	/** Resolve the component tag for a new SCE artifact: null (commit-scoped) for
+	 * signature-class types, the attaching component otherwise. */
+	public static UUID sceArtifactComponentTag(ArtifactData.ArtifactType type, UUID componentUuid) {
+		return (type != null && COMMIT_SCOPED_ARTIFACT_TYPES.contains(type)) ? null : componentUuid;
+	}
 
 	public static SourceCodeEntryData scEntryDataFactory(SceDto sceDto) {
 		SourceCodeEntryData sced = new SourceCodeEntryData();

--- a/backend/src/main/java/io/reliza/model/dto/VexImportResult.java
+++ b/backend/src/main/java/io/reliza/model/dto/VexImportResult.java
@@ -18,6 +18,10 @@ public class VexImportResult {
     private int proposalsCreated;
     private int proposalsAutoAccepted;
     private int proposalsAutoRejected;
+    // AUTO_ACCEPT statements whose VulnAnalysis write was deferred behind a
+    // PENDING MitigationAttestation (conditional claims: environmental
+    // justifications or workarounds). Subset of proposalsAutoAccepted.
+    private int attestationsDeferred;
     private int proposalsDemoted;
     private int statementsErrored;
     private int statementsUnmatched;

--- a/backend/src/main/java/io/reliza/model/dto/VexImportSummary.java
+++ b/backend/src/main/java/io/reliza/model/dto/VexImportSummary.java
@@ -30,6 +30,9 @@ public class VexImportSummary {
     private int proposalsCreated;
     private int proposalsAutoAccepted;
     private int proposalsAutoRejected;
+    // Subset of proposalsAutoAccepted whose analysis write is deferred behind a
+    // PENDING MitigationAttestation (conditional claims).
+    private int attestationsDeferred;
     private int statementsUnmatched;
     private int statementsErrored;
     // Capped at MAX_ERROR_MESSAGES so a pathological VEX can't bloat the artifact record.
@@ -43,6 +46,7 @@ public class VexImportSummary {
         s.setProposalsCreated(r.getProposalsCreated());
         s.setProposalsAutoAccepted(r.getProposalsAutoAccepted());
         s.setProposalsAutoRejected(r.getProposalsAutoRejected());
+        s.setAttestationsDeferred(r.getAttestationsDeferred());
         s.setStatementsUnmatched(r.getStatementsUnmatched());
         s.setStatementsErrored(r.getStatementsErrored());
         List<String> errors = r.getErrorMessages();

--- a/backend/src/main/java/io/reliza/service/ArtifactGatherService.java
+++ b/backend/src/main/java/io/reliza/service/ArtifactGatherService.java
@@ -30,7 +30,11 @@ public class ArtifactGatherService {
 		Set<UUID> artifactIds = new HashSet<>(rd.getArtifacts());
 		if (null != rd.getSourceCodeEntry()) {
 			var sce = getSourceCodeEntryService.getSourceCodeEntryData(rd.getSourceCodeEntry()).get();
-			List<UUID> sceArtIds = sce.getArtifacts().stream().filter(scea -> rd.getComponent().equals(scea.componentUuid())).map(scea -> scea.artifactUuid()).toList();
+			// null component tag = commit-scoped artifact (signature / signed
+			// payload) -- belongs to every release referencing this SCE.
+			List<UUID> sceArtIds = sce.getArtifacts().stream()
+					.filter(scea -> scea.componentUuid() == null || rd.getComponent().equals(scea.componentUuid()))
+					.map(scea -> scea.artifactUuid()).toList();
 			artifactIds.addAll(sceArtIds);
 		}
 		// skip inbound deliverables

--- a/backend/src/main/java/io/reliza/service/ReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseService.java
@@ -1191,7 +1191,10 @@ public class ReleaseService {
 			WhoUpdated wu) throws IOException, RelizaException {
 		UUID orgUuid = bd.getOrg();
 		List<SCEArtifact> sceArts= new LinkedList<>();
-		if (null != artIds) sceArts = artIds.stream().map(x -> new SCEArtifact(x, bd.getComponent())).toList();
+		if (null != artIds) sceArts = artIds.stream().map(x -> new SCEArtifact(x,
+				SourceCodeEntryData.sceArtifactComponentTag(
+						artifactService.getArtifactData(x).map(ArtifactData::getType).orElse(null),
+						bd.getComponent()))).toList();
 		sceDto.setArtifacts(sceArts);
 		sceDto.setBranch(bd.getUuid());
 		sceDto.setOrganizationUuid(orgUuid);
@@ -1576,7 +1579,10 @@ public class ReleaseService {
 
 			// Attach artifacts to SCE
 			for (UUID artId : artIds) {
-				SCEArtifact sceArt = new SCEArtifact(artId, cd.getUuid());
+				SCEArtifact sceArt = new SCEArtifact(artId,
+						SourceCodeEntryData.sceArtifactComponentTag(
+								artifactService.getArtifactData(artId).map(ArtifactData::getType).orElse(null),
+								cd.getUuid()));
 				sourceCodeEntryService.addArtifact(sceUuid, sceArt, wu);
 			}
 

--- a/backend/src/main/java/io/reliza/service/SourceCodeEntryService.java
+++ b/backend/src/main/java/io/reliza/service/SourceCodeEntryService.java
@@ -534,7 +534,10 @@ public class SourceCodeEntryService {
 		SourceCodeEntry sce = getSourceCodeEntryService.getSourceCodeEntry(sceUuid).get();
 		SourceCodeEntryData sced = SourceCodeEntryData.dataFromRecord(sce);
 		List<SCEArtifact> artifacts = sced.getArtifacts();
-		artifacts.remove(replaceArt);
+		// Match on artifactUuid only -- the stored entry's component tag may be a
+		// concrete uuid (component-scoped) or null (commit-scoped), and the caller
+		// can't know which without reading the SCE first.
+		artifacts.removeIf(a -> a.artifactUuid().equals(replaceArt.artifactUuid()));
 		artifacts.add(art);
 		sced.setArtifacts(artifacts);
 		Map<String,Object> recordData = Utils.dataToRecord(sced);

--- a/backend/src/main/java/io/reliza/service/VexImportService.java
+++ b/backend/src/main/java/io/reliza/service/VexImportService.java
@@ -308,8 +308,14 @@ public class VexImportService {
             case AUTO_ACCEPT -> {
                 VexStatementProposalData created = proposalService.createProposal(candidate, wu);
                 result.getCreatedProposalUuids().add(created.getUuid());
-                proposalService.accept(created.getUuid(), wu);
+                VexStatementProposalData accepted = proposalService.accept(created.getUuid(), wu);
                 result.setProposalsAutoAccepted(result.getProposalsAutoAccepted() + 1);
+                if (accepted.getMitigationAttestation() != null) {
+                    // Conditional claim -- the VulnAnalysis write is deferred until the
+                    // mitigation is attested. Count it so the import outcome can say so
+                    // instead of looking like a silently ignored statement.
+                    result.setAttestationsDeferred(result.getAttestationsDeferred() + 1);
+                }
             }
         }
     }

--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -1495,7 +1495,8 @@ public class ReleaseDatafetcher {
 					deliverableService.addArtifact(deliverableId, artId, wu);
 				} else if(ArtifactBelongsTo.SCE.equals(belongsTo) && artifactInput.containsKey("sce")){
 					UUID sceUuid = UUID.fromString((String)artifactInput.get("sce"));
-					SCEArtifact sceArt = new SCEArtifact(artId, cd.getUuid());
+					SCEArtifact sceArt = new SCEArtifact(artId,
+							SourceCodeEntryData.sceArtifactComponentTag(artDto.getType(), cd.getUuid()));
 					sourceCodeEntryService.addArtifact(sceUuid, sceArt, wu);
 				} else { //default case, attach to the release
 					releaseService.addArtifact(artId, ord.get().getUuid(),  wu);
@@ -1508,7 +1509,8 @@ public class ReleaseDatafetcher {
 					deliverableService.replaceArtifact(deliverableId,inputArtifactUuid, artId, wu);
 				} else if(ArtifactBelongsTo.SCE.equals(belongsTo) && artifactInput.containsKey("sce")){
 					UUID sceUuid = UUID.fromString((String)artifactInput.get("sce"));
-					SCEArtifact sceArt = new SCEArtifact(artId, cd.getUuid());
+					SCEArtifact sceArt = new SCEArtifact(artId,
+							SourceCodeEntryData.sceArtifactComponentTag(artDto.getType(), cd.getUuid()));
 					SCEArtifact replaceArt = new SCEArtifact(inputArtifactUuid, cd.getUuid());
 					sourceCodeEntryService.replaceArtifact(sceUuid, replaceArt, sceArt, wu);
 				} else { //default case, attach to the release

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -3171,6 +3171,10 @@ type VexImportSummary {
 	proposalsCreated: Int
 	proposalsAutoAccepted: Int
 	proposalsAutoRejected: Int
+	# Subset of proposalsAutoAccepted whose Finding Analysis write is deferred
+	# behind a PENDING MitigationAttestation (conditional claims: environmental
+	# justifications like requires_environment, or exploitable-with-workaround).
+	attestationsDeferred: Int
 	statementsUnmatched: Int
 	statementsErrored: Int
 	errorMessages: [String]


### PR DESCRIPTION
Clean scripted sync of the shared backend source tree from the ReARM Pro backend — **no CE-side reconciliation needed** (`mvn test-compile` green against the existing oss tree, sync-script exclusions honored, no private-reference leaks in the added lines).

Brings:
- **Commit-scoped SCE artifact tagging with a null component** (`SourceCodeEntryData`/`SourceCodeEntryService`/`ArtifactGatherService` + schema) — backing the UI change already on main that shows commit-scoped artifacts on every release sharing the commit.
- **VEX import outcome follow-ups** (`VexImportResult`/`VexImportSummary`/`VexImportService`/`ReleaseService`/`ReleaseDatafetcher`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)