### PR TITLE
docs: correct trial length and make both install paths first-class

### DIFF
--- a/documentation_site/docs/get-started/index.md
+++ b/documentation_site/docs/get-started/index.md
@@ -3,7 +3,7 @@
 ## Getting ReARM
 Refer to the [Installation Section](/installation/) for instructions how to install ReARM Community Edition.
 
-To start with no-obligation free 90-day trial of ReARM Pro, contact Reliza at [info@reliza.io](mailto:info@reliza.io).
+To start with no-obligation free 60-day trial of ReARM Pro, contact Reliza at [info@reliza.io](mailto:info@reliza.io).
 
 The fastest way to see ReARM in action is to register with your email and password on [the Public Demo instance](https://demo.rearmhq.com). You will get a read-only user of the Demo Organization connected to Dependency Track and will be able to create other organizations. Note that any data on the Public Demo instance may be deleted from time to time.
 

--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -1,8 +1,12 @@
 # Installation of ReARM Community Edition
-Open-source ReARM Community Edition (Licensed per AGPL 3.0) may be deployed using Docker Compose or via Helm Chart.
+Open-source ReARM Community Edition (Licensed per AGPL 3.0) can be installed two ways: with [Docker Compose](#installation-via-docker-compose), or with the [Helm chart](#installation-via-helm-chart) on Kubernetes. Both are fully supported, and neither is limited to local use - either can serve a single evaluation on your laptop or a deployment your whole team reaches at its own domain.
 
-## Local Installation Via Docker Compose
+If you already run Kubernetes, the Helm chart is the recommended option for production. Docker Compose is the quickest way to get an instance running on a single host, and suits evaluations, demos and smaller self-hosted deployments.
+
+## Installation Via Docker Compose
 Time it takes: 5 minutes.
+
+The compose stack runs wherever Docker does - your laptop, a VM, or a server your team reaches at its own domain. The walkthrough below brings it up on localhost first because that needs no configuration at all; [deploying on a remote host or domain](#deploying-on-a-remote-host-or-domain) is a couple of settings on top.
 
 #### Pre-requisites
 You need an operational Docker engine with Docker Compose version 2.24.0 or newer.
@@ -33,7 +37,9 @@ docker compose up -d
 
 Open `http://localhost:8092` in your browser. No configuration file is needed for a localhost deployment: every setting has a working default.
 
-#### Reaching ReARM from another machine
+#### Deploying on a remote host or domain
+Nothing about the compose stack is localhost-only. To serve it to other machines, point it at the host users will type in the browser and enable the TLS front.
+
 Nothing in ReARM rejects plain http - this is a browser rule. Parts of the Web Crypto API are exposed only in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts), and the Keycloak client library uses them to build the login request: `crypto.randomUUID` for the OIDC state and nonce, and `crypto.subtle` for the PKCE challenge. Over plain http they are undefined and the page fails immediately with `Web Crypto API is not available`.
 
 A secure context means `https`, or an origin on `localhost` / `127.0.0.1`. So the default localhost deployment above is fine over http, and so is a remote host tunnelled to a local port - but a deployment users reach at its own hostname or IP has to serve TLS.


### PR DESCRIPTION
Four small changes to the install and getting-started pages, off current main.

## 1. Pro trial: 90 -> 60 days

`get-started` advertised a 90-day trial. The pricing page has said **60** in three places for some time, so the docs were the stale copy.

## 2. An intro that helps you choose

The page opened with a single line naming the two methods and no guidance. It now states that both are fully supported, links to each with an in-page anchor, and gives the one thing a reader needs to decide: if you already run Kubernetes, the Helm chart is the recommended option for production; compose is the quickest way onto a single host and suits evaluations, demos and smaller self-hosted deployments.

## 3. "Local Installation Via Docker Compose" -> "Installation Via Docker Compose"

The word *local* was doing real damage — it read as a property of the compose path rather than of the walkthrough.

## 4. Compose is not localhost-only

Reinforcing the same point in two more places, since this has caused confusion before:

- the compose section now opens with "The compose stack runs wherever Docker does - your laptop, a VM, or a server your team reaches at its own domain", and links ahead to the remote-host steps
- "Reaching ReARM from another machine" is now **"Deploying on a remote host or domain"**, opening with "Nothing about the compose stack is localhost-only"

The localhost walkthrough stays first, because it genuinely needs no configuration — it is now framed as the starting point rather than the boundary.

## Anchor note

Renaming the heading moves its anchor from `#local-installation-via-docker-compose` to `#installation-via-docker-compose`. I checked before renaming: nothing links to the old anchor. Several published release posts on the landing site link to `https://docs.rearmhq.com/installation/#installation-via-helm-chart`, which is **untouched**.

## Verified

- site builds clean
- all three in-page links resolve to ids that exist in the rendered HTML (`installation-via-docker-compose`, `installation-via-helm-chart`, `deploying-on-a-remote-host-or-domain`)
- no `90-day` remains in the rendered output
- both files ASCII-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)