### PR TITLE
fix(ui): show Component Kind on all Pro installation types

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -297,12 +297,12 @@
                                                 </span>
                                             </div>
                                         </div>
-                                        <div class="versionSchemaBlock" v-if="updatedComponent && componentData && (componentData.type === 'COMPONENT') && myUser.installationType === 'SAAS'">
+                                        <div class="versionSchemaBlock" v-if="updatedComponent && componentData && (componentData.type === 'COMPONENT') && supportsComponentKind">
                                             <label  id="componentKindLabel" for="componentKind">Component Kind</label>
                                             <n-select v-if="isWritable" v-on:update:value="updateComponentKind" :options="[{label: 'Generic', value: 'GENERIC'}, {label: 'Helm', value: 'HELM'}]" v-model:value="updatedComponent.kind" clearable />
                                             <n-input v-if="!isWritable" type="text" :value="updatedComponent.kind" readonly/>
                                         </div>
-                                        <div class="versionSchemaBlock" v-if="(updatedComponent && componentData && updatedComponent.kind === 'HELM' && updatedComponent.authentication  && myUser.installationType === 'SAAS')">
+                                        <div class="versionSchemaBlock" v-if="(updatedComponent && componentData && updatedComponent.kind === 'HELM' && updatedComponent.authentication  && supportsComponentKind)">
                                             <label id="componentAuthTypeLabel" for="componentAuthType">Component Auth Type</label>
                                             <n-select v-if="isWritable" :options="componentAuthTypes" v-model:value="updatedComponent.authentication.type" />
                                             <n-input v-if="!isWritable" type="text" :value="updatedComponent.authentication.type" readonly/>
@@ -1259,6 +1259,11 @@ const isComponent : Ref<boolean> = ref(true)
 
 const myUser = store.getters.myuser
 const myPerspective: ComputedRef<string> = computed((): string => store.getters.myperspective)
+
+// Component Kind, and the Helm authentication fields it unlocks, are Pro
+// features: available on every Pro installation type (SAAS, DEMO,
+// MANAGED_SERVICE) and absent only on OSS.
+const supportsComponentKind : boolean = myUser?.installationType !== 'OSS'
 
 const isAdmin : boolean = commonFunctions.isAdmin(orguuid.value, myUser)
 const isWritable : ComputedRef<boolean> = computed((): boolean => {
@@ -2617,7 +2622,7 @@ const componentAuthTypes = [
 const secrets = ref([])
 
 const fetchSecretsIfAllowed = async function() {
-    if (isWritable && myUser.installationType === 'SAAS') {
+    if (isWritable && supportsComponentKind) {
         secrets.value = await loadSecrets(componentData.value.org)
     }
 }


### PR DESCRIPTION
`Component Kind` (GENERIC / HELM) was missing from component settings on the DEMO installation.

## Cause

A UI gate only — `installationType === 'SAAS'` in `ComponentView.vue`. Nothing on the backend restricts it:

- neither `ComponentDataFetcher` nor `ComponentService` reference `InstallationType`
- `kind` is a plain field on `ComponentData`, defaulting to `GENERIC`
- the update mutation accepts it regardless of installation type

So components on DEMO and MANAGED_SERVICE could already hold a kind; there was simply no way to set one.

## Change

Replaces the three SAAS-only gates with a single flag, available on every Pro installation type and absent only on OSS:

```ts
const supportsComponentKind : boolean = myUser?.installationType !== 'OSS'
```

Two of those gates are dependent on the first, and fixing only the selector would have left the Helm path half-configured:

| line | gate | effect if left on SAAS |
|---|---|---|
| 300 | `Component Kind` selector | the reported symptom |
| 305 | `Component Auth Type` (renders when `kind === 'HELM'`) | HELM selectable, auth type unsettable |
| 2625 | `fetchSecretsIfAllowed()` | Auth Login/Password Secret dropdowns are **not** installation-gated, so they would render with an empty option list |

Sharing one flag keeps them from drifting apart again. `ComponentView.vue` is the only UI surface referencing `'HELM'`; `CreateComponent.vue` does not offer kind at creation, so a component starts `GENERIC` and is changed in settings.

## Verification

`npm run build` compiles clean. No `installationType === 'SAAS'` gates remain in the file.

Two pre-existing repo issues meant I could not lint or fully typecheck, only build — both unrelated to this change:

- `vue-tsc` fails on `tsconfig.json` deprecations (`TS5107` `moduleResolution=node10`, `TS5101` `baseUrl`)
- `eslint` cannot run at all; it still expects the legacy `.eslintrc` format and exits with a migration notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)