### PR TITLE
docs(landing): news post for the ReARM 26.07.158 release

### DIFF
--- a/landing_site/src/content/news/2026-07-29-rearm-26-07-158-release.md
+++ b/landing_site/src/content/news/2026-07-29-rearm-26-07-158-release.md
@@ -1,0 +1,62 @@
+---
+title: "ReARM 26.07.158: Notifications, Dependency-Track 5, and Simpler CE Deployment"
+date: "2026-07-29"
+---
+
+We're announcing a major release of ReARM [v26.07.158](https://github.com/relizaio/rearm/releases/tag/26.07.158). Detailed information is available on its [release view](https://demo.rearmhq.com/release/show/85c3651f-2bd1-46c5-a8ce-24cf02d832c8) on the ReARM Demo instance. ReARM Pro installations have already been upgraded; ReARM CE users are encouraged to upgrade to benefit from the changes described below.
+
+
+**Notifications**
+
+The headline of this release is a reworked notifications platform. ReARM now models notification channels, subscriptions that decide which events reach which channels, and channel groups for fanning a single subscription out to several destinations. Every delivery is recorded, so there is a delivery history showing what was sent, where it went, and whether it succeeded — with an expandable payload and deep links back to the release or event that triggered it. Alongside this, each user gets a personalized inbox: a bell in the top navigation with unread counts, severity, filtering, and read state that follows the user rather than the browser.
+
+Supported destinations include Slack, Microsoft Teams, generic HTTPS webhooks with optional bearer-token or HMAC-SHA256 signing, email digests, and Microsoft Sentinel via the Azure Log Analytics ingestion API. Subscriptions can be scoped by event type and severity, and on ReARM Pro they can carry expression-based policies for finer-grained routing. The personalized inbox is available on both editions, and channel configuration is part of ReARM Pro in this release — Slack and Microsoft Teams channels will become available on ReARM CE in future releases.
+
+
+**Dependency-Track 5**
+
+ReARM now supports Dependency-Track 5. The Dependency-Track integration has been substantially rewritten as part of this work, and the integration card in Organization Settings now displays the Dependency-Track version ReARM has detected, so it is immediately clear which backend an organization is talking to.
+
+Organization administrators also get a force re-upload control. This is not a per-BOM action: it re-submits every project for the organization and triggers a full re-analysis, so an organization's entire Dependency-Track state can be rebuilt from ReARM. It is heavier than a routine sync and is intended for recovery — for example after a Dependency-Track migration, or when rebuilding an instance from scratch. Dependency-Track 5 support is available on both ReARM CE and ReARM Pro.
+
+
+**A Helm Chart for Dependency-Track 5**
+
+We are also open-sourcing the Helm chart we use to run Dependency-Track 5 for ReARM, published with its first release, [0.1.3](https://github.com/relizaio/rearm/releases/tag/dependency-track-5-helm-0.1.3). It lives in the ReARM repository under `deploy`, which is MIT licensed, and wraps the official Dependency-Track chart rather than replacing it.
+
+ReARM works with any Dependency-Track instance, so this chart is purely a convenience for teams that do not already run one. Its main advantage is that it serves Dependency-Track on a **single hostname**: Dependency-Track is two services, and deployed as-is that means publishing two hosts, obtaining two certificates, and dealing with cross-origin traffic between the browser and the API. In this chart the frontend proxies `/api` to the API server inside the cluster, so only one host is exposed and the API Server URI and Frontend URI you enter into ReARM are the same value. It also brings a bundled PostgreSQL instance with optional backups, generated database and key-encryption credentials that survive upgrades, digest-pinned images throughout, and compression plus security headers on the frontend. See the [documentation](https://docs.rearmhq.com/integrations/dtrackChart.html) for details.
+
+
+**Simpler ReARM CE Deployment**
+
+Installing ReARM CE no longer requires bringing your own OCI registry. Both the Docker Compose stack and the Helm chart can now run a bundled [zot](https://zotregistry.dev) registry for BOM and artifact storage — enabled by default in Compose and opt-in for Helm — so a first installation needs no external registry and no credentials of your own. An external registry remains fully supported for anyone who prefers one. The Compose stack has also been consolidated onto a single optional `.env` file, and a localhost deployment now needs no configuration at all. The [installation documentation](https://docs.rearmhq.com/installation/) has been rewritten around this.
+
+
+**Known Exploited Vulnerabilities**
+
+This release introduces KEV support in ReARM. Known Exploited Vulnerability data is configured per organization and can be sourced from both the CISA catalog and VulnCheck, with each source recorded as its own assertion rather than collapsed into a single flag — so it is clear which catalog flagged a vulnerability. KEV status is surfaced across the analysis view, the changelog, the home dashboard and trend widgets, with a details modal showing the underlying assertions, including ransomware-campaign context where a source provides it. KEV support is available on both editions.
+
+
+**VEX, VDR and Findings Over Time**
+
+The VEX and VDR import path is substantially deeper this release, including support for source-code-entry all-component artifacts, free-form key artifact upload, and reporting of attestation-deferred statements. Imports now report the result in detail — how many statements were applied and how many found no matching finding — so a partial import is visible at a glance instead of needing to be inferred from the data afterwards. A new *Finding changes over time* changelog tab tracks how a component's findings move between scans, with newly-KEV and severity-increase attribution, branch context, and drill-down into the individual findings behind each change.
+
+
+**Distribution and Component Ownership**
+
+ReARM Pro gains a preview of a new Distribution module, covering clients, sites and shipments with device classification. Component ownership metadata lands alongside it, with approval routing and the *Needs my approval* queue available on ReARM Pro.
+
+
+**Platform Upgrade**
+
+The backend moves to Spring Boot 4.1.0 and Java 25, with Keycloak 26.7.0 and a base image refresh across all components. Keycloak login is hardened with PKCE and refresh-failure recovery, and the UI is now served with security headers and a Content-Security-Policy.
+
+
+**Dependency Updates**
+
+This release contains a number of dependency updates, including those fixing underlying CVEs in dependencies. ReARM users are encouraged to upgrade to this release to benefit from these fixes.
+
+
+**Release Identification**
+
+We are continuing to publish TEIs for all ReARM releases. TEI for this release: *urn:tei:purl:demo.rearmhq.com:pkg:github/relizaio/rearm@26.07.158*.


### PR DESCRIPTION
News post for [v26.07.158](https://github.com/relizaio/rearm/releases/tag/26.07.158), following the format of the previous release posts.

Leads on the three headline items: the reworked **notifications platform**, **Dependency-Track 5 support**, and the **Dependency-Track 5 Helm chart** being open-sourced alongside it. Then the usual sections — simpler CE deployment, KEV, VEX/VDR and findings over time, Distribution, platform upgrade, dependency updates, TEI.

## Edition claims verified in code

Rather than taking the release notes at face value:

- **Dependency-Track 5** — both editions. CE's schema exposes `dependencyTrackVersion` and the CE backend carries the integration changes.
- **KEV** — both editions. CE's schema has the KEV types (`KevRecordDetails`, `KevSourceAssertion`, `KevRansomwareCampaign`) and CE has the per-org VulnCheck integration.
- **Distribution** — genuinely Pro-only. `ClientService`, `SiteService` and `DistributionArchiver` exist only under `service/saas/`.
- **Notifications** — described by capability rather than per-channel edition. The CE backend ships the Slack, Teams and webhook dispatchers (byte-identical service classes to Pro), while the UI currently exposes channel configuration on Pro only. The post states that the inbox is on both editions, channel configuration is Pro in this release, and Slack/Teams are coming to CE.

## Two corrections to what the release notes imply

**Force re-upload is org-wide, not per-BOM.** The mutation is `forceReuploadDtrackData(orgUuid)` and the backend comment says it "rebuilds DTrack projects and forces a full re-analysis". The post describes it as rebuilding an organization's entire Dependency-Track state, with the recovery framing the UI itself warns about ("use for recovery only") — a reader who mistook it for a routine refresh would be in for a heavy surprise.

**KEV is new in this release**, so it is written as an introduction rather than a migration to a multi-source model.

## Verified

- landing site builds; post renders at `/news/2026-07-29-rearm-26-07-158-release/` and appears in the news listing
- all six outbound links resolve (200): GitHub release, demo release view, DT5 chart release, both docs pages, zotregistry.dev
- no pull-request links anywhere, per the house style
- docs links use the `.html` form, which is what the docsite actually serves

🤖 Generated with [Claude Code](https://claude.com/claude-code)