### PR TITLE
feat(ui): component durable-owner picker + ownership status on Component Settings (RFC Phase 4 UI)

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -397,6 +397,39 @@
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="versionSchemaBlock" v-if="updatedComponent && componentData && ownershipSupported">
+                                            <label>Owner</label>
+                                            <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
+                                                <div v-if="componentOwnership && componentOwnership.ownership">
+                                                    <n-tag :type="ownershipTagType(componentOwnership.ownership.status)" size="small">
+                                                        {{ componentOwnership.ownership.status }}
+                                                    </n-tag>
+                                                    <span v-if="ownerLabel" style="margin-left: 8px;">{{ ownerLabel }}</span>
+                                                    <span v-if="componentOwnership.ownership.reason" class="text-muted" style="display: block; margin-top: 4px;">
+                                                        {{ componentOwnership.ownership.reason }}
+                                                    </span>
+                                                </div>
+                                                <div v-if="isWritable" style="display: flex; gap: 8px; margin-top: 8px; align-items: center;">
+                                                    <n-select
+                                                        style="width: 110px;"
+                                                        v-model:value="ownerDraftType"
+                                                        :options="[{label: 'Team', value: 'TEAM'}, {label: 'User', value: 'USER'}]"
+                                                        @update:value="ownerDraftRef = null" />
+                                                    <n-select
+                                                        style="flex: 1; min-width: 0;"
+                                                        filterable
+                                                        v-model:value="ownerDraftRef"
+                                                        :options="ownerDraftType === 'TEAM' ? userGroups : users"
+                                                        :placeholder="ownerDraftType === 'TEAM' ? 'Pick a team (user group)' : 'Pick a user'" />
+                                                    <n-button type="primary" size="small" :loading="savingOwner" :disabled="!ownerDraftRef" @click="saveOwner">
+                                                        Set owner
+                                                    </n-button>
+                                                </div>
+                                                <span class="text-muted" style="margin-top: 4px;">
+                                                    The durable owner accountable for this {{ words.component }}. A team is durable (survives members leaving); a single user is flagged non-durable.
+                                                </span>
+                                            </div>
+                                        </div>
                                         <div class="versionSchemaBlock" v-if="updatedComponent && componentData">
                                             <label>{{ words.componentFirstUpper }} Leads</label>
                                             <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
@@ -1470,6 +1503,10 @@ async function fetchApprovalPolicies () {
 const openComponentSettings = async function() {
     await fetchApprovalPolicies()
     await fetchEffectiveApprovalPolicy()
+    // Durable ownership (Phase 4 UI): load the owner picker's team list + the
+    // computed ownership status when the settings panel opens.
+    loadUserGroups()
+    loadOwnership()
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
     showComponentSettingsModal.value = true
     
@@ -3324,6 +3361,101 @@ const users: Ref<any[]> = ref([])
 async function loadUsers() {
     const usersRaw = await store.dispatch('fetchUsers', orguuid.value)
     users.value = usersRaw.map((ur: any) => {return {label: ur.name || ur.email, value: ur.uuid}} )
+}
+
+// ---- Durable ownership (RFC Phase 4 UI): read owner/ownership + set an owner ----
+// Fetched via a DEDICATED query so a backend that predates these Pro fields (a CE
+// mirror) fails only THIS query -> we hide the section, rather than breaking the
+// shared component load.
+const COMPONENT_OWNERSHIP_QUERY = gql`
+    query componentOwnership($componentUuid: ID!) {
+        component(componentUuid: $componentUuid) {
+            uuid
+            owner { ownerType ownerRef }
+            ownership { status durable derived reason }
+        }
+    }`
+const GET_USER_GROUPS_QUERY = gql`
+    query getUserGroups($org: ID!) { getUserGroups(org: $org) { uuid name } }`
+const SET_COMPONENT_OWNER_MUTATION = gql`
+    mutation setComponentOwner($component: UpdateComponentInput!) {
+        updateComponent(component: $component) { uuid }
+    }`
+
+const componentOwnership = ref<any>(null)
+const ownershipSupported = ref<boolean>(true)
+const userGroups = ref<{ label: string, value: string }[]>([])
+const ownerDraftType = ref<'TEAM' | 'USER'>('TEAM')
+const ownerDraftRef = ref<string | null>(null)
+const savingOwner = ref<boolean>(false)
+
+const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default' =>
+    s === 'OWNED' ? 'success'
+        : (s === 'NON_DURABLE' || s === 'DEGRADED') ? 'warning'
+            : s === 'UNSET' ? 'default'  // no owner yet -> neutral, not alarming
+                : 'error'                // ORPHANED (or unknown) -> needs attention
+
+const ownerLabel = computed<string | null>(() => {
+    const o = componentOwnership.value?.owner
+    if (!o || !o.ownerRef) return null
+    const list = o.ownerType === 'TEAM' ? userGroups.value : users.value
+    const hit = list.find((x: any) => x.value === o.ownerRef)
+    return `${hit?.label || o.ownerRef} (${o.ownerType === 'TEAM' ? 'team' : 'user'})`
+})
+
+async function loadOwnership() {
+    const uuid = componentData.value?.uuid
+    if (!uuid) return
+    try {
+        const res = await graphqlClient.query({
+            query: COMPONENT_OWNERSHIP_QUERY,
+            variables: { componentUuid: uuid },
+            fetchPolicy: 'network-only',
+        })
+        componentOwnership.value = res.data?.component || null
+        ownershipSupported.value = true
+        const o = componentOwnership.value?.owner
+        if (o && o.ownerType && o.ownerRef) { ownerDraftType.value = o.ownerType; ownerDraftRef.value = o.ownerRef }
+    } catch {
+        // Backend without the ownership fields (older / CE mirror) -> hide the section.
+        ownershipSupported.value = false
+    }
+}
+
+async function loadUserGroups() {
+    try {
+        const res = await graphqlClient.query({
+            query: GET_USER_GROUPS_QUERY,
+            variables: { org: orguuid.value },
+            fetchPolicy: 'network-only',
+        })
+        userGroups.value = (res.data?.getUserGroups || [])
+            .filter((g: any) => g)
+            .map((g: any) => ({ label: g.name, value: g.uuid }))
+    } catch {
+        userGroups.value = []
+    }
+}
+
+async function saveOwner() {
+    if (!ownerDraftRef.value || !componentData.value?.uuid) return
+    savingOwner.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: SET_COMPONENT_OWNER_MUTATION,
+            variables: { component: {
+                uuid: componentData.value.uuid,
+                name: componentData.value.name,
+                owner: { ownerType: ownerDraftType.value, ownerRef: ownerDraftRef.value },
+            } },
+        })
+        notify('success', 'Owner updated', 'Component owner set.')
+        await loadOwnership()
+    } catch (err: any) {
+        notify('error', 'Failed to set owner', commonFunctions.parseGraphQLError(err.toString()))
+    } finally {
+        savingOwner.value = false
+    }
 }
 
 async function initLoad() {


### PR DESCRIPTION
## What & why

The durable-owner feature (`Component.owner` / `Component.ownership` / `updateComponent(owner:)`) shipped **backend/API-only** (Phase 4a/b). This is its **first UI** — an **"Owner"** section on the Component Settings panel, right above "Component Leads", so an admin can *see* and *set* a component's owner without the API.

## What's here
- **Ownership status badge** — `OWNED` (green) / `NON_DURABLE` / `DEGRADED` (amber) / `UNSET` (neutral) / `ORPHANED` (red) — with the computed `reason` and the current owner's name.
- **Owner picker** (writable users): a **Team / User** toggle + a searchable ref dropdown (teams from `getUserGroups(org)`; users reuse the org-users list the Leads field already loads) + **"Set owner"** → `updateComponent(component:{uuid,name,owner})` → reloads the badge.

## Safety
- **Drift-safe:** owner/ownership are fetched via a **dedicated** query, isolated from the shared component fragment. On a backend that predates the fields (older/CE mirror) that one query fails → `ownershipSupported=false` → the whole section **hides**, never breaking the settings panel. All three GraphQL ops were **validated against the live backend** before review.
- **Non-clobbering write:** `{uuid, name, owner}` relies on the server "null field = leave unchanged" convention (`name` is the current name, required by `UpdateComponentInput`), so only `owner` changes.

## Review (combined correctness + conventions)
Verdict: **safe, no blockers** — verified drift-safety, the no-clobber write, the `TEAM/USER` enum match, and query signatures against the live schema. Applied its findings: **UNSET** renders neutral (not the alarming red of `ORPHANED` — a never-owned component shouldn't look broken); dropped the misleading **`clearable`** X (there's no clear-owner path).

## Known gaps (backend, not this PR)
- **No clear-owner path** yet (`updateComponent` has no owner removal).
- **"Component Leads" not yet folded into Owner** (the RFC's leads-retirement is future work).

## Validation
`vite build` compiles; ASCII-clean. No component test harness for `ComponentView` (baseline-consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)