### PR TITLE
docs: refresh install instructions and document the DT5 chart

### DIFF
--- a/deploy/docker-compose/README.md
+++ b/deploy/docker-compose/README.md
@@ -22,10 +22,17 @@ so the login flow works over plain http.
 
 ## Scenario 2: remote host by IP (eval)
 
-Browsers only expose the Web Crypto API -- which the PKCE login flow
-requires -- in secure contexts (https or localhost). A deployment
-reached by IP or hostname therefore **must** run the TLS profile;
-plain http will fail at login with `Web Crypto API is not available`.
+Nothing here blocks plain http; browsers do. Parts of the Web Crypto API
+are exposed only in secure contexts, and keycloak-js uses them to build
+the login request -- `crypto.randomUUID` for the OIDC state and nonce,
+`crypto.subtle` for the PKCE challenge. A secure context means https, or
+an origin on localhost / 127.0.0.1, so a deployment users reach at its
+own hostname or IP **must** run the TLS profile; over plain http the page
+fails immediately with `Web Crypto API is not available`.
+
+Note the state and nonce are generated before PKCE is even considered, so
+this is not a consequence of the S256 setting -- turning PKCE off would
+not make plain http work (and keycloak-js 26 accepts no other value).
 
 ```bash
 cp .env.example .env

--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -64,7 +64,11 @@ function sidebar() {
             },
             {text: 'Slack', link: '/integrations/slack'},
             {text: 'Microsoft Teams', link: '/integrations/msteams'},
-            {text: 'Dependency-Track', link: '/integrations/dtrack'},
+            {text: 'Dependency-Track', link: '/integrations/dtrack',
+              items: [
+                {text: 'Dependency-Track 5 Helm Chart', link: '/integrations/dtrackChart'}
+              ]
+            },
             {text: 'Identity Providers', link: '/integrations/identityProviders',
               items: [
                 {text: 'Microsoft', link: '/integrations/identityProviders/microsoft'}

--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -5,8 +5,11 @@ Open-source ReARM Community Edition (Licensed per AGPL 3.0) may be deployed usin
 Time it takes: 5 minutes.
 
 #### Pre-requisites
-1. You need to have an operational Docker engine with Docker Compose version 2.24.0 or newer on your local machine.
-2. ReARM uses [OCI](https://opencontainers.org/) compatible storage to store xBOM files and other artifacts. Examples include Docker Hub, ACR, ECR, GCR. One of the quickest options is to use Reliza Hub product which gives you 1GB of free storage - see instructions how to set up [here](https://docs.relizahub.com/registry/). You would need an account with push permissions, so you would need to know OCI repository `login`, `password`, `uri` and `namespace` (optional) property. `Namespace` means relative location of your storage, i.e. if you are planning to store artifacts under `https://registry.relizahub.com/430fcdde-d7bc-4542-ad5b-4f534f4942f0-private`, then your `uri` property is `https://registry.relizahub.com` and your `namespace` property is `430fcdde-d7bc-4542-ad5b-4f534f4942f0-private`. Samples are given in our docker compose file and would be further clarified below.
+You need an operational Docker engine with Docker Compose version 2.24.0 or newer.
+
+That is all. ReARM stores xBOM files and other artifacts in [OCI](https://opencontainers.org/) compatible storage, and the compose stack ships with a bundled [zot](https://zotregistry.dev) registry that is enabled by default - so no external registry, and no credentials of your own, are required to get started. The registry runs inside the stack and is not published on a host port.
+
+If you would rather keep artifacts in a registry you already run, see [using an external OCI registry](/installation/#optional-using-an-external-oci-registry) below.
 
 #### Prepare Installation
 1. Clone ReARM git repository:
@@ -18,30 +21,51 @@ git clone https://github.com/relizaio/rearm.git
 cd deploy/docker-compose
 ```
 
-#### Set up env files referencing OCI connectivity
-As discussed above, you need to have credentials ready for OCI storage. With that you need to create 3 env files in the docker-compose directory (note that .env files in this directory are added to .gitignore). Below are samples of possible credentials, you should modify the values according to your OCI storage.
-
-1. core.env
-```
-RELIZAPROP_OCIARTIFACTS_REGISTRY_NAMESPACE="430fcdde-d7bc-4542-ad5b-4f534f4942f0-private"
-```
-
-2. oci.env
-```
-REGISTRY_HOST="registry.relizahub.com"
-REGISTRY_USERNAME="myusername"
-REGISTRY_TOKEN="mypassword"
-```
-
-3. rebom.env
-```
-OCIARTIFACTS_REGISTRY_NAMESPACE="430fcdde-d7bc-4542-ad5b-4f534f4942f0-private"
-```
-
 #### Start the docker compose stack
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
+
+Open `http://localhost:8092` in your browser. No configuration file is needed for a localhost deployment: every setting has a working default.
+
+#### Reaching ReARM from another machine
+Browsers only expose the Web Crypto API - which the login flow requires - in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), meaning `https` or `localhost`. A deployment reached by IP or hostname therefore has to serve TLS, or login fails with `Web Crypto API is not available`.
+
+The stack includes an optional TLS front for this. Copy the template and set the host:
+
+```bash
+cp .env.example .env
+```
+
+```
+REARM_HOST=rearm.example.com     # what users type in the browser
+REARM_PROTOCOL=https
+REARM_TLS_HOST=rearm.example.com # bare host or IP, no port
+REARM_ACME_EMAIL=you@example.com # omit for a self-signed certificate
+COMPOSE_PROFILES=tls
+```
+
+With `REARM_ACME_EMAIL` set and ports 80/443 reachable from the internet, certificates come from Let's Encrypt; without it traefik serves a self-signed certificate, which is fine for an IP-based evaluation.
+
+Note that the Keycloak realm import happens on first boot only, so changing `REARM_HOST` afterwards means either wiping the Keycloak volume (`docker compose down -v`, which destroys local users) or editing the `login-app` client in the Keycloak admin console.
+
+#### Optional: using an external OCI registry
+Skip this if you are happy with the bundled registry.
+
+To store artifacts in your own registry, set the following in `.env`. `OCI_USE_PLAIN_HTTP=false` matters: the default of `true` suits only the in-network bundled registry and would otherwise send credentials in the clear.
+
+```
+OCI_REGISTRY_HOST=registry.example.com
+OCI_REGISTRY_USERNAME=myusername
+OCI_REGISTRY_TOKEN=mypassword
+OCI_REGISTRY_NAMESPACE=my-namespace
+OCI_USE_PLAIN_HTTP=false
+OCI_BUNDLED_REGISTRY_REPLICAS=0
+```
+
+`OCI_REGISTRY_NAMESPACE` is the relative location inside the registry: for artifacts under `https://registry.example.com/my-namespace`, the host is `registry.example.com` and the namespace is `my-namespace`. `OCI_BUNDLED_REGISTRY_REPLICAS=0` stops the bundled registry from starting, since nothing will be using it.
+
+`.env` is gitignored and carries credentials - keep it that way, and consider `chmod 600`. Earlier releases used separate `core.env`, `oci.env` and `rebom.env` files; those are still honoured for backward compatibility, but `.env` is the supported place for new installations. See [`.env.example`](https://github.com/relizaio/rearm/blob/main/deploy/docker-compose/.env.example) for every available setting.
 
 Then proceed to the [create administrative user](/installation/#create-your-administrative-user-and-log-in) section.
 
@@ -51,7 +75,11 @@ Pre-requisites: You need to have a running Kubernetes cluster.
 
 Note: below shows quick installation method and assumes stack running on http://rearm.localhost. For various options and hardening refer to the values file of ReARM helm chart in the [GitHub repository](https://github.com/relizaio/rearm).
 
-Create your local values file `rearm-values.yaml` specifying custom parameters, especially hostname and OCI registry credentials. Note that `registryNamespace` property means relative location of your storage, i.e. if you are planning to store artifacts under `https://registry.relizahub.com/430fcdde-d7bc-4542-ad5b-4f534f4942f0-private`, then your registry host property is `registry.relizahub.com` and your `registryNamespace` property is `430fcdde-d7bc-4542-ad5b-4f534f4942f0-private`. See sample below for the full example:
+Create your local values file `rearm-values.yaml` specifying custom parameters, especially the hostname and where artifacts are stored.
+
+As with the compose stack, the chart can run a bundled [zot](https://zotregistry.dev) registry in the cluster, so no external registry or credentials are needed. Unlike compose it is **off by default**, because switching it on for an existing installation would repoint it away from the registry it already uses. The two options are shown below - pick one.
+
+##### Option A: bundled registry (no external storage needed)
 
 ```yaml
 leHost: rearm.localhost
@@ -64,17 +92,46 @@ keycloak:
 
 ociArtifactService:
   enabled: true
-  registryHost: registry.relizahub.com
-  registryUser: registry_user
-  registryToken: registry_token
-  
+  bundledRegistry:
+    enabled: true
+    storage: 20Gi
+
 rebom:
   backend:
     oci:
       enabled: "true"
       serviceHost: http://rearm-oci-artifact
-      registryHost: registry.relizahub.com
-      registryNamespace: 430fcdde-d7bc-4542-ad5b-4f534f4942f0-private
+      registryNamespace: rearm
+```
+
+With the bundled registry, `registryNamespace` is a plain repository prefix such as `rearm`. A registry password is generated on first install and preserved across upgrades, so artifacts stay reachable; the credentials Secret and the registry volume both survive `helm uninstall`, since the stored artifacts outlive the release.
+
+##### Option B: external OCI registry
+
+Here `registryNamespace` is the relative location inside your registry: for artifacts under `https://registry.example.com/my-namespace`, the registry host is `registry.example.com` and the namespace is `my-namespace`.
+
+```yaml
+leHost: rearm.localhost
+projectHost: rearm.localhost
+projectProtocol: http
+
+keycloak:
+  strict_host: true
+  issuer_uri: http://rearm.localhost
+
+ociArtifactService:
+  enabled: true
+  registryHost: registry.example.com
+  registryUser: registry_user
+  registryToken: registry_token
+
+rebom:
+  backend:
+    oci:
+      enabled: "true"
+      serviceHost: http://rearm-oci-artifact
+      registryHost: registry.example.com
+      registryNamespace: my-namespace
 ```
 
 Note that there are other ways to set up the secrets in a more secure way, but we discuss the simplest approach here. In any case, make sure not to check in any secrets to a source code repository.

--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -11,6 +11,11 @@ That is all. ReARM stores xBOM files and other artifacts in [OCI](https://openco
 
 If you would rather keep artifacts in a registry you already run, see [using an external OCI registry](/installation/#optional-using-an-external-oci-registry) below.
 
+#### Recommended: a Dependency-Track instance
+ReARM runs perfectly well without one - you can store and version xBOMs, manage releases and track dependencies between them. What you do not get is SBOM analysis: vulnerability scanning and policy violations come from [Dependency-Track](https://dependencytrack.org), so without it releases carry no findings.
+
+Connecting one is highly recommended. If you already run an instance, see [Dependency-Track integration](/integrations/dtrack). If you do not, we publish a [Dependency-Track 5 Helm chart](/integrations/dtrackChart) that serves the UI and API on a single hostname. It can be added at any time, before or after installing ReARM.
+
 #### Prepare Installation
 1. Clone ReARM git repository:
 ```
@@ -74,6 +79,8 @@ Then proceed to the [create administrative user](/installation/#create-your-admi
 ## Installation Via Helm Chart
 Time it takes: 5 minutes.
 Pre-requisites: You need to have a running Kubernetes cluster.
+
+As with the compose installation, a [Dependency-Track](https://dependencytrack.org) instance is highly recommended but not required - without one ReARM works, but releases carry no vulnerability or policy-violation findings. See [Dependency-Track integration](/integrations/dtrack) to connect an existing instance, or our [Dependency-Track 5 Helm chart](/integrations/dtrackChart) to deploy one alongside ReARM.
 
 Note: below shows quick installation method and assumes stack running on http://rearm.localhost. For various options and hardening refer to the values file of ReARM helm chart in the [GitHub repository](https://github.com/relizaio/rearm).
 

--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -29,7 +29,9 @@ docker compose up -d
 Open `http://localhost:8092` in your browser. No configuration file is needed for a localhost deployment: every setting has a working default.
 
 #### Reaching ReARM from another machine
-Browsers only expose the Web Crypto API - which the login flow requires - in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), meaning `https` or `localhost`. A deployment reached by IP or hostname therefore has to serve TLS, or login fails with `Web Crypto API is not available`.
+Nothing in ReARM rejects plain http - this is a browser rule. Parts of the Web Crypto API are exposed only in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), and the Keycloak client library uses them to build the login request: `crypto.randomUUID` for the OIDC state and nonce, and `crypto.subtle` for the PKCE challenge. Over plain http they are undefined and the page fails immediately with `Web Crypto API is not available`.
+
+A secure context means `https`, or an origin on `localhost` / `127.0.0.1`. So the default localhost deployment above is fine over http, and so is a remote host tunnelled to a local port - but a deployment users reach at its own hostname or IP has to serve TLS.
 
 The stack includes an optional TLS front for this. Copy the template and set the host:
 

--- a/documentation_site/docs/integrations/dtrack.md
+++ b/documentation_site/docs/integrations/dtrack.md
@@ -4,7 +4,9 @@
 ReARM relies on [Dependency-Track](https://dependencytrack.org) for SBOM analysis, including vulnerability scans and policy violations. If you are using ReARM Pro, Dependency Track integration will be set up for you by Reliza. If you are using ReARM Community Edition or your organization on [ReARM Public Demo](https://demo.rearmhq.com), follow these instructions below:
 
 ## Pre-requisites
-You need to have a running instance of Dependency-Track.
+You need to have a running instance of Dependency-Track. Any instance works, however it was deployed.
+
+If you do not have one yet, we publish a [Dependency-Track 5 Helm chart](/integrations/dtrackChart) that serves the UI and the API on a single hostname, which makes the URIs below simpler to fill in.
 
 ## Dependency-Track Part
 1. In your Dependency-Track instance, open `Administration` section in the menu bar on the left.

--- a/documentation_site/docs/integrations/dtrackChart.md
+++ b/documentation_site/docs/integrations/dtrackChart.md
@@ -1,0 +1,92 @@
+# Dependency-Track 5 Helm Chart
+
+ReARM relies on [Dependency-Track](https://dependencytrack.org) for SBOM analysis. **Any Dependency-Track instance works** - if you already run one, or use a managed one, simply point ReARM at it as described in [Dependency-Track integration](/integrations/dtrack).
+
+This page covers a convenience chart we publish for teams who do not already have an instance and want one that fits ReARM without extra plumbing. It is a thin community wrapper around the official [Dependency-Track chart](https://github.com/DependencyTrack/helm-charts), published under AGPL 3.0 alongside ReARM Community Edition.
+
+## Why use this chart
+
+The wrapper exists mainly to solve one awkward part of a stock Dependency-Track deployment.
+
+**A single hostname.** Dependency-Track is two services: an API server and a frontend. Deployed as-is they are separately exposed, so you end up publishing two hosts, obtaining two certificates and - because the browser calls the API directly - dealing with CORS between them. The ReARM integration form asks for an API Server URI *and* a Frontend URI precisely because they are usually different.
+
+**The backend is proxied through the UI.** In this chart the frontend's nginx proxies `/api` to the API server inside the cluster, so only the frontend is exposed. One host, one certificate, no cross-origin traffic, and both URIs you enter into ReARM are the same value.
+
+It also brings a few things you would otherwise assemble yourself:
+
+- a bundled PostgreSQL instance, with an optional backup CronJob to S3 or Azure
+- database credentials and the Dependency-Track key-encryption-key generated on first install and preserved across upgrades, with several handling modes (generated, plaintext, sealed, or provisioned out-of-band)
+- every image pinned by digest, including the ones inherited from the upstream chart
+- gzip compression and security headers on the frontend, and an optional HSTS toggle
+- a Traefik `IngressRoute` with Let's Encrypt, or a plain route for running behind an existing load balancer
+
+If none of that is useful to you, a stock Dependency-Track install is perfectly fine - ReARM does not care how it was deployed.
+
+## Installation
+
+Pre-requisites: a running Kubernetes cluster with Traefik as the ingress controller.
+
+The chart is published as an OCI artifact and is publicly readable, so no registry login is needed:
+
+```bash
+helm install dtrack5 oci://registry.rearmhq.com/library/dtrack5 \
+  --version 0.1.0 --create-namespace -n dtrack5 \
+  -f dtrack5-values.yaml
+```
+
+A minimal values file needs little more than the hostname:
+
+```yaml
+# Host the Dependency-Track UI is served on - this is also the API host,
+# because the frontend proxies /api to the API server.
+ingressHost: dtrack.example.com
+
+# TLS terminated here by Traefik with a Let's Encrypt certificate.
+# Use traefikBehindLb instead when TLS terminates at an upstream LB.
+useTraefikLe: true
+traefikBehindLb: false
+
+postgres:
+  enabled: true
+  postgresStorage: 4G
+```
+
+### Secrets
+
+The chart manages two secrets: the PostgreSQL credentials and the Dependency-Track key-encryption-key. One setting governs both:
+
+| `create_secret_in_chart` | behaviour |
+|---|---|
+| `generated` (default) | values generated on first install and never rotated by later upgrades; they also survive `helm uninstall` and are reused on reinstall |
+| `plaintext` | taken verbatim from `secrets.pgpassword` / `secrets.kek` |
+| `sealed` | `SealedSecret` resources from kubeseal ciphertext; requires the sealed-secrets controller |
+| `none` | the chart creates nothing - provision the Secrets yourself |
+
+`generated` relies on Helm's `lookup`, which is a no-op under `helm template` and `--dry-run`. Rendering pipelines that never talk to the cluster (ArgoCD-style) would regenerate the values on every render, so use `sealed` or `none` there.
+
+### Optional settings
+
+```yaml
+# Strict-Transport-Security, emitted by Traefik at the TLS edge.
+# Off by default: a browser honours HSTS for the whole max-age once it
+# has seen it, so enable it deliberately, per host.
+hsts:
+  enabled: true
+  maxAge: 31536000
+  includeSubdomains: true
+  preload: false
+
+# Nightly database backup to S3 or Azure. Requires a secret holding the
+# bucket credentials - see the values file for the expected keys.
+backups:
+  enabled: true
+  schedule: "0 1 * * *"
+  storageType: s3
+  secretName: rearm-backup
+```
+
+Every available setting is documented in the chart's [values file](https://github.com/relizaio/rearm/blob/main/deploy/helm/dtrack5-helm/values.yaml).
+
+## Connecting it to ReARM
+
+Once Dependency-Track is up, follow [Dependency-Track integration](/integrations/dtrack) to create the API key and configure the integration. The one simplification with this chart: the API Server URI and the Frontend URI are the same value - `https://` plus your `ingressHost`.


### PR DESCRIPTION
Brings the install page in line with both deployment paths as they actually work today, and adds a page for the Dependency-Track 5 chart.

## Why the install page needed this

It still opened by telling readers to obtain OCI storage credentials and hand-write `core.env`, `oci.env` and `rebom.env`. The compose stack now bundles a zot registry and reads a single optional `.env`, so a localhost deployment needs **no credentials and no configuration file at all**. Anyone following the old page was doing setup that stopped being necessary some time ago.

**Docker Compose** is rewritten around what the stack does now:

- bring it up, open `http://localhost:8092`, done
- `.env` only enters the picture to move off localhost or to use an external registry
- the TLS profile is documented, because a non-localhost deployment *cannot log in* without it: the login flow needs the Web Crypto API, which browsers only expose in a secure context
- the legacy env files get one line as still honoured, so existing installs are not left guessing

**Helm** now shows the bundled registry too, since the chart grew the same option. Presented as two alternatives rather than one path with a caveat, because `registryNamespace` means different things in each - a plain repository prefix for the bundled registry, a location inside your registry for an external one.

## Dependency-Track 5 chart page

New page nested under the existing Dependency-Track integration, which it cross-links both ways.

It opens by making clear **any Dependency-Track instance works** and this is only a convenience for teams that do not already have one. The "why" section explains what the wrapper actually buys, which is mostly one thing: Dependency-Track is two services, and deployed as-is that means two hosts, two certificates, and CORS between them - which is exactly why the ReARM integration form asks for an API Server URI *and* a Frontend URI. In this chart the frontend's nginx proxies `/api` to the API server in-cluster, so there is a single exposed host and both URIs are the same value.

Then the secondary benefits (bundled PostgreSQL with optional backups, generated and preserved secrets with the four handling modes, digest-pinned images, gzip and security headers, HSTS toggle), installation from the published OCI chart, and a pointer back to the integration steps.

## Verified

- every value quoted checked against the actual charts and compose files (ports, variable names, defaults, secret modes)
- the install command checked against the published chart, which pulls and installs anonymously
- `npm run docs:build` passes; it caught a dead link on the first run, now fixed
- new page renders, sidebar entry resolves, and the legacy env filenames survive only in the backward-compatibility sentence
- files are ASCII-clean (the one non-ASCII byte in `config.mjs` is the pre-existing copyright symbol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)