### PR TITLE
fix(helm): stop the CE chart naming a pull secret that does not exist

### DIFF
--- a/deploy/helm/rearm-helm/Chart.yaml
+++ b/deploy/helm/rearm-helm/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: 1.1.1
 
-appVersion: "26.07.153"
+appVersion: "26.07.155"
 
 dependencies:
 - name: postgresql

--- a/deploy/helm/rearm-helm/values.yaml
+++ b/deploy/helm/rearm-helm/values.yaml
@@ -34,7 +34,12 @@ image:
   htpasswdImage: docker.io/library/httpd:2.4.68-alpine3.24@sha256:1b766f17b84026429b7cb243317b142921b24432336e798bc881c43f45ed9567
   pullPolicy: IfNotPresent
 
-imagePullSecrets: [ {"name":"regcred"} ]
+# Empty by default: every image this chart references is publicly pullable,
+# so a fresh install needs no credentials. Naming a secret that does not
+# exist makes kubelet log a FailedToRetrieveImagePullSecret warning on every
+# pod sync -- roughly once a minute, per pod, for the life of the deployment.
+# Set this if you mirror the images into a private registry.
+imagePullSecrets: []
 nameOverride: "rearm"
 fullnameOverride: ""
 


### PR DESCRIPTION
Found while verifying the 1.1.1 release. `imagePullSecrets` defaulted to `regcred`, which a CE user installing from the public images has no reason to have.

```yaml
-imagePullSecrets: [ {"name":"regcred"} ]
+imagePullSecrets: []
```

## Why it matters more than it looks

Pulls succeed regardless — kubelet warns and falls back to an anonymous pull — so nothing is broken. The problem is that the warning is **not a one-off**. Kubelet re-emits `FailedToRetrieveImagePullSecret` on every pod sync, for as long as the pod lives.

Measured on a scratch namespace, one pod, image already local and pod healthy the whole time:

```
t+60s   count=2
t+120s  count=3
t+180s  count=4
t+240s  count=5
t+360s  count=6
        count=8   (at ~8m49s)
```

An identical control pod with **no** `imagePullSecrets` emitted none, confirming the default is the sole cause.

On a default install that is ~9 warnings/minute, so roughly **540/hour**. Events expire after about an hour, so nothing accumulates in storage — but an operator running `kubectl get events` against a perfectly healthy deployment sees a wall of Warnings and little else, and anything consuming the event stream (monitoring, exporters, Warning-keyed alerts) gets the same.

## Consistency

`rearm-documentation-helm` and `rearm-landing-helm` already ship `imagePullSecrets: []`. This chart was the outlier. The **Pro chart keeps `regcred`**, which is correct — those images are private.

## Verified

Installed the chart with the new default:

- all 9 pods Running, every image pulled **by digest with no credentials**
- **zero** `FailedToRetrieveImagePullSecret` events, resampled across several minutes of steady state
- remaining Warnings are the usual startup ones (backend/Keycloak probes during boot), and their counts are static rather than climbing
- UI 200, `/api/healthCheck` 200 `OK`, Keycloak 302
- setting the value explicitly still renders exactly as before, for anyone mirroring images into a private registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)