### PR TITLE
refactor(ui): drop code that could never run

### DIFF
--- a/ui/src/components/InstanceRevision.vue
+++ b/ui/src/components/InstanceRevision.vue
@@ -230,7 +230,7 @@ const targetIndividualReleases: ComputedRef<any> = computed((): any => {
     if (!list || !list.length) return targetRls
     list.forEach((rl: any) => {
         if (selectedNamespace.value && selectedNamespace.value !== 'ALL' && selectedNamespace.value !== rl.namespace) return
-        let tgtRl = store.getters.releaseById(rl.release) || store.getters.getProxyRelease(rl.release)
+        let tgtRl = store.getters.releaseById(rl.release)
         if (!tgtRl) return
         let tgtArt: any = 'Not Set'
         if (tgtRl.artifactDetails) {
@@ -266,10 +266,7 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
     if (updatedInstance.value && updatedInstance.value.releases && updatedInstance.value.releases.length) {
         updatedInstance.value.releases.forEach((rl: any, index: number) => {
             if (!selectedNamespace.value || selectedNamespace.value === 'ALL' || selectedNamespace.value === rl.namespace) {
-                let deployedRl = store.getters.releaseById(rl.release)
-                if(!deployedRl){
-                    deployedRl = store.getters.getProxyRelease(rl.release)
-                }
+                const deployedRl = store.getters.releaseById(rl.release)
                 if (deployedRl) {
                     let deployedArt
                     if (deployedRl.artifactDetails && deployedRl.artifactDetails) {
@@ -286,8 +283,6 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
                         index: index,
                         namespace: rl.namespace,
                         state: rl.state,
-                        branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.name : undefined,
-                        branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.uuid : undefined,
                         diff: false
                     }
                     if (!dRlObj.artifact) {

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -457,7 +457,7 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-json';
 import 'prismjs/themes/prism-tomorrow.css';
 import { AlertOff24Regular, AlertOn24Regular, Edit24Regular, Target20Regular, DismissCircle20Regular} from '@vicons/fluent'
-import { Box, Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History } from '@vicons/tabler'
+import { Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History } from '@vicons/tabler'
 import { Commit } from '@vicons/carbon'
 import constants from '@/utils/constants'
 import CreateInstance from '@/components/CreateInstance.vue'
@@ -986,15 +986,6 @@ const notify = async function (type: NotificationType, title: string, content: s
     })
 }
 
-const copyToClipboard = async function (text: string) {
-    try {
-        navigator.clipboard.writeText(text);
-        notify('info', 'Copied', `Copied: ${text}`)
-    } catch (error) {
-        console.error(error)
-    }
-}
-
 const deleteProperty = function (uuid: string, namespace: string, product: string) {
     updatedInstance.value.properties = updatedInstance.value.properties.filter((p: any) => !(p.uuid === uuid && p.namespace === namespace && p.product === product))
     save()
@@ -1081,27 +1072,16 @@ const parseDeployedReleases = function (releases: any) {
             selectedNamespace.value === rl.namespace) {
             let deployedRl = rl.releaseDetails
             if (deployedRl) {
-                let deployedDel
-                if (deployedRl.deliverableDetails && deployedRl.deliverableDetails.length) {
-                    let delArr = deployedRl.deliverableDetails.filter((ad: any) => (ad.uuid === rl.deliverable))
-                    if (delArr && delArr.length) deployedDel = delArr[0]
-                }
                 let dRlObj = {
                     originalReleaseId: rl.release,
                     release: deployedRl,
-                    deliverable: deployedDel,
                     type: rl.type,
                     component: deployedRl.componentDetails.name,
                     componentUuid: deployedRl.componentDetails.uuid,
                     componentType: deployedRl.componentDetails.type,
                     index: index,
                     namespace: rl.namespace,
-                    state: rl.state,
-                    branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.name : undefined,
-                    branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.uuid : undefined
-                }
-                if (!dRlObj.deliverable) {
-                    dRlObj.deliverable = 'Not Set'
+                    state: rl.state
                 }
                 deployedRls.push(dRlObj)
             }
@@ -1707,22 +1687,6 @@ const targetReleaseFeilds: any[] = [
                 trigger: () => tooltipTrigger,
                 default: () => tooltipDefault
             }))
-            if(row.deliverable && row.deliverable !== 'Not Set'){
-                const artSha = row.deliverable.identifier + (row.deliverable.digests.length ?  '@' + row.deliverable.digests[0] : '')
-                els.push(h(NTooltip, {
-                    trigger: 'hover'
-                }, {
-                    trigger: () => h(NIcon, {
-                        title: 'Copy to clipboard',
-                        class: 'icons clickable',
-                        size: 24,
-                        onClick: () => copyToClipboard(artSha)
-                    },{
-                        default: () => h(Box)
-                    }),
-                    default: () => artSha
-                }))
-            }
             return els
         }
     },
@@ -1949,22 +1913,6 @@ const deployedReleaseFeilds: any[] = [
                             default: () => commit
                         })
                     ))
-            }
-            if(row.deliverable && row.deliverable !== 'Not Set'){
-                const artSha = row.deliverable.identifier + (row.deliverable.digestRecords.length ?  '@' + row.deliverable.digestRecords[0].value : '')
-                els.push(h(NTooltip, {
-                    trigger: 'hover'
-                }, {
-                    trigger: () => h(NIcon, {
-                        title: 'Copy to clipboard',
-                        class: 'icons clickable',
-                        size: 24,
-                        onClick: () => copyToClipboard(artSha)
-                    },{
-                        default: () => h(Box)
-                    }),
-                    default: () => artSha
-                }))
             }
             return h('span', {}, els)
         }

--- a/ui/src/components/ReleaseRevision.vue
+++ b/ui/src/components/ReleaseRevision.vue
@@ -188,10 +188,7 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
     let deployedRls: any[] = []
     if (release.value && release.value.parentReleases && release.value.parentReleases.length) {
         release.value.parentReleases.forEach((rl: any, index: number) => {
-            let deployedRl = parentReleasesMap.value.get(rl.release)
-            if(!deployedRl){
-                deployedRl = store.getters.getProxyRelease(rl.release)
-            }
+            const deployedRl = parentReleasesMap.value.get(rl.release)
             if (deployedRl) {
                 let deployedArt
                 if (deployedRl.artifactDetails && deployedRl.artifactDetails) {
@@ -208,8 +205,6 @@ const deployedReleases: ComputedRef<any> = computed((): any => {
                     index: index,
                     namespace: rl.namespace,
                     state: rl.state,
-                    branch: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.name : undefined,
-                    branchUuid: (deployedRl.type !== 'PLACEHOLDER') ? deployedRl.branchDetails?.uuid : undefined,
                     diff: false
                 }
                 if (!dRlObj.artifact) {


### PR DESCRIPTION
Follow-up to #225. Removes the unreachable code that investigation turned up, rather than leaving it to mislead the next reader — chasing these dead paths is what made the last two rounds take as long as they did.

**No behaviour change.** Every deletion is either unreachable or a value nothing consumes. 5 insertions, 67 deletions.

## What went

**`store.getters.getProxyRelease` (3 call sites)** — called in `InstanceRevision` ×2 and `ReleaseRevision` ×1, but **never defined**, in the current tree or anywhere in this repo's history. Reaching it threw `getProxyRelease is not a function` rather than producing the intended fallback. Both call sites already guard on a missing release, so a store miss now skips the row instead of throwing — strictly better than today.

**`branch` / `branchUuid` (3 components)** — computed on every deployed-release row in `InstanceRevision`, `ReleaseRevision` and `InstanceView`, and read in none of them. The sibling target-release rows in the same files never carried them at all, which is the tell. This also removes the last reader of `branchDetails` in `InstanceRevision`, so the `?.` guard added in #225 goes with it.

**InstanceView's deliverable path** — the enrichment keyed off `deployedRl.deliverableDetails`, which is not a field on `Release`; the schema has `inboundDeliverableDetails`. So `deployedDel` was always `undefined`, the row's `deliverable` was always `'Not Set'`, and both render blocks behind `if (row.deliverable && row.deliverable !== 'Not Set')` were dead. For good measure they read `identifier` and `digests`, neither of which exists on `Deliverable`.

The **Deliverable column keeps its commit tooltip** and loses only the copy-icon that never rendered. Worth being explicit: the capability is *unimplemented*, not lost — showing the deployed deliverable needs a decision on which deliverables an instance should surface (`inboundDeliverableDetails` is about deliverables a release consumes, which may not be the right set) before it's worth wiring up.

**Orphans left by the above** — `copyToClipboard` and the `Box` icon import in `InstanceView` had no remaining users. Other components keep their own `copyToClipboard`.

## Verified

- `npm run build` clean
- `vitest run`: 57 passed, 1 failed — the **pre-existing** `notificationInboxSchemaDrift` failure, unchanged and reproducible on clean `main`
- repo-wide grep for `getProxyRelease`, `deliverableDetails`, `deployedDel`, and the removed orphans returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)