### PR TITLE
feat(ui): inbox scope toggle (For me / All org activity) + Direct-primary badge (RFC Phase 2c)

### DIFF
--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -16,9 +16,24 @@
                 <n-tab-pane name="inbox" tab="Inbox" data-testid="inbox-tab">
                 <div class="tab-toolbar">
                     <div class="tab-toolbar-info">
-                        Your personal triage queue. Org-admins see every delivery; perspective-members see deliveries that touch a release in one of their perspectives.
+                        <template v-if="inboxScope === 'ORG_ALL'">
+                            All org activity — every delivery in the org. The bell badge still counts only your personal unread.
+                        </template>
+                        <template v-else>
+                            Your personal triage queue — deliveries relevant to you: releases on your components and perspectives, plus items addressed to you.
+                        </template>
                     </div>
-                    <n-space size="small">
+                    <n-space size="small" align="center">
+                        <n-radio-group
+                            v-if="isOrgAdmin"
+                            :value="inboxScope"
+                            size="small"
+                            @update:value="setInboxScope"
+                            data-testid="inbox-scope-toggle"
+                        >
+                            <n-radio-button value="PERSONAL">For me</n-radio-button>
+                            <n-radio-button value="ORG_ALL">All org activity</n-radio-button>
+                        </n-radio-group>
                         <n-button
                             v-if="canWrite && selectedInboxRows.length > 0"
                             size="small"
@@ -31,7 +46,7 @@
                             Mark {{ selectedInboxRows.length }} read
                         </n-button>
                         <n-button
-                            v-if="canWrite && inboxUnreadCount > 0"
+                            v-if="canOfferMarkAll"
                             size="small"
                             secondary
                             @click="markAllReadConfirm"
@@ -459,6 +474,25 @@ const inboxPageCount = computed<number>(() =>
 const inboxUnreadOnly = ref<boolean>(true)
 const inboxStatusFilter = ref<string | null>(null)
 const inboxEventTypeFilter = ref<string | null>(null)
+// Phase 2c inbox scope. PERSONAL (default) = my triage queue; ORG_ALL = the
+// org-wide firehose, admin-only (a non-admin's ORG_ALL collapses to PERSONAL
+// server-side, so it's harmless, but we only offer the toggle to admins). Only
+// the list + mark-all follow this; the badge stays PERSONAL (Direct-primary).
+const inboxScope = ref<'PERSONAL' | 'ORG_ALL'>('PERSONAL')
+function setInboxScope (scope: 'PERSONAL' | 'ORG_ALL'): void {
+    if (inboxScope.value === scope) return
+    inboxScope.value = scope
+    inboxPage.value = 1
+    selectedInboxRows.value = []
+    loadInbox()
+}
+// Offer "Mark all read" when the CURRENT scope has something to sweep. The badge
+// (inboxUnreadCount) is PERSONAL, so in ORG_ALL fall back to the visible list
+// total -- otherwise an admin with 0 personal unread but org-wide unread visible
+// would see no button.
+const canOfferMarkAll = computed<boolean>(() =>
+    canWrite.value && (inboxUnreadCount.value > 0
+        || (inboxScope.value === 'ORG_ALL' && inboxTotalCount.value > 0)))
 const selectedInboxRows = ref<string[]>([])
 const inboxBulkLoading = ref<boolean>(false)
 const inboxMarkAllLoading = ref<boolean>(false)
@@ -592,6 +626,15 @@ const MARK_ALL_READ_MUTATION = gql`
     }
 `
 
+// Scoped variant so a mark-all under the ORG_ALL view sweeps org-wide (matching
+// the visible list), not just the personal slice. Used only for ORG_ALL; the
+// default arg-less mutation stays safe against a backend without the arg.
+const MARK_ALL_READ_MUTATION_SCOPED = gql`
+    mutation markAllNotificationsRead($orgUuid: ID!, $inboxScope: NotificationInboxScope) {
+        markAllNotificationsRead(orgUuid: $orgUuid, inboxScope: $inboxScope) { count hasMore }
+    }
+`
+
 const RELEASES_NEEDING_MY_APPROVAL_QUERY = gql`
     query releasesNeedingMyApproval($orgUuid: ID!) {
         releasesNeedingMyApproval(orgUuid: $orgUuid) {
@@ -696,15 +739,26 @@ async function loadInbox (): Promise<void> {
     inboxLoading.value = true
     try {
         const offset = (inboxPage.value - 1) * inboxPageSize.value
-        const { page, degraded } = await loadNotificationInboxPage(graphqlClient, {
+        const inboxVars: Record<string, any> = {
             orgUuid: orgUuid.value,
             unreadOnly: inboxUnreadOnly.value,
             status: inboxStatusFilter.value,
             eventType: inboxEventTypeFilter.value,
             limit: inboxPageSize.value,
             offset,
-        }, inboxFullRejected)
+        }
+        // Send inboxScope only for the non-default ORG_ALL view so the default
+        // path stays arg-less (drift-safe); PERSONAL is the backend default.
+        if (inboxScope.value === 'ORG_ALL') inboxVars.inboxScope = 'ORG_ALL'
+        const { page, degraded, scopeUnsupported } = await loadNotificationInboxPage(
+            graphqlClient, inboxVars, inboxFullRejected)
         if (myToken !== inboxInflightToken) return
+        // Backend without ORG_ALL support: the loader already served PERSONAL.
+        // Reset the toggle so the UI matches what was fetched, and say so once.
+        if (scopeUnsupported && inboxScope.value === 'ORG_ALL') {
+            inboxScope.value = 'PERSONAL'
+            message.info('Org-wide view is not available on this backend; showing your personal inbox.')
+        }
         inboxDegraded.value = degraded
         // Once this backend has rejected the full selection, skip straight to
         // the core selection on subsequent loads so we don't pay the
@@ -879,22 +933,34 @@ async function bulkMarkRead (): Promise<void> {
 }
 
 function markAllReadConfirm (): void {
-    const n = Math.min(inboxUnreadCount.value, 500)
-    const remainder = Math.max(0, inboxUnreadCount.value - 500)
-    const tail = remainder > 0
-        ? ` Backend caps a single sweep at 500 — re-run to clear the remaining ${remainder}.`
-        : ''
+    const orgAll = inboxScope.value === 'ORG_ALL'
+    // In ORG_ALL the sweep is org-wide (up to 500), which the PERSONAL badge
+    // count doesn't measure -- so don't promise a specific number there.
+    let content: string
+    if (orgAll) {
+        content = 'This marks org-wide unread notifications as read — up to 500 per sweep; re-run to clear any remaining.'
+    } else {
+        const n = Math.min(inboxUnreadCount.value, 500)
+        const remainder = Math.max(0, inboxUnreadCount.value - 500)
+        const tail = remainder > 0
+            ? ` Backend caps a single sweep at 500 — re-run to clear the remaining ${remainder}.`
+            : ''
+        content = `This marks up to ${n} unread item(s) as read.${tail}`
+    }
     dialog.warning({
-        title: 'Mark every visible unread notification as read?',
-        content: `This marks up to ${n} unread item(s) as read.${tail}`,
+        title: orgAll ? 'Mark all org-wide unread as read?' : 'Mark every visible unread notification as read?',
+        content,
         positiveText: 'Mark all read',
         negativeText: 'Cancel',
         onPositiveClick: async () => {
             inboxMarkAllLoading.value = true
             try {
+                const orgAll = inboxScope.value === 'ORG_ALL'
                 const res = await graphqlClient.mutate({
-                    mutation: MARK_ALL_READ_MUTATION,
-                    variables: { orgUuid: orgUuid.value },
+                    mutation: orgAll ? MARK_ALL_READ_MUTATION_SCOPED : MARK_ALL_READ_MUTATION,
+                    variables: orgAll
+                        ? { orgUuid: orgUuid.value, inboxScope: 'ORG_ALL' }
+                        : { orgUuid: orgUuid.value },
                 })
                 const result = res.data?.markAllNotificationsRead
                 const marked = result?.count || 0
@@ -1081,6 +1147,9 @@ watch(orgUuid, () => {
     inboxDegraded.value = false
     inboxFullRejected = false
     selectedInboxRows.value = []
+    // Reset scope: admin-ness is per-org, so a stale ORG_ALL from the previous
+    // org would strand a non-admin here with a hidden toggle and no way back.
+    inboxScope.value = 'PERSONAL'
     approvalsItems.value = []
     approvalsCount.value = 0
     if (orgUuid.value) {

--- a/ui/src/utils/notificationInboxQuery.spec.ts
+++ b/ui/src/utils/notificationInboxQuery.spec.ts
@@ -3,11 +3,12 @@ import {
     loadNotificationInboxPage,
     INBOX_QUERY_FULL,
     INBOX_QUERY_CORE,
+    INBOX_QUERY_FULL_SCOPED,
     INBOX_CORE_ITEM_FIELDS,
     INBOX_ENRICHMENT_ITEM_FIELDS,
 } from './notificationInboxQuery'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
-import type { DocumentNode } from 'graphql'
+import { print, type DocumentNode } from 'graphql'
 
 // The generic retry/classify logic is covered in graphqlDriftFallback.spec.ts.
 // These tests cover the inbox WIRING: field partitioning, the two documents,
@@ -29,6 +30,11 @@ describe('inbox field partitioning', () => {
     })
     it('builds distinct FULL and CORE documents', () => {
         expect(INBOX_QUERY_FULL).not.toBe(INBOX_QUERY_CORE)
+    })
+    it('scoped documents are distinct and carry $inboxScope; arg-less ones do not', () => {
+        expect(INBOX_QUERY_FULL_SCOPED).not.toBe(INBOX_QUERY_FULL)
+        expect(print(INBOX_QUERY_FULL_SCOPED)).toContain('inboxScope')
+        expect(print(INBOX_QUERY_FULL)).not.toContain('inboxScope')
     })
 })
 
@@ -58,6 +64,56 @@ describe('loadNotificationInboxPage', () => {
         expect(res.degraded).toBe(true)
         expect(res.page.items).toHaveLength(1)
         expect('channelName' in res.page.items[0]).toBe(false)
+    })
+
+    it('uses the arg-less document when no inboxScope is given (drift-safe default)', async () => {
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                expect(query).toBe(INBOX_QUERY_FULL)
+                return { data: { notificationInbox: { items: [], totalCount: 0 } } }
+            },
+        }
+        await loadNotificationInboxPage(client, { orgUuid: 'o1' })
+    })
+
+    it('uses the scoped document only when inboxScope is provided (ORG_ALL)', async () => {
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                expect(query).toBe(INBOX_QUERY_FULL_SCOPED)
+                return { data: { notificationInbox: { items: [], totalCount: 0 } } }
+            },
+        }
+        const res = await loadNotificationInboxPage(client, { orgUuid: 'o1', inboxScope: 'ORG_ALL' })
+        expect(res.degraded).toBe(false)
+    })
+
+    it('degrades a scoped request to the arg-less PERSONAL query when the backend lacks inboxScope', async () => {
+        const seen: DocumentNode[] = []
+        const client: DriftFallbackClient = {
+            async query ({ query }: { query: DocumentNode }) {
+                seen.push(query)
+                // Both scoped documents fail as schema drift; the arg-less
+                // documents then succeed.
+                if (query === INBOX_QUERY_FULL || query === INBOX_QUERY_CORE) {
+                    return { data: { notificationInbox: { items: [{ uuid: 'a' }], totalCount: 1 } } }
+                }
+                throw validationError()
+            },
+        }
+        const res = await loadNotificationInboxPage(client, { orgUuid: 'o1', inboxScope: 'ORG_ALL' })
+        expect(res.scopeUnsupported).toBe(true)
+        expect(res.page.items).toHaveLength(1)
+        expect(seen).toContain(INBOX_QUERY_FULL_SCOPED)
+        expect(seen.some(q => q === INBOX_QUERY_FULL || q === INBOX_QUERY_CORE)).toBe(true)
+    })
+
+    it('does NOT degrade scope on a non-drift error (surfaces it)', async () => {
+        const client: DriftFallbackClient = {
+            async query () { throw new Error('Failed to fetch') },
+        }
+        await expect(
+            loadNotificationInboxPage(client, { orgUuid: 'o1', inboxScope: 'ORG_ALL' }),
+        ).rejects.toThrow(/failed to fetch/i)
     })
 
     it('skipFull requests only the core document', async () => {

--- a/ui/src/utils/notificationInboxQuery.ts
+++ b/ui/src/utils/notificationInboxQuery.ts
@@ -12,6 +12,7 @@ import gql from 'graphql-tag'
 import type { DocumentNode } from 'graphql'
 import {
     loadWithSchemaDriftFallback,
+    isSchemaDriftError,
     type DriftFallbackClient,
 } from '@/utils/graphqlDriftFallback'
 
@@ -37,7 +38,14 @@ export const INBOX_ENRICHMENT_ITEM_FIELDS: string[] = [
     'channelDisabledReason',
 ]
 
-function buildInboxQuery (itemFields: string[]): DocumentNode {
+// `withScope` adds the Phase-2c `inboxScope` arg (admin "All org activity"
+// toggle). It is OMITTED from the default documents on purpose: PERSONAL is the
+// backend default, so the arg-less query works against any backend (incl. a CE
+// mirror that predates inboxScope). Only an admin opting into ORG_ALL uses the
+// scoped variant, so the new arg never breaks the default path.
+function buildInboxQuery (itemFields: string[], withScope = false): DocumentNode {
+    const scopeVar = withScope ? ', $inboxScope: NotificationInboxScope' : ''
+    const scopeArg = withScope ? ', inboxScope: $inboxScope' : ''
     return gql`
         query notificationInbox(
             $orgUuid: ID!,
@@ -45,7 +53,7 @@ function buildInboxQuery (itemFields: string[]): DocumentNode {
             $status: NotificationDeliveryStatusEnum,
             $eventType: NotificationEventTypeEnum,
             $limit: Int,
-            $offset: Int
+            $offset: Int${scopeVar}
         ) {
             notificationInbox(
                 orgUuid: $orgUuid,
@@ -53,7 +61,7 @@ function buildInboxQuery (itemFields: string[]): DocumentNode {
                 status: $status,
                 eventType: $eventType,
                 limit: $limit,
-                offset: $offset
+                offset: $offset${scopeArg}
             ) {
                 items { ${itemFields.join(' ')} }
                 totalCount unreadCount limit offset
@@ -66,12 +74,21 @@ export const INBOX_QUERY_FULL: DocumentNode = buildInboxQuery(
     [...INBOX_CORE_ITEM_FIELDS, ...INBOX_ENRICHMENT_ITEM_FIELDS],
 )
 export const INBOX_QUERY_CORE: DocumentNode = buildInboxQuery(INBOX_CORE_ITEM_FIELDS)
+// Scoped variants (carry $inboxScope), used only when a non-default scope is requested.
+export const INBOX_QUERY_FULL_SCOPED: DocumentNode = buildInboxQuery(
+    [...INBOX_CORE_ITEM_FIELDS, ...INBOX_ENRICHMENT_ITEM_FIELDS], true,
+)
+export const INBOX_QUERY_CORE_SCOPED: DocumentNode = buildInboxQuery(INBOX_CORE_ITEM_FIELDS, true)
 
 export interface InboxPageResult {
     page: any
     // true when the full selection was rejected and we fell back to core --
     // rows are present but enrichment (e.g. channelName) is absent.
     degraded: boolean
+    // true when a scoped (ORG_ALL) request hit a backend WITHOUT the inboxScope
+    // arg and was served the arg-less PERSONAL query instead. The caller should
+    // reset its scope toggle to PERSONAL and inform the user.
+    scopeUnsupported: boolean
 }
 
 // Load one inbox page, tolerating schema drift. Pass `skipFull=true` once a
@@ -82,12 +99,39 @@ export async function loadNotificationInboxPage (
     variables: Record<string, any>,
     skipFull = false,
 ): Promise<InboxPageResult> {
+    const extractPath = (d: any) => d?.notificationInbox
+    // Use the scoped documents only when a scope is actually requested (an admin
+    // on ORG_ALL). Absent inboxScope -> the arg-less documents, which the spec
+    // pins and which stay safe against a backend without the arg.
+    const scoped = variables.inboxScope != null
+    if (scoped) {
+        try {
+            const { data, degraded } = await loadWithSchemaDriftFallback(client, {
+                fullQuery: INBOX_QUERY_FULL_SCOPED,
+                coreQuery: INBOX_QUERY_CORE_SCOPED,
+                variables, extractPath, skipFull,
+            })
+            return { page: data, degraded, scopeUnsupported: false }
+        } catch (err: any) {
+            // A backend without the inboxScope arg (e.g. a CE mirror predating
+            // Phase 2a) rejects BOTH scoped documents as schema drift. Degrade to
+            // the arg-less PERSONAL query so the inbox still renders instead of
+            // erroring, and flag scopeUnsupported so the caller resets the toggle.
+            // Non-drift errors (auth / network / server) surface unchanged.
+            if (!isSchemaDriftError(err)) throw err
+            const { inboxScope, ...personalVars } = variables
+            const { data, degraded } = await loadWithSchemaDriftFallback(client, {
+                fullQuery: INBOX_QUERY_FULL,
+                coreQuery: INBOX_QUERY_CORE,
+                variables: personalVars, extractPath, skipFull,
+            })
+            return { page: data, degraded, scopeUnsupported: true }
+        }
+    }
     const { data, degraded } = await loadWithSchemaDriftFallback(client, {
         fullQuery: INBOX_QUERY_FULL,
         coreQuery: INBOX_QUERY_CORE,
-        variables,
-        extractPath: (d: any) => d?.notificationInbox,
-        skipFull,
+        variables, extractPath, skipFull,
     })
-    return { page: data, degraded }
+    return { page: data, degraded, scopeUnsupported: false }
 }


### PR DESCRIPTION
## What & why

Completes the inbox-scope work: exposes the Phase-2a backend `inboxScope` arg in the bell inbox UI. An **admin-only "For me / All org activity" segmented toggle** switches the inbox **list** and **mark-all** between PERSONAL (default) and ORG_ALL. The bell **badge stays PERSONAL** — the *Direct-primary badge*: it always counts what's actionable for *you*, even while an admin views the org-wide firehose. Updates the stale "org-admins see every delivery" copy to match the PERSONAL default.

**Drift-safe by design:** `inboxScope` is sent **only** for ORG_ALL, via new scoped query/mutation documents; the default PERSONAL path stays **arg-less** (byte-identical to before), so it can never break against a backend (e.g. a CE mirror) that predates the arg.

## Two-layer gate (run pre-PR) — findings applied
- **#1 capability gap (both layers):** an admin on a backend *without* `inboxScope` no longer hard-errors the inbox. `loadNotificationInboxPage` catches the scoped-document schema-drift (`isSchemaDriftError`) and **degrades to the arg-less PERSONAL query**, returning `scopeUnsupported` so the component resets the toggle and informs the user once. Non-drift errors (auth/network/server) still surface unchanged.
- **#2 org-switch strand (L1):** the `orgUuid` watcher now resets `inboxScope` to PERSONAL, so a stale ORG_ALL can't strand a non-admin with a hidden toggle.
- **#3 mark-all/ORG_ALL mismatch (L1):** the "Mark all read" button is offered from the visible list in ORG_ALL (not the PERSONAL badge count), and the confirm dialog no longer promises a specific personal number for an org-wide sweep.

Layer 1 verdict: safe (no data leak — backend `ORG_ALL→PERSONAL` collapse is the backstop; badge stays PERSONAL confirmed). Layer 2: meets the UI codebase's conventions bar.

## Tests
`notificationInboxQuery.spec` **11** (+ scoped/arg-less routing, scoped→arg-less graceful degrade, non-drift-surfaces, scoped-doc distinctness). `vite build` compiles the SFC.

## Notes for the reviewer
- The pre-existing `notificationInboxSchemaDrift.spec` failure is **unrelated** to this PR — the CE mirror caught up on the `channel*` enrichment fields, so `INBOX_QUERY_FULL` now validates against it and the "FULL is invalid vs CE" assertion flips. Not touched here; worth a separate look at the CORE/ENRICHMENT split (verified it fails on `main` without this change).
- This file uses em-dashes in user-facing copy by local convention (the plain-ASCII rule is for backend Java source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)