### PR TITLE
fix(ui): component-scope the DTrack badge and status-poll artifact sweeps

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1273,7 +1273,7 @@ import { useStore } from 'vuex'
 import constants from '@/utils/constants'
 import { DownloadLink} from '@/utils/commonTypes'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
-import { getReleaseScanStatus, isDtrackConfiguredForOrg } from '@/utils/releaseScanStatus'
+import { getReleaseScanStatus, isDtrackConfiguredForOrg, collectArtifactsForStatus } from '@/utils/releaseScanStatus'
 import { processMetricsData } from '@/utils/metrics'
 import { annotateKnownExploited, fetchArtifactKevVulnIds } from '@/utils/kevService'
 import { exportFindingsToPdf } from '@/utils/pdfExport'
@@ -3120,11 +3120,10 @@ function stopStatusPolling () {
 }
 function hasPendingStatuses (): boolean {
     if (release.value?.sbomReconcilePending) return true
-    const allArtifacts: any[] = [
-        ...(release.value?.artifactDetails || []),
-        ...((release.value?.sourceCodeEntryDetails?.artifactDetails) || []),
-        ...((release.value?.variantDetails || []).flatMap((v: any) => (v?.outboundDeliverableDetails || []).flatMap((d: any) => d?.artifactDetails || [])))
-    ]
+    // Same component-scoped artifact set as the badge — polling must not
+    // spin forever on another component's SCE artifact that this release
+    // neither displays nor waits on.
+    const allArtifacts: any[] = collectArtifactsForStatus(release.value)
     return allArtifacts.some((a: any) => {
         if (!a) return false
         if (a.enrichmentStatus === 'PENDING') return true

--- a/ui/src/utils/releaseScanStatus.spec.ts
+++ b/ui/src/utils/releaseScanStatus.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// releaseScanStatus imports the graphql client (for the org-integration
+// lookup), which transitively boots keycloak against window at module load —
+// mock it out; these tests only exercise the pure status logic.
+vi.mock('./graphql', () => ({ default: { query: vi.fn() } }))
+
+import { collectArtifactsForStatus, getReleaseScanStatus } from './releaseScanStatus'
+
+/** A minimal unscanned BOM artifact — the shape isBomDtrackPending flags. */
+function pendingBom (componentUuid?: string) {
+    return { type: 'BOM', componentUuid, metrics: {} }
+}
+function scannedBom (componentUuid?: string) {
+    return { type: 'BOM', componentUuid, metrics: { firstScanned: '2026-07-12T21:52:12Z' } }
+}
+
+const OWN_COMPONENT = 'aaaaaaaa-0000-0000-0000-000000000001'
+const OTHER_COMPONENT = 'bbbbbbbb-0000-0000-0000-000000000002'
+
+function releaseWithSceArts (arts: any[], componentUuid: string | null = OWN_COMPONENT) {
+    return {
+        componentDetails: componentUuid ? { uuid: componentUuid } : undefined,
+        metrics: { firstScanned: '2026-07-12T22:00:00Z' },
+        sourceCodeEntryDetails: { artifactDetails: arts },
+        variantDetails: []
+    }
+}
+
+describe('collectArtifactsForStatus SCE component scoping', () => {
+    it('excludes another component\'s SCE artifacts', () => {
+        const release = releaseWithSceArts([pendingBom(OTHER_COMPONENT), scannedBom(OWN_COMPONENT)])
+        const collected = collectArtifactsForStatus(release)
+        expect(collected).toHaveLength(1)
+        expect(collected[0].componentUuid).toBe(OWN_COMPONENT)
+    })
+
+    it('keeps commit-scoped signature artifacts from any component', () => {
+        const release = releaseWithSceArts([
+            { type: 'SIGNATURE', componentUuid: OTHER_COMPONENT },
+            { type: 'SIGNED_PAYLOAD', componentUuid: OTHER_COMPONENT }
+        ])
+        expect(collectArtifactsForStatus(release)).toHaveLength(2)
+    })
+
+    it('keeps artifacts with no component attribution (commit-scoped convention)', () => {
+        const release = releaseWithSceArts([pendingBom(undefined)])
+        expect(collectArtifactsForStatus(release)).toHaveLength(1)
+    })
+
+    it('falls back to including everything when the release lacks component fields', () => {
+        const release = releaseWithSceArts([pendingBom(OTHER_COMPONENT)], null)
+        expect(collectArtifactsForStatus(release)).toHaveLength(1)
+    })
+})
+
+describe('getReleaseScanStatus with shared-SCE artifacts', () => {
+    it('does not report DTrack pending for another component\'s unscanned BOM', () => {
+        // The 2026-07-12 prod shape: this release's own BOMs are scanned, but a
+        // sibling component's fs-BOM on the shared commit never was. The badge
+        // must not pin on an artifact the artifact table does not display.
+        const release = releaseWithSceArts([scannedBom(OWN_COMPONENT), pendingBom(OTHER_COMPONENT)])
+        expect(getReleaseScanStatus(release, true).kind).toBe('ready')
+    })
+
+    it('still reports DTrack pending for this component\'s own unscanned BOM', () => {
+        const release = releaseWithSceArts([pendingBom(OWN_COMPONENT)])
+        expect(getReleaseScanStatus(release, true).kind).toBe('dtrack-pending')
+    })
+})

--- a/ui/src/utils/releaseScanStatus.ts
+++ b/ui/src/utils/releaseScanStatus.ts
@@ -101,11 +101,34 @@ function rejectedStatus (): ReleaseScanStatus {
     }
 }
 
-function collectArtifactsForStatus (release: any): any[] {
+/** Commit-scoped SCE artifact types — properties of the commit, not of any
+ *  one component; shown (and counted) on every release sharing the SCE. */
+const COMMIT_SCOPED_ARTIFACT_TYPES = ['SIGNATURE', 'SIGNED_PAYLOAD']
+
+/**
+ * Collect the artifacts that should drive this release's scan-status badge.
+ *
+ * SCE artifacts are component-scoped to match the release-view artifact
+ * table: SCEs are canonical per (vcs, commit) and shared across every
+ * component built from that commit, with per-component artifacts tagged
+ * with the attaching component's uuid. Another component's still-scanning
+ * BOM must not pin this release's badge on "DTrack pending" — the table
+ * doesn't even display that artifact, so the badge would point at nothing
+ * (observed in prod: one component's stuck fs-BOM kept every release
+ * sharing the commit on a permanent pending badge). Falls back to
+ * including everything when the row lacks component attribution fields
+ * (older data / slimmer fragments).
+ */
+export function collectArtifactsForStatus (release: any): any[] {
     const out: any[] = []
     if (Array.isArray(release?.artifactDetails)) out.push(...release.artifactDetails)
     if (Array.isArray(release?.sourceCodeEntryDetails?.artifactDetails)) {
-        out.push(...release.sourceCodeEntryDetails.artifactDetails)
+        const releaseComponent = release?.componentDetails?.uuid || release?.component
+        out.push(...release.sourceCodeEntryDetails.artifactDetails.filter((ad: any) =>
+            !ad?.componentUuid
+            || !releaseComponent
+            || ad.componentUuid === releaseComponent
+            || COMMIT_SCOPED_ARTIFACT_TYPES.includes(ad?.type)))
     }
     if (Array.isArray(release?.variantDetails)) {
         for (const v of release.variantDetails) {


### PR DESCRIPTION
Companion to relizaio/rearm-saas#329 (pipeline hardening for the 2026-07-12 incident).

## Problem

The scan-status badge (`getReleaseScanStatus`) and the release-view status polling swept **all** SCE artifacts, while the artifact table (since #206) displays only commit-scoped artifacts plus the release's own component's. On a commit shared by several components (monorepo dep-bump builds), another component's still-unscanned BOM pinned every sibling release on a permanent **DTrack pending** badge — pointing at an artifact the table doesn't even display — and kept the status poll spinning.

## Fix

- `collectArtifactsForStatus` (now exported) applies the same scoping as the table: commit-scoped types (SIGNATURE/SIGNED_PAYLOAD), null `componentUuid`, or the release's own component. Conservative fallback: include everything when the row lacks attribution fields (older data / slim list fragments — which omit artifact `type` and never matched the BOM check anyway).
- The release-view poll gate (`hasPendingStatuses`) reuses the collector instead of its own unfiltered sweep.
- New vitest spec covering the scoping rules, including the exact prod shape (own BOM scanned + sibling BOM pending → `ready`, not `dtrack-pending`).

## Validation

- `npm run build` green; new spec 6/6 green.
- Full `npm test`: 42/43 — the 1 failure is `notificationInboxSchemaDrift.spec.ts`, **pre-existing on clean main** (verified via stash) and unrelated: the CE-mirror drift assertion expects the FULL inbox selection to be invalid against the CE schema and it no longer is. Worth a separate look.

Agentic session: `badge-filter-consistency-1784858679` (signed commit + trailers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)