### PR TITLE
fix(ui): child-release query asks for a DigestRecord field that does not exist

### DIFF
--- a/ui/src/components/ReleaseEl.vue
+++ b/ui/src/components/ReleaseEl.vue
@@ -18,7 +18,7 @@
                         <n-icon :id="'artifacts' + release.uuid" size="20"><Box /></n-icon>
                     </template>
                     <p v-for="art in release.artifactDetails" :key=art.uuid>
-                        {{ art.displayIdentifier + (art.digestRecords.length ?  '@' + art.digestRecords[0].value : '') }}
+                        {{ art.displayIdentifier + (art.digestRecords?.length ?  '@' + art.digestRecords[0].digest : '') }}
                     </p>
                 </n-tooltip>
             </span>

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -165,7 +165,7 @@ const CHILD_RELEASE_GQL_DATA = `
         uuid
         displayIdentifier
         digestRecords {
-            value
+            digest
         }
     }
     parentReleases {

--- a/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
+++ b/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse } from 'graphql'
+import graphqlQueries from './graphqlQueries'
+
+// These release selection sets are interpolated into `gql` templates at
+// runtime (store.fetchReleasesByOrgUuids and friends). scripts/validate-graphql
+// only parses statically-analysable documents, so it skips every template
+// containing ${...} -- which is exactly where CHILD_RELEASE_GQL_DATA lived
+// when it shipped asking for a DigestRecord.value field that has never
+// existed. The whole query fails validation at runtime, so a single wrong
+// field name blanks the view rather than degrading it.
+//
+// Checked against the CE schema only. It ships in this repo, so the path
+// always resolves and there is nothing to skip; the Pro schema lives in a
+// separate repository that is not available here. CE is expected to match
+// Pro (it may lag on updates), so a field valid on CE is valid on Pro.
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+// Read eagerly: a missing schema is a broken checkout, and should fail the
+// suite rather than quietly skip every assertion below.
+const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+
+// Every fragment here is a selection set on Release, so each one is checked in
+// the operation shape the UI actually sends it in.
+const RELEASE_FRAGMENTS: Array<[string, string]> = [
+    ['ChildReleaseGqlData', graphqlQueries.ChildReleaseGqlData],
+    ['MultiReleaseGqlData', graphqlQueries.MultiReleaseGqlData],
+    ['BranchReleaseListGqlData', graphqlQueries.BranchReleaseListGqlData]
+]
+
+function asReleaseQuery (fragment: string) {
+    return parse(`query FragmentCheck($orgId: ID!, $releaseIds: [ID]) {
+        releases(orgFilter: $orgId, releaseFilter: $releaseIds) {
+            ${fragment}
+        }
+    }`)
+}
+
+describe('release selection fragments vs the CE schema', () => {
+    it.each(RELEASE_FRAGMENTS)('%s is valid against the CE schema', (_name, fragment) => {
+        expect(validate(ceSchema, asReleaseQuery(fragment)).map(e => e.message)).toEqual([])
+    })
+})


### PR DESCRIPTION
Fixes the 400 on `FetchReleasesByOrgUuids` when opening instance side-by-side history.

## Root cause

`CHILD_RELEASE_GQL_DATA` selects `digestRecords { value }`, but `DigestRecord` is:

```graphql
type DigestRecord{
	algo: TeaArtifactChecksumType
	digest: String
	scope: DigestScope
}
```

There is no `value`. GraphQL rejects the whole operation at validation, so the caller gets no releases at all. Confirmed against the sandbox:

```
Validation error (FieldUndefined@[releases/artifactDetails/digestRecords/value])
 : Field 'value' in type 'DigestRecord' is undefined
```

`value` was never valid — the field has been `{algo, digest, scope}` since it was introduced, and the fragment shipped with `value` in #106. Every other digest selection in the UI already uses `algo digest [scope]`; this was the lone outlier.

Two call sites go through this fragment, so both are broken: `InstanceRevision.vue` (the side-by-side history) and `ReleaseEl.vue` (product child-release list).

## Fix

- `graphqlQueries.ts`: `value` -> `digest`
- `ReleaseEl.vue`: rendered `digestRecords[0].value`, so even a passing query would have printed `@undefined`. Now reads `.digest`, and uses `?.length` so an artifact with no digest records doesn't throw.

## Why nothing caught it

`scripts/validate-graphql.mjs` skips any `gql` template containing an interpolation:

```js
if (body.includes('${')) continue
```

That drops **86 of 383** gql documents — including every fragment-composed query in `store.ts`, which is where this one lives. They're dropped before the counter, so the run reports "checked 295 documents, 0 failures" without hinting that 86 were never looked at. The script's comment says dynamic documents are "covered by the vitest schema-drift test instead", but that test covers only the notification inbox.

This PR adds `releaseFragmentsSchemaDrift.spec.ts`, validating `ChildReleaseGqlData`, `MultiReleaseGqlData` and `BranchReleaseListGqlData` in the operation shape the UI sends them in, against the CE schema that ships in this repo. CE only: its path always resolves here so there is nothing to conditionally skip, and CE is expected to match Pro even if it lags on updates. Reverting the one-word fix turns it red with `Cannot query field "value" on type "DigestRecord"`.

That's a targeted patch, not a fix for the general blind spot; see below.

## Verified

Against the sandbox, building a release with a digest-bearing artifact and running the shipped fragment verbatim:

```
release 0.1.0 status=ACTIVE component=vfix-440352c9
artifact doc-440352c9 digestRecords=[{"digest":"f639dc34..."},{"digest":"aa429c4b..."}]
ReleaseEl label -> doc-440352c9@f639dc34d58584bd34a86e9a52f954309cb15cd95327bc16d413700c55a3286a
```

New spec passes (3 tests); full `vitest run` has one **pre-existing** failure in `notificationInboxSchemaDrift.spec.ts`, unrelated to this change and reproducible on a clean checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
