### PR TITLE
fix(ui): stop leaking output-only presetConfig into NotificationFilterInput (BUG 1)

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -253,7 +253,8 @@ import {
     subscriptionStatusOptions, eventTypeOptions, severityOptions,
     LIST_CHANNELS_QUERY, LIST_GROUPS_CORE_QUERY,
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
-    extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType
+    extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType,
+    buildNotificationFilterInput
 } from '@/utils/notificationsCommon'
 import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 
@@ -544,13 +545,11 @@ async function saveSubscription (): Promise<void> {
         subModalError.value = `Route ${emptyRouteIdx + 1} has no channels or groups — pick at least one.`
         return
     }
-    // Overlay the modeled filter fields on top of the original blob so
-    // `presetConfigJson` survives instead of being nulled on every edit.
-    const filterInput: any = {
-        ...(f._rawFilter || {}),
-        mode: f.filterMode,
-        celExpression: f.filterMode === 'ADVANCED' ? f.celExpression : null,
-    }
+    // Build the filter input from ONLY the fields NotificationFilterInput
+    // accepts (mode / presetConfigJson / celExpression); the as-loaded blob
+    // carries an unmodelled `presetConfig` object that must not leak into the
+    // input (it 400s the mutation). See buildNotificationFilterInput.
+    const filterInput = buildNotificationFilterInput(f._rawFilter, f.filterMode, f.celExpression)
     const input: any = {
         uuid: f.uuid || undefined,
         expectedRevision: f.expectedRevision,

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -11,6 +11,7 @@ vi.mock('@/utils/commonFunctions', () => ({
 import { print } from 'graphql'
 import {
     relativeTime,
+    buildNotificationFilterInput,
     LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY,
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
 } from './notificationsCommon'
@@ -76,5 +77,47 @@ describe('relativeTime', () => {
         const out = relativeTime(ago(40 * DAY), now)
         expect(out).not.toMatch(/ago$/)
         expect(out.length).toBeGreaterThan(0)
+    })
+})
+
+// Edit -> Save of a subscription 400'd because the as-loaded filter blob
+// (output shape) carries a `presetConfig` object that was spread into
+// NotificationFilterInput, which only accepts mode/presetConfigJson/celExpression.
+describe('buildNotificationFilterInput', () => {
+    it('never leaks the output-only presetConfig key into the input', () => {
+        const out = buildNotificationFilterInput(
+            { mode: 'PRESET', celExpression: null, presetConfig: { sev: 'CRITICAL' } },
+            'PRESET', '')
+        expect('presetConfig' in out).toBe(false)
+        expect(Object.keys(out).sort()).toEqual(['celExpression', 'mode', 'presetConfigJson'])
+    })
+    it('maps an output presetConfig object into presetConfigJson (stringified)', () => {
+        const out = buildNotificationFilterInput(
+            { presetConfig: { sev: 'CRITICAL', envs: ['prod'] } }, 'PRESET', '')
+        expect(out.presetConfigJson).toBe(JSON.stringify({ sev: 'CRITICAL', envs: ['prod'] }))
+    })
+    it('passes through an already-string presetConfigJson unchanged', () => {
+        const out = buildNotificationFilterInput({ presetConfigJson: '{"sev":"HIGH"}' }, 'PRESET', '')
+        expect(out.presetConfigJson).toBe('{"sev":"HIGH"}')
+    })
+    it('omits presetConfigJson when neither preset field is present', () => {
+        const out = buildNotificationFilterInput({}, 'PRESET', '')
+        expect('presetConfigJson' in out).toBe(false)
+    })
+    it('load -> resave-unchanged round-trip is a valid input (no invalid keys)', () => {
+        // Simulate the loaded output blob then a save with no user edits.
+        const loaded = { mode: 'PRESET', celExpression: null, presetConfig: { sev: 'CRITICAL' } }
+        const out = buildNotificationFilterInput(loaded, 'PRESET', '')
+        const allowed = new Set(['mode', 'presetConfigJson', 'celExpression'])
+        Object.keys(out).forEach(k => expect(allowed.has(k), `unexpected input field ${k}`).toBe(true))
+    })
+    it('carries celExpression only in ADVANCED mode', () => {
+        expect(buildNotificationFilterInput({}, 'ADVANCED', 'event.kevListed == true').celExpression)
+            .toBe('event.kevListed == true')
+        expect(buildNotificationFilterInput({}, 'PRESET', 'event.kevListed == true').celExpression)
+            .toBe(null)
+    })
+    it('tolerates a null/undefined rawFilter (Create path)', () => {
+        expect(buildNotificationFilterInput(null, 'PRESET', '')).toEqual({ mode: 'PRESET', celExpression: null })
     })
 })

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -315,3 +315,32 @@ function buildSubscriptionsQuery (fields: string) {
 }
 export const LIST_SUBSCRIPTIONS_QUERY = buildSubscriptionsQuery(`${SUBSCRIPTION_CORE_FIELDS} ${SUBSCRIPTION_ENRICHMENT_FIELDS}`)
 export const LIST_SUBSCRIPTIONS_CORE_QUERY = buildSubscriptionsQuery(SUBSCRIPTION_CORE_FIELDS)
+
+/**
+ * Build the payload for `NotificationFilterInput` from the modeled UI fields
+ * plus the as-loaded output blob (`_rawFilter`). Only `mode`,
+ * `presetConfigJson` and `celExpression` are valid input fields; the output
+ * blob carries an unmodelled `presetConfig` OBJECT that must NOT be spread
+ * into the input — doing so 400s the mutation ("field presetConfig not
+ * defined for NotificationFilterInput") and silently loses every Edit -> Save.
+ * Preset state is preserved by mapping `presetConfig` -> `presetConfigJson`.
+ */
+export function buildNotificationFilterInput (
+    rawFilter: Record<string, any> | null | undefined,
+    filterMode: string,
+    celExpression: string,
+): { mode: string, celExpression: string | null, presetConfigJson?: string } {
+    const raw = rawFilter || {}
+    const out: { mode: string, celExpression: string | null, presetConfigJson?: string } = {
+        mode: filterMode,
+        celExpression: filterMode === 'ADVANCED' ? celExpression : null,
+    }
+    if (raw.presetConfigJson != null) {
+        out.presetConfigJson = raw.presetConfigJson
+    } else if (raw.presetConfig != null) {
+        out.presetConfigJson = typeof raw.presetConfig === 'string'
+            ? raw.presetConfig
+            : JSON.stringify(raw.presetConfig)
+    }
+    return out
+}


### PR DESCRIPTION
## Problem (BUG 1 — editing a subscription 400s and persists nothing)

`SubscriptionsOfOrg.vue` loads a subscription's filter by parsing the **output** blob (`row.filter`) into `_rawFilter` — which carries a `presetConfig` **object**. On save it spread `...(f._rawFilter)` into the GraphQL `filter` argument. But `NotificationFilterInput` accepts only **`mode` / `presetConfigJson` / `celExpression`**, so the leaked `presetConfig` key returns:

> `field 'presetConfig' that is not defined for input object type 'NotificationFilterInput'` → **400**, nothing persists.

This broke editing *any* existing subscription.

## Fix

Extract `buildNotificationFilterInput(rawFilter, filterMode, celExpression)` into `notificationsCommon.ts`. It builds **only** the three valid input fields and preserves preset state by mapping the output `presetConfig` **object** → `presetConfigJson` (`JSON.stringify`; passes through an already-string `presetConfigJson`). Because the input has exactly those three fields, nothing legitimate is dropped — only the invalid `presetConfig` (which is *remapped*, not lost).

Verified against the backend: `toFilterConfig` parses `presetConfigJson` as a JSON string → `Map`, so `JSON.stringify(presetConfig)` is the correct wire shape.

## Review (two-layer gate)
- **Correctness:** merge-ready — confirmed input/output field sets, the `presetConfig`→`presetConfigJson` wire shape, and the Create / round-trip paths.
- **Conventions:** idiomatic (helper placement in `notificationsCommon`, explicit return type, test style); nits applied.

## Tests
7 unit tests on the helper (`notificationsCommon.spec.ts`), incl. the **load→resave-unchanged round-trip** and a **"no invalid keys leak"** guard (asserts the input is exactly `{mode, presetConfigJson, celExpression}`), plus `presetConfig`-object→`presetConfigJson` mapping, string passthrough, Create-path (null `_rawFilter`), and `celExpression` mode-gating.

> Note: the UI suite has one **pre-existing** unrelated failure (`notificationInboxSchemaDrift.spec.ts`, a CE-mirror schema-snapshot drift) that fails on clean `main` — not touched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
