### PR TITLE
docs(dtrack5-helm): add a chart README

### DIFF
--- a/deploy/helm/dtrack5-helm/README.md
+++ b/deploy/helm/dtrack5-helm/README.md
@@ -26,11 +26,11 @@ Alongside that:
 
 ```bash
 helm install dtrack5 oci://registry.rearmhq.com/library/dtrack5 \
-  --version 0.1.2 --create-namespace -n dtrack5 \
+  --create-namespace -n dtrack5 \
   -f dtrack5-values.yaml
 ```
 
-The chart is public, so no registry login is needed. Full instructions, the settings worth knowing, and how to connect the result to ReARM are in the [documentation](https://docs.rearmhq.com/integrations/dtrackChart). Every value is documented inline in [`values.yaml`](./values.yaml).
+That installs the latest published version; add `--version` to pin one. The chart is public, so no registry login is needed. Full instructions, the settings worth knowing, and how to connect the result to ReARM are in the [documentation](https://docs.rearmhq.com/integrations/dtrackChart). Every value is documented inline in [`values.yaml`](./values.yaml).
 
 ## How it is built
 

--- a/deploy/helm/dtrack5-helm/README.md
+++ b/deploy/helm/dtrack5-helm/README.md
@@ -1,0 +1,65 @@
+# dtrack5
+
+Helm chart that deploys [Dependency-Track](https://dependencytrack.org) 5 for use with [ReARM](https://github.com/relizaio/rearm).
+
+ReARM works with any Dependency-Track instance - if you already run one, just point ReARM at it. This chart is for teams that do not, and want one that fits ReARM without extra plumbing.
+
+## Relationship to upstream
+
+This is a thin wrapper around the official [Dependency-Track Helm chart](https://github.com/DependencyTrack/helm-charts). That chart is pinned in `Chart.yaml`, vendored under `charts/`, and does all the real work of running the api-server and frontend; everything here sits around it.
+
+The upstream chart is Copyright (c) the Dependency-Track authors and licensed under Apache-2.0 - a copy ships as [`LICENSE-dependency-track`](./LICENSE-dependency-track). The wrapper itself is MIT, see [`LICENSE`](./LICENSE).
+
+## What the wrapper adds
+
+**A single hostname.** Dependency-Track is two services. Deployed as-is they are separately exposed, so you publish two hosts, obtain two certificates, and the browser talks cross-origin to the API. Here the frontend's nginx proxies `/api` to the api-server inside the cluster and only the frontend is exposed, so the API Server URI and Frontend URI you give ReARM are the same value.
+
+Alongside that:
+
+- a bundled PostgreSQL instance, with an optional backup CronJob to S3 or Azure
+- the database credentials and the Dependency-Track key-encryption-key generated on first install and preserved across upgrades, with `generated` / `plaintext` / `sealed` / `none` handling modes
+- every image pinned by digest, including the two inherited from upstream
+- gzip and security headers on the frontend nginx, and an optional HSTS toggle
+- a Traefik `IngressRoute`, either terminating TLS with Let's Encrypt or plain when running behind an existing load balancer
+
+## Installing
+
+```bash
+helm install dtrack5 oci://registry.rearmhq.com/library/dtrack5 \
+  --version 0.1.2 --create-namespace -n dtrack5 \
+  -f dtrack5-values.yaml
+```
+
+The chart is public, so no registry login is needed. Full instructions, the settings worth knowing, and how to connect the result to ReARM are in the [documentation](https://docs.rearmhq.com/integrations/dtrackChart). Every value is documented inline in [`values.yaml`](./values.yaml).
+
+## How it is built
+
+The upstream chart is a pinned dependency, vendored into the repository:
+
+```yaml
+dependencies:
+- name: dependency-track
+  version: "2.0.0-rc.3"          # exact: pre-release versions are not matched by range constraints
+  repository: "https://dependencytrack.github.io/helm-charts"
+```
+
+`helm dependency update` resolves that into `charts/dependency-track-<version>.tgz` and writes `Chart.lock`. Both the archive and the lock file are committed, so a build never depends on the upstream repository being reachable and the exact bytes are reviewable.
+
+CI packages the directory and publishes it to `registry.rearmhq.com/library/dtrack5` on merges to `main`, with an SBOM and a public Sigstore signature. The chart version in `Chart.yaml` is bumped by CI, so do not hand-edit it.
+
+### Bumping Dependency-Track
+
+1. Set the new `version` under `dependencies` in `Chart.yaml`, and `appVersion` to the Dependency-Track release it ships.
+2. Delete the old `charts/*.tgz` and run `helm dependency update .` to fetch the new one and refresh `Chart.lock`.
+3. Update the two upstream image digests in `values.yaml`. They are pinned independently of the subchart, so they do **not** follow `appVersion` on their own - leaving them stale means the chart claims a version it does not run. Resolve them from the registry, for example:
+   ```bash
+   crane digest dependencytrack/apiserver:<version>
+   crane digest dependencytrack/frontend:<version>
+   ```
+4. Check the diff between the old and new subchart before trusting it. Upstream releases have gone out that change nothing but `appVersion`, and ones that move templates; `helm template` output either way is the thing to compare.
+
+### Notes for maintainers
+
+- Images are expressed as `<version>@sha256:...` in the `tag` field. The subchart builds the reference itself and only emits `repo@digest` when the tag *starts with* `sha256:`, so this form is what keeps the version readable while pulling by digest.
+- The frontend nginx configuration lives in `mounted_files/nginx-conf` and is mounted as a ConfigMap. The nginx entrypoint runs envsubst over it once at container start, so editing it does not take effect on `helm upgrade` alone - roll the frontend afterwards. See the comment in `templates/nginx-conf-cm.yaml`.
+- Any resource this chart creates for the first time during an `upgrade` rather than an `install` - the HSTS middleware, when you switch `hsts.enabled` on - ends up client-side owned. The first later change to one of its values then fails with a conflict against helm itself, and keeps failing; one `helm upgrade --force-conflicts` clears it permanently. Fresh installs are unaffected.

--- a/documentation_site/docs/integrations/dtrackChart.md
+++ b/documentation_site/docs/integrations/dtrackChart.md
@@ -30,7 +30,7 @@ The chart is published as an OCI artifact and is publicly readable, so no regist
 
 ```bash
 helm install dtrack5 oci://registry.rearmhq.com/library/dtrack5 \
-  --version 0.1.0 --create-namespace -n dtrack5 \
+  --create-namespace -n dtrack5 \
   -f dtrack5-values.yaml
 ```
 


### PR DESCRIPTION
Adds a `README.md` to the dtrack5 chart directory, covering upstream provenance and how the chart is built and maintained.

## On the convention

Charts conventionally carry one. Helm lists `README.md` as an optional standard chart file alongside `LICENSE`, Artifact Hub renders it as the package page, and the upstream Dependency-Track chart vendored here ships one (generated by helm-docs). `helm create` does **not** scaffold it, which is likely why none of our four charts had one - so this is the first.

## What is in it

Deliberately not a copy of the [documentation page](https://docs.rearmhq.com/integrations/dtrackChart), which stays the place for user-facing detail. This covers what that page does not:

- **Relationship to upstream** - that this is a thin wrapper, the upstream chart does the real work, and the licensing split (upstream Apache-2.0 with the copy that ships as `LICENSE-dependency-track`, wrapper MIT)
- **What the wrapper adds** - led by the single-hostname point, since that is the reason to prefer it
- **How it is built** - the upstream chart as a pinned dependency vendored under `charts/`, with both the archive and `Chart.lock` committed so a build never depends on the upstream repository being reachable, and CI publishing to `registry.rearmhq.com/library/dtrack5` with an SBOM and Sigstore signature
- **Bumping Dependency-Track** - written down because one step is easy to miss: the two image digests are pinned *independently* of the subchart and do not follow `appVersion` on their own, so skipping them leaves the chart claiming a version it does not run
- **Notes for maintainers** - the `<version>@sha256:...` tag form and why it works, the nginx ConfigMap needing a frontend rollout, and the helm ownership trap for resources first created during an upgrade

## Verified

Every claim checked against the chart rather than written from memory: chart version, subchart pin, both LICENSE files, secret modes, the `tag@digest` form, the HSTS toggle, backup storage types, and that `Chart.lock` and the vendored archive are both tracked.

`helm lint` clean, `helm package` includes the README, and the docs URL uses the extensionless form the existing external links already use (`/integrations/dtrack`, not `.html`). ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)