### PR TITLE
sync(backend): mirror shared backend from rearm-saas — VDR enrichment fix + Team primitive

### DIFF
--- a/backend/src/main/java/io/reliza/model/TeamRole.java
+++ b/backend/src/main/java/io/reliza/model/TeamRole.java
@@ -1,0 +1,30 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.model;
+
+/**
+ * The role a member plays on a Team (the {@link UserGroup} primitive).
+ *
+ * <p><strong>A role is an addressing LABEL and never grants access.</strong> It
+ * answers "who on this team do I escalate a KEV finding to?", not "who may write
+ * this component". Membership stays decoupled from RBAC (RFC sec. 4.1): a team
+ * may additionally be granted a permission, but that is a separate, explicit
+ * choice that no role here implies. Nothing in the authorization path reads this
+ * enum -- it feeds notification/escalation targeting only.
+ *
+ * <p>{@code CUSTOM} is the escape hatch for org-defined roles: the operator's
+ * label travels alongside in {@code customRole} rather than widening this enum,
+ * so the known set stays a closed vocabulary (house rule: enums over magic
+ * strings) while orgs are not boxed in.
+ */
+public enum TeamRole {
+	TEAM_LEAD,
+	SECURITY_SPECIALIST,
+	DEVELOPER,
+	QA,
+	PROJECT_MANAGER,
+	PRODUCT_MANAGER,
+	CUSTOM;
+}

--- a/backend/src/main/java/io/reliza/model/UserGroupData.java
+++ b/backend/src/main/java/io/reliza/model/UserGroupData.java
@@ -7,10 +7,16 @@ package io.reliza.model;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -29,7 +35,75 @@ import io.reliza.model.dto.UserGroupPermissionDto;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserGroupData extends RelizaDataParent implements RelizaObject {
-	
+
+	/**
+	 * An addressing role attached to a registered ReARM user already on this
+	 * team's roster ({@link #getAllUsers()}). This is a pure annotation -- it
+	 * does NOT add anyone to the team, so the roster keeps exactly one source of
+	 * truth ({@code users} + {@code manualUsers}) and SSO sync stays untouched.
+	 * A {@code userRef} with no matching roster entry is rejected on write.
+	 *
+	 * <p>{@code customRole} carries the operator's label when {@code role} is
+	 * {@link TeamRole#CUSTOM}, and is null otherwise. See {@link TeamRole} --
+	 * roles never grant access.
+	 */
+	public record TeamMemberRole (UUID userRef, TeamRole role, String customRole) {}
+
+	/**
+	 * A team member who is not a registered ReARM user, reachable only by a
+	 * freeform contact (email / Slack handle) -- the team-level analogue of
+	 * {@code ComponentData.FreeformContact}, plus a role. Both freeform fields
+	 * are operator-supplied and are HTML-sanitized via
+	 * {@link #sanitizeExternalMembers} before persistence, since they render
+	 * back into the team UI.
+	 *
+	 * <p><strong>External members deliberately do NOT count toward the durability
+	 * bar</strong> (DECIDED 2026-07-28): they live outside {@code users} /
+	 * {@code manualUsers}, so {@link #getAllUsers()} -- and therefore
+	 * {@code ComponentOwnershipService.isTeamDurable} -- ignores them by
+	 * construction. Durability means "survives a departure", which needs
+	 * accountable, lifecycle-managed accounts; an external contact is
+	 * addressable but confers no durability.
+	 */
+	public record ExternalTeamMember (String name, String contact, TeamRole role, String customRole) {}
+
+	/**
+	 * Returns a sanitized copy of {@code externalMembers} with each freeform
+	 * field run through jsoup {@code Safelist.basic()} -- the same safelist the
+	 * component contact path uses for operator-supplied text. Null input yields
+	 * null; null individual fields are preserved as null. Role fields are
+	 * enum/label data and are passed through untouched apart from the label,
+	 * which is operator text and so is sanitized too.
+	 */
+	/**
+	 * Returns a sanitized copy of {@code memberRoles}. Only {@code customRole} is
+	 * operator-supplied free text ({@code userRef} is a UUID and {@code role} an
+	 * enum), but it is the same class of label as
+	 * {@link ExternalTeamMember#customRole} and renders into the same team UI, so
+	 * it gets the same treatment -- sanitize-on-write applies to the WHOLE new
+	 * surface, not just the external half.
+	 */
+	public static List<TeamMemberRole> sanitizeMemberRoles (List<TeamMemberRole> memberRoles) {
+		if (null == memberRoles) return null;
+		return memberRoles.stream()
+				.map(mr -> new TeamMemberRole(
+						mr.userRef(),
+						mr.role(),
+						StringUtils.isEmpty(mr.customRole()) ? mr.customRole() : Jsoup.clean(mr.customRole(), Safelist.basic())))
+				.collect(Collectors.toList());
+	}
+
+	public static List<ExternalTeamMember> sanitizeExternalMembers (List<ExternalTeamMember> externalMembers) {
+		if (null == externalMembers) return null;
+		return externalMembers.stream()
+				.map(m -> new ExternalTeamMember(
+						StringUtils.isEmpty(m.name()) ? m.name() : Jsoup.clean(m.name(), Safelist.basic()),
+						StringUtils.isEmpty(m.contact()) ? m.contact() : Jsoup.clean(m.contact(), Safelist.basic()),
+						m.role(),
+						StringUtils.isEmpty(m.customRole()) ? m.customRole() : Jsoup.clean(m.customRole(), Safelist.basic())))
+				.collect(Collectors.toList());
+	}
+
 	private UUID uuid;
 	@JsonProperty(CommonVariables.NAME_FIELD)
 	private String name;
@@ -47,6 +121,12 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 	private Set<UUID> manualUsers = new LinkedHashSet<>(); // manually added users (not managed by SSO sync)
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups = new LinkedHashSet<>(); // SSO groups connected to this user group
+	/** Addressing roles for roster users; annotation only -- never a roster of its own. */
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles = new LinkedList<>();
+	/** Non-ReARM team members; addressable, but excluded from durability by design. */
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers = new LinkedList<>();
 	@JsonProperty
 	private UUID resourceGroup = CommonVariables.DEFAULT_RESOURCE_GROUP;
 
@@ -128,6 +208,42 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 		return allUsers;
 	}
 	
+	public List<TeamMemberRole> getMemberRoles() {
+		return new LinkedList<>(memberRoles);
+	}
+
+	private void setMemberRoles(Collection<TeamMemberRole> memberRoles) {
+		this.memberRoles = new LinkedList<>(memberRoles);
+	}
+
+	public List<ExternalTeamMember> getExternalMembers() {
+		return new LinkedList<>(externalMembers);
+	}
+
+	private void setExternalMembers(Collection<ExternalTeamMember> externalMembers) {
+		this.externalMembers = new LinkedList<>(externalMembers);
+	}
+
+	/**
+	 * The addressing role recorded for a roster user, if any. Used by the
+	 * escalation path ("notify the security specialist on this component's owner
+	 * team"); absence means the user is on the team with no declared role.
+	 *
+	 * <p>Deliberately re-checks {@link #hasUser} rather than trusting the stored
+	 * annotation: a role can outlive its member. Write-time validation only fires
+	 * when the caller sends {@code memberRoles}, so an update that shrinks the
+	 * roster with {@code memberRoles} omitted -- and SSO-driven removals via
+	 * {@code UserGroupService.removeUserFromGroupInternal}, which never touches
+	 * this field -- both leave a role pointing at an ex-member. Filtering on read
+	 * closes every such path by construction, so escalation can never target
+	 * someone who has left the team.
+	 */
+	@JsonIgnore
+	public Optional<TeamMemberRole> getRoleForUser(UUID userUuid) {
+		if (!hasUser(userUuid)) return Optional.empty();
+		return memberRoles.stream().filter(mr -> null != mr.userRef() && mr.userRef().equals(userUuid)).findFirst();
+	}
+
 	public Set<String> getConnectedSsoGroups() {
 		return new LinkedHashSet<>(connectedSsoGroups);
 	}
@@ -254,7 +370,23 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 		} else {
 			updatedUserGroupData.setConnectedSsoGroups(ugd.getConnectedSsoGroups());
 		}
-		
+
+		// Sanitize on write, not on read: the freeform custom-label / name /
+		// contact fields are operator text rendered back into the team UI. Both
+		// member lists get it -- sanitizing only the external half would leave
+		// memberRoles[].customRole as an unescaped sink.
+		if (null != updateUgd.getMemberRoles()) {
+			updatedUserGroupData.setMemberRoles(sanitizeMemberRoles(updateUgd.getMemberRoles()));
+		} else {
+			updatedUserGroupData.setMemberRoles(ugd.getMemberRoles());
+		}
+
+		if (null != updateUgd.getExternalMembers()) {
+			updatedUserGroupData.setExternalMembers(sanitizeExternalMembers(updateUgd.getExternalMembers()));
+		} else {
+			updatedUserGroupData.setExternalMembers(ugd.getExternalMembers());
+		}
+
 		return updatedUserGroupData;
 	}
 	
@@ -288,6 +420,8 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 				.users(ugd.getUsers())
 				.manualUsers(ugd.getManualUsers())
 				.connectedSsoGroups(ugd.getConnectedSsoGroups())
+				.memberRoles(ugd.getMemberRoles())
+				.externalMembers(ugd.getExternalMembers())
 				.build();
 	}
 

--- a/backend/src/main/java/io/reliza/model/dto/UpdateUserGroupDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/UpdateUserGroupDto.java
@@ -5,6 +5,7 @@
 package io.reliza.model.dto;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.reliza.common.CommonVariables;
 import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import lombok.Builder;
 import lombok.Data;
 
@@ -36,4 +39,8 @@ public class UpdateUserGroupDto {
 	private UserGroupStatus status;
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups;
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles;
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers;
 }

--- a/backend/src/main/java/io/reliza/model/dto/UserGroupWebDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/UserGroupWebDto.java
@@ -4,6 +4,7 @@
 
 package io.reliza.model.dto;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.reliza.common.CommonVariables;
 import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.UserPermission.Permissions;
 import lombok.Builder;
 import lombok.Data;
@@ -36,4 +39,8 @@ public class UserGroupWebDto {
 	private Set<UUID> manualUsers;
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups;
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles;
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers;
 }

--- a/backend/src/main/java/io/reliza/service/ReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseService.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
@@ -40,6 +41,7 @@ import org.cyclonedx.model.Property;
 import org.cyclonedx.model.vulnerability.Vulnerability;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating;
 import org.cyclonedx.model.vulnerability.Vulnerability.Source;
+import org.cyclonedx.parsers.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -2997,20 +2999,39 @@ public class ReleaseService {
 			// Build components list: PURLs as library components + releases as application components
 			List<Component> components = new ArrayList<>();
 			
-			// Try to get enriched components from merged SBOM
+			// Try to get enriched components from merged SBOM.
+			//
+			// The merged BOM is bound by CycloneDX's OWN parser, never by Utils.OM.
+			// cyclonedx-core-java is a Jackson 2 library: it models `licenses` as a
+			// single LicenseChoice while the spec serialises it as an ARRAY, and
+			// bridges the two with deserializers registered through Jackson 2
+			// annotations (org.cyclonedx.util.deserializer.*). Utils.OM is Jackson 3
+			// (tools.jackson), which cannot see those annotations -- so binding a
+			// component with it threw MismatchedInputException on the FIRST component
+			// carrying licenses, aborting this loop and silently degrading EVERY
+			// component in the VDR to the minimal purl-only fallback while the
+			// document still exported and still validated. Live since the Jackson 3
+			// upgrade (2026-05-22) until 2026-07-28.
+			//
+			// cyclonedx-core-java 13.0.0 does NOT fix this -- it is still Jackson 2
+			// (jackson-bom 2.22.x, licenses still a singular LicenseChoice), and
+			// upstream has no Jackson 3 migration open. So the rule stands: never
+			// bind org.cyclonedx.model.* with Utils.OM; round-trip through the
+			// library's own parser, which carries its own mapper. parse() does not
+			// schema-validate, so this is as lenient as the hand-rolled walk it
+			// replaces. Covered by @vdr_export in rearm-integration-tests.
 			Map<String, Component> purlComponentMap = new HashMap<>();
 			try {
 				JsonNode mergedBomJsonNode = getReleaseSbomAsJsonNode(
-					releaseData.getUuid(), false, false, null, BomStructureType.FLAT, 
+					releaseData.getUuid(), false, false, null, BomStructureType.FLAT,
 					releaseData.getOrg(), WhoUpdated.getAutoWhoUpdated(), null
 				);
-				
-				// Extract components array from JsonNode and convert to Component objects
-				JsonNode componentsNode = mergedBomJsonNode.get("components");
-				if (componentsNode != null && componentsNode.isArray()) {
-					for (JsonNode compNode : componentsNode) {
-						// Convert JsonNode to Component using Jackson
-						Component comp = Utils.OM.treeToValue(compNode, Component.class);
+
+				Bom mergedBom = new JsonParser().parse(
+						Utils.OM.writeValueAsBytes(mergedBomJsonNode));
+				List<Component> mergedComponents = mergedBom.getComponents();
+				if (mergedComponents != null) {
+					for (Component comp : mergedComponents) {
 						if (comp != null && comp.getPurl() != null) {
 							// Normalize PURL for consistent lookups
 							String normalizedPurl = Utils.minimizePurl(comp.getPurl());
@@ -3029,6 +3050,10 @@ public class ReleaseService {
 					log.error("Failed to enrich VDR components from merged SBOM: {}", e.getMessage(), e);
 				}
 				// Continue with empty map - will use minimal components
+			} catch (ParseException e) {
+				// Merged BOM is not parseable as CycloneDX -- degrade to minimal
+				// components rather than failing the whole export.
+				log.error("Failed to parse merged SBOM while enriching VDR components: {}", e.getMessage(), e);
 			} catch (JacksonException e) {
 				log.error("JSON processing error while enriching VDR components: {}", e.getMessage(), e);
 				// Continue with empty map - will use minimal components

--- a/backend/src/main/java/io/reliza/service/UserGroupService.java
+++ b/backend/src/main/java/io/reliza/service/UserGroupService.java
@@ -5,12 +5,15 @@
 package io.reliza.service;
 
 import java.time.ZonedDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -23,9 +26,12 @@ import io.reliza.common.CommonVariables.TableName;
 import io.reliza.common.CommonVariables.UserGroupStatus;
 import io.reliza.common.Utils;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.model.TeamRole;
 import io.reliza.model.UserData;
 import io.reliza.model.UserGroup;
 import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.UserPermission;
 import io.reliza.model.UserPermission.PermissionFunction;
 import io.reliza.model.UserPermission.PermissionType;
@@ -144,6 +150,18 @@ public class UserGroupService {
 			}
 		}
 		
+		// Team-member validation lives here, next to the other domain rules
+		// (name uniqueness / restore conflict) rather than in the data fetcher,
+		// so every caller of this method is held to the invariant -- not just the
+		// GraphQL one. Sanitize BEFORE validating so the checks see exactly what
+		// will persist: a customRole of "<script>x</script>" is non-empty on the
+		// way in but sanitizes to "", which is precisely the state the CUSTOM
+		// rule exists to reject.
+		updateUserGroupDto.setMemberRoles(UserGroupData.sanitizeMemberRoles(updateUserGroupDto.getMemberRoles()));
+		updateUserGroupDto.setExternalMembers(UserGroupData.sanitizeExternalMembers(updateUserGroupDto.getExternalMembers()));
+		validateMemberRoles(updateUserGroupDto.getMemberRoles(), effectiveRoster(ugd, updateUserGroupDto));
+		validateExternalMembers(updateUserGroupDto.getExternalMembers());
+
 		UserGroupData updatedUgd = UserGroupData.updateUserGroupData(ugd, updateUserGroupDto);
 
 		// check if group permissions are being elevated from read to write
@@ -183,6 +201,73 @@ public class UserGroupService {
 			}
 		}
 		return count;
+	}
+
+	/**
+	 * The roster this update will LAND on -- mirrors
+	 * {@code UserGroupData.updateUserGroupData}'s merge (null means keep
+	 * existing, non-null replaces), so adding a user and giving them a role in
+	 * the same call works. Package-private for test access.
+	 */
+	static Set<UUID> effectiveRoster(UserGroupData existing, UpdateUserGroupDto dto) {
+		Set<UUID> roster = new LinkedHashSet<>(
+				null != dto.getUsers() ? dto.getUsers() : existing.getUsers());
+		roster.addAll(null != dto.getManualUsers() ? dto.getManualUsers() : existing.getManualUsers());
+		return roster;
+	}
+
+	/**
+	 * A role annotates an EXISTING roster member -- it must never be a back door
+	 * for adding someone to a team, which would fork the roster into two sources
+	 * of truth. Note this only fires when the caller SENDS memberRoles; a role
+	 * can still go stale when the roster shrinks separately, which is why
+	 * {@code UserGroupData.getRoleForUser} re-checks membership on read.
+	 */
+	static void validateMemberRoles(List<TeamMemberRole> memberRoles, Set<UUID> roster) throws RelizaException {
+		if (null == memberRoles) return;
+		Set<UUID> seen = new LinkedHashSet<>();
+		for (TeamMemberRole mr : memberRoles) {
+			if (null == mr.userRef() || !roster.contains(mr.userRef())) {
+				throw new RelizaException(
+						"A team role can only be assigned to an existing team member: " + mr.userRef());
+			}
+			if (!seen.add(mr.userRef())) {
+				// getRoleForUser returns a single Optional, so a second entry for
+				// the same user would be silently dropped -- reject instead of
+				// persisting a role that never takes effect.
+				throw new RelizaException("Duplicate team role for member: " + mr.userRef());
+			}
+			validateCustomRole(mr.role(), mr.customRole());
+		}
+	}
+
+	/** External members carry no roster identity, so identity/reachability is all we can check. */
+	static void validateExternalMembers(List<ExternalTeamMember> externalMembers) throws RelizaException {
+		if (null == externalMembers) return;
+		for (ExternalTeamMember em : externalMembers) {
+			// Checked post-sanitization: GraphQL String! rejects null but not "",
+			// and a pure-markup value sanitizes down to "". An external member
+			// without a contact is unreachable, which defeats the point of storing
+			// one at all.
+			if (StringUtils.isBlank(em.name()) || StringUtils.isBlank(em.contact())) {
+				throw new RelizaException("An external team member requires a non-blank name and contact");
+			}
+			validateCustomRole(em.role(), em.customRole());
+		}
+	}
+
+	/**
+	 * These are malformed-input errors, not authorization failures, so they go
+	 * through {@link RelizaException} -- the domain validation channel
+	 * {@code GraphQLExceptionHandlers.handleReliza} surfaces as BAD_REQUEST with
+	 * the actual message. Throwing AccessDeniedException here would flatten every
+	 * one of them to a generic "Not authorized", misleading both the operator
+	 * fixing their request and anyone reading the logs.
+	 */
+	static void validateCustomRole(TeamRole role, String customRole) throws RelizaException {
+		if (TeamRole.CUSTOM == role && StringUtils.isBlank(customRole)) {
+			throw new RelizaException("A CUSTOM team role requires a customRole label");
+		}
 	}
 
 	private boolean hasWritePermissions(UserGroupData ugd) {

--- a/backend/src/main/java/io/reliza/ws/UserGroupDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/UserGroupDataFetcher.java
@@ -103,7 +103,10 @@ public class UserGroupDataFetcher {
 
 		validateUsersInOrganization(userGroupInput.getUsers(), ugd.get().getOrg(), groupUuid);
 		validateUsersInOrganization(userGroupInput.getManualUsers(), ugd.get().getOrg(), groupUuid);
-		
+		// Team-member roles / external members are sanitized and validated inside
+		// UserGroupService.updateUserGroupComprehensive, so every caller of that
+		// service method is held to the same invariant, not just this fetcher.
+
 		var approvals = userGroupInput.getApprovals();
 		OrganizationData od = getOrganizationService.getOrganizationData(ugd.get().getOrg()).get();
 		

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -2193,8 +2193,40 @@ type UserGroupWebDto {
 	permissions: Permissions
 	status: UserGroupStatus
 	connectedSsoGroups: [String]
+	# Addressing roles for roster users (annotation only -- a role never grants
+	# access, and listing a user here does NOT add them to the team).
+	memberRoles: [TeamMemberRole]
+	# Team members who are not registered ReARM users. Addressable for
+	# notification/escalation, but excluded from the durability bar by design.
+	externalMembers: [ExternalTeamMember]
 	createdDate: DateTime
 	lastUpdatedBy: ID
+}
+
+# The role a member plays on a Team. An addressing LABEL only -- never grants
+# access (membership stays decoupled from RBAC). CUSTOM carries an org-defined
+# label alongside in customRole.
+enum TeamRole {
+	TEAM_LEAD
+	SECURITY_SPECIALIST
+	DEVELOPER
+	QA
+	PROJECT_MANAGER
+	PRODUCT_MANAGER
+	CUSTOM
+}
+
+type TeamMemberRole {
+	userRef: ID
+	role: TeamRole
+	customRole: String
+}
+
+type ExternalTeamMember {
+	name: String
+	contact: String
+	role: TeamRole
+	customRole: String
 }
 
 type EmailObject {
@@ -4482,6 +4514,25 @@ input UpdateUserGroupInput {
 	approvals: [String]
 	status: UserGroupStatus
 	connectedSsoGroups: [String]
+	# Each userRef must already be on the roster (users + manualUsers); a role
+	# annotates an existing member, it never adds one.
+	memberRoles: [TeamMemberRoleInput]
+	externalMembers: [ExternalTeamMemberInput]
+}
+
+input TeamMemberRoleInput {
+	userRef: ID!
+	role: TeamRole!
+	# Required when role is CUSTOM, ignored otherwise.
+	customRole: String
+}
+
+input ExternalTeamMemberInput {
+	name: String!
+	contact: String!
+	role: TeamRole!
+	# Required when role is CUSTOM, ignored otherwise.
+	customRole: String
 }
 
 input UserGroupPermissionInput {

--- a/backend/src/test/java/io/reliza/model/UserGroupTeamMembersTest.java
+++ b/backend/src/test/java/io/reliza/model/UserGroupTeamMembersTest.java
@@ -1,0 +1,189 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.common.Utils;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
+import io.reliza.model.dto.UpdateUserGroupDto;
+
+/**
+ * Pins the Team-primitive additions (T1: member roles + external members) at the
+ * model layer, where the JSONB round-trip actually happens.
+ *
+ * <p>The headline invariant is the durability one: <strong>external (non-ReARM)
+ * members must not count toward the {@code DURABLE_MIN_MEMBERS} bar</strong>
+ * (DECIDED 2026-07-28). That holds by construction because externals live
+ * outside {@code users}/{@code manualUsers} and {@code getAllUsers()} -- which
+ * {@code ComponentOwnershipService.isTeamDurable} counts -- never sees them.
+ * It is pinned here so a future refactor that folds externals into the roster
+ * fails loudly instead of silently making one-person teams look durable.
+ */
+class UserGroupTeamMembersTest {
+
+	private static final UUID USER_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final UUID USER_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+	private static UserGroupData fromJson(String json) {
+		return Utils.OM.readValue(json, UserGroupData.class);
+	}
+
+	// ---------- durability: externals are addressable but never durable ----------
+
+	@Test
+	void externalMembersDoNotCountTowardTheDurabilityRoster() {
+		// One real member + two externals. A naive "count everyone" rule would
+		// read 3 and call this durable; the roster must still report exactly 1.
+		UserGroupData ugd = fromJson("""
+				{"name":"Docs Team","manualUsers":["%s"],
+				 "externalMembers":[
+				   {"name":"Ext One","contact":"ext1@vendor.example","role":"SECURITY_SPECIALIST"},
+				   {"name":"Ext Two","contact":"ext2@vendor.example","role":"DEVELOPER"}]}
+				""".formatted(USER_A));
+		assertEquals(2, ugd.getExternalMembers().size(), "externals must still be stored and addressable");
+		assertEquals(1, ugd.getAllUsers().size(),
+				"getAllUsers -- what the durability bar counts -- must exclude external members");
+		assertTrue(ugd.getAllUsers().contains(USER_A));
+	}
+
+	@Test
+	void rosterUsersStillCountNormally() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","users":["%s"],"manualUsers":["%s"]}
+				""".formatted(USER_A, USER_B));
+		assertEquals(2, ugd.getAllUsers().size(), "SSO + manual users both count toward durability");
+	}
+
+	// ---------- roles are annotations on the roster ----------
+
+	@Test
+	void roleLookupResolvesForARosterUserAndIsEmptyOtherwise() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"TEAM_LEAD"}]}
+				""".formatted(USER_A, USER_A));
+		var role = ugd.getRoleForUser(USER_A);
+		assertTrue(role.isPresent());
+		assertEquals(TeamRole.TEAM_LEAD, role.get().role());
+		assertTrue(ugd.getRoleForUser(USER_B).isEmpty(), "no role recorded -> empty, not a default role");
+	}
+
+	@Test
+	void roleIsNotReadableForSomeoneNoLongerOnTheRoster() {
+		// A role can outlive its member: write-time validation only fires when the
+		// caller sends memberRoles, and SSO-driven removals never touch the field.
+		// Read-side filtering is what stops escalation targeting an ex-member.
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"SECURITY_SPECIALIST"}]}
+				""".formatted(USER_A, USER_B));
+		assertTrue(ugd.getRoleForUser(USER_B).isEmpty(),
+				"a stale role for a departed member must not resolve");
+		assertEquals(1, ugd.getMemberRoles().size(),
+				"the stored annotation is left intact -- only the read is filtered");
+	}
+
+	@Test
+	void memberRoleCustomLabelIsSanitized() {
+		// The external half is not the only freeform sink: memberRoles[].customRole
+		// is operator text too and renders into the same team UI.
+		List<TeamMemberRole> sanitized = UserGroupData.sanitizeMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.CUSTOM, "<script>alert(1)</script>Release Captain")));
+		assertFalse(sanitized.get(0).customRole().contains("<script"));
+		assertTrue(sanitized.get(0).customRole().contains("Release Captain"));
+	}
+
+	@Test
+	void customRoleCarriesItsOperatorLabel() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"CUSTOM","customRole":"Release Captain"}]}
+				""".formatted(USER_A, USER_A));
+		var role = ugd.getRoleForUser(USER_A).orElseThrow();
+		assertEquals(TeamRole.CUSTOM, role.role());
+		assertEquals("Release Captain", role.customRole());
+	}
+
+	// ---------- sanitization of operator-supplied freeform text ----------
+
+	@Test
+	void sanitizeExternalMembersStripsScriptMarkupButKeepsBenignText() {
+		List<ExternalTeamMember> sanitized = UserGroupData.sanitizeExternalMembers(List.of(
+				new ExternalTeamMember("<script>alert(1)</script>Vendor",
+						"<img src=x onerror=alert(1)>ops@vendor.example",
+						TeamRole.CUSTOM, "<script>x</script>On-call")));
+		ExternalTeamMember m = sanitized.get(0);
+		assertFalse(m.name().contains("<script"), "script markup must not survive into the team UI");
+		assertTrue(m.name().contains("Vendor"), "benign text survives");
+		assertFalse(m.contact().contains("onerror"));
+		assertTrue(m.contact().contains("ops@vendor.example"));
+		assertFalse(m.customRole().contains("<script"));
+		assertTrue(m.customRole().contains("On-call"));
+	}
+
+	@Test
+	void sanitizeExternalMembersIsNullSafe() {
+		assertNull(UserGroupData.sanitizeExternalMembers(null));
+		ExternalTeamMember m = UserGroupData.sanitizeExternalMembers(
+				List.of(new ExternalTeamMember(null, null, TeamRole.QA, null))).get(0);
+		assertNull(m.name(), "null fields are preserved, not coerced to empty");
+		assertNull(m.contact());
+		assertEquals(TeamRole.QA, m.role());
+	}
+
+	// ---------- update merge: null means keep, non-null means replace ----------
+
+	@Test
+	void updateKeepsExistingMembersWhenFieldsOmitted() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"QA"}],
+				 "externalMembers":[{"name":"Ext","contact":"e@x.example","role":"DEVELOPER"}]}
+				""".formatted(USER_A, USER_A));
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder().name("Platform Renamed").build());
+		assertEquals("Platform Renamed", merged.getName());
+		assertEquals(1, merged.getMemberRoles().size(), "omitted memberRoles must be preserved");
+		assertEquals(1, merged.getExternalMembers().size(), "omitted externalMembers must be preserved");
+	}
+
+	@Test
+	void updateSanitizesExternalMembersOnWrite() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333"}
+				""");
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder()
+						.externalMembers(List.of(new ExternalTeamMember(
+								"<script>bad</script>Vendor", "ops@vendor.example", TeamRole.DEVELOPER, null)))
+						.build());
+		assertFalse(merged.getExternalMembers().get(0).name().contains("<script"),
+				"sanitization happens on the write path, not on read");
+	}
+
+	@Test
+	void updateReplacesMemberRolesWhenSupplied() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333","manualUsers":["%s","%s"],
+				 "memberRoles":[{"userRef":"%s","role":"QA"}]}
+				""".formatted(USER_A, USER_B, USER_A));
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder()
+						.memberRoles(List.of(new TeamMemberRole(USER_B, TeamRole.TEAM_LEAD, null)))
+						.build());
+		assertEquals(1, merged.getMemberRoles().size());
+		assertEquals(USER_B, merged.getMemberRoles().get(0).userRef(), "supplied list replaces wholesale");
+		assertTrue(merged.getRoleForUser(USER_A).isEmpty());
+	}
+}

--- a/backend/src/test/java/io/reliza/service/ComponentOwnershipServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/ComponentOwnershipServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import io.reliza.common.CommonVariables.UserGroupStatus;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.common.Utils;
 import io.reliza.model.ComponentData;
 import io.reliza.model.ComponentData.ComponentOwner;
 import io.reliza.model.ComponentOwnerType;
@@ -122,6 +123,31 @@ class ComponentOwnershipServiceTest {
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
 		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
 		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status());
+		assertFalse(o.durable());
+	}
+
+	/**
+	 * End-to-end counterpart to {@code UserGroupTeamMembersTest}: uses a REAL
+	 * (non-mocked) UserGroupData so {@code getAllUsers()} is the production
+	 * implementation, proving external members never reach the durability count.
+	 * DECIDED 2026-07-28 -- externals are addressable but confer no durability,
+	 * so a 1-real-member team stays NON_DURABLE no matter how many externals it
+	 * carries. Mocking {@code getAllUsers} (as the helper above does) could not
+	 * catch a regression that folded externals into the roster.
+	 */
+	@Test
+	void storedTeamWithExternalMembersStaysNonDurableOnOneRealMember() {
+		UUID t = UUID.randomUUID();
+		UserGroupData realTeam = Utils.OM.readValue("""
+				{"name":"Docs Team","org":"%s","status":"ACTIVE","manualUsers":["%s"],
+				 "externalMembers":[
+				   {"name":"Ext One","contact":"e1@vendor.example","role":"SECURITY_SPECIALIST"},
+				   {"name":"Ext Two","contact":"e2@vendor.example","role":"DEVELOPER"}]}
+				""".formatted(org, UUID.randomUUID()), UserGroupData.class);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(realTeam));
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status(),
+				"two external members must not lift a one-person team over the durability bar");
 		assertFalse(o.durable());
 	}
 

--- a/backend/src/test/java/io/reliza/service/UserGroupTeamValidationTest.java
+++ b/backend/src/test/java/io/reliza/service/UserGroupTeamValidationTest.java
@@ -1,0 +1,146 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.common.Utils;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.TeamRole;
+import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
+import io.reliza.model.dto.UpdateUserGroupDto;
+
+/**
+ * Covers the Team-member write-path invariants enforced in
+ * {@link UserGroupService} (T1). These validators are the ONLY thing keeping
+ * {@code memberRoles} an annotation rather than a second roster, so they are
+ * pinned directly rather than through the GraphQL layer.
+ *
+ * <p>They live on the service (not the data fetcher) so that every caller of
+ * {@code updateUserGroupComprehensive} is held to them -- these tests exercise
+ * them at that boundary.
+ */
+class UserGroupTeamValidationTest {
+
+	private static final UUID USER_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final UUID USER_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+	private static final UUID STRANGER = UUID.fromString("99999999-9999-9999-9999-999999999999");
+
+	private static UserGroupData group(String json) {
+		return Utils.OM.readValue(json, UserGroupData.class);
+	}
+
+	// ---------- effectiveRoster mirrors the merge (null = keep, non-null = replace) ----------
+
+	@Test
+	void effectiveRosterFallsBackToStoredWhenUpdateOmitsMembers() {
+		UserGroupData existing = group("""
+				{"name":"T","manualUsers":["%s"],"users":["%s"]}""".formatted(USER_A, USER_B));
+		Set<UUID> roster = UserGroupService.effectiveRoster(existing, UpdateUserGroupDto.builder().build());
+		assertEquals(Set.of(USER_A, USER_B), roster);
+	}
+
+	@Test
+	void effectiveRosterUsesIncomingListWhenSupplied() {
+		UserGroupData existing = group("""
+				{"name":"T","manualUsers":["%s"]}""".formatted(USER_A));
+		Set<UUID> roster = UserGroupService.effectiveRoster(existing,
+				UpdateUserGroupDto.builder().manualUsers(Set.of(USER_B)).build());
+		assertTrue(roster.contains(USER_B));
+		assertTrue(!roster.contains(USER_A), "a replaced roster must not retain the old members");
+	}
+
+	// ---------- a role may only annotate an existing member ----------
+
+	@Test
+	void roleForNonRosterUserIsRejected() {
+		RelizaException e = assertThrows(RelizaException.class, () ->
+				UserGroupService.validateMemberRoles(
+						List.of(new TeamMemberRole(STRANGER, TeamRole.DEVELOPER, null)),
+						Set.of(USER_A)));
+		assertTrue(e.getMessage().contains(STRANGER.toString()),
+				"the message should name the offending user so the operator can fix it");
+	}
+
+	@Test
+	void roleForUserAddedInTheSameCallIsAccepted() {
+		// The roster is computed post-merge, so "add a member and give them a
+		// role in one mutation" must work -- otherwise the UI would need two round trips.
+		assertDoesNotThrow(() -> UserGroupService.validateMemberRoles(
+				List.of(new TeamMemberRole(USER_B, TeamRole.TEAM_LEAD, null)),
+				Set.of(USER_A, USER_B)));
+	}
+
+	@Test
+	void nullMemberRolesIsANoOp() {
+		assertDoesNotThrow(() -> UserGroupService.validateMemberRoles(null, Set.of()));
+	}
+
+	@Test
+	void duplicateRoleForSameUserIsRejected() {
+		// getRoleForUser returns a single Optional, so a second entry would be
+		// silently dropped -- reject rather than persist a role that never applies.
+		assertThrows(RelizaException.class, () -> UserGroupService.validateMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.QA, null),
+						new TeamMemberRole(USER_A, TeamRole.TEAM_LEAD, null)),
+				Set.of(USER_A)));
+	}
+
+	// ---------- CUSTOM requires a label, checked post-sanitization ----------
+
+	@Test
+	void customRoleWithoutLabelIsRejected() {
+		assertThrows(RelizaException.class, () -> UserGroupService.validateCustomRole(TeamRole.CUSTOM, null));
+		assertThrows(RelizaException.class, () -> UserGroupService.validateCustomRole(TeamRole.CUSTOM, ""));
+	}
+
+	@Test
+	void customRoleThatSanitizesToEmptyIsRejected() {
+		// The order matters: "<script>x</script>" is non-blank on the way in but
+		// sanitizes to "", which is exactly the state the CUSTOM rule forbids.
+		// Sanitizing first is what makes this reachable.
+		List<TeamMemberRole> sanitized = UserGroupData.sanitizeMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.CUSTOM, "<script>x</script>")));
+		assertThrows(RelizaException.class,
+				() -> UserGroupService.validateMemberRoles(sanitized, Set.of(USER_A)));
+	}
+
+	@Test
+	void nonCustomRoleNeedsNoLabel() {
+		assertDoesNotThrow(() -> UserGroupService.validateCustomRole(TeamRole.SECURITY_SPECIALIST, null));
+	}
+
+	// ---------- external members must stay reachable ----------
+
+	@Test
+	void externalMemberWithBlankContactIsRejected() {
+		assertThrows(RelizaException.class, () -> UserGroupService.validateExternalMembers(
+				List.of(new ExternalTeamMember("Vendor", "  ", TeamRole.DEVELOPER, null))));
+	}
+
+	@Test
+	void externalMemberThatSanitizesToBlankNameIsRejected() {
+		// GraphQL String! stops null but not a pure-markup value that sanitizes away.
+		List<ExternalTeamMember> sanitized = UserGroupData.sanitizeExternalMembers(
+				List.of(new ExternalTeamMember("<script>x</script>", "ops@vendor.example", TeamRole.QA, null)));
+		assertThrows(RelizaException.class, () -> UserGroupService.validateExternalMembers(sanitized));
+	}
+
+	@Test
+	void wellFormedExternalMemberIsAccepted() {
+		assertDoesNotThrow(() -> UserGroupService.validateExternalMembers(
+				List.of(new ExternalTeamMember("Vendor Ops", "ops@vendor.example", TeamRole.CUSTOM, "On-call"))));
+	}
+}

--- a/backend/src/test/java/io/reliza/service/VdrComponentBindingTest.java
+++ b/backend/src/test/java/io/reliza/service/VdrComponentBindingTest.java
@@ -1,0 +1,114 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import io.reliza.common.Utils;
+
+/**
+ * Pins how VDR component enrichment binds a merged SBOM into the CycloneDX Java
+ * model (see {@code ReleaseService.buildVdrBom}).
+ *
+ * <p>The regression these exist for: cyclonedx-core-java is a Jackson 2 library.
+ * It models {@code licenses} as a single {@code LicenseChoice} while the spec
+ * serialises it as an ARRAY, and bridges the two with deserializers registered
+ * through Jackson 2 annotations. {@code Utils.OM} is Jackson 3
+ * ({@code tools.jackson}) and cannot see those annotations, so binding a
+ * component with it blew up on the first component carrying licenses — aborting
+ * enrichment and silently degrading every component in the VDR to the minimal
+ * purl-only fallback, while the document still exported and still validated.
+ *
+ * <p>Live from the Jackson 3 upgrade (2026-05-22) until 2026-07-28. Note that
+ * cyclonedx-core-java 13.0.0 does NOT resolve this — it is still Jackson 2 with
+ * {@code licenses} still a singular {@code LicenseChoice} — so the fix is to
+ * bind through the library's own parser, and the second test below is what
+ * keeps that decision honest if anyone reaches for {@code Utils.OM} again.
+ */
+public class VdrComponentBindingTest {
+
+	/** A component carrying the ARRAY-shaped `licenses` the spec mandates. */
+	private static final String BOM_WITH_LICENSED_COMPONENT = """
+			{
+			  "bomFormat": "CycloneDX",
+			  "specVersion": "1.6",
+			  "version": 1,
+			  "components": [
+			    {
+			      "type": "library",
+			      "name": "minimist",
+			      "version": "1.2.0",
+			      "purl": "pkg:npm/minimist@1.2.0",
+			      "bom-ref": "pkg:npm/minimist@1.2.0",
+			      "licenses": [{"license": {"id": "MIT"}}]
+			    }
+			  ]
+			}
+			""";
+
+	/**
+	 * The enrichment contract: the library's own parser binds the licenses array
+	 * and keeps the rest of the component detail the VDR is supposed to carry.
+	 */
+	@Test
+	public void cyclonedxParserBindsLicensesArray() throws Exception {
+		Bom bom = new JsonParser().parse(BOM_WITH_LICENSED_COMPONENT.getBytes(StandardCharsets.UTF_8));
+
+		assertNotNull(bom.getComponents(), "components must bind");
+		assertEquals(1, bom.getComponents().size());
+		Component c = bom.getComponents().get(0);
+
+		assertEquals("pkg:npm/minimist@1.2.0", c.getPurl());
+		// Version is the other field the minimal fallback cannot supply — a VDR
+		// consumer may read a missing version as "all versions affected".
+		assertEquals("1.2.0", c.getVersion());
+
+		assertNotNull(c.getLicenses(), "licenses must bind (this is the whole bug)");
+		assertNotNull(c.getLicenses().getLicenses(), "license list must bind");
+		assertEquals(1, c.getLicenses().getLicenses().size());
+		assertEquals("MIT", c.getLicenses().getLicenses().get(0).getId());
+	}
+
+	/**
+	 * The guard rail: binding the same document with the Jackson 3 mapper still
+	 * fails, and must keep failing. If a future Jackson/cyclonedx combination
+	 * ever makes this pass, the workaround above can be revisited — but until
+	 * then this test is what stops the round-trip being "simplified" back.
+	 */
+	@Test
+	public void jackson3MapperCannotBindCyclonedxComponent() {
+		assertThrows(Exception.class, () -> {
+			var tree = Utils.OM.readTree(BOM_WITH_LICENSED_COMPONENT);
+			for (var compNode : tree.get("components")) {
+				Utils.OM.treeToValue(compNode, Component.class);
+			}
+		}, "Utils.OM (Jackson 3) must not be used to bind org.cyclonedx.model types");
+	}
+
+	/** A component with no licenses binds fine either way — pins the trigger. */
+	@Test
+	public void componentWithoutLicensesBindsWithBothMappers() throws Exception {
+		String bomJson = BOM_WITH_LICENSED_COMPONENT
+				.replace(",\n      \"licenses\": [{\"license\": {\"id\": \"MIT\"}}]", "");
+		assertTrue(!bomJson.contains("licenses"), "fixture must have dropped the licenses array");
+
+		Bom bom = new JsonParser().parse(bomJson.getBytes(StandardCharsets.UTF_8));
+		assertEquals("pkg:npm/minimist@1.2.0", bom.getComponents().get(0).getPurl());
+
+		var tree = Utils.OM.readTree(bomJson);
+		Component viaJackson3 = Utils.OM.treeToValue(tree.get("components").get(0), Component.class);
+		assertEquals("pkg:npm/minimist@1.2.0", viaJackson3.getPurl());
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/TeamRoleSchemaEnumSyncTest.java
+++ b/backend/src/test/java/io/reliza/ws/TeamRoleSchemaEnumSyncTest.java
@@ -1,0 +1,90 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.TeamRole;
+
+/**
+ * Regression guard for the Team-primitive role enum (sibling of
+ * {@code ComponentOwnershipSchemaEnumSyncTest} /
+ * {@code NotificationSchemaEnumSyncTest}).
+ *
+ * <p>{@code TeamRole} is declared in BOTH the Java model and
+ * {@code schema.graphqls}, and DGS binds the GraphQL enum to the Java enum of the
+ * same name -- so a value present on one side but not the other silently breaks
+ * binding. Adding an org-facing role is exactly the kind of change that lands on
+ * one side only, and the failure mode (a role that cannot be selected, or a
+ * deserialization error at request time) is invisible until runtime. This test
+ * parses the raw schema (no Spring / DGS) and asserts the value sets are equal.
+ */
+class TeamRoleSchemaEnumSyncTest {
+
+	/** "enum Foo { ... }" block -- captures the body between the braces. */
+	private static final Pattern ENUM_BLOCK = Pattern.compile(
+			"enum\\s+(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+	@Test
+	void teamRoleEnumIsInSync() {
+		assertEnumInSync("TeamRole",
+				Arrays.stream(TeamRole.values()).map(Enum::name)
+						.collect(Collectors.toCollection(TreeSet::new)));
+	}
+
+	private void assertEnumInSync(String schemaEnumName, Set<String> javaValues) {
+		Set<String> schemaValues = readSchemaEnum(schemaEnumName);
+		assertEquals(javaValues, schemaValues,
+				"GraphQL enum " + schemaEnumName + " drifted from Java enum;"
+						+ " missing in schema: " + diff(javaValues, schemaValues)
+						+ "; extra in schema: " + diff(schemaValues, javaValues));
+	}
+
+	private static Set<String> diff(Set<String> a, Set<String> b) {
+		Set<String> r = new LinkedHashSet<>(a);
+		r.removeAll(b);
+		return r;
+	}
+
+	private static Set<String> readSchemaEnum(String enumName) {
+		String schema = readSchema();
+		Matcher m = ENUM_BLOCK.matcher(schema);
+		while (m.find()) {
+			if (!enumName.equals(m.group(1))) continue;
+			Set<String> out = new TreeSet<>();
+			for (String raw : m.group(2).split("\\R")) {
+				String line = raw.trim();
+				int hash = line.indexOf('#');
+				if (hash >= 0) line = line.substring(0, hash).trim();
+				if (line.isEmpty()) continue;
+				out.add(line);
+			}
+			return out;
+		}
+		throw new AssertionError("Did not find enum " + enumName + " in schema.graphqls");
+	}
+
+	private static String readSchema() {
+		try (InputStream in = TeamRoleSchemaEnumSyncTest.class.getResourceAsStream(
+				"/schema/schema.graphqls")) {
+			if (in == null) throw new IllegalStateException("schema.graphqls not on test classpath");
+			return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/UserGroupTest.java
+++ b/backend/src/test/java/io/reliza/ws/UserGroupTest.java
@@ -24,7 +24,10 @@ import io.reliza.exceptions.RelizaException;
 import io.reliza.model.Organization;
 import io.reliza.model.User;
 import io.reliza.model.UserData;
+import io.reliza.model.TeamRole;
 import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.WhoUpdated;
 import io.reliza.model.dto.CreateUserGroupDto;
 import io.reliza.model.dto.UpdateUserGroupDto;
@@ -501,6 +504,12 @@ public class UserGroupTest {
 				.groupId(created.getUuid())
 				.users(Set.of(testUser1, testUser2))
 				.connectedSsoGroups(Set.of("lifecycle-sso"))
+				// T1 Team fields: exercised through the real JSONB round-trip so a
+				// serialization-side break (record component or enum that fails to
+				// bind) is caught here rather than by hand-written fixture JSON.
+				.memberRoles(List.of(new TeamMemberRole(testUser1, TeamRole.TEAM_LEAD, null)))
+				.externalMembers(List.of(new ExternalTeamMember(
+						"Lifecycle Vendor", "vendor@lifecycle.example", TeamRole.CUSTOM, "On-call")))
 				.build();
 		userGroupService.updateUserGroupComprehensive(enrichDto, WhoUpdated.getTestWhoUpdated());
 
@@ -521,6 +530,17 @@ public class UserGroupTest {
 		Assertions.assertTrue(restored.getUsers().contains(testUser1));
 		Assertions.assertTrue(restored.getUsers().contains(testUser2));
 		Assertions.assertTrue(restored.getConnectedSsoGroups().contains("lifecycle-sso"));
+		// T1: roles + external members survive the deactivate/restore cycle
+		Assertions.assertEquals(1, restored.getMemberRoles().size());
+		Assertions.assertEquals(TeamRole.TEAM_LEAD, restored.getMemberRoles().get(0).role());
+		Assertions.assertEquals(testUser1, restored.getMemberRoles().get(0).userRef());
+		Assertions.assertTrue(restored.getRoleForUser(testUser1).isPresent(),
+				"the role must resolve for a user still on the roster");
+		Assertions.assertEquals(1, restored.getExternalMembers().size());
+		Assertions.assertEquals("Lifecycle Vendor", restored.getExternalMembers().get(0).name());
+		Assertions.assertEquals("On-call", restored.getExternalMembers().get(0).customRole());
+		Assertions.assertEquals(2, restored.getAllUsers().size(),
+				"the external member must not have joined the durability roster");
 	}
 
 	// ==================== T8: CREATE-AFTER-RESTORE CYCLE ====================


### PR DESCRIPTION
Mirrors the shared backend tree from rearm-saas via `backend/copy-src.sh`, which by
design leaves `oss/` and `saas/` untouched on both sides.

## What comes across

**1. VDR component enrichment fix** (rearm-saas#372)

VDR export enriches its components from the release's merged SBOM. That enrichment bound
the SBOM with our Jackson 3 mapper, but cyclonedx-core-java is a **Jackson 2** library: it
models `licenses` as a single `LicenseChoice` while the spec serialises it as an ARRAY,
and bridges the two with deserializers registered through Jackson 2 annotations that
Jackson 3 cannot see. It threw on the **first** component carrying licenses, which aborted
the enrichment loop and silently degraded **every** component in the document to the
minimal purl-only fallback — losing licenses, version, hashes and supplier — while the VDR
still exported and still validated, so nothing surfaced to the caller.

Vulnerabilities were never affected: they are built outside the failing block, and the
minimal components keep `bom-ref` set to the PURL so `affects[].ref` still resolves. That
is why it stayed quiet. Live since the Jackson 3 upgrade (2026-05-22).

Now bound through the library's own parser, which carries its own mapper. `parse()` does
not schema-validate, so this is as lenient as the hand-rolled walk it replaces, and an
unparseable BOM degrades to minimal components rather than failing the export.

Note: cyclonedx-core-java **13.0.0 does not fix this** — still Jackson 2, `licenses` still
a singular `LicenseChoice`, and no Jackson 3 migration open upstream.

**2. UserGroup elevated into the Team primitive** (rearm-saas#371) — member roles, external
members, `TeamRole`, and the accompanying schema and tests. This had not been mirrored
yet, so it rides along with this sync rather than being part of the VDR work.

## Verification

- `mvn test-compile` clean against CE's own `oss/` tree — **no OSS reconciliation needed**.
- CE already carries cyclonedx-core-java 12.0.1, so the new parser imports resolve with
  **no dependency change**.
- `VdrComponentBindingTest` passes here 3/3, including a guard rail asserting `Utils.OM`
  still cannot bind cyclonedx model types — so the round-trip is not "simplified" back.
- End-to-end on the SaaS side, the `@vdr_export` harness scenario went red → green against
  a build of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
