### PR TITLE
feat(ui): team notification channels + Teams route target (T3)

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -650,6 +650,31 @@
                                 </n-dynamic-input>
                             </n-space>
 
+                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
+                                <n-h5>
+                                    <n-text depth="1">
+                                        Notification Channels:
+                                    </n-text>
+                                </n-h5>
+                                <n-text depth="3" style="font-size: 12px;">
+                                    Where this team is reachable — for example its Slack channel. A subscription
+                                    can then target the team instead of a channel, and if the team moves channel,
+                                    every subscription follows automatically.
+                                </n-text>
+                                <n-alert v-if="orgChannelsFailed" type="warning" style="margin-bottom: 8px;">
+                                    Could not load this organization's channels, so the list below may be
+                                    incomplete. Other team edits still save normally; channel changes are
+                                    skipped until you reload.
+                                </n-alert>
+                                <n-select
+                                    v-model:value="teamChannels"
+                                    multiple
+                                    :options="teamChannelOptions"
+                                    placeholder="No channels — this team can only be reached by email"
+                                    style="width: 100%; min-width: 400px;"
+                                />
+                            </n-space>
+
                             <ScopedPermissions
                                 v-model="userGroupScopedPermissions"
                                 :org-uuid="orgResolved"
@@ -1203,6 +1228,8 @@ import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
 import constants from '../utils/constants'
 import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
+import { buildChannelOptions } from '@/utils/channelOptions'
+import { TYPE_LABELS } from '@/utils/notificationsCommon'
 import { buildMemberRolesPayload, buildExternalMembersPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
@@ -1938,13 +1965,23 @@ function getUserGroupEditableState(group: any) {
         // an untouched blank row added by "+" (or stray whitespace) reads as
         // dirty while producing nothing to save.
         memberRoles: teamMemberRolesPayload(),
-        externalMembers: teamExternalMembersPayload()
+        externalMembers: teamExternalMembersPayload(),
+        notificationChannels: teamChannels.value
     }
 }
 
 // Keyed by user uuid rather than held as a list: the backend rejects two roles
 // for the same member, and a per-member map makes that impossible to express.
 const teamRoles: Ref<TeamRoleMap> = ref({})
+const teamChannels: Ref<string[]> = ref([])
+const orgChannels: Ref<any[]> = ref([])
+const orgChannelsFailed = ref(false)
+
+// Shared builder so a channel that was disabled or deleted after being picked
+// still renders a name here instead of a bare uuid (BUG 2) -- and stays
+// removable so the operator can clear it.
+const teamChannelOptions = computed(() =>
+    buildChannelOptions(orgChannels.value, teamChannels.value, TYPE_LABELS))
 const teamExternalMembers: Ref<any[]> = ref([])
 
 /**
@@ -2096,6 +2133,9 @@ async function loadUserGroups() {
         notify('error', 'Error', 'Failed to load user groups')
     }
     await loadTeamMemberFields()
+    // Outside loadTeamMemberFields' try: a channel-load failure must not reach
+    // its drift classifier and hide all three team sections.
+    await loadOrgChannels()
 }
 
 // Team member roles + external members (T1) are loaded by a SEPARATE query on
@@ -2111,6 +2151,29 @@ async function loadUserGroups() {
 const teamFieldsSupported: Ref<boolean | null> = ref(null)
 const groupTeamMembers: Ref<Record<string, any>> = ref({})
 
+/** Channel list for the Team editor's channel picker. */
+async function loadOrgChannels() {
+    orgChannelsFailed.value = false
+    try {
+        const res = await graphqlClient.query({
+            query: gql`
+                query notificationChannelsForTeams($orgUuid: ID!) {
+                    notificationChannels(orgUuid: $orgUuid) { uuid name type status }
+                }`,
+            variables: { orgUuid: orgResolved.value },
+            fetchPolicy: 'no-cache'
+        })
+        orgChannels.value = res.data?.notificationChannels || []
+    } catch (error: any) {
+        // Do NOT leave orgChannels empty on a transient failure: buildChannelOptions
+        // would then relabel every healthy saved channel as "(deleted channel)".
+        // Flag it instead so the picker can say so.
+        console.warn('Notification channels unavailable', error?.message)
+        orgChannels.value = []
+        orgChannelsFailed.value = true
+    }
+}
+
 async function loadTeamMemberFields() {
     try {
         const response = await graphqlClient.query({
@@ -2120,6 +2183,7 @@ async function loadTeamMemberFields() {
                         uuid
                         memberRoles { userRef role customRole }
                         externalMembers { name contact role customRole }
+                        notificationChannels
                     }
                 }`,
             variables: { org: orgResolved.value },
@@ -2129,7 +2193,8 @@ async function loadTeamMemberFields() {
         for (const g of (response.data.getUserGroups || [])) {
             map[g.uuid] = {
                 memberRoles: g.memberRoles || [],
-                externalMembers: g.externalMembers || []
+                externalMembers: g.externalMembers || [],
+                notificationChannels: g.notificationChannels || []
             }
         }
         groupTeamMembers.value = map
@@ -4206,6 +4271,10 @@ async function updateUserGroup() {
         // Omitting them means "keep existing" on the backend; sending [] would
         // REPLACE, i.e. delete. Never send from an unknown state.
         if (teamMembersKnown.value) {
+            // Omit when the channel list failed to load: sending the current value
+            // would be based on an incomplete picker, and disabling the picker
+            // instead would block every unrelated team edit (rename, members).
+            if (!orgChannelsFailed.value) updateInput.notificationChannels = teamChannels.value
             updateInput.memberRoles = teamMemberRolesPayload()
             updateInput.externalMembers = teamExternalMembersPayload()
         }
@@ -4248,6 +4317,7 @@ async function editUserGroup(groupUuid: string) {
             roleMap[mr.userRef] = { role: mr.role, customRole: mr.customRole || '' }
         }
         teamRoles.value = roleMap
+        teamChannels.value = [...(tm.notificationChannels || [])]
         teamExternalMembers.value = commonFunctions.deepCopy(tm.externalMembers).map((e: any) => ({
             name: e.name || '',
             contact: e.contact || '',

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -155,6 +155,23 @@
                                         </n-form-item>
                                     </n-gi>
                                     <n-gi :span="22" :offset="0">
+                                        <n-form-item :label="i === 0 ? 'Teams (optional)' : ''" :show-feedback="false">
+                                            <n-select
+                                                v-model:value="r.teams"
+                                                :options="teamOptions"
+                                                multiple
+                                                placeholder="(none)"
+                                                clearable
+                                                data-testid="route-teams"
+                                            />
+                                        </n-form-item>
+                                        <div class="muted-12" style="margin-top: -6px; margin-bottom: 6px;">
+                                            Delivers to each team's own notification channels, resolved when the
+                                            event fires — so if a team changes its channel, this route follows
+                                            automatically.
+                                        </div>
+                                    </n-gi>
+                                    <n-gi :span="22" :offset="0">
                                         <n-form-item :label="i === 0 ? 'Perspectives (delivery filter)' : ''" :show-feedback="false">
                                             <n-select
                                                 v-model:value="r.perspectives"
@@ -248,6 +265,8 @@ import { CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabl
 import { useRouter } from 'vue-router'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
+import { buildChannelOptions, withGhosts } from '@/utils/channelOptions'
+import { isSchemaDriftError } from '@/utils/graphqlDriftFallback'
 import {
     ChannelRow, ChannelGroupRow, SubscriptionRow, TYPE_LABELS,
     subscriptionStatusOptions, eventTypeOptions, severityOptions,
@@ -287,6 +306,7 @@ interface SubscriptionRoute {
     whenSeverityAtLeast: string | null
     channels: string[]
     channelGroups: string[]
+    teams: string[]
     // Delivery filter: restricts which events this route's channels deliver
     // to the listed perspectives. NOT the inbox/bell visibility gate. Empty
     // = no restriction (all perspectives).
@@ -317,7 +337,7 @@ interface SubscriptionForm {
 }
 
 function freshRoute (): SubscriptionRoute {
-    return { whenSeverityAtLeast: null, channels: [], channelGroups: [], perspectives: [] }
+    return { whenSeverityAtLeast: null, channels: [], channelGroups: [], teams: [], perspectives: [] }
 }
 
 function freshSubscriptionForm (): SubscriptionForm {
@@ -363,30 +383,31 @@ const eventTypeOptionsForForm = computed(() =>
 )
 
 const channelOptions = computed(() => {
-    const enabled = channels.value
-        .filter(c => c.status === 'ENABLED')
-        .map(c => ({ label: `${c.name} (${TYPE_LABELS[c.type] || c.type})`, value: c.uuid }))
-    const known = new Set(enabled.map(o => o.value))
-    // BUG 2: a route can still reference a channel that is now DISABLED or
-    // DELETED -- neither is in the enabled option list, so the n-select tag would
-    // render a bare UUID. Add a labeled "ghost" option for each already-referenced
-    // value so the tag reads a name (disabled) or "(deleted channel) <short>",
-    // mirroring the Delivery History label. NOT marked `disabled`: a disabled
-    // option makes the selected tag non-removable in n-select, which would trap
-    // the very dangling ref the user came to clean up -- keep it removable.
-    const byUuid = new Map(channels.value.map(c => [c.uuid, c]))
+    // Ghost handling for already-referenced DISABLED/DELETED channels lives in
+    // the shared builder (BUG 2) -- the Team editor needs the identical
+    // behaviour, and a second copy is how that fix silently rots.
     const referenced = new Set<string>()
     for (const r of subForm.value.routes) for (const ch of (r.channels || [])) referenced.add(ch)
-    const ghosts = [...referenced]
-        .filter(u => !known.has(u))
-        .map(u => {
-            const c = byUuid.get(u)
-            const label = c
-                ? `${c.name} (${TYPE_LABELS[c.type] || c.type}) (disabled)`
-                : `(deleted channel) ${String(u).slice(0, 8)}`
-            return { label, value: u }
-        })
-    return [...enabled, ...ghosts]
+    return buildChannelOptions(channels.value, referenced, TYPE_LABELS)
+})
+
+const teams = ref<any[]>([])
+
+const teamOptions = computed(() => {
+    const selectable = teams.value
+        .filter((t: any) => t.status !== 'INACTIVE')
+        .map((t: any) => ({
+            // Surface the channel count: a team with none delivers nothing, and
+            // that is invisible otherwise.
+            label: `${t.name} (${(t.notificationChannels || []).length} ch)`,
+            value: t.uuid,
+        }))
+    const referenced = new Set<string>()
+    for (const r of subForm.value.routes) for (const t of (r.teams || [])) referenced.add(t)
+    // Same shared builder as the channel picker, so the "keep dangling refs
+    // visible and removable" behaviour cannot drift between the two.
+    return withGhosts(selectable, teams.value, referenced,
+        (t: any, uuid) => t ? `${t.name} (deactivated)` : `(deleted team) ${String(uuid).slice(0, 8)}`)
 })
 
 const channelGroupOptions = computed(() =>
@@ -470,6 +491,33 @@ async function loadChannelGroups (): Promise<void> {
     }
 }
 
+async function loadTeams (): Promise<void> {
+    // Isolated query + soft failure: teams-with-channels is a newer field, and a
+    // backend predating it must cost only the Teams route target, not the whole
+    // subscription editor.
+    try {
+        const res = await graphqlClient.query({
+            query: gql`
+                query getUserGroupsForRoutes($org: ID!) {
+                    getUserGroups(org: $org) { uuid name status notificationChannels }
+                }`,
+            variables: { org: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        teams.value = res.data?.getUserGroups || []
+    } catch (e: any) {
+        // Only schema drift means "this backend is older". A 401/5xx must not
+        // blank the list: saved team targets have no ghost source then, and the
+        // route would render bare UUIDs.
+        if (isSchemaDriftError(e)) {
+            console.warn('Team route targets unavailable on this backend', e?.message)
+            teams.value = []
+        } else {
+            message.error(`Failed to load teams: ${extractError(e)}`)
+        }
+    }
+}
+
 async function loadSubscriptions (): Promise<void> {
     subscriptionsLoading.value = true
     try {
@@ -522,6 +570,7 @@ function openEditSubscription (row: SubscriptionRow): void {
                 whenSeverityAtLeast: r.whenSeverityAtLeast || null,
                 channels: Array.isArray(r.channels) ? [...r.channels] : [],
                 channelGroups: Array.isArray(r.channelGroups) ? [...r.channelGroups] : [],
+                teams: Array.isArray(r.teams) ? [...r.teams] : [],
                 perspectives: Array.isArray(r.perspectives) ? [...r.perspectives] : [],
                 _raw: r,
             }))
@@ -556,14 +605,16 @@ async function saveSubscription (): Promise<void> {
         subModalError.value = 'Name, at least one event type, and at least one route are required.'
         return
     }
-    // Every route must have at least one channel or one group; backend
-    // rejects empty {channels, channelGroups} anyway, but catch it
-    // client-side for a cleaner error path.
+    // Every route must have at least one channel, group or team; the backend
+    // rejects an empty {channels, channelGroups, teams} anyway, but catch it
+    // client-side for a cleaner error path. Teams count: naming a team INSTEAD
+    // of a channel is the point -- its channel is resolved at fan-out.
     const emptyRouteIdx = f.routes.findIndex(r =>
         (r.channels || []).length === 0 && (r.channelGroups || []).length === 0
+        && (r.teams || []).length === 0
     )
     if (emptyRouteIdx >= 0) {
-        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels or groups — pick at least one.`
+        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels, groups or teams — pick at least one.`
         return
     }
     // Build the filter input from ONLY the fields NotificationFilterInput
@@ -587,6 +638,7 @@ async function saveSubscription (): Promise<void> {
             whenSeverityAtLeast: r.whenSeverityAtLeast,
             channels: r.channels,
             channelGroups: r.channelGroups,
+            teams: r.teams,
             perspectives: r.perspectives,
         })),
         dedupWindowMinutes: f.dedupWindowMinutes,
@@ -869,6 +921,7 @@ onMounted(async () => {
     await Promise.all([
         loadChannels(),
         loadChannelGroups(),
+        loadTeams(),
         loadSubscriptions(),
         store.dispatch('fetchPerspectives', orgUuid.value),
     ])

--- a/ui/src/utils/channelOptions.spec.ts
+++ b/ui/src/utils/channelOptions.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { buildChannelOptions } from './channelOptions'
+
+const TYPES = { SLACK: 'Slack', EMAIL: 'Email' }
+
+const channels = [
+    { uuid: 'a', name: 'Alerts', type: 'SLACK', status: 'ENABLED' },
+    { uuid: 'b', name: 'Old', type: 'EMAIL', status: 'DISABLED' },
+]
+
+describe('buildChannelOptions', () => {
+    it('lists enabled channels with a type-qualified label', () => {
+        expect(buildChannelOptions(channels, [], TYPES))
+            .toEqual([{ label: 'Alerts (Slack)', value: 'a' }])
+    })
+
+    it('adds a ghost for a referenced DISABLED channel so it is not a bare uuid', () => {
+        const opts = buildChannelOptions(channels, ['b'], TYPES)
+        expect(opts.map(o => o.value)).toEqual(['a', 'b'])
+        expect(opts[1].label).toBe('Old (Email) (disabled)')
+    })
+
+    it('adds a ghost for a referenced DELETED channel', () => {
+        const opts = buildChannelOptions(channels, ['deadbeef-cafe'], TYPES)
+        expect(opts[1].label).toBe('(deleted channel) deadbeef')
+    })
+
+    it('does not duplicate a referenced channel that is still enabled', () => {
+        expect(buildChannelOptions(channels, ['a'], TYPES)).toHaveLength(1)
+    })
+
+    it('does not duplicate the same dangling reference twice', () => {
+        // Two routes can reference the same dead channel; one ghost is enough.
+        expect(buildChannelOptions(channels, ['gone', 'gone'], TYPES)).toHaveLength(2)
+    })
+
+    it('tolerates empty inputs', () => {
+        expect(buildChannelOptions([], [], TYPES)).toEqual([])
+    })
+
+    it('still shows a junk reference so it can be removed', () => {
+        // Hiding a null/'' entry would leave it in the saved data with no way to
+        // clear it -- the opposite of why ghosts exist.
+        const opts = buildChannelOptions(channels, ['' as any], TYPES)
+        expect(opts).toHaveLength(2)
+        expect(opts[1].label).toMatch(/deleted channel/)
+    })
+})

--- a/ui/src/utils/channelOptions.ts
+++ b/ui/src/utils/channelOptions.ts
@@ -1,0 +1,75 @@
+// Shared builder for notification-channel <n-select> options.
+//
+// Extracted because two surfaces now pick channels -- subscription routes and a
+// Team's own channels (T3) -- and the tricky half is identical in both: a saved
+// reference can point at a channel that has since been DISABLED or DELETED.
+// Neither appears in the enabled list, so the select tag would render a bare
+// UUID and the operator could not tell what it was, let alone clean it up.
+// Duplicating that logic is how the second copy silently loses the fix.
+
+export interface ChannelLike {
+    uuid: string
+    name?: string
+    type?: string
+    status?: string
+}
+
+export interface SelectOption {
+    label: string
+    value: string
+}
+
+/**
+ * Generic ghost-option builder. Both channel and team pickers hide entries that
+ * are no longer selectable (disabled channels, deactivated teams) while a saved
+ * reference may still point at one -- and a bare uuid tag is unremovable in
+ * practice because the operator cannot tell what it is. Ghosts are deliberately
+ * NOT marked `disabled`: that makes the tag non-removable in n-select, trapping
+ * the dangling reference the operator opened the editor to clear.
+ */
+export function withGhosts<T extends { uuid: string }>(
+    selectable: SelectOption[],
+    all: T[],
+    referenced: Iterable<string>,
+    ghostLabel: (found: T | undefined, uuid: string) => string,
+): SelectOption[] {
+    const known = new Set(selectable.map(o => o.value))
+    const byUuid = new Map(all.map(x => [x.uuid, x]))
+    const ghosts: SelectOption[] = []
+    const seen = new Set<string>()
+    for (const u of referenced) {
+        if (known.has(u) || seen.has(u)) continue
+        seen.add(u)
+        ghosts.push({ label: ghostLabel(byUuid.get(u), u), value: u })
+    }
+    return [...selectable, ...ghosts]
+}
+
+export function channelLabel (c: ChannelLike, typeLabels: Record<string, string> = {}): string {
+    return `${c.name} (${typeLabels[c.type || ''] || c.type})`
+}
+
+/**
+ * Enabled channels, plus a labelled "ghost" option for every already-referenced
+ * value that is no longer selectable.
+ *
+ * Ghosts are deliberately NOT marked `disabled`: a disabled option makes the
+ * selected tag non-removable in n-select, which would trap the very dangling
+ * reference the operator opened the editor to remove.
+ *
+ * @param referenced values already saved against this field, which must remain
+ *                   renderable even when they are no longer valid choices
+ */
+export function buildChannelOptions (
+    channels: ChannelLike[],
+    referenced: Iterable<string>,
+    typeLabels: Record<string, string> = {},
+): SelectOption[] {
+    const list = channels || []
+    const selectable = list
+        .filter(c => c.status === 'ENABLED')
+        .map(c => ({ label: channelLabel(c, typeLabels), value: c.uuid }))
+    return withGhosts(selectable, list, referenced, (found, uuid) => found
+        ? `${channelLabel(found, typeLabels)} (disabled)`
+        : `(deleted channel) ${String(uuid).slice(0, 8)}`)
+}


### PR DESCRIPTION
UI for **rearm-saas #376** (depends on it).

## What it adds
- **Team editor** (Org Settings → User Groups) gains a **Notification Channels** field — where this team is reachable, e.g. its Slack channel.
- **Subscription routes** gain a **Teams** target alongside channels and channel groups. Options carry a channel count — **`Platform Team (0 ch)`** — because a team with no channels delivers nothing, and that's otherwise invisible until an alert never arrives.
- Copy explains **why** you'd target a team rather than a channel: the route follows the team when they change channel. That's the whole value, and it's invisible otherwise.

## One shared ghost builder, not two copies
Extracted `utils/channelOptions.ts` (+ spec) from `SubscriptionsOfOrg` and refactored **both** pickers onto it. The tricky half is identical in both: a saved reference can point at a channel that has since been **DISABLED or DELETED**, neither of which appears in the enabled list — so the tag renders a bare UUID the operator can't identify, let alone clear. A generic `withGhosts()` now backs the channel *and* team pickers so that behaviour can't drift.

## Review fixes
- **A deactivated team rendered as a bare UUID**, because the picker hides INACTIVE teams — the same bug the extraction exists to prevent, in the very feature that extracted it. Teams now get a ghost arm: `X (deactivated)`.
- **I duplicated `TYPE_LABELS` and typed the key wrong** (`MSTEAMS` vs `MS_TEAMS`), so an MS Teams channel rendered as a raw enum — exactly the *"second copy silently rots"* failure the extracted module's own header argues against. Now imports the canonical map.
- **A transient channel-load failure relabelled every healthy saved channel `(deleted channel)`.** Now flagged with an inline warning, and the field is omitted from the payload so unrelated team edits (rename, members) still save.
- Soft-failure catch gates on `isSchemaDriftError` — a 401/5xx must not be mistaken for "older backend", since team refs have no ghost source once the list is blanked.
- Client-side route-emptiness check now counts teams, matching the backend — a **teams-only route is legitimate**.
- `channelOptions` no longer hides `null`/`''` references: hiding them made the junk reference **unremovable**, inverting the reason ghosts exist.

## Testing
7 unit tests for the shared builder (ghost anchoring, dedup, disabled-vs-deleted labels, junk refs stay removable). **Live-validated on the sandbox** via UI hot-swap: team channel round-trip, a teams-only subscription created through the UI (verified at the data layer as `teams:[…], channels:[], channelGroups:[]`), and the deactivate → `(deactivated)` label → still-saves flow.

## Follow-up (noted, not dropped)
`channelOptions.ts` arguably belongs in `notificationsCommon.ts`, which already owns the channel row shapes and `TYPE_LABELS`. Left as a follow-up to keep this diff reviewable.

## Pre-existing, unrelated
`src/utils/notificationInboxSchemaDrift.spec.ts` fails on clean `main` too (CE mirror caught up, stale assertion) — verified by stashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)