### PR TITLE
fix(landing): relative redirects - stop https-to-http downgrade on slash 301s

### DIFF
--- a/landing_site/nginx/default.conf
+++ b/landing_site/nginx/default.conf
@@ -5,6 +5,15 @@ server {
     root   /usr/share/nginx/html;
     index  index.html;
 
+    # Emit relative Location headers on nginx-generated redirects (notably the
+    # built-in directory trailing-slash 301 for Astro's /page -> /page/ dirs).
+    # Without this, nginx builds an absolute URL from the scheme IT sees -- and
+    # since TLS terminates at the ingress, that's http://, downgrading
+    # https://rearmhq.com/pricing -> http://rearmhq.com/pricing/ (plaintext hop
+    # for non-HSTS clients, http canonical for crawlers). A relative
+    # "Location: /pricing/" preserves whatever scheme the client used.
+    absolute_redirect off;
+
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
## Problem

```
curl -sSIL https://rearmhq.com/pricing
HTTP/1.1 301 Moved Permanently
Location: http://rearmhq.com/pricing/     <-- https downgraded to http
```

Astro emits directory-style pages (`pricing/index.html`), so extensionless URLs hit nginx's built-in directory trailing-slash 301 — and nginx builds the Location **absolutely from the scheme it sees**, which is plain http behind the TLS-terminating ingress. Consequences: a plaintext hop for first-visit/non-HSTS clients and curl, and an `http://` canonical for crawlers. (Returning browsers are shielded by the HSTS header already being set.) Nothing to do with the helm chart's `ingressHost` — it's baked into the container's nginx.

## Fix

`absolute_redirect off;` — nginx emits relative Locations (`/pricing/`), the client resolves them against the scheme it used, and the SEO-friendly canonical-slash 301 stays.

## Validation

In the exact pinned image (`nginx:1.31.2-alpine3.23-slim@sha256:dd722b…`):
- `nginx -t` clean.
- Live container with the patched config + a `pricing/` dir: `GET /pricing` → `301` `Location: /pricing/` (relative).

Agentic session: signed commit + trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)