### PR TITLE
docs(compose): note that the bootstrap admin password stays readable

### DIFF
--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -64,6 +64,8 @@
 # The console is reachable from anywhere the deployment is, so change the
 # password for anything beyond localhost. Seeded on first start only --
 # set it before bringing the stack up, or change it in the console later.
+# Whatever is set here stays readable in this file and in `docker inspect`,
+# so rotating from the console after first login is recommended regardless.
 #KEYCLOAK_ADMIN_USER=admin
 #KEYCLOAK_ADMIN_PASSWORD=change-me
 


### PR DESCRIPTION
Two-line follow-up so the CE and Pro `.env.example` Keycloak blocks are identical.

The comment stopped at *how* to set the Keycloak admin password, which leaves the impression that setting it is the end of it. Whatever goes there stays readable in the file and in `docker inspect`, so rotating from the console after first login is worth doing regardless. The installation docs say this; someone editing `.env` should not have to find it elsewhere.

Same two lines as relizaio/rearm-saas#373, which mirrors #235 onto the Pro stack. With this, the `--- Keycloak admin ---` block is byte-identical in both repos.

`docker compose config` still valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)