### PR TITLE
feat(ui): team assignment rules editor + clear owner (T2b)

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -424,6 +424,12 @@
                                                     <n-button type="primary" size="small" :loading="savingOwner" :disabled="!ownerDraftRef" @click="saveOwner">
                                                         Set owner
                                                     </n-button>
+                                                    <!-- Only meaningful when a stored owner exists: clearing hands the
+                                                         component back to org team-assignment rules. -->
+                                                    <n-button v-if="componentOwnership && componentOwnership.owner && componentOwnership.owner.ownerRef"
+                                                        size="small" :loading="savingOwner" @click="clearOwner">
+                                                        Clear owner
+                                                    </n-button>
                                                 </div>
                                                 <span class="text-muted" style="margin-top: 4px;">
                                                     The durable owner accountable for this {{ words.component }}. A team is durable (survives members leaving); a single user is flagged non-durable.
@@ -3372,7 +3378,10 @@ const COMPONENT_OWNERSHIP_QUERY = gql`
         component(componentUuid: $componentUuid) {
             uuid
             owner { ownerType ownerRef }
-            ownership { status durable derived reason }
+            # ownerType/ownerRef are selected on ownership too: an owner can come
+            # from an org team-assignment rule, in which case the per-component
+            # stored owner is null but the component IS owned.
+            ownership { ownerType ownerRef status durable derived reason }
         }
     }`
 const GET_USER_GROUPS_QUERY = gql`
@@ -3396,7 +3405,17 @@ const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default
                 : 'error'                // ORPHANED (or unknown) -> needs attention
 
 const ownerLabel = computed<string | null>(() => {
-    const o = componentOwnership.value?.owner
+    // Fall back to the RESOLVED ownership when there is no per-component stored
+    // owner: an org team-assignment rule can own a component without anything
+    // being stored on it. Reading only `owner` showed a green OWNED badge with
+    // no name next to it -- "owned by whom?".
+    // UNSET means "no owner, here is a suggestion" -- ownership.ownerRef is
+    // populated for it, so falling back blindly would print the suggested team
+    // beside an UNSET tag as though it owned the component.
+    const resolved = componentOwnership.value?.ownership
+    const o = componentOwnership.value?.owner?.ownerRef
+        ? componentOwnership.value.owner
+        : (resolved && resolved.status !== 'UNSET' ? resolved : null)
     if (!o || !o.ownerRef) return null
     const list = o.ownerType === 'TEAM' ? userGroups.value : users.value
     const hit = list.find((x: any) => x.value === o.ownerRef)
@@ -3434,6 +3453,29 @@ async function loadUserGroups() {
             .map((g: any) => ({ label: g.name, value: g.uuid }))
     } catch {
         userGroups.value = []
+    }
+}
+
+/**
+ * Removes the stored owner so org team-assignment rules apply again. Sent as an
+ * explicit clearOwner flag because owner:null already means "no change" on the
+ * update input -- there is no way to express "remove it" with owner alone.
+ */
+async function clearOwner() {
+    const uuid = componentData.value?.uuid
+    if (!uuid) return
+    savingOwner.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: SET_COMPONENT_OWNER_MUTATION,
+            variables: { component: { uuid, name: componentData.value.name, clearOwner: true } }
+        })
+        notify('success', 'Owner cleared', 'Team assignment rules now apply to this ' + words.value.component + '.')
+        await loadOwnership()
+    } catch (error: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(error.message))
+    } finally {
+        savingOwner.value = false
     }
 }
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -673,6 +673,12 @@
                         </n-space>
                         </div>
                     </n-modal>
+
+                    <OrgTeamAssignmentRules
+                        :orgUuid="orgResolved"
+                        :isWritable="isWritable"
+                        :teams="userGroups"
+                        :components="allComponents"/>
                 </div>
             </n-tab-pane>
 
@@ -1208,6 +1214,7 @@ import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
 import OrgIntegrations from './OrgIntegrations.vue'
 import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
+import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
 import AiAgentPoliciesOfOrg from './AiAgentPoliciesOfOrg.vue'
 import CommittersOfOrg from './CommittersOfOrg.vue'
 import { FetchPolicy } from '@apollo/client'
@@ -1250,6 +1257,9 @@ async function loadTabSpecificData (tabName: string) {
         ])
         loadInvitedUsers(true)
     } else if (tabName === "userGroups") {
+        // Products as well as components: the team-assignment preview filters on
+        // type, so a PRODUCT/ANY rule would otherwise preview "matches 0".
+        store.dispatch('fetchProducts', orgResolved.value)
         await loadUsers() // Load users for the user selection dropdown
         if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
         loadUserGroups()

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -586,6 +586,70 @@
                                 />
                             </n-space>
 
+                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
+                                <n-h5>
+                                    <n-text depth="1">
+                                        Member Roles:
+                                    </n-text>
+                                </n-h5>
+                                <n-text depth="3" style="font-size: 12px;">
+                                    A role labels who to contact — for example, escalating a KEV finding to the
+                                    team's security specialist. Roles do not grant any permissions.
+                                </n-text>
+                                <n-text v-if="!rosterMembers.length" depth="3" style="font-size: 12px;">
+                                    Add users to the group first, then assign their roles here.
+                                </n-text>
+                                <div v-for="m in rosterMembers" :key="m.uuid"
+                                    style="display: flex; gap: 8px; align-items: center; margin-top: 6px;">
+                                    <span style="min-width: 240px;">{{ m.label }}</span>
+                                    <n-select
+                                        :value="teamRoles[m.uuid]?.role || null"
+                                        :options="constants.TeamRoles"
+                                        placeholder="No role"
+                                        clearable
+                                        style="width: 220px;"
+                                        @update:value="(v: string | null) => setMemberRole(m.uuid, v)"
+                                    />
+                                    <n-input
+                                        v-if="teamRoles[m.uuid]?.role === constants.TeamRoleCustom"
+                                        :value="teamRoles[m.uuid]?.customRole || ''"
+                                        placeholder="Custom role label (required)"
+                                        style="width: 240px;"
+                                        @update:value="(v: string) => setMemberCustomRole(m.uuid, v)"
+                                    />
+                                </div>
+                            </n-space>
+
+                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
+                                <n-h5>
+                                    <n-text depth="1">
+                                        External Members (no ReARM account):
+                                    </n-text>
+                                </n-h5>
+                                <n-text depth="3" style="font-size: 12px;">
+                                    People reachable only by email or handle, such as a vendor contact. They can be
+                                    notified, but do not count toward the team's durability.
+                                </n-text>
+                                <n-dynamic-input
+                                    v-model:value="teamExternalMembers"
+                                    :on-create="onAddExternalMember"
+                                >
+                                    <template #default="{ value }">
+                                        <div style="display: flex; gap: 8px; width: 100%;">
+                                            <n-input v-model:value="value.name"
+                                                placeholder="Name" style="width: 200px;" />
+                                            <n-input v-model:value="value.contact"
+                                                placeholder="Email or handle" style="width: 240px;" />
+                                            <n-select v-model:value="value.role" :options="constants.TeamRoles"
+                                                placeholder="No role" clearable style="width: 200px;" />
+                                            <n-input v-if="value.role === constants.TeamRoleCustom"
+                                                v-model:value="value.customRole"
+                                                placeholder="Custom role label" style="width: 200px;" />
+                                        </div>
+                                    </template>
+                                </n-dynamic-input>
+                            </n-space>
+
                             <ScopedPermissions
                                 v-model="userGroupScopedPermissions"
                                 :org-uuid="orgResolved"
@@ -597,10 +661,13 @@
                                 :clusters="orgClusters"
                             />
                         </n-flex>
+                        <n-alert v-if="teamMembersError" type="warning" style="margin-top: 16px;">
+                            {{ teamMembersError }}
+                        </n-alert>
                         <n-space style="margin-top: 20px;">
                             <n-button v-if="restoreMode" type="success" @click="confirmRestoreUserGroup">Restore Group</n-button>
                             <template v-else-if="userGroupPermissionsDirty">
-                                <n-button type="success" @click="updateUserGroup">Save Changes</n-button>
+                                <n-button type="success" :disabled="!!teamMembersError" @click="updateUserGroup">Save Changes</n-button>
                                 <n-button type="warning" @click="editUserGroup(selectedUserGroup.uuid)">Reset Changes</n-button>
                             </template>
                         </n-space>
@@ -1129,6 +1196,8 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
 import constants from '../utils/constants'
+import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
+import { buildMemberRolesPayload, buildExternalMembersPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
@@ -1846,14 +1915,80 @@ const userPermissionsDirty = computed(() => {
     return commonFunctions.stableStringify(userScopedPermissions.value) !== commonFunctions.stableStringify(userScopedPermissionsOriginal.value)
 })
 
+// Projects the modal's editable state. NOTE the team-member keys come from
+// the module-level editor refs (teamRoles / teamExternalMembers), not from
+// `group` -- they are per-modal editor state, not part of the group record.
 function getUserGroupEditableState(group: any) {
     return {
         name: group?.name || '',
         description: group?.description || '',
         manualUsers: group?.manualUsers || [],
-        connectedSsoGroups: group?.connectedSsoGroups || []
+        connectedSsoGroups: group?.connectedSsoGroups || [],
+        // Compare the NORMALIZED payload, not the raw editor arrays -- otherwise
+        // an untouched blank row added by "+" (or stray whitespace) reads as
+        // dirty while producing nothing to save.
+        memberRoles: teamMemberRolesPayload(),
+        externalMembers: teamExternalMembersPayload()
     }
 }
+
+// Keyed by user uuid rather than held as a list: the backend rejects two roles
+// for the same member, and a per-member map makes that impossible to express.
+const teamRoles: Ref<TeamRoleMap> = ref({})
+const teamExternalMembers: Ref<any[]> = ref([])
+
+/**
+ * True only when we have actually loaded this group's team data. Guards both
+ * rendering and the save payload: hydrating an empty editor from a not-yet-
+ * loaded map and then saving would send [], which the backend applies as a
+ * REPLACE -- wiping the team's roles and external members.
+ */
+const teamMembersKnown = computed(() =>
+    teamFieldsSupported.value === true
+    && !!selectedUserGroup.value?.uuid
+    && !!groupTeamMembers.value[selectedUserGroup.value.uuid])
+
+/** Roster members eligible for a role: manually-added plus SSO-inherited. */
+const rosterMembers = computed(() => {
+    const ids = [
+        ...(selectedUserGroup.value?.manualUsers || []),
+        ...(selectedUserGroup.value?.users || [])
+    ]
+    return [...new Set(ids)].map((uuid: any) => ({
+        uuid,
+        label: userOptions.value.find((o: any) => o.value === uuid)?.label || uuid
+    }))
+})
+
+function memberLabelFor(uuid: string): string {
+    return rosterMembers.value.find(m => m.uuid === uuid)?.label || uuid
+}
+
+function teamMemberRolesPayload() {
+    return buildMemberRolesPayload(teamRoles.value, rosterMembers.value.map(m => m.uuid))
+}
+
+function teamExternalMembersPayload() {
+    return buildExternalMembersPayload(teamExternalMembers.value)
+}
+
+function setMemberRole(uuid: string, role: string | null) {
+    teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), role }
+}
+
+function setMemberCustomRole(uuid: string, customRole: string) {
+    teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), customRole }
+}
+
+function onAddExternalMember() {
+    return { name: '', contact: '', role: null, customRole: '' }
+}
+
+/** Pre-submit mirror of the backend rules, so an invalid row names itself
+ *  instead of failing the whole mutation with a generic server error. */
+const teamMembersError = computed(() => teamMembersKnown.value
+    ? validateTeamMembers(teamMemberRolesPayload(), teamExternalMembersPayload(), memberLabelFor)
+    : null)
 
 const userGroupPermissionsDirty = computed(() => {
     const scopedDirty = userGroupScopedPermissionsOriginal.value
@@ -1949,6 +2084,58 @@ async function loadUserGroups() {
     } catch (error: any) {
         console.error('Error loading user groups:', error)
         notify('error', 'Error', 'Failed to load user groups')
+    }
+    await loadTeamMemberFields()
+}
+
+// Team member roles + external members (T1) are loaded by a SEPARATE query on
+// purpose. Folding these fields into getUserGroups above would make the whole
+// User Groups tab fail against a backend that predates them -- the same
+// field-selection drift that has broken a tab before. Isolated here, a lagging
+// backend costs us only these two optional sections, which we then hide.
+//
+// null = not probed yet. The distinction matters: the backend treats a non-null
+// list as a REPLACE, so sending [] because we had not loaded yet would silently
+// delete every role and external member on the team. Unknown => render nothing
+// and send nothing (omitted = keep).
+const teamFieldsSupported: Ref<boolean | null> = ref(null)
+const groupTeamMembers: Ref<Record<string, any>> = ref({})
+
+async function loadTeamMemberFields() {
+    try {
+        const response = await graphqlClient.query({
+            query: gql`
+                query getUserGroupsTeamMembers($org: ID!) {
+                    getUserGroups(org: $org) {
+                        uuid
+                        memberRoles { userRef role customRole }
+                        externalMembers { name contact role customRole }
+                    }
+                }`,
+            variables: { org: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        const map: Record<string, any> = {}
+        for (const g of (response.data.getUserGroups || [])) {
+            map[g.uuid] = {
+                memberRoles: g.memberRoles || [],
+                externalMembers: g.externalMembers || []
+            }
+        }
+        groupTeamMembers.value = map
+        teamFieldsSupported.value = true
+    } catch (error: any) {
+        // Only a schema-drift-shaped failure means "this backend is older".
+        // A 401/500/network blip must NOT be mistaken for that: this flag also
+        // gates the save payload, so misclassifying would strip roles and
+        // external members from the next save with no operator-visible signal.
+        if (isSchemaDriftError(error)) {
+            console.warn('Team member fields unavailable on this backend', error?.message)
+            teamFieldsSupported.value = false
+        } else {
+            groupTeamMembers.value = {}
+            notify('error', 'Error', 'Failed to load team member roles')
+        }
     }
 }
 
@@ -3956,6 +4143,10 @@ async function createUserGroup() {
 
 async function updateUserGroup() {
     if (!selectedUserGroup.value.uuid) return
+    if (teamMembersError.value) {
+        notify('error', 'Cannot save', teamMembersError.value)
+        return
+    }
     
     try {
         const scopedData = userGroupScopedPermissions.value
@@ -4000,6 +4191,13 @@ async function updateUserGroup() {
             status: selectedUserGroup.value.status,
             connectedSsoGroups: selectedUserGroup.value.connectedSsoGroups || [],
             permissions
+        } as any
+        // Only send the team fields when this group's data was actually loaded.
+        // Omitting them means "keep existing" on the backend; sending [] would
+        // REPLACE, i.e. delete. Never send from an unknown state.
+        if (teamMembersKnown.value) {
+            updateInput.memberRoles = teamMemberRolesPayload()
+            updateInput.externalMembers = teamExternalMembersPayload()
         }
         
         const response = await graphqlClient.mutate({
@@ -4034,6 +4232,18 @@ async function editUserGroup(groupUuid: string) {
     const group = userGroups.value.find(g => g.uuid === groupUuid)
     if (group) {
         selectedUserGroup.value = commonFunctions.deepCopy(group)
+        const tm = groupTeamMembers.value[groupUuid] || { memberRoles: [], externalMembers: [] }
+        const roleMap: Record<string, any> = {}
+        for (const mr of tm.memberRoles) {
+            roleMap[mr.userRef] = { role: mr.role, customRole: mr.customRole || '' }
+        }
+        teamRoles.value = roleMap
+        teamExternalMembers.value = commonFunctions.deepCopy(tm.externalMembers).map((e: any) => ({
+            name: e.name || '',
+            contact: e.contact || '',
+            role: e.role || null,
+            customRole: e.customRole || ''
+        }))
         await Promise.all([
             loadPerspectives(),
             store.dispatch('fetchComponents', orgResolved.value),

--- a/ui/src/components/OrgTeamAssignmentRules.vue
+++ b/ui/src/components/OrgTeamAssignmentRules.vue
@@ -1,0 +1,278 @@
+<template>
+    <div class="team-assignment-rules" v-if="!loadFailed">
+        <div class="header">
+            <h4>Team Assignment Rules</h4>
+            <n-tooltip trigger="hover">
+                <template #trigger>
+                    <n-icon size="16" style="cursor: help;"><QuestionMark/></n-icon>
+                </template>
+                Assign an owner team by name pattern instead of picking one on every
+                component. When a component has no owner of its own, the list below is
+                walked in order and the first rule whose name regex AND type filter
+                match becomes its owner. A per-component owner always wins. List order
+                is the priority order — reorder with the up/down arrows.
+            </n-tooltip>
+        </div>
+
+        <div class="actions">
+            <n-button v-if="isWritable" type="primary" @click="openAdd">
+                <template #icon><n-icon><CirclePlus/></n-icon></template>
+                Add rule
+            </n-button>
+        </div>
+
+        <n-data-table
+            :columns="columns"
+            :data="rules"
+            :pagination="false"
+            :bordered="false"/>
+
+        <n-modal
+            preset="dialog"
+            :show-icon="false"
+            style="width: 600px;"
+            v-model:show="editorOpen"
+            :title="editorTitle">
+            <n-form :model="draft" label-placement="top" class="mt-3">
+                <n-form-item label="Name" required>
+                    <n-input v-model:value="draft.name" placeholder="e.g. Frontend components"/>
+                </n-form-item>
+                <n-form-item label="Component name regex" required>
+                    <n-input v-model:value="draft.namePattern" placeholder="frontend-.*"/>
+                </n-form-item>
+                <n-form-item label="Applies to" required>
+                    <n-radio-group v-model:value="draft.componentType">
+                        <n-radio value="ANY">Components and products</n-radio>
+                        <n-radio value="COMPONENT">Components only</n-radio>
+                        <n-radio value="PRODUCT">Products only</n-radio>
+                    </n-radio-group>
+                </n-form-item>
+                <n-form-item label="Owner Team" required>
+                    <n-select
+                        v-model:value="draft.ownerTeam"
+                        :options="teamOptions"
+                        placeholder="Select a team"/>
+                </n-form-item>
+                <!-- Match preview: a pattern here can claim hundreds of components at
+                     once, so show the blast radius before saving rather than after. -->
+                <n-alert :type="previewType" style="margin-bottom: 12px;">
+                    <template #header>{{ previewHeader }}</template>
+                    <div v-if="preview.names.length" style="font-size: 12px;">
+                        {{ preview.names.join(', ') }}
+                        <span v-if="preview.more > 0"> and {{ preview.more }} more</span>
+                    </div>
+                    <div style="font-size: 11px; opacity: 0.75; margin-top: 4px;">
+                        Preview only — evaluated in your browser. The server matches with
+                        Java regex, which differs in rare edge cases.
+                    </div>
+                </n-alert>
+                <n-space>
+                    <n-button type="primary" :disabled="!canSave" @click="saveDraft">Save</n-button>
+                    <n-button @click="editorOpen = false">Cancel</n-button>
+                </n-space>
+            </n-form>
+        </n-modal>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, h, onMounted, reactive, ref } from 'vue'
+import { useStore } from 'vuex'
+import {
+    NAlert, NButton, NDataTable, NForm, NFormItem, NIcon, NInput, NModal, NRadio, NRadioGroup,
+    NSelect, NSpace, NTooltip, useNotification
+} from 'naive-ui'
+import { CirclePlus, QuestionMark, Edit as EditIcon, Trash, ArrowUp, ArrowDown } from '@vicons/tabler'
+import { previewMatches } from '@/utils/teamAssignmentPreview'
+
+const props = defineProps<{
+    orgUuid: string,
+    isWritable: boolean,
+    // Teams and components are already loaded by the parent; passing them in
+    // avoids a second round of queries just to label rows and preview matches.
+    teams: any[],
+    components: any[]
+}>()
+
+const store = useStore()
+const notification = useNotification()
+
+const rules = ref<any[]>([])
+
+const editorOpen = ref(false)
+const editingIndex = ref<number | null>(null)
+const draft = reactive({
+    name: '',
+    namePattern: '',
+    componentType: 'ANY' as 'ANY' | 'COMPONENT' | 'PRODUCT',
+    ownerTeam: ''
+})
+
+const editorTitle = computed(() => editingIndex.value === null ? 'Add rule' : 'Edit rule')
+
+const teamOptions = computed(() => (props.teams || [])
+    .filter((t: any) => t.status !== 'INACTIVE')
+    .map((t: any) => ({ label: t.name || t.uuid, value: t.uuid })))
+
+const teamLabel = (uuid: string) => {
+    if (!uuid) return '—'
+    const found = (props.teams || []).find((t: any) => t.uuid === uuid)
+    if (!found) return uuid + ' (missing)'
+    if (found.status === 'INACTIVE') return found.name + ' (archived)'
+    return found.name || uuid
+}
+
+const typeLabel = (t: string | null | undefined) => {
+    if (!t || t === 'ANY') return 'Any (Components and products)'
+    if (t === 'COMPONENT') return 'Components only'
+    if (t === 'PRODUCT') return 'Products only'
+    return t
+}
+
+const preview = computed(() =>
+    previewMatches(draft.namePattern, draft.componentType, props.components))
+
+const previewType = computed(() => {
+    if (!preview.value.previewable) return 'warning'
+    return preview.value.total === 0 ? 'warning' : 'success'
+})
+
+const previewHeader = computed(() => {
+    if (!draft.namePattern) return 'Enter a pattern to preview which components it matches'
+    // Java accepts constructs JS does not (possessive quantifiers, atomic
+    // groups). That means "cannot preview here", not "invalid" -- the server is
+    // the authority, so we say so and still allow saving.
+    if (!preview.value.previewable) return 'Cannot preview this pattern in the browser'
+    if (preview.value.total === 0) return 'Matches no components right now'
+    return `Matches ${preview.value.total} component${preview.value.total === 1 ? '' : 's'}`
+})
+
+const canSave = computed(() => !!(draft.name && draft.namePattern && draft.ownerTeam))
+
+const resetDraft = () => {
+    draft.name = ''
+    draft.namePattern = ''
+    draft.componentType = 'ANY'
+    draft.ownerTeam = ''
+}
+
+const openAdd = () => {
+    resetDraft()
+    editingIndex.value = null
+    editorOpen.value = true
+}
+
+const openEdit = (idx: number) => {
+    const r = rules.value[idx]
+    draft.name = r.name
+    draft.namePattern = r.namePattern
+    draft.componentType = r.componentType || 'ANY'
+    draft.ownerTeam = r.ownerTeam
+    editingIndex.value = idx
+    editorOpen.value = true
+}
+
+const saveDraft = async () => {
+    if (!canSave.value) return
+    const ruleObject = {
+        name: draft.name,
+        namePattern: draft.namePattern,
+        componentType: draft.componentType,
+        ownerTeam: draft.ownerTeam
+    }
+    const next = rules.value.slice()
+    if (editingIndex.value === null) next.push(ruleObject)
+    else next.splice(editingIndex.value, 1, ruleObject)
+    await persist(next, 'Rule saved.')
+    editorOpen.value = false
+}
+
+const remove = async (idx: number) => {
+    const next = rules.value.slice()
+    next.splice(idx, 1)
+    await persist(next, 'Rule deleted.')
+}
+
+const move = async (idx: number, delta: number) => {
+    const target = idx + delta
+    if (target < 0 || target >= rules.value.length) return
+    const next = rules.value.slice()
+    const [item] = next.splice(idx, 1)
+    next.splice(target, 0, item)
+    await persist(next, 'Rule reordered.')
+}
+
+const persist = async (next: any[], successMsg: string) => {
+    try {
+        rules.value = await store.dispatch('setGlobalTeamAssignmentRules', {
+            orgUuid: props.orgUuid,
+            rules: next.map((r: any) => ({
+                name: r.name,
+                namePattern: r.namePattern,
+                componentType: r.componentType || 'ANY',
+                ownerTeam: r.ownerTeam
+            }))
+        })
+        notification.success({ title: 'Saved', content: successMsg, duration: 3500 })
+    } catch (e: any) {
+        notification.error({ title: 'Save failed', content: e?.message || 'Unknown error', duration: 6000 })
+    }
+}
+
+const columns = computed(() => [
+    { title: 'Order', key: 'order', width: 70, render: (_: any, idx: number) => `${idx + 1}` },
+    { title: 'Name', key: 'name' },
+    { title: 'Component name regex', key: 'namePattern' },
+    { title: 'Applies to', key: 'componentType', render: (row: any) => typeLabel(row.componentType) },
+    { title: 'Owner Team', key: 'ownerTeam', render: (row: any) => teamLabel(row.ownerTeam) },
+    {
+        title: 'Actions',
+        key: 'actions',
+        width: 200,
+        render: (row: any, idx: number) => h('div', { style: 'display: flex; gap: 6px;' },
+            props.isWritable ? [
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move up', onClick: () => move(idx, -1) },
+                    { default: () => h(ArrowUp) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Move down', onClick: () => move(idx, 1) },
+                    { default: () => h(ArrowDown) }),
+                h(NIcon, { size: 22, class: 'clickable', title: 'Edit', onClick: () => openEdit(idx) },
+                    { default: () => h(EditIcon) }),
+                h(NIcon, { size: 22, class: 'clickable', style: 'color: #d03050;', title: 'Delete',
+                    onClick: () => remove(idx) }, { default: () => h(Trash) })
+            ] : [])
+    }
+])
+
+const loadFailed = ref(false)
+
+onMounted(async () => {
+    try {
+        rules.value = (await store.dispatch('fetchOrgTeamAssignmentRules', props.orgUuid)) || []
+    } catch (e: any) {
+        // A backend predating this feature would otherwise leave an empty table
+        // with a live Add button that can only fail.
+        console.warn('Team assignment rules unavailable on this backend', e?.message)
+        loadFailed.value = true
+    }
+})
+</script>
+
+<style scoped lang="scss">
+.team-assignment-rules {
+    padding: 0.5rem 0;
+    margin-top: 1.5rem;
+}
+.header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+.actions {
+    margin-bottom: 0.75rem;
+}
+.mt-3 { margin-top: 0.75rem; }
+.clickable {
+    cursor: pointer;
+}
+</style>

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1266,6 +1266,36 @@ const storeObject : any = {
             const found = orgs.find((o: any) => o.uuid === orgUuid)
             return found?.globalApprovalPolicyRules || []
         },
+        async fetchOrgTeamAssignmentRules (context: any, orgUuid: string) {
+            // organizations (plural, no args) is the resolver the org-settings
+            // surfaces use -- the single-org organization(orgUuid:) query returns
+            // null here. Same shape as fetchOrgApprovalPolicyRules above.
+            const response = await graphqlClient.query({
+                query: gql`
+                    query orgTeamAssignmentRules {
+                        organizations {
+                            uuid
+                            globalTeamAssignmentRules { name namePattern componentType ownerTeam }
+                        }
+                    }`,
+                fetchPolicy: 'no-cache'
+            })
+            const orgs = response.data.organizations || []
+            return orgs.find((o: any) => o.uuid === orgUuid)?.globalTeamAssignmentRules || []
+        },
+        async setGlobalTeamAssignmentRules (context: any, payload: { orgUuid: string, rules: any[] }) {
+            const data = await graphqlClient.mutate({
+                mutation: gql`
+                    mutation setGlobalTeamAssignmentRules($orgUuid: ID!, $rules: [GlobalTeamAssignmentRuleInput!]!) {
+                        setGlobalTeamAssignmentRules(orgUuid: $orgUuid, rules: $rules) {
+                            uuid
+                            globalTeamAssignmentRules { name namePattern componentType ownerTeam }
+                        }
+                    }`,
+                variables: { orgUuid: payload.orgUuid, rules: payload.rules }
+            })
+            return data.data.setGlobalTeamAssignmentRules.globalTeamAssignmentRules || []
+        },
         async setGlobalApprovalPolicyRules (context: any, payload: { orgUuid: string, rules: any[] }) {
             const data = await graphqlClient.mutate({
                 mutation: gql`

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -223,6 +223,19 @@ const BATCH_MODE_HELP = {
     exampleJson: '[{"name": "lodash", "version": "4.17.21"}, {"name": "express"}]'
 }
 
+// Team member roles (backend TeamRole enum). A role is an addressing LABEL --
+// it never grants access. CUSTOM carries an operator-supplied label alongside.
+const TEAM_ROLE_CUSTOM = 'CUSTOM'
+const TEAM_ROLES = [
+    { label: 'Team Lead', value: 'TEAM_LEAD' },
+    { label: 'Security Specialist', value: 'SECURITY_SPECIALIST' },
+    { label: 'Developer', value: 'DEVELOPER' },
+    { label: 'QA', value: 'QA' },
+    { label: 'Project Manager', value: 'PROJECT_MANAGER' },
+    { label: 'Product Manager', value: 'PRODUCT_MANAGER' },
+    { label: 'Custom...', value: TEAM_ROLE_CUSTOM }
+]
+
 export default {
     VersionTypes: VERSION_TYPES,
     BranchVersionTypes: BRANCH_VERSION_TYPES,
@@ -258,5 +271,7 @@ export default {
     PermissionTypes: PERMISSION_TYPES,
     PermissionTypesWithAdmin: PERMISSION_TYPES_WITH_ADMIN,
     PermissionFunctions: PERMISSION_FUNCTIONS,
-    EssentialReadPermissionFunctions: ESSENTIAL_READ_PERMISSION_FUNCTIONS
+    EssentialReadPermissionFunctions: ESSENTIAL_READ_PERMISSION_FUNCTIONS,
+    TeamRoles: TEAM_ROLES,
+    TeamRoleCustom: TEAM_ROLE_CUSTOM
 }

--- a/ui/src/utils/teamAssignmentPreview.spec.ts
+++ b/ui/src/utils/teamAssignmentPreview.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { previewMatches } from './teamAssignmentPreview'
+
+const comps = [
+    { name: 'rebom-backend', type: 'COMPONENT' },
+    { name: 'rebom-frontend', type: 'COMPONENT' },
+    { name: 'Rebom Suite', type: 'PRODUCT' },
+    { name: 'unrelated', type: 'COMPONENT' },
+]
+
+describe('previewMatches', () => {
+    it('anchors fully, matching the backend Pattern.matcher(...).matches()', () => {
+        // "rebom-" would match as a prefix but must NOT match the whole name.
+        expect(previewMatches('rebom-', 'ANY', comps).total).toBe(0)
+        expect(previewMatches('rebom-.*', 'ANY', comps).total).toBe(2)
+    })
+
+    it('honours the component type filter', () => {
+        expect(previewMatches('.*', 'PRODUCT', comps).total).toBe(1)
+        expect(previewMatches('.*', 'COMPONENT', comps).total).toBe(3)
+        expect(previewMatches('.*', 'ANY', comps).total).toBe(4)
+    })
+
+    it('truncates and reports the remainder', () => {
+        const many = Array.from({ length: 12 }, (_, i) => ({ name: `c${i}`, type: 'COMPONENT' }))
+        const r = previewMatches('c.*', 'ANY', many, 8)
+        expect(r.names).toHaveLength(8)
+        expect(r.more).toBe(4)
+        expect(r.total).toBe(12)
+    })
+
+    it('reports not-previewable rather than throwing on a JS-invalid pattern', () => {
+        const r = previewMatches('[unclosed', 'ANY', comps)
+        expect(r.previewable).toBe(false)
+        expect(r.total).toBe(0)
+    })
+
+    it('treats Java-only syntax as not-previewable, not invalid', () => {
+        // Possessive quantifiers are valid Java and rejected by JS. The caller
+        // must NOT block saving on this -- the server is the authority.
+        const r = previewMatches('a*+', 'ANY', comps)
+        expect(r.previewable).toBe(false)
+    })
+
+    it('empty pattern previews nothing without erroring', () => {
+        const r = previewMatches('', 'ANY', comps)
+        expect(r.previewable).toBe(true)
+        expect(r.total).toBe(0)
+    })
+})

--- a/ui/src/utils/teamAssignmentPreview.ts
+++ b/ui/src/utils/teamAssignmentPreview.ts
@@ -1,0 +1,53 @@
+// Pure logic for the team-assignment rule match preview. Extracted from the SFC
+// so the one thing most likely to drift silently -- anchoring parity with the
+// backend -- is unit-tested.
+//
+// The backend matches with Pattern.matcher(name).matches(), i.e. FULLY ANCHORED.
+// Anchoring here too is what keeps the preview honest; without it the preview
+// would over-report (a substring match would look like a hit).
+
+export interface PreviewResult {
+    // false only when the pattern cannot be compiled by the JS engine. Note the
+    // Java engine accepts constructs JS does not (possessive quantifiers,
+    // atomic groups, inline flags), so this is "cannot preview", NOT "invalid" --
+    // callers must not block saving on it.
+    previewable: boolean
+    error: string
+    total: number
+    names: string[]
+    more: number
+}
+
+export interface PreviewComponent { name?: string, type?: string }
+
+export const PREVIEW_LIMIT = 8
+
+export function previewMatches (
+    pattern: string,
+    componentType: string,
+    components: PreviewComponent[],
+    limit: number = PREVIEW_LIMIT,
+): PreviewResult {
+    if (!pattern) return { previewable: true, error: '', total: 0, names: [], more: 0 }
+    let re: RegExp
+    try {
+        re = new RegExp(`^(?:${pattern})$`)
+    } catch (e: any) {
+        return {
+            previewable: false,
+            error: e?.message || 'Cannot preview this pattern in the browser',
+            total: 0, names: [], more: 0
+        }
+    }
+    const matched = (components || [])
+        .filter(c => componentType === 'ANY' || !componentType || c.type === componentType)
+        .filter(c => re.test(c.name || ''))
+        .map(c => c.name as string)
+    return {
+        previewable: true,
+        error: '',
+        total: matched.length,
+        names: matched.slice(0, limit),
+        more: Math.max(0, matched.length - limit)
+    }
+}

--- a/ui/src/utils/teamMembers.spec.ts
+++ b/ui/src/utils/teamMembers.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import {
+    buildMemberRolesPayload,
+    buildExternalMembersPayload,
+    validateTeamMembers,
+} from './teamMembers'
+
+const A = '11111111-1111-1111-1111-111111111111'
+const B = '22222222-2222-2222-2222-222222222222'
+const label = (u: string) => (u === A ? 'Alice' : u === B ? 'Bob' : u)
+
+describe('buildMemberRolesPayload', () => {
+    it('emits a role for a roster member', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'QA' } }, [A]))
+            .toEqual([{ userRef: A, role: 'QA', customRole: null }])
+    })
+
+    it('drops a role for someone removed from the roster in this session', () => {
+        // The backend rejects a role whose userRef is not on the post-merge
+        // roster, and that rejection fails the WHOLE mutation -- so the editor
+        // must never emit one.
+        expect(buildMemberRolesPayload({ [A]: { role: 'QA' }, [B]: { role: 'TEAM_LEAD' } }, [A]))
+            .toEqual([{ userRef: A, role: 'QA', customRole: null }])
+    })
+
+    it('omits a cleared dropdown rather than emitting a null role', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: null, customRole: 'stale' } }, [A])).toEqual([])
+    })
+
+    it('keeps the label only for CUSTOM and trims it', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'CUSTOM', customRole: '  Release Captain  ' } }, [A]))
+            .toEqual([{ userRef: A, role: 'CUSTOM', customRole: 'Release Captain' }])
+    })
+
+    it('nulls a stale label left behind after switching away from CUSTOM', () => {
+        expect(buildMemberRolesPayload({ [A]: { role: 'DEVELOPER', customRole: 'Release Captain' } }, [A]))
+            .toEqual([{ userRef: A, role: 'DEVELOPER', customRole: null }])
+    })
+})
+
+describe('buildExternalMembersPayload', () => {
+    it('drops a wholly blank scaffold row added by "+"', () => {
+        expect(buildExternalMembersPayload([{ name: '', contact: '', role: null, customRole: '' }])).toEqual([])
+    })
+
+    it('keeps a half-filled row so validation can flag it', () => {
+        expect(buildExternalMembersPayload([{ name: 'Vendor', contact: '', role: 'QA' }]))
+            .toEqual([{ name: 'Vendor', contact: '', role: 'QA', customRole: null }])
+    })
+
+    it('trims name and contact', () => {
+        expect(buildExternalMembersPayload([{ name: ' V ', contact: ' v@x.example ', role: 'QA' }]))
+            .toEqual([{ name: 'V', contact: 'v@x.example', role: 'QA', customRole: null }])
+    })
+})
+
+describe('validateTeamMembers', () => {
+    it('passes a well-formed payload', () => {
+        expect(validateTeamMembers(
+            [{ userRef: A, role: 'QA', customRole: null }],
+            [{ name: 'V', contact: 'v@x.example', role: 'DEVELOPER', customRole: null }],
+            label)).toBeNull()
+    })
+
+    it('names the member whose CUSTOM role has no label', () => {
+        const err = validateTeamMembers([{ userRef: A, role: 'CUSTOM', customRole: null }], [], label)
+        expect(err).toContain('Alice')
+    })
+
+    it('rejects an external member missing a contact', () => {
+        const err = validateTeamMembers([], [{ name: 'Vendor', contact: '', role: 'QA', customRole: null }], label)
+        expect(err).toContain('Vendor')
+    })
+
+    it('rejects an external member with a CUSTOM role and no label', () => {
+        const err = validateTeamMembers(
+            [], [{ name: 'Vendor', contact: 'v@x.example', role: 'CUSTOM', customRole: null }], label)
+        expect(err).toContain('Vendor')
+    })
+})

--- a/ui/src/utils/teamMembers.ts
+++ b/ui/src/utils/teamMembers.ts
@@ -1,0 +1,83 @@
+// Pure payload/validation helpers for the Team editor (member roles + external
+// members). Kept out of the SFC so they are unit-testable, and so the DIRTY
+// comparison and the SAVE payload can be built by the same code -- comparing a
+// raw editor array against a filtered/trimmed payload is what makes a modal
+// look dirty while having nothing to send.
+import constants from '@/utils/constants'
+
+export interface TeamMemberRolePayload {
+    userRef: string
+    role: string
+    customRole: string | null
+}
+
+export interface ExternalTeamMemberPayload {
+    name: string
+    contact: string
+    role: string
+    customRole: string | null
+}
+
+/** Editor state for roles is keyed by user uuid: the backend rejects two roles
+ *  for the same member, and a map cannot express that. */
+export type TeamRoleMap = Record<string, { role?: string | null, customRole?: string | null }>
+
+function customLabel (role: string | null | undefined, customRole: string | null | undefined): string | null {
+    return role === constants.TeamRoleCustom ? ((customRole || '').trim() || null) : null
+}
+
+/**
+ * Roles for members still on the roster. Anyone dropped from the group in this
+ * editing session is excluded -- the backend rejects a role whose userRef is not
+ * on the post-merge roster, so emitting one would fail the entire mutation.
+ */
+export function buildMemberRolesPayload (roles: TeamRoleMap, rosterUuids: string[]): TeamMemberRolePayload[] {
+    const roster = new Set(rosterUuids)
+    return Object.entries(roles || {})
+        .filter(([uuid, v]) => !!v && !!v.role && roster.has(uuid))
+        .map(([uuid, v]) => ({
+            userRef: uuid,
+            role: v.role as string,
+            customRole: customLabel(v.role, v.customRole)
+        }))
+}
+
+/** Rows where BOTH name and contact are blank are treated as untouched scaffolding
+ *  and dropped; a half-filled row is kept so validation can flag it. */
+export function buildExternalMembersPayload (rows: any[]): ExternalTeamMemberPayload[] {
+    return (rows || [])
+        .filter(r => (r.name || '').trim() || (r.contact || '').trim())
+        .map(r => ({
+            name: (r.name || '').trim(),
+            contact: (r.contact || '').trim(),
+            role: r.role,
+            customRole: customLabel(r.role, r.customRole)
+        }))
+}
+
+/**
+ * Mirrors the backend's rejection rules so the operator gets a specific,
+ * pre-submit message naming the offending member -- instead of a generic
+ * server error that also aborts unrelated permission/SSO edits made in the
+ * same modal. Returns null when the payload is submittable.
+ */
+export function validateTeamMembers (
+    roles: TeamMemberRolePayload[],
+    externals: ExternalTeamMemberPayload[],
+    labelFor: (uuid: string) => string,
+): string | null {
+    for (const r of roles) {
+        if (r.role === constants.TeamRoleCustom && !r.customRole) {
+            return `Enter a custom role label for ${labelFor(r.userRef)}, or pick a listed role.`
+        }
+    }
+    for (const e of externals) {
+        if (!e.name || !e.contact) {
+            return `External member "${e.name || e.contact}" needs both a name and a contact.`
+        }
+        if (e.role === constants.TeamRoleCustom && !e.customRole) {
+            return `Enter a custom role label for external member "${e.name}", or pick a listed role.`
+        }
+    }
+    return null
+}


### PR DESCRIPTION
UI for **rearm-saas #374** (depends on it).

Adds a **Team Assignment Rules** editor and closes the "cannot un-pin an owner" gap that T2 created.

## What it adds
- **Rules editor** — a clone of `OrgGlobalApprovalPolicyRules.vue` with the policy select swapped for an owner-team select, so the two org-wide rule surfaces behave identically (ordered table, ↑↓ reorder, edit/delete, first-match-wins tooltip, whole-list replace).
- **Match preview** — *"Matches 3 components: Apache Log4j API, Apache Log4j Core, Apache Log4j2"* live as you type. The sibling has none, but a team-assignment pattern can claim hundreds of components at once, so the blast radius belongs in front of the operator **before** saving.
- **Clear owner** — a button on the component Owner section (shown only when a stored owner exists) sending the new `clearOwner` flag, handing the component back to rule-based assignment.

## Deliberate divergence from the sibling
**Placement**: Org Settings → **User Groups**, next to the teams themselves, rather than its own tab under Policies. Decided 2026-07-29 — the admin managing teams is who writes these rules.

## Review fixes applied
- **Preview logic extracted** to `utils/teamAssignmentPreview.ts` + spec. Anchoring parity with the backend (`Pattern.matcher(name).matches()`) is exactly the thing that drifts silently, so it's pinned by tests instead of living inline in the SFC.
- **Save is no longer blocked** when the browser can't parse a pattern. Java accepts constructs JS doesn't (possessive quantifiers, atomic groups) — that means *"cannot preview here"*, not *"invalid"*, and the server is the authority. Copy reworded.
- **`ownerLabel` no longer mislabels a suggestion.** The fallback I added for rule-derived owners was too broad and printed the *suggested* team beside an `UNSET` tag as if it owned the component.
- **`fetchProducts` now dispatched** for the User Groups tab — without it a `PRODUCT`/`ANY` rule previewed "matches 0". Visible in testing: preview went 2 → 3.
- **`onMounted` guarded** so a backend predating the feature hides the section rather than leaving a dead table with a live Add button.
- camelCase prop bindings; dropped a redundant `v-if` inside an already-admin-gated pane.

Also selects `ownership.ownerType/ownerRef` so a **rule-assigned owner renders its team name** — previously a rule-owned component showed a green `OWNED` badge with no owner name at all.

## Testing
6 new unit tests (`teamAssignmentPreview.spec.ts`): anchoring, type filter, truncation, and JS-invalid vs Java-only syntax. Live-validated on the sandbox via UI hot-swap with Playwright — rules list, preview, invalid-pattern handling, save-not-blocked.

## Known follow-ups
The component still takes `teams`/`components` as props, coupling it to `OrgSettings`. The clean fix is a hydrated `ownerTeamDetails` resolver on the backend (the sibling has `approvalPolicyDetails`) — noted on #374.

## Pre-existing, unrelated
`src/utils/notificationInboxSchemaDrift.spec.ts` fails on clean `main` too (CE mirror caught up, stale assertion). Verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)