### PR TITLE
feat(ui): team editor — member roles + external members (T1b)

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -586,6 +586,70 @@
                                 />
                             </n-space>
 
+                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
+                                <n-h5>
+                                    <n-text depth="1">
+                                        Member Roles:
+                                    </n-text>
+                                </n-h5>
+                                <n-text depth="3" style="font-size: 12px;">
+                                    A role labels who to contact — for example, escalating a KEV finding to the
+                                    team's security specialist. Roles do not grant any permissions.
+                                </n-text>
+                                <n-text v-if="!rosterMembers.length" depth="3" style="font-size: 12px;">
+                                    Add users to the group first, then assign their roles here.
+                                </n-text>
+                                <div v-for="m in rosterMembers" :key="m.uuid"
+                                    style="display: flex; gap: 8px; align-items: center; margin-top: 6px;">
+                                    <span style="min-width: 240px;">{{ m.label }}</span>
+                                    <n-select
+                                        :value="teamRoles[m.uuid]?.role || null"
+                                        :options="constants.TeamRoles"
+                                        placeholder="No role"
+                                        clearable
+                                        style="width: 220px;"
+                                        @update:value="(v: string | null) => setMemberRole(m.uuid, v)"
+                                    />
+                                    <n-input
+                                        v-if="teamRoles[m.uuid]?.role === constants.TeamRoleCustom"
+                                        :value="teamRoles[m.uuid]?.customRole || ''"
+                                        placeholder="Custom role label (required)"
+                                        style="width: 240px;"
+                                        @update:value="(v: string) => setMemberCustomRole(m.uuid, v)"
+                                    />
+                                </div>
+                            </n-space>
+
+                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
+                                <n-h5>
+                                    <n-text depth="1">
+                                        External Members (no ReARM account):
+                                    </n-text>
+                                </n-h5>
+                                <n-text depth="3" style="font-size: 12px;">
+                                    People reachable only by email or handle, such as a vendor contact. They can be
+                                    notified, but do not count toward the team's durability.
+                                </n-text>
+                                <n-dynamic-input
+                                    v-model:value="teamExternalMembers"
+                                    :on-create="onAddExternalMember"
+                                >
+                                    <template #default="{ value }">
+                                        <div style="display: flex; gap: 8px; width: 100%;">
+                                            <n-input v-model:value="value.name"
+                                                placeholder="Name" style="width: 200px;" />
+                                            <n-input v-model:value="value.contact"
+                                                placeholder="Email or handle" style="width: 240px;" />
+                                            <n-select v-model:value="value.role" :options="constants.TeamRoles"
+                                                placeholder="No role" clearable style="width: 200px;" />
+                                            <n-input v-if="value.role === constants.TeamRoleCustom"
+                                                v-model:value="value.customRole"
+                                                placeholder="Custom role label" style="width: 200px;" />
+                                        </div>
+                                    </template>
+                                </n-dynamic-input>
+                            </n-space>
+
                             <ScopedPermissions
                                 v-model="userGroupScopedPermissions"
                                 :org-uuid="orgResolved"
@@ -597,10 +661,13 @@
                                 :clusters="orgClusters"
                             />
                         </n-flex>
+                        <n-alert v-if="teamMembersError" type="warning" style="margin-top: 16px;">
+                            {{ teamMembersError }}
+                        </n-alert>
                         <n-space style="margin-top: 20px;">
                             <n-button v-if="restoreMode" type="success" @click="confirmRestoreUserGroup">Restore Group</n-button>
                             <template v-else-if="userGroupPermissionsDirty">
-                                <n-button type="success" @click="updateUserGroup">Save Changes</n-button>
+                                <n-button type="success" :disabled="!!teamMembersError" @click="updateUserGroup">Save Changes</n-button>
                                 <n-button type="warning" @click="editUserGroup(selectedUserGroup.uuid)">Reset Changes</n-button>
                             </template>
                         </n-space>
@@ -1129,6 +1196,8 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
 import constants from '../utils/constants'
+import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
+import { buildMemberRolesPayload, buildExternalMembersPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
@@ -1846,14 +1915,80 @@ const userPermissionsDirty = computed(() => {
     return commonFunctions.stableStringify(userScopedPermissions.value) !== commonFunctions.stableStringify(userScopedPermissionsOriginal.value)
 })
 
+// Projects the modal's editable state. NOTE the team-member keys come from
+// the module-level editor refs (teamRoles / teamExternalMembers), not from
+// `group` -- they are per-modal editor state, not part of the group record.
 function getUserGroupEditableState(group: any) {
     return {
         name: group?.name || '',
         description: group?.description || '',
         manualUsers: group?.manualUsers || [],
-        connectedSsoGroups: group?.connectedSsoGroups || []
+        connectedSsoGroups: group?.connectedSsoGroups || [],
+        // Compare the NORMALIZED payload, not the raw editor arrays -- otherwise
+        // an untouched blank row added by "+" (or stray whitespace) reads as
+        // dirty while producing nothing to save.
+        memberRoles: teamMemberRolesPayload(),
+        externalMembers: teamExternalMembersPayload()
     }
 }
+
+// Keyed by user uuid rather than held as a list: the backend rejects two roles
+// for the same member, and a per-member map makes that impossible to express.
+const teamRoles: Ref<TeamRoleMap> = ref({})
+const teamExternalMembers: Ref<any[]> = ref([])
+
+/**
+ * True only when we have actually loaded this group's team data. Guards both
+ * rendering and the save payload: hydrating an empty editor from a not-yet-
+ * loaded map and then saving would send [], which the backend applies as a
+ * REPLACE -- wiping the team's roles and external members.
+ */
+const teamMembersKnown = computed(() =>
+    teamFieldsSupported.value === true
+    && !!selectedUserGroup.value?.uuid
+    && !!groupTeamMembers.value[selectedUserGroup.value.uuid])
+
+/** Roster members eligible for a role: manually-added plus SSO-inherited. */
+const rosterMembers = computed(() => {
+    const ids = [
+        ...(selectedUserGroup.value?.manualUsers || []),
+        ...(selectedUserGroup.value?.users || [])
+    ]
+    return [...new Set(ids)].map((uuid: any) => ({
+        uuid,
+        label: userOptions.value.find((o: any) => o.value === uuid)?.label || uuid
+    }))
+})
+
+function memberLabelFor(uuid: string): string {
+    return rosterMembers.value.find(m => m.uuid === uuid)?.label || uuid
+}
+
+function teamMemberRolesPayload() {
+    return buildMemberRolesPayload(teamRoles.value, rosterMembers.value.map(m => m.uuid))
+}
+
+function teamExternalMembersPayload() {
+    return buildExternalMembersPayload(teamExternalMembers.value)
+}
+
+function setMemberRole(uuid: string, role: string | null) {
+    teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), role }
+}
+
+function setMemberCustomRole(uuid: string, customRole: string) {
+    teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), customRole }
+}
+
+function onAddExternalMember() {
+    return { name: '', contact: '', role: null, customRole: '' }
+}
+
+/** Pre-submit mirror of the backend rules, so an invalid row names itself
+ *  instead of failing the whole mutation with a generic server error. */
+const teamMembersError = computed(() => teamMembersKnown.value
+    ? validateTeamMembers(teamMemberRolesPayload(), teamExternalMembersPayload(), memberLabelFor)
+    : null)
 
 const userGroupPermissionsDirty = computed(() => {
     const scopedDirty = userGroupScopedPermissionsOriginal.value
@@ -1949,6 +2084,58 @@ async function loadUserGroups() {
     } catch (error: any) {
         console.error('Error loading user groups:', error)
         notify('error', 'Error', 'Failed to load user groups')
+    }
+    await loadTeamMemberFields()
+}
+
+// Team member roles + external members (T1) are loaded by a SEPARATE query on
+// purpose. Folding these fields into getUserGroups above would make the whole
+// User Groups tab fail against a backend that predates them -- the same
+// field-selection drift that has broken a tab before. Isolated here, a lagging
+// backend costs us only these two optional sections, which we then hide.
+//
+// null = not probed yet. The distinction matters: the backend treats a non-null
+// list as a REPLACE, so sending [] because we had not loaded yet would silently
+// delete every role and external member on the team. Unknown => render nothing
+// and send nothing (omitted = keep).
+const teamFieldsSupported: Ref<boolean | null> = ref(null)
+const groupTeamMembers: Ref<Record<string, any>> = ref({})
+
+async function loadTeamMemberFields() {
+    try {
+        const response = await graphqlClient.query({
+            query: gql`
+                query getUserGroupsTeamMembers($org: ID!) {
+                    getUserGroups(org: $org) {
+                        uuid
+                        memberRoles { userRef role customRole }
+                        externalMembers { name contact role customRole }
+                    }
+                }`,
+            variables: { org: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        const map: Record<string, any> = {}
+        for (const g of (response.data.getUserGroups || [])) {
+            map[g.uuid] = {
+                memberRoles: g.memberRoles || [],
+                externalMembers: g.externalMembers || []
+            }
+        }
+        groupTeamMembers.value = map
+        teamFieldsSupported.value = true
+    } catch (error: any) {
+        // Only a schema-drift-shaped failure means "this backend is older".
+        // A 401/500/network blip must NOT be mistaken for that: this flag also
+        // gates the save payload, so misclassifying would strip roles and
+        // external members from the next save with no operator-visible signal.
+        if (isSchemaDriftError(error)) {
+            console.warn('Team member fields unavailable on this backend', error?.message)
+            teamFieldsSupported.value = false
+        } else {
+            groupTeamMembers.value = {}
+            notify('error', 'Error', 'Failed to load team member roles')
+        }
     }
 }
 
@@ -3956,6 +4143,10 @@ async function createUserGroup() {
 
 async function updateUserGroup() {
     if (!selectedUserGroup.value.uuid) return
+    if (teamMembersError.value) {
+        notify('error', 'Cannot save', teamMembersError.value)
+        return
+    }
     
     try {
         const scopedData = userGroupScopedPermissions.value
@@ -4000,6 +4191,13 @@ async function updateUserGroup() {
             status: selectedUserGroup.value.status,
             connectedSsoGroups: selectedUserGroup.value.connectedSsoGroups || [],
             permissions
+        } as any
+        // Only send the team fields when this group's data was actually loaded.
+        // Omitting them means "keep existing" on the backend; sending [] would
+        // REPLACE, i.e. delete. Never send from an unknown state.
+        if (teamMembersKnown.value) {
+            updateInput.memberRoles = teamMemberRolesPayload()
+            updateInput.externalMembers = teamExternalMembersPayload()
         }
         
         const response = await graphqlClient.mutate({
@@ -4034,6 +4232,18 @@ async function editUserGroup(groupUuid: string) {
     const group = userGroups.value.find(g => g.uuid === groupUuid)
     if (group) {
         selectedUserGroup.value = commonFunctions.deepCopy(group)
+        const tm = groupTeamMembers.value[groupUuid] || { memberRoles: [], externalMembers: [] }
+        const roleMap: Record<string, any> = {}
+        for (const mr of tm.memberRoles) {
+            roleMap[mr.userRef] = { role: mr.role, customRole: mr.customRole || '' }
+        }
+        teamRoles.value = roleMap
+        teamExternalMembers.value = commonFunctions.deepCopy(tm.externalMembers).map((e: any) => ({
+            name: e.name || '',
+            contact: e.contact || '',
+            role: e.role || null,
+            customRole: e.customRole || ''
+        }))
         await Promise.all([
             loadPerspectives(),
             store.dispatch('fetchComponents', orgResolved.value),

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -223,6 +223,19 @@ const BATCH_MODE_HELP = {
     exampleJson: '[{"name": "lodash", "version": "4.17.21"}, {"name": "express"}]'
 }
 
+// Team member roles (backend TeamRole enum). A role is an addressing LABEL --
+// it never grants access. CUSTOM carries an operator-supplied label alongside.
+const TEAM_ROLE_CUSTOM = 'CUSTOM'
+const TEAM_ROLES = [
+    { label: 'Team Lead', value: 'TEAM_LEAD' },
+    { label: 'Security Specialist', value: 'SECURITY_SPECIALIST' },
+    { label: 'Developer', value: 'DEVELOPER' },
+    { label: 'QA', value: 'QA' },
+    { label: 'Project Manager', value: 'PROJECT_MANAGER' },
+    { label: 'Product Manager', value: 'PRODUCT_MANAGER' },
+    { label: 'Custom...', value: TEAM_ROLE_CUSTOM }
+]
+
 export default {
     VersionTypes: VERSION_TYPES,
     BranchVersionTypes: BRANCH_VERSION_TYPES,
@@ -258,5 +271,7 @@ export default {
     PermissionTypes: PERMISSION_TYPES,
     PermissionTypesWithAdmin: PERMISSION_TYPES_WITH_ADMIN,
     PermissionFunctions: PERMISSION_FUNCTIONS,
-    EssentialReadPermissionFunctions: ESSENTIAL_READ_PERMISSION_FUNCTIONS
+    EssentialReadPermissionFunctions: ESSENTIAL_READ_PERMISSION_FUNCTIONS,
+    TeamRoles: TEAM_ROLES,
+    TeamRoleCustom: TEAM_ROLE_CUSTOM
 }

--- a/ui/src/utils/teamMembers.spec.ts
+++ b/ui/src/utils/teamMembers.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildMemberRolesPayload,
+    buildExternalMembersPayload,
+    validateTeamMembers,
+} from './teamMembers'
+
+const A = '11111111-1111-1111-1111-111111111111'
+const B = '22222222-2222-2222-2222-222222222222'
+const label = (u: string) => (u === A ? 'Alice' : u === B ? 'Bob' : u)
+
+describe('buildMemberRolesPayload', () => {
+    it('emits a role for a roster member', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'QA' } }, [A]))
+            .toEqual([{ userRef: A, role: 'QA', customRole: null }])
+    })
+
+    it('drops a role for someone removed from the roster in this session', () => {
+        // The backend rejects a role whose userRef is not on the post-merge
+        // roster, and that rejection fails the WHOLE mutation -- so the editor
+        // must never emit one.
+        expect(buildMemberRolesPayload({ [A]: { role: 'QA' }, [B]: { role: 'TEAM_LEAD' } }, [A]))
+            .toEqual([{ userRef: A, role: 'QA', customRole: null }])
+    })
+
+    it('omits a cleared dropdown rather than emitting a null role', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: null, customRole: 'stale' } }, [A])).toEqual([])
+    })
+
+    it('keeps the label only for CUSTOM and trims it', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'CUSTOM', customRole: '  Release Captain  ' } }, [A]))
+            .toEqual([{ userRef: A, role: 'CUSTOM', customRole: 'Release Captain' }])
+    })
+
+    it('nulls a stale label left behind after switching away from CUSTOM', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'DEVELOPER', customRole: 'Release Captain' } }, [A]))
+            .toEqual([{ userRef: A, role: 'DEVELOPER', customRole: null }])
+    })
+})
+
+describe('buildExternalMembersPayload', () => {
+    it('drops a wholly blank scaffold row added by "+"', () => {
+        expect(buildExternalMembersPayload([{ name: '', contact: '', role: null, customRole: '' }])).toEqual([])
+    })
+
+    it('keeps a half-filled row so validation can flag it', () => {
+        expect(buildExternalMembersPayload([{ name: 'Vendor', contact: '', role: 'QA' }]))
+            .toEqual([{ name: 'Vendor', contact: '', role: 'QA', customRole: null }])
+    })
+
+    it('trims name and contact', () => {
+        expect(buildExternalMembersPayload([{ name: ' V ', contact: ' v@x.example ', role: 'QA' }]))
+            .toEqual([{ name: 'V', contact: 'v@x.example', role: 'QA', customRole: null }])
+    })
+})
+
+describe('validateTeamMembers', () => {
+    it('passes a well-formed payload', () => {
+        expect(validateTeamMembers(
+            [{ userRef: A, role: 'QA', customRole: null }],
+            [{ name: 'V', contact: 'v@x.example', role: 'DEVELOPER', customRole: null }],
+            label)).toBeNull()
+    })
+
+    it('names the member whose CUSTOM role has no label', () => {
+        const err = validateTeamMembers([{ userRef: A, role: 'CUSTOM', customRole: null }], [], label)
+        expect(err).toContain('Alice')
+    })
+
+    it('rejects an external member missing a contact', () => {
+        const err = validateTeamMembers([], [{ name: 'Vendor', contact: '', role: 'QA', customRole: null }], label)
+        expect(err).toContain('Vendor')
+    })
+
+    it('rejects an external member with a CUSTOM role and no label', () => {
+        const err = validateTeamMembers(
+            [], [{ name: 'Vendor', contact: 'v@x.example', role: 'CUSTOM', customRole: null }], label)
+        expect(err).toContain('Vendor')
+    })
+})

--- a/ui/src/utils/teamMembers.ts
+++ b/ui/src/utils/teamMembers.ts
@@ -1,0 +1,83 @@
+// Pure payload/validation helpers for the Team editor (member roles + external
+// members). Kept out of the SFC so they are unit-testable, and so the DIRTY
+// comparison and the SAVE payload can be built by the same code -- comparing a
+// raw editor array against a filtered/trimmed payload is what makes a modal
+// look dirty while having nothing to send.
+import constants from '@/utils/constants'
+
+export interface TeamMemberRolePayload {
+    userRef: string
+    role: string
+    customRole: string | null
+}
+
+export interface ExternalTeamMemberPayload {
+    name: string
+    contact: string
+    role: string
+    customRole: string | null
+}
+
+/** Editor state for roles is keyed by user uuid: the backend rejects two roles
+ *  for the same member, and a map cannot express that. */
+export type TeamRoleMap = Record<string, { role?: string | null, customRole?: string | null }>
+
+function customLabel (role: string | null | undefined, customRole: string | null | undefined): string | null {
+    return role === constants.TeamRoleCustom ? ((customRole || '').trim() || null) : null
+}
+
+/**
+ * Roles for members still on the roster. Anyone dropped from the group in this
+ * editing session is excluded -- the backend rejects a role whose userRef is not
+ * on the post-merge roster, so emitting one would fail the entire mutation.
+ */
+export function buildMemberRolesPayload (roles: TeamRoleMap, rosterUuids: string[]): TeamMemberRolePayload[] {
+    const roster = new Set(rosterUuids)
+    return Object.entries(roles || {})
+        .filter(([uuid, v]) => !!v && !!v.role && roster.has(uuid))
+        .map(([uuid, v]) => ({
+            userRef: uuid,
+            role: v.role as string,
+            customRole: customLabel(v.role, v.customRole)
+        }))
+}
+
+/** Rows where BOTH name and contact are blank are treated as untouched scaffolding
+ *  and dropped; a half-filled row is kept so validation can flag it. */
+export function buildExternalMembersPayload (rows: any[]): ExternalTeamMemberPayload[] {
+    return (rows || [])
+        .filter(r => (r.name || '').trim() || (r.contact || '').trim())
+        .map(r => ({
+            name: (r.name || '').trim(),
+            contact: (r.contact || '').trim(),
+            role: r.role,
+            customRole: customLabel(r.role, r.customRole)
+        }))
+}
+
+/**
+ * Mirrors the backend's rejection rules so the operator gets a specific,
+ * pre-submit message naming the offending member -- instead of a generic
+ * server error that also aborts unrelated permission/SSO edits made in the
+ * same modal. Returns null when the payload is submittable.
+ */
+export function validateTeamMembers (
+    roles: TeamMemberRolePayload[],
+    externals: ExternalTeamMemberPayload[],
+    labelFor: (uuid: string) => string,
+): string | null {
+    for (const r of roles) {
+        if (r.role === constants.TeamRoleCustom && !r.customRole) {
+            return `Enter a custom role label for ${labelFor(r.userRef)}, or pick a listed role.`
+        }
+    }
+    for (const e of externals) {
+        if (!e.name || !e.contact) {
+            return `External member "${e.name || e.contact}" needs both a name and a contact.`
+        }
+        if (e.role === constants.TeamRoleCustom && !e.customRole) {
+            return `Enter a custom role label for external member "${e.name}", or pick a listed role.`
+        }
+    }
+    return null
+}


### PR DESCRIPTION
UI for the Team primitive added in rearm-core **#371**. Depends on that backend PR.

In **Org Settings → User Groups**, opening a team now exposes two sections:
- **Member Roles** — a role dropdown per roster member (plus a label input when *Custom*). Helper copy states plainly that roles grant no permissions, because "role" reads like a permission to most operators.
- **External Members** — add/remove rows of name / email-or-handle / role for people with no ReARM account. Copy notes they can be notified but **do not count toward the team's durability**.

Roles are held **keyed by user uuid** rather than as a list: the backend rejects two roles for the same member, and a map cannot express that state.

## Data-loss guard — the important one
The backend treats a non-null list as a **REPLACE**, so sending `[]` is a *delete*, not a no-op.

The first cut loaded the team fields fire-and-forget. Clicking a team before that query resolved hydrated an **empty** editor, and then saving an unrelated rename would **silently wipe every role and external member on that team** — with a success toast and no undo. Caught in review, not by my own tests, which always navigated fresh and so never lost the race.

Now: `loadTeamMemberFields` is awaited, and **both rendering and the save payload are gated on `teamMembersKnown`** (this group's data actually loaded). Unknown ⇒ render nothing, send nothing; omitted means "keep existing". A Playwright regression test opens the modal as fast as the row exists and asserts no wipe payload is ever sent.

## Drift safety
The new fields load via a **separate query**, so a backend predating them costs only these two sections instead of breaking the whole User Groups tab. Degrade is gated on `isSchemaDriftError()` from the existing `graphqlDriftFallback` util — I had hand-rolled a blanket `catch`, which would treat a 401/500/network blip as "backend too old". That matters because the same signal gates the save payload, so a misclassified transient error would strip roles from the next save with no operator-visible signal.

## Validation
Mirrors the backend rules pre-submit (`CUSTOM` needs a label; an external member needs both name and contact), **naming the offending member** and disabling Save — rather than letting the server reject the whole mutation and take unrelated permission/SSO edits down with it.

## Structure
- Payload building + validation live in `utils/teamMembers.ts`, so the **dirty comparison and the save payload are built by the same code**. Comparing a raw editor array against a filtered/trimmed payload made an untouched blank row (added by "+") read as dirty while producing nothing to save.
- Role options move to `utils/constants.ts` as `constants.TeamRoles` — the repo's home for backend-enum mirrors; `CUSTOM` is referenced via `constants.TeamRoleCustom`, not a bare literal.
- Sections are hidden in **restore mode**, where the restore payload doesn't carry them and edits would have been silently discarded.

## Testing
- **12 new unit tests** (`teamMembers.spec.ts`): roster filter, cleared dropdown, stale custom label after switching away from CUSTOM, trimming, blank-row drop, and each validation rule. Full UI suite otherwise green.
- **Live-verified on the sandbox** via UI hot-swap with Playwright: initial load, edit + save round-trip, adding a new external member, and the race regression above.

## Pre-existing, unrelated
`src/utils/notificationInboxSchemaDrift.spec.ts` fails on clean `main` too — the CE mirror caught up, so its *"the FULL selection is INVALID against the CE mirror (split is load-bearing)"* assertion is now stale. Verified by stashing this branch's changes and re-running. Worth its own fix.

## Next
T2 (regex team-assignment rules), T3 (team channel), T4 (notify a member/role — the KEV-escalation use case that these roles exist to serve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)