### PR TITLE
fix(ui): side-by-side views read release/artifact fields nothing returns

### DIFF
--- a/ui/src/components/InstanceRevision.vue
+++ b/ui/src/components/InstanceRevision.vue
@@ -78,7 +78,7 @@
                     <div>
                         <a href="#" @click="$event => {$event.preventDefault(); selectedReleaseUuid = drl.release.uuid; showReleaseViewModal = true; }" class="clickable">{{ drl.release.version }}</a>
                     </div>
-                    <div>{{ drl.artifact === 'Not Set' ? 'Not Set' : (drl.artifact.identifier || 'Not Set') }}</div>
+                    <div>{{ drl.artifact === 'Not Set' ? 'Not Set' : (drl.artifact.displayIdentifier || 'Not Set') }}</div>
                     <div>{{ drl.namespace }}</div>
                     <div>{{ drl.state || '—' }}</div>
                 </div>
@@ -132,10 +132,10 @@
                                 <template #trigger>
                                     <n-icon
                                         class="clickable icons"
-                                        @click="copyToClipboard(drl.artifact.identifier + (drl.artifact.digests.length ?  '@' + drl.artifact.digests[0] : ''))"
+                                        @click="copyToClipboard(drl.artifact.displayIdentifier + (drl.artifact.digestRecords?.length ?  '@' + drl.artifact.digestRecords[0].digest : ''))"
                                         size="20"><Box /></n-icon>
                                 </template>
-                                {{ drl.artifact.identifier + (drl.artifact.digests.length ?  '@' + drl.artifact.digests[0] : '') }}
+                                {{ drl.artifact.displayIdentifier + (drl.artifact.digestRecords?.length ?  '@' + drl.artifact.digestRecords[0].digest : '') }}
                             </n-tooltip>
                         </span>
                         <span v-else>Not Set</span>
@@ -286,8 +286,8 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
                         index: index,
                         namespace: rl.namespace,
                         state: rl.state,
-                        branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails.name : undefined,
-                        branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails.uuid : undefined,
+                        branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.name : undefined,
+                        branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.uuid : undefined,
                         diff: false
                     }
                     if (!dRlObj.artifact) {

--- a/ui/src/components/ReleaseRevision.vue
+++ b/ui/src/components/ReleaseRevision.vue
@@ -74,10 +74,10 @@
                                 <template #trigger>
                                     <n-icon
                                         class="clickable icons"
-                                        @click="copyToClipboard(drl.artifact.displayIdentifier + (drl.artifact.digests.length ?  '@' + drl.artifact.digests[0] : ''))"
+                                        @click="copyToClipboard(drl.artifact.displayIdentifier + (drl.artifact.digestRecords?.length ?  '@' + drl.artifact.digestRecords[0].digest : ''))"
                                         size="20"><Box /></n-icon>
                                 </template>
-                                {{ drl.artifact.displayIdentifier + (drl.artifact.digests.length ?  '@' + drl.artifact.digests[0] : '') }}
+                                {{ drl.artifact.displayIdentifier + (drl.artifact.digestRecords?.length ?  '@' + drl.artifact.digestRecords[0].digest : '') }}
                             </n-tooltip>
                         </span>
                         <span v-else>Not Set</span>
@@ -208,8 +208,8 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
                     index: index,
                     namespace: rl.namespace,
                     state: rl.state,
-                    branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails.name : undefined,
-                    branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails.uuid : undefined,
+                    branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.name : undefined,
+                    branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.uuid : undefined,
                     diff: false
                 }
                 if (!dRlObj.artifact) {


### PR DESCRIPTION
Follow-up to #224. Fixing the `DigestRecord.value` typo made `FetchReleasesByOrgUuids` succeed, so the side-by-side views ran for the first time since the slim child-release fragment landed in #106 — and hit the next mismatch. These components were written against an older release/artifact shape than the fragment returns.

## The reported crash

```
TypeError: can't access property "name", S.branchDetails is undefined
```

`InstanceRevision.vue` reads `deployedRl.branchDetails.name` / `.uuid`, but `CHILD_RELEASE_GQL_DATA` deliberately omits branch details ("no metrics, tags, tickets, branch details…").

The two values derived from it — `branch` and `branchUuid` — are **not rendered anywhere** in the component, so this guards the access rather than pulling `branchDetails` back into a fragment that was trimmed on purpose. `InstanceView.vue:1100` already applies exactly this guard at the equivalent line; `InstanceRevision` and `ReleaseRevision` were simply never updated to match.

## Two more that were queued up behind it

Auditing every field these components read against what their queries actually select turned up two more, both of which you would have hit next:

| read | actual field on `Artifact` | effect |
|---|---|---|
| `artifact.digests` (both views) | `digestRecords: [DigestRecord]` | sits on a `.length` → **TypeError** as soon as a deployed release matches an artifact |
| `artifact.identifier` (InstanceRevision) | `displayIdentifier` | silently rendered `Not Set` for every artifact in the target-release column |

`Artifact` has `displayIdentifier` and `digestRecords`; it has never had `identifier` or `digests`.

## Verification

Re-ran the audit after the change: every field either component reads off a release or an artifact is now one its queries select (`ReleaseRevision` composes three `gql` documents; the union covers it). `npm run build` is clean.

Worth noting for review: this class of bug — a component reading a field its query does not select — is invisible to both `scripts/validate-graphql` and the schema-drift specs, since the query itself is perfectly valid. Only the consumer is wrong. The audit I ran is a throwaway script, not a committed guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)