### PR TITLE
fix(rebom): enrichment config probe must reflect actual per-org state

### DIFF
--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -695,9 +695,16 @@ export async function enrichCycloneDxBom(
  * gate be exercised before a real BEAR integration exists.
  */
 export async function isEnrichmentConfigured(org: string): Promise<boolean> {
-  if (process.env.ENRICHMENT_PENDING_IF_NOT_CONFIGURED === 'true') {
-    return true;
-  }
+  // Deliberately does NOT honor ENRICHMENT_PENDING_IF_NOT_CONFIGURED: that
+  // flag marks new BOMs PENDING so a later-configured BEAR can enrich them
+  // retroactively (see getInitialEnrichmentStatus) — it does not mean
+  // enrichment is available NOW. Consumers of this probe gate real work on
+  // the answer: ReARM's synthetic-DTrack submitOrg holds an org's components
+  // back until enrichment completes, and the enrichment scheduler skips
+  // orgs without credentials — so answering "configured" for a cred-less
+  // org deadlocks that org's scanning pipeline forever (observed on a
+  // sandbox with the flag set: every fresh org's BOMs froze at PENDING and
+  // nothing ever reached Dependency-Track).
   const integration = await getBearIntegration(org);
   return integration.configured;
 }


### PR DESCRIPTION
Root cause of the 3 vuln-notification producer failures in tonight's full e2e pass (168/171) on psclaude.

## The deadlock

- psclaude sets `rebom.backend.enrichmentPendingIfNotConfigured: true` (instance override; chart default false).
- With that flag, `isEnrichmentConfigured` returned **true for every org** — but the flag's purpose is to mark new BOMs PENDING so a later-configured BEAR can enrich them retroactively (`getInitialEnrichmentStatus`), not to claim enrichment is available now.
- The ReARM backend's synthetic-DTrack `submitOrg` gates an org's components on completed enrichment when this probe says configured; rebom's enrichment scheduler meanwhile **skips orgs without credentials** (debug-level, invisible).
- Net: every fresh org (all e2e run orgs) froze — BOMs PENDING forever, zero components bucketed, nothing ever reached Dependency-Track, `NEW_VULN_AFFECTS_RELEASES` never fired. Verified live: components created after 02:42 across 4 fresh orgs — 0 enriched, 0 bucketed; orgs **with** BEAR creds enriched + bucketed normally.

## Fix

The probe now returns the actual per-org BEAR integration state. Flag semantics on initial BOM status are untouched — retroactive enrichment still works as designed. Cred-less orgs ship to synthetic DTrack immediately (the pre-BEAR-gate behavior).

## Validation

- `npm run test:ci`: identical pass/fail counts to clean main (35 pre-existing failures are DB-dependent unit tests that need the CI postgres; none touch this function).
- After deploy, the e2e `@dtrack` lane should go green — the three failing scenarios were `notifications_producer_dtrack.feature` fresh-org timeouts.

Agentic session: signed commit + trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)