### PR TITLE
docs: one authoritative statement on the Keycloak admin credentials

### DIFF
--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -162,6 +162,21 @@ helm upgrade --install --create-namespace -n rearm -f rearm-values.yaml rearm oc
 Unless you are deploying on the chart's default host, set the login URIs next - see [Configuring login URIs](/installation/#configuring-login-uris). Then proceed to creating your Administrative User.
 
 
+## Keycloak Admin Credentials
+Time it takes: 2 minutes.
+Applies to: every installation.
+
+ReARM delegates user management to Keycloak, whose admin console is served at your ReARM URI with the `/kauth/` suffix. Reliza ships `admin / admin` so that a first evaluation works out of the box.
+
+Keep those defaults only where nothing else can reach the deployment - a localhost evaluation on your own machine. Anywhere else, change them: the console is reachable wherever the deployment is, and whoever reaches it controls the identity provider that guards every ReARM account.
+
+Set them before the first start. They are bootstrapped once, so editing the configuration afterwards has no effect:
+
+- **Compose**: `KEYCLOAK_ADMIN_USER` and `KEYCLOAK_ADMIN_PASSWORD` in `.env`
+- **Helm**: `keycloak.secrets.adminpassword` in your values file
+
+If the deployment is already running, change the password from the console instead: log in, and in the `master` realm go to `Users` -> `admin` -> `Credentials` -> `Reset password`.
+
 ## Configuring Login URIs
 Time it takes: 2 minutes.
 Applies to: every Helm installation, and Docker Compose deployments whose `REARM_HOST` changed after first boot.
@@ -175,17 +190,7 @@ Keycloak only redirects back to URIs its `login-app` client already knows. If th
 To set them by hand:
 
 1. Navigate to the Keycloak login path at your ReARM URI with the `/kauth/` suffix - for example `https://rearm.example.com/kauth`.
-2. Log in with the Keycloak admin credentials from your compose or Helm configuration. Unless you changed them, Reliza ships `admin / admin`.
-
-   ::: warning Change these before exposing the deployment
-   The Keycloak admin console is reachable wherever your deployment is, so `admin / admin` on a non-localhost host hands anyone who finds it full control of your identity provider.
-
-   Set them before first start - they are bootstrapped once and later changes to the configuration have no effect:
-   - **Compose**: `KEYCLOAK_ADMIN_USER` and `KEYCLOAK_ADMIN_PASSWORD` in `.env`
-   - **Helm**: `keycloak.secrets.adminpassword` in your values file
-
-   If the deployment is already running, change the password in the Keycloak console instead, in the `master` realm you just logged into: `Users` -> `admin` -> `Credentials` -> `Reset password`.
-   :::
+2. Log in with your [Keycloak admin credentials](/installation/#keycloak-admin-credentials). This section applies to deployments that are not on localhost, so if they are still `admin / admin`, change them.
 3. In the upper left of the screen, switch realm from Keycloak to Reliza.
 4. Go to the `Clients` menu and click the `login-app` client. Add your user-facing URI to `Valid redirect URIs`, `Valid post logout redirect URIs` and `Web origins` - for example `https://rearm.example.com/*` in each. You may remove the existing preset defaults.
 
@@ -195,7 +200,7 @@ Pre-requisites: Installed ReARM via Docker Compose or a Helm chart.
 
 User management is done via Keycloak. To create your first user, navigate to the Keycloak login path at your ReARM URI with `/kauth/` suffix. In example, for the base local docker compose installation this would be `http://localhost:8092/kauth/` .
 
-Log in with default Keycloak credentials defined in docker compose or Helm configuration. The defaults provided by Reliza if you have no local modifications are `admin / admin`. You may also modify these credentials or switch to a different admin account after logging in.
+Log in with your [Keycloak admin credentials](/installation/#keycloak-admin-credentials). If this deployment is reachable by anyone other than you and they are still `admin / admin`, change them before going further.
 
 In the upper left part of the screen, switch realm from Keycloak to Reliza. Click on `Users`, then `Add user`. Set `Email verified` to on, enter your email and optionally First and Last Name and click 'Create'.
 

--- a/documentation_site/docs/installation/index.md
+++ b/documentation_site/docs/installation/index.md
@@ -177,6 +177,14 @@ Set them before the first start. They are bootstrapped once, so editing the conf
 
 If the deployment is already running, change the password from the console instead: log in, and in the `master` realm go to `Users` -> `admin` -> `Credentials` -> `Reset password`.
 
+### Rotating after the first login
+
+Whatever you configure above is bootstrap material, and it stays readable where you put it - in `.env` on the compose host, or in your values file and the Kubernetes Secret the chart renders from it, which is base64-encoded rather than encrypted. Anyone with the file, the repository it is committed to, or read access to Secrets in the namespace can recover it, and `docker inspect` will show it on a compose host.
+
+So for anything beyond a localhost evaluation we strongly recommend logging in once and rotating the password from the console, in the `master` realm: `Users` -> `admin` -> `Credentials` -> `Reset password`. That leaves the live credential somewhere the configuration never recorded it. Nothing enforces this, so it is worth doing while the installation is still fresh in mind.
+
+If you would rather not hold the bootstrap value in plain text at all, the Helm chart can take it as a SealedSecret instead - set `keycloak.create_secret_in_chart` to `sealed` and supply kubeseal ciphertext, or to `none` and provision the Secret yourself.
+
 ## Configuring Login URIs
 Time it takes: 2 minutes.
 Applies to: every Helm installation, and Docker Compose deployments whose `REARM_HOST` changed after first boot.


### PR DESCRIPTION
Fixes the contradiction you spotted: the page said two different things about the same account.

| section | what it said | who reads it |
|---|---|---|
| Configuring Login URIs | leaving `admin / admin` hands over the identity provider | only Helm users, and compose users who changed `REARM_HOST` |
| Create Your Administrative User | "You **may** also modify these credentials" | everyone |

The weaker message had the wider audience, which is the wrong way round.

## Approach

I did not simply raise the severity in the second place - that would leave two copies of the same guidance to drift apart again, which is how this arose in the first place. The guidance now lives in one short `## Keycloak Admin Credentials` section that both places link to.

It also draws the line the previous wording never did:

> Keep those defaults only where nothing else can reach the deployment - a localhost evaluation on your own machine. Anywhere else, change them: the console is reachable wherever the deployment is, and whoever reaches it controls the identity provider that guards every ReARM account.

Plus how to set them per install path, the first-start-only caveat, and the console fallback for a running deployment.

Each of the two references keeps a one-line reminder scoped to its own context, so a reader who does not follow the link still gets the point rather than assuming the account is someone else's problem:

- Configuring Login URIs: "This section applies to deployments that are not on localhost, so if they are still `admin / admin`, change them."
- Create Your Administrative User: "If this deployment is reachable by anyone other than you and they are still `admin / admin`, change them before going further."


## Second commit: rotating after first login

Setting a non-default password in `.env` or values is better than `admin / admin`, but it is not the end of it - that value stays readable where it was put:

- compose: in `.env` on the host, and visible via `docker inspect`
- Helm: in the values file, wherever that file is committed, and in a Secret that is **base64-encoded, not encrypted**, readable by anyone with `get` on Secrets in the namespace

So the section now asks readers to log in once and rotate from the console for anything beyond a localhost evaluation, which leaves the live credential somewhere the configuration never recorded it.

Phrased as a strong recommendation and **explicitly noted as unenforced** - nothing in the stack can make this happen, and the docs should not imply otherwise.

It also points at the alternative for anyone who would rather not hold the bootstrap value in plain text at all: the chart already accepts the Keycloak secret as a `sealed` SealedSecret, or `none` for externally provisioned.

## Verified

Site builds clean; the `keycloak-admin-credentials` anchor exists and both references resolve to it; no "may also modify" language remains; every remaining `admin / admin` mention now carries the constraint; the rotation guidance contains no must/required/mandatory language; file ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
