### PR TITLE
fix(ui): component changelog prefers window posture-diff over release-pairwise findings

### DIFF
--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -283,7 +283,12 @@
                 <!-- AGGREGATED mode: Show top-level aggregated changes -->
                 <div v-else-if="aggregationType === 'AGGREGATED' && changelog.__typename === 'AggregatedChangelog'">
                     <p style="margin-bottom: 10px; font-style: italic;">{{ aggregatedDescription }}</p>
-                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" />
+                    <!-- Prefer the window posture-diff when the backend computed one: it anchors
+                         New/Resolved/StillPresent on the finding-change event dates, so a new CVE
+                         hitting an EXISTING release inside the window classifies as New. The legacy
+                         findingChanges list is release-pairwise (anchored on release creation) and
+                         can never surface that case; it remains the fallback for uncertified orgs. -->
+                    <FindingChangesDisplayWithAttribution :finding-changes="changelog.postureFindingChanges ?? changelog.findingChanges" :show-attribution="true" :org-uuid="changelog.orgUuid" :over-time-finding-changes="changelog.overTimeFindingChanges" :scope-label="props.componentprop ? 'component' : 'organization'" />
                 </div>
             </n-tab-pane>
         </n-tabs>

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -215,6 +215,10 @@ export interface AggregatedChangelog {
     branches: AggregatedBranchChanges[]
     sbomChanges: SbomChangesWithAttribution
     findingChanges: FindingChangesWithAttribution
+    // Window posture-diff (New/Resolved/StillPresent anchored on finding-change
+    // event dates). Null when the org is not v3-certified or the flag is off;
+    // when present the UI prefers it over the release-pairwise findingChanges.
+    postureFindingChanges?: FindingChangesWithAttribution | null
     overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 
@@ -246,6 +250,10 @@ export interface AggregatedOrganizationChangelog {
     components: ComponentChangelog[]
     sbomChanges: SbomChangesWithAttribution
     findingChanges: FindingChangesWithAttribution
+    // Window posture-diff (New/Resolved/StillPresent anchored on finding-change
+    // event dates). Null when the org is not v3-certified or the flag is off;
+    // when present the UI prefers it over the release-pairwise findingChanges.
+    postureFindingChanges?: FindingChangesWithAttribution | null
     overTimeFindingChanges: MetricsRevisionFindingChange[]
 }
 


### PR DESCRIPTION
Fixes: a new CVE hitting an existing release mid-window showed as Still Present (or not at all) in the Component Changelog, because the AGGREGATED view rendered the legacy release-pairwise `findingChanges` list — which anchors on release creation dates, so a finding can only be New if a release created in-window introduced it.

The backend already computes `postureFindingChanges` for certified orgs — anchored on `finding_change_events_v3` event dates, verified live on the sandbox (new hit on a pre-window release → `isNetAppeared: true`, originals → Still Present) — and the UI query already fetched it; the component view just never rendered it. This wires the stated contract ("UI prefers postureFindingChanges when present"): prefer posture, fall back to legacy for uncertified orgs / flag-off deployments. Same fragment shape, so the display component is unchanged.

Validation: vite build + type-check clean; backend behavior for both window shapes verified against the FS-deployed `26.07.54` (= merged rearm-saas main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)