### PR TITLE
deploy(helm): opt-in bundled zot registry for CE

### DIFF
--- a/deploy/helm/rearm-helm/templates/_helpers.tpl
+++ b/deploy/helm/rearm-helm/templates/_helpers.tpl
@@ -49,3 +49,97 @@ Selector labels
 app.kubernetes.io/name: {{ include "rearm.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Bundled registry password.
+
+Single source of truth: the zot Secret renders it, and the OCI artifact
+service checksums it to roll when it changes. In "generated" mode the
+existing Secret is looked up first so an upgrade does not rotate the
+password out from under artifacts already pushed under it. In "external"
+mode the chart never sees the value, so this renders empty.
+*/}}
+{{- define "rearm.zotPassword" -}}
+{{- $br := .Values.ociArtifactService.bundledRegistry -}}
+{{- $mode := $br.create_secret_in_chart | default "generated" -}}
+{{- if eq $mode "plaintext" -}}
+{{- if not $br.password -}}
+{{- fail "ociArtifactService.bundledRegistry.password is required when create_secret_in_chart is \"plaintext\"" -}}
+{{- end -}}
+{{- $br.password -}}
+{{- else if eq $mode "generated" -}}
+{{- if not (hasKey .Values "zotGeneratedPassword") -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-zot-credentials" .Release.Name) -}}
+{{- $pw := "" -}}
+{{- if and $existing $existing.data (index $existing.data "REGISTRY_TOKEN") -}}
+{{- $pw = index $existing.data "REGISTRY_TOKEN" | b64dec -}}
+{{- else -}}
+{{- $pw = randAlphaNum 32 -}}
+{{- end -}}
+{{- /* Memoized: this template is rendered by both the Secret and the
+       artifact service's rollout checksum. On a first install lookup
+       finds nothing and randAlphaNum would hand each caller a DIFFERENT
+       password, so the checksum would describe a credential the Secret
+       never received and every deployment would roll once for nothing. */}}
+{{- $_ := set .Values "zotGeneratedPassword" $pw -}}
+{{- end -}}
+{{- .Values.zotGeneratedPassword -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Registry connection env for everything that talks to the artifact
+registry. CE has a single consumer (the OCI artifact service); the
+helper mirrors the Pro chart so the two stay diffable.
+
+Kept in one place because these have to agree: pointing one at the
+bundled registry while the other still reads the external
+oci-registry-secrets (which the chart stops creating when the bundled
+registry is on) leaves it authenticating with nothing.
+
+The external-registry secret is optional, as it has always been for the
+artifact service: the chart creates it by default, and a deployment that
+manages it outside the chart should not be blocked from starting.
+*/}}
+{{- define "rearm.ociRegistryEnv" -}}
+{{- $br := .Values.ociArtifactService.bundledRegistry -}}
+{{- if $br.enabled }}
+{{- $zotSecret := $br.existingSecret | default (printf "%s-zot-credentials" .Release.Name) }}
+- name: REGISTRY_HOST
+  value: {{ printf "%s-zot:5000" .Release.Name | quote }}
+- name: REGISTRY_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ $zotSecret }}
+      key: REGISTRY_USERNAME
+- name: REGISTRY_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $zotSecret }}
+      key: REGISTRY_TOKEN
+{{- else }}
+- name: REGISTRY_HOST
+  value: {{ .Values.ociArtifactService.registryHost }}
+- name: REGISTRY_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: oci-registry-secrets
+      key: REGISTRY_USERNAME
+      optional: true
+- name: REGISTRY_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: oci-registry-secrets
+      key: REGISTRY_TOKEN
+      optional: true
+{{- end }}
+{{- end -}}
+
+{{/*
+Whether registry traffic is plain HTTP. The bundled registry is
+in-cluster HTTP; an external one must not be, so the configured value
+only applies when the bundled registry is off.
+*/}}
+{{- define "rearm.ociPlainHttp" -}}
+{{- ternary "true" (.Values.ociArtifactService.usePlainHttp | default "false" | toString) .Values.ociArtifactService.bundledRegistry.enabled -}}
+{{- end -}}

--- a/deploy/helm/rearm-helm/templates/oci-artifact-deployment.yaml
+++ b/deploy/helm/rearm-helm/templates/oci-artifact-deployment.yaml
@@ -15,6 +15,16 @@ spec:
       name: rearm-oci-artifact-pod
   template:
     metadata:
+{{- if .Values.ociArtifactService.bundledRegistry.enabled }}
+      annotations:
+        # Registry credentials arrive as secretKeyRef env vars, which are
+        # resolved once at pod start. Without this the pod keeps a rotated
+        # password until something else happens to restart it, and every
+        # push fails 401 against a registry that rebuilt its htpasswd.
+        # Empty in "external" mode -- the chart cannot see that password,
+        # so rolling on change is the operator's to do.
+        checksum/zot-credentials: {{ include "rearm.zotPassword" . | sha256sum }}
+{{- end }}
       labels:
         {{- include "rearm.selectorLabels" . | nindent 8 }}
         servicehook: {{ .Release.Name }}-oci-artifact
@@ -27,27 +37,14 @@ spec:
       containers:
         - name: {{ .Chart.Name }}-oci-artifact
           image: "{{ .Values.image.ociArtifactImage }}"
-          env: 
-            - name: REGISTRY_HOST
-              value: {{ .Values.ociArtifactService.registryHost }}
-            - name: REGISTRY_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: oci-registry-secrets
-                  key: REGISTRY_USERNAME
-                  optional: true
-            - name: REGISTRY_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: oci-registry-secrets
-                  key: REGISTRY_TOKEN
-                  optional: true
+          env:
+            {{- include "rearm.ociRegistryEnv" . | nindent 12 }}
             - name: LOG_TYPE
               value: {{ .Values.ociArtifactService.logFormatType | default "plain" | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.ociArtifactService.logLevel | default "info" | quote }}
             - name: USE_PLAIN_HTTP
-              value: {{ .Values.ociArtifactService.usePlainHttp | default "false" | quote }}
+              value: {{ include "rearm.ociPlainHttp" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -67,7 +64,7 @@ spec:
             periodSeconds: 10
 
 ---
-{{- if .Values.ociArtifactService.create_secret_in_chart}}
+{{- if and .Values.ociArtifactService.create_secret_in_chart (not .Values.ociArtifactService.bundledRegistry.enabled)}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/deploy/helm/rearm-helm/templates/zot.yaml
+++ b/deploy/helm/rearm-helm/templates/zot.yaml
@@ -1,0 +1,221 @@
+{{/*
+Bundled OCI registry (zot) -- opt-in, mirroring the compose stack's
+bundled registry. When enabled, the OCI artifact service stores
+artifacts in this in-cluster registry instead of an external one, so a
+deployment needs no external registry credentials at all.
+
+Credentials follow the same create_secret_in_chart contract the rest of
+the charts use. In "generated" mode the password is looked up from the
+existing Secret first, so a helm upgrade does NOT rotate it -- rotating
+it would orphan every artifact already pushed under the old credential.
+
+Storage is a standalone PVC rather than a StatefulSet
+volumeClaimTemplate. Helm creates resources newly introduced by an
+upgrade with a client-side Update, and volumeClaimTemplates is an atomic
+list under server-side apply -- so the NEXT upgrade conflicts on the
+whole list and fails. Nothing the chart can send fixes that: the stored
+copy carries apiserver-defaulted status and creationTimestamp fields a
+template cannot reproduce. Enabling the bundled registry would have
+blocked every subsequent upgrade of the release.
+
+The htpasswd file zot authenticates against is built at pod start by an
+init container rather than templated with sprig's htpasswd: bcrypt salts
+are random, so templating it would produce a different hash on every
+render and restart zot on every upgrade for no reason.
+*/}}
+{{- if and .Values.ociArtifactService.enabled .Values.ociArtifactService.bundledRegistry.enabled }}
+{{- $br := .Values.ociArtifactService.bundledRegistry }}
+{{- $secretName := printf "%s-zot-credentials" .Release.Name }}
+{{- $mode := $br.create_secret_in_chart | default "generated" }}
+{{- if or (eq $mode "generated") (eq $mode "plaintext") }}
+{{- $password := include "rearm.zotPassword" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rearm.labels" . | nindent 4 }}
+  annotations:
+    # Survive `helm uninstall`: artifacts pushed under this credential
+    # outlive the release, and a regenerated password would lock the
+    # registry's existing content away from the artifact service.
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  REGISTRY_USERNAME: {{ $br.username | default "rearm" | b64enc | quote }}
+  REGISTRY_TOKEN: {{ $password | b64enc | quote }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-zot-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rearm.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {
+      "distSpecVersion": "1.1.1",
+      "storage": {
+        "rootDirectory": "/var/lib/zot",
+        "dedupe": {{ $br.dedupe | default false }},
+        "gc": {{ $br.gc | default false }}
+      },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000",
+        "auth": {
+          "htpasswd": {
+            "path": "/etc/zot/auth/htpasswd"
+          }
+        }
+      },
+      "log": {
+        "level": {{ $br.logLevel | default "warn" | quote }}
+      }
+    }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-zot-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rearm.labels" . | nindent 4 }}
+  annotations:
+    # Same reasoning as the credentials Secret: the artifacts outlive the
+    # release, so uninstall must not take the volume with it.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  {{- with $br.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $br.storage | default "20Gi" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-zot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: rearm-zot-service
+    {{- include "rearm.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5000
+      targetPort: 5000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "rearm.selectorLabels" . | nindent 4 }}
+    name: rearm-zot-pod
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-zot
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "rearm.labels" . | nindent 4 }}
+    name: rearm-zot
+spec:
+  replicas: 1
+  serviceName: {{ .Release.Name }}-zot
+  selector:
+    matchLabels:
+      {{- include "rearm.selectorLabels" . | nindent 6 }}
+      name: rearm-zot-pod
+  template:
+    metadata:
+      annotations:
+        # The init container below rebuilds htpasswd from the Secret, but
+        # only when the pod starts. Without this a rotated password leaves
+        # zot validating against the old hash while the artifact service
+        # already sends the new one, and every push 401s.
+        checksum/zot-credentials: {{ include "rearm.zotPassword" . | sha256sum }}
+      labels:
+        {{- include "rearm.selectorLabels" . | nindent 8 }}
+        name: rearm-zot-pod
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      initContainers:
+        # Rebuilds the htpasswd file from the Secret on every start, so a
+        # credential change takes effect on the next rollout.
+        - name: htpasswd
+          image: "{{ .Values.image.htpasswdImage }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - htpasswd -Bbc /auth/htpasswd "$REGISTRY_USERNAME" "$REGISTRY_TOKEN"
+          env:
+            - name: REGISTRY_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $br.existingSecret | default $secretName }}
+                  key: REGISTRY_USERNAME
+            - name: REGISTRY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $br.existingSecret | default $secretName }}
+                  key: REGISTRY_TOKEN
+          volumeMounts:
+            - name: zot-auth
+              mountPath: /auth
+      containers:
+        - name: zot
+          image: "{{ .Values.image.zotImage }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["serve", "/etc/zot/config.json"]
+          ports:
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+          # TCP, not HTTP: with htpasswd auth on, every zot endpoint --
+          # including /v2/ -- answers 401 to an unauthenticated request,
+          # and an httpGet probe treats that as a failure and restarts the
+          # pod forever. The minimal image ships no unauthenticated health
+          # route (mgmt/search extensions are compiled out), so a listening
+          # socket is the available liveness signal.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 6
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 3
+            periodSeconds: 10
+          {{- with $br.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: zot-config
+              mountPath: /etc/zot/config.json
+              subPath: config.json
+              readOnly: true
+            - name: zot-auth
+              mountPath: /etc/zot/auth
+              readOnly: true
+            - name: zot-data
+              mountPath: /var/lib/zot
+      volumes:
+        - name: zot-config
+          configMap:
+            name: {{ .Release.Name }}-zot-config
+        - name: zot-auth
+          emptyDir: {}
+        - name: zot-data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-zot-data
+{{- end }}

--- a/deploy/helm/rearm-helm/values.yaml
+++ b/deploy/helm/rearm-helm/values.yaml
@@ -30,6 +30,8 @@ image:
   postgresImage: registry.relizahub.com/library/rearm-postgres:0.1.6@sha256:7c3d99ee4d4bbfb9a784f4e35e653aea07ebdf4ce32cd90f85fd888e717612ee
   rebomBackend: registry.relizahub.com/library/rebom-backend:0.20.4@sha256:1b75c28fe1fa2e28b25b2fdd80e2cbd1cc43751b64657020cf6e87c7428e6dc3
   flywayImage: docker.io/redgate/flyway:11.20.3-alpine@sha256:52cdd559dc8ae38a17b56615e3c7137d9b01470271112525b40373de470bb005
+  zotImage: ghcr.io/project-zot/zot-minimal:v2.1.18@sha256:892f2a5a63dd99bdf85320fee5448506119328a6d5e1a2d14d4db876be595236
+  htpasswdImage: docker.io/library/httpd:2.4-alpine@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567
   pullPolicy: IfNotPresent
 
 imagePullSecrets: [ {"name":"regcred"} ]
@@ -109,6 +111,50 @@ ociArtifactService:
   registryUser: changeme # change
   registryToken: changeme # change
   create_secret_in_chart: true
+  # Bundled OCI registry (zot), opt-in. Mirrors the compose stack's
+  # bundled registry: turn this on and artifacts are stored in-cluster,
+  # with no external registry or credentials required. The registryHost /
+  # registryUser / registryToken values above are then unused.
+  # NB: set rebom.backend.oci.registryNamespace to a plain repository
+  # prefix (e.g. "rearm") when using this -- the default placeholder is
+  # for the external registry layout.
+  bundledRegistry:
+    # Enabling this on a FRESH install needs nothing special.
+    #
+    # It is only when ADDING the bundled registry to a deployment that
+    # already exists that one deploy must run with --force-conflicts
+    # (ReARM CD exposes this as an option). Helm creates resources
+    # introduced by an upgrade with client-side ownership, so the first
+    # later change to any zot value -- a routine zot image bump included
+    # -- otherwise fails with a conflict against helm itself, and keeps
+    # failing. One forced deploy clears it permanently; no flag is needed
+    # for any upgrade after that.
+    enabled: false
+    # Credential handling, same contract as the other charts:
+    #   generated -- random password on first install, preserved across
+    #                upgrades via lookup (never rotated silently).
+    #                Requires helm install/upgrade: `helm template` has no
+    #                cluster to look up, so it mints a fresh password on
+    #                every render. Use plaintext or external if you render
+    #                manifests and apply them separately.
+    #   plaintext -- take bundledRegistry.password verbatim
+    #   external  -- provide existingSecret with REGISTRY_USERNAME /
+    #                REGISTRY_TOKEN keys; the chart creates no Secret
+    create_secret_in_chart: generated
+    username: rearm
+    password: ""
+    existingSecret: ""
+    # Backed by a standalone PVC. Growing `storage` on a later upgrade
+    # works if the storage class allows expansion; shrinking it does not.
+    # storageClassName is fixed once the claim is bound -- changing it
+    # means deleting the PVC, which discards the stored artifacts.
+    storage: 20Gi
+    storageClassName: ""
+    logLevel: warn
+    # zot-side storage features; both off matches the compose default.
+    dedupe: false
+    gc: false
+    resources: {}
 
 useTraefikLe: true
 traefikBehindLb: false


### PR DESCRIPTION
Ports the bundled [zot](https://zotregistry.dev) registry from the Pro chart to CE, kept as close to it as possible so the two stay diffable.

```yaml
ociArtifactService:
  bundledRegistry:
    enabled: true
```

Turn it on and artifacts live in an in-cluster registry — no external registry, no external credentials. Off by default: flipping the default would repoint existing deployments away from their configured registry. Default render is unchanged apart from a trailing space after `env:`.

## What came across from Pro

Same `zot.yaml`, same helper names (`rearm.zotPassword`, `rearm.ociRegistryEnv`, `rearm.ociPlainHttp`), same `create_secret_in_chart` contract (`generated` / `plaintext` / `external`). CE has no artifact backup cronjob, so the registry-env helper has a single consumer here — kept anyway rather than inlined, so the two charts continue to line up.

It also carries the fixes that live upgrade testing found on the Pro side:

- storage is a **standalone PVC**, not a StatefulSet `volumeClaimTemplate` (atomic list under server-side apply → every later upgrade conflicts)
- the generated password is **memoized**, so the Secret and the rollout checksum agree on a first install
- both the artifact service and the zot StatefulSet carry a `checksum/zot-credentials` annotation, so a rotated credential rolls both sides instead of leaving zot validating the old htpasswd
- zot probes are `tcpSocket`: under htpasswd auth every endpoint including `/v2/` answers 401 to an unauthenticated request, which an `httpGet` probe reads as failure

## One Helm behaviour worth knowing (not chart-specific)

Enabling this on an **existing** release means Helm creates the zot resources during an upgrade, which gives them client-side (`Update`) ownership alongside `Apply`. The first change to any zot value then conflicts with helm itself:

```
conflict with "helm" using apps/v1: .spec.template.spec.containers[name="zot"].image
```

Confirmed this is generic rather than something about these templates: changing plain `logLevel` conflicts on the ConfigMap's `.data.config.json`, and a resource created at *install* (`ce-oci-artifact`) has only an `Apply` entry while the upgrade-created `ce-zot` has both. Any newly-added template in either chart carries the same one-time trap.

**One `helm upgrade --force-conflicts` clears it permanently** (ReARM CD exposes this as an option). Verified: after one forced deploy, the zot image rotated twice more with no flag. Documented in `values.yaml`; the same note is going to the Pro chart, which has identical behaviour.

**Fresh installs that include zot from the start are completely unaffected** — verified directly, not inferred. Installing with `bundledRegistry.enabled=true` gives every zot resource clean `helm/Apply` ownership (no `Update` entry), and image rotation, `logLevel`, container resources and credential rotation all then apply with no flag.

## Verification

Against a live cluster, not just rendered output:

| check | result |
|---|---|
| install pre-change chart → upgrade twice, zot **off** | `deployed`, no workload generation changes, zero zot resources |
| artifact push through deployed service → deployed registry | HTTP 200, present in `/v2/_catalog` |
| anonymous `/v2/_catalog` | 401 |
| generated password across repeated upgrades | stable, no spurious rollouts |
| zot image rotation after one forced deploy | two rotations, no flag needed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
