### PR TITLE
fix(ui): notification diagnosability -- affected-release deep links + labeled stale channels (BUG 5, BUG 2)

### DIFF
--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -345,6 +345,24 @@
                         </n-descriptions-item>
                     </n-descriptions>
 
+                    <!-- BUG 5: affected releases as deep links (the header says
+                         "affects N releases" but only the raw JSON listed them).
+                         Navigation closes both drawers so the release page isn't
+                         rendered underneath them. -->
+                    <div v-if="affectedReleasesView.length" class="inbox-affected-releases" data-testid="inbox-affected-releases">
+                        <div class="inbox-affected-title">Affected releases ({{ affectedReleasesView.length }})</div>
+                        <n-space size="small" :wrap="true">
+                            <router-link
+                                v-for="(ar, idx) in affectedReleasesView"
+                                :key="`${ar.uuid}-${idx}`"
+                                :to="`/release/show/${ar.uuid}`"
+                                @click="inboxDrawerOpen = false; inboxListDrawerOpen = false"
+                            >
+                                {{ ar.label }}
+                            </router-link>
+                        </n-space>
+                    </div>
+
                     <!-- Structured payload view. Pretty-printed JSON as the
                          generic fallback; approval events additionally get
                          the typed summary above.
@@ -548,6 +566,22 @@ const inboxDrawerPayload = computed<Record<string, unknown> | null>(() => {
     } catch {
         return null
     }
+})
+
+// BUG 5: the drawer says "affects N releases" but the payload's affectedReleases
+// were only visible in the raw JSON. Surface them as release deep-links.
+// AffectedRelease shape (rearm-core): { uuid, component (name), version, ... }.
+interface AffectedReleaseLink { uuid: string, label: string }
+const affectedReleasesView = computed<AffectedReleaseLink[]>(() => {
+    const arr = inboxDrawerPayload.value?.affectedReleases
+    if (!Array.isArray(arr)) return []
+    return arr.reduce<AffectedReleaseLink[]>((acc, r: any) => {
+        const uuid = typeof r?.uuid === 'string' ? r.uuid : null
+        if (!uuid) return acc
+        const parts = [r?.component, r?.version].filter((p: any) => typeof p === 'string' && p)
+        acc.push({ uuid, label: parts.length ? parts.join(' ') : uuid })
+        return acc
+    }, [])
 })
 
 interface ApprovalPayloadView {
@@ -1309,6 +1343,7 @@ onUnmounted(() => {
 /* Inbox drawer — payload viewer. Monospace + wrap-on-word so a deeply-nested
  * JSON doesn't blow the drawer's horizontal extent. */
 .inbox-drawer-desc { font-size: 14px; line-height: 1.45; }
+.inbox-affected-title { font-size: 12px; font-weight: 600; margin-bottom: 4px; color: var(--n-text-color-2, #666); }
 .inbox-drawer-payload {
     font-family: var(--font-mono, monospace);
     font-size: 12px;

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -362,11 +362,32 @@ const eventTypeOptionsForForm = computed(() =>
             : o)
 )
 
-const channelOptions = computed(() =>
-    channels.value
+const channelOptions = computed(() => {
+    const enabled = channels.value
         .filter(c => c.status === 'ENABLED')
         .map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
-)
+    const known = new Set(enabled.map(o => o.value))
+    // BUG 2: a route can still reference a channel that is now DISABLED or
+    // DELETED -- neither is in the enabled option list, so the n-select tag would
+    // render a bare UUID. Add a labeled "ghost" option for each already-referenced
+    // value so the tag reads a name (disabled) or "(deleted channel) <short>",
+    // mirroring the Delivery History label. NOT marked `disabled`: a disabled
+    // option makes the selected tag non-removable in n-select, which would trap
+    // the very dangling ref the user came to clean up -- keep it removable.
+    const byUuid = new Map(channels.value.map(c => [c.uuid, c]))
+    const referenced = new Set<string>()
+    for (const r of subForm.value.routes) for (const ch of (r.channels || [])) referenced.add(ch)
+    const ghosts = [...referenced]
+        .filter(u => !known.has(u))
+        .map(u => {
+            const c = byUuid.get(u)
+            const label = c
+                ? `${c.name} (${TYPE_LABELS[c.type] || c.type}) (disabled)`
+                : `(deleted channel) ${String(u).slice(0, 8)}`
+            return { label, value: u }
+        })
+    return [...enabled, ...ghosts]
+})
 
 const channelGroupOptions = computed(() =>
     channelGroups.value.map(g => ({


### PR DESCRIPTION
## What & why

Two self-contained **notification diagnosability** fixes from the walkthrough findings log.

- **BUG 5 — inbox drawer "affects N releases" now deep-links.** The drawer header said "affects N releases" but the `affectedReleases` were only visible in the raw JSON payload. They're now rendered as **release deep-links** (`/release/show/{uuid}`), reusing the existing approval-event deep-link pattern (closes both drawers on click). `affectedReleasesView` guards a missing/non-array payload, entries without a `uuid`, and non-string `component`/`version`.
- **BUG 2 — subscription route no longer shows a bare channel UUID.** The channel multiselect filtered options to ENABLED channels only, so a route referencing a now-**disabled** or **deleted** channel rendered a raw UUID tag. `channelOptions` now appends a labeled **ghost option** for each referenced-but-not-enabled value — `"name (type) (disabled)"` or `"(deleted channel) <short>"`, mirroring the Delivery History wording — so an admin can see *and clean up* the dangling reference.

## Review (combined correctness + conventions) — findings applied
- **Medium:** ghost options are **not** marked `disabled` — a disabled option makes the selected tag non-removable in `n-select`, which would trap the very dangling ref the user came to remove. Kept removable (cost: the ghost also shows in the dropdown — harmless).
- **Low/defensive:** `String(u)` guards a theoretically non-string persisted channel entry.
- **Nit:** the affected-release `v-for` keys on `uuid + index` to avoid a duplicate-key warning if a release repeats.

Verdict: safe. No correctness/convention blockers. Reviewer's one smoke-check (tag removability) is pre-empted by dropping `disabled`.

## Deferred — need backend (NOT UI-only)
- **BUG 3** (payload view in Delivery History): the `notificationDeliveries` query returns **no `payloadJson`** — the payload lives on the outbox event, which the delivery result doesn't expose. Needs a rearm-core change (expose payload on the delivery result or a fetch-by-outboxEventUuid query).
- **BUG 4** (deep-link to a specific event/delivery): `notificationDeliveries` filters by channel/subscription/status/origin only — **no event/delivery arg** — so "View delivery log" can only land on the channel. Needs a rearm-core filter param.

## Validation
`vite build` compiles both SFCs; ASCII-clean. No component test harness exists for these files (both changes are component-internal computeds), consistent with the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)