### PR TITLE
fix(backend): VDR component enrichment — bind merged SBOM with the CycloneDX parser

### DIFF
--- a/backend/src/main/java/io/reliza/service/ReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/ReleaseService.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.generators.BomGeneratorFactory;
 import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
@@ -40,6 +41,7 @@ import org.cyclonedx.model.Property;
 import org.cyclonedx.model.vulnerability.Vulnerability;
 import org.cyclonedx.model.vulnerability.Vulnerability.Rating;
 import org.cyclonedx.model.vulnerability.Vulnerability.Source;
+import org.cyclonedx.parsers.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -2997,20 +2999,39 @@ public class ReleaseService {
 			// Build components list: PURLs as library components + releases as application components
 			List<Component> components = new ArrayList<>();
 			
-			// Try to get enriched components from merged SBOM
+			// Try to get enriched components from merged SBOM.
+			//
+			// The merged BOM is bound by CycloneDX's OWN parser, never by Utils.OM.
+			// cyclonedx-core-java is a Jackson 2 library: it models `licenses` as a
+			// single LicenseChoice while the spec serialises it as an ARRAY, and
+			// bridges the two with deserializers registered through Jackson 2
+			// annotations (org.cyclonedx.util.deserializer.*). Utils.OM is Jackson 3
+			// (tools.jackson), which cannot see those annotations -- so binding a
+			// component with it threw MismatchedInputException on the FIRST component
+			// carrying licenses, aborting this loop and silently degrading EVERY
+			// component in the VDR to the minimal purl-only fallback while the
+			// document still exported and still validated. Live since the Jackson 3
+			// upgrade (2026-05-22) until 2026-07-28.
+			//
+			// cyclonedx-core-java 13.0.0 does NOT fix this -- it is still Jackson 2
+			// (jackson-bom 2.22.x, licenses still a singular LicenseChoice), and
+			// upstream has no Jackson 3 migration open. So the rule stands: never
+			// bind org.cyclonedx.model.* with Utils.OM; round-trip through the
+			// library's own parser, which carries its own mapper. parse() does not
+			// schema-validate, so this is as lenient as the hand-rolled walk it
+			// replaces. Covered by @vdr_export in rearm-integration-tests.
 			Map<String, Component> purlComponentMap = new HashMap<>();
 			try {
 				JsonNode mergedBomJsonNode = getReleaseSbomAsJsonNode(
-					releaseData.getUuid(), false, false, null, BomStructureType.FLAT, 
+					releaseData.getUuid(), false, false, null, BomStructureType.FLAT,
 					releaseData.getOrg(), WhoUpdated.getAutoWhoUpdated(), null
 				);
-				
-				// Extract components array from JsonNode and convert to Component objects
-				JsonNode componentsNode = mergedBomJsonNode.get("components");
-				if (componentsNode != null && componentsNode.isArray()) {
-					for (JsonNode compNode : componentsNode) {
-						// Convert JsonNode to Component using Jackson
-						Component comp = Utils.OM.treeToValue(compNode, Component.class);
+
+				Bom mergedBom = new JsonParser().parse(
+						Utils.OM.writeValueAsBytes(mergedBomJsonNode));
+				List<Component> mergedComponents = mergedBom.getComponents();
+				if (mergedComponents != null) {
+					for (Component comp : mergedComponents) {
 						if (comp != null && comp.getPurl() != null) {
 							// Normalize PURL for consistent lookups
 							String normalizedPurl = Utils.minimizePurl(comp.getPurl());
@@ -3029,6 +3050,10 @@ public class ReleaseService {
 					log.error("Failed to enrich VDR components from merged SBOM: {}", e.getMessage(), e);
 				}
 				// Continue with empty map - will use minimal components
+			} catch (ParseException e) {
+				// Merged BOM is not parseable as CycloneDX -- degrade to minimal
+				// components rather than failing the whole export.
+				log.error("Failed to parse merged SBOM while enriching VDR components: {}", e.getMessage(), e);
 			} catch (JacksonException e) {
 				log.error("JSON processing error while enriching VDR components: {}", e.getMessage(), e);
 				// Continue with empty map - will use minimal components

--- a/backend/src/test/java/io/reliza/service/VdrComponentBindingTest.java
+++ b/backend/src/test/java/io/reliza/service/VdrComponentBindingTest.java
@@ -1,0 +1,114 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import io.reliza.common.Utils;
+
+/**
+ * Pins how VDR component enrichment binds a merged SBOM into the CycloneDX Java
+ * model (see {@code ReleaseService.buildVdrBom}).
+ *
+ * <p>The regression these exist for: cyclonedx-core-java is a Jackson 2 library.
+ * It models {@code licenses} as a single {@code LicenseChoice} while the spec
+ * serialises it as an ARRAY, and bridges the two with deserializers registered
+ * through Jackson 2 annotations. {@code Utils.OM} is Jackson 3
+ * ({@code tools.jackson}) and cannot see those annotations, so binding a
+ * component with it blew up on the first component carrying licenses — aborting
+ * enrichment and silently degrading every component in the VDR to the minimal
+ * purl-only fallback, while the document still exported and still validated.
+ *
+ * <p>Live from the Jackson 3 upgrade (2026-05-22) until 2026-07-28. Note that
+ * cyclonedx-core-java 13.0.0 does NOT resolve this — it is still Jackson 2 with
+ * {@code licenses} still a singular {@code LicenseChoice} — so the fix is to
+ * bind through the library's own parser, and the second test below is what
+ * keeps that decision honest if anyone reaches for {@code Utils.OM} again.
+ */
+public class VdrComponentBindingTest {
+
+	/** A component carrying the ARRAY-shaped `licenses` the spec mandates. */
+	private static final String BOM_WITH_LICENSED_COMPONENT = """
+			{
+			  "bomFormat": "CycloneDX",
+			  "specVersion": "1.6",
+			  "version": 1,
+			  "components": [
+			    {
+			      "type": "library",
+			      "name": "minimist",
+			      "version": "1.2.0",
+			      "purl": "pkg:npm/minimist@1.2.0",
+			      "bom-ref": "pkg:npm/minimist@1.2.0",
+			      "licenses": [{"license": {"id": "MIT"}}]
+			    }
+			  ]
+			}
+			""";
+
+	/**
+	 * The enrichment contract: the library's own parser binds the licenses array
+	 * and keeps the rest of the component detail the VDR is supposed to carry.
+	 */
+	@Test
+	public void cyclonedxParserBindsLicensesArray() throws Exception {
+		Bom bom = new JsonParser().parse(BOM_WITH_LICENSED_COMPONENT.getBytes(StandardCharsets.UTF_8));
+
+		assertNotNull(bom.getComponents(), "components must bind");
+		assertEquals(1, bom.getComponents().size());
+		Component c = bom.getComponents().get(0);
+
+		assertEquals("pkg:npm/minimist@1.2.0", c.getPurl());
+		// Version is the other field the minimal fallback cannot supply — a VDR
+		// consumer may read a missing version as "all versions affected".
+		assertEquals("1.2.0", c.getVersion());
+
+		assertNotNull(c.getLicenses(), "licenses must bind (this is the whole bug)");
+		assertNotNull(c.getLicenses().getLicenses(), "license list must bind");
+		assertEquals(1, c.getLicenses().getLicenses().size());
+		assertEquals("MIT", c.getLicenses().getLicenses().get(0).getId());
+	}
+
+	/**
+	 * The guard rail: binding the same document with the Jackson 3 mapper still
+	 * fails, and must keep failing. If a future Jackson/cyclonedx combination
+	 * ever makes this pass, the workaround above can be revisited — but until
+	 * then this test is what stops the round-trip being "simplified" back.
+	 */
+	@Test
+	public void jackson3MapperCannotBindCyclonedxComponent() {
+		assertThrows(Exception.class, () -> {
+			var tree = Utils.OM.readTree(BOM_WITH_LICENSED_COMPONENT);
+			for (var compNode : tree.get("components")) {
+				Utils.OM.treeToValue(compNode, Component.class);
+			}
+		}, "Utils.OM (Jackson 3) must not be used to bind org.cyclonedx.model types");
+	}
+
+	/** A component with no licenses binds fine either way — pins the trigger. */
+	@Test
+	public void componentWithoutLicensesBindsWithBothMappers() throws Exception {
+		String bomJson = BOM_WITH_LICENSED_COMPONENT
+				.replace(",\n      \"licenses\": [{\"license\": {\"id\": \"MIT\"}}]", "");
+		assertTrue(!bomJson.contains("licenses"), "fixture must have dropped the licenses array");
+
+		Bom bom = new JsonParser().parse(bomJson.getBytes(StandardCharsets.UTF_8));
+		assertEquals("pkg:npm/minimist@1.2.0", bom.getComponents().get(0).getPurl());
+
+		var tree = Utils.OM.readTree(bomJson);
+		Component viaJackson3 = Utils.OM.treeToValue(tree.get("components").get(0), Component.class);
+		assertEquals("pkg:npm/minimist@1.2.0", viaJackson3.getPurl());
+	}
+}


### PR DESCRIPTION
Ports the VDR component enrichment fix from rearm-saas#372. **Two files only** — see
"Scope" below for why this isn't the full mirror.

## The bug

VDR export lists one component per vulnerable PURL, enriched from the release's merged
SBOM. That enrichment bound the SBOM with our **Jackson 3** mapper into
`org.cyclonedx.model.Component`.

cyclonedx-core-java is a **Jackson 2** library. It models `licenses` as a single
`LicenseChoice` while the spec serialises it as an ARRAY, and bridges the two with
deserializers registered through Jackson 2 annotations that Jackson 3 cannot see:

```
Cannot deserialize value of type org.cyclonedx.model.LicenseChoice from Array value
  (through reference chain: org.cyclonedx.model.Component["licenses"])
```

The throw aborts the loop at the **first** component carrying licenses, so **every**
component in the document degrades to the minimal purl-only fallback — losing licenses,
version, hashes and supplier. The VDR still exports and still validates, so nothing
surfaces to the caller. Licenses in a VDR are compliance evidence, and a missing `version`
can reasonably be read as "all versions affected".

**Vulnerabilities were never affected** — they are built outside the failing block,
straight from `vulnerabilityDetails`, and minimal components keep `bom-ref` set to the
PURL so `affects[].ref` still resolves. That is exactly why this stayed quiet.

Live since the Jackson 3 upgrade (2026-05-22).

## The fix

Bind the merged BOM through CycloneDX's **own** parser, which carries its own mapper and
deserializers. `parse()` does not schema-validate, so this is as lenient as the hand-rolled
`JsonNode` walk it replaces, and a `ParseException` catch keeps an unparseable BOM
degrading to minimal components rather than failing the export.

cyclonedx-core-java **13.0.0 does not fix this** — verified against the published artifact:
still `jackson-bom` 2.22.x, `licenses` still a singular `LicenseChoice`, zero
`tools/jackson` references, and no Jackson 3 migration open upstream.

## Scope

Taken from the `copy-src.sh` shared-tree mirror but deliberately narrowed to these two
files. The full mirror also carried the UserGroup → Team primitive work
(rearm-saas#371), which is still WIP and should sync on its own schedule rather than
riding along with a bugfix.

## Verification

- `mvn test-compile` clean against this repo's own `oss/` tree — **no OSS reconciliation
  needed**, and verified with the Team work *absent*, not just alongside it.
- cyclonedx-core-java 12.0.1 was already present here, so **no dependency change**.
- `VdrComponentBindingTest` passes 3/3, including a guard rail asserting `Utils.OM` still
  cannot bind cyclonedx model types — it fails if the round-trip is ever "simplified" back.
- On the SaaS side the `@vdr_export` harness scenario went red → green against a build of
  this fix, with the backend logging zero enrichment errors afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
