### PR TITLE
fix(ui): expose on CE what the CE backend already allows (notifications)

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="org-integrations">
-        <!-- Segmented sub-tab pill control. OSS hides Webhooks + PR Validation
-             (same scope as the previous "CI Integrations" + Webhooks hide). -->
+        <!-- Segmented sub-tab pill control. CE hides Webhooks + PR Validation
+             (the CI surface). Subscriptions + Channel groups stay: CE ships the
+             whole notification stack, and a channel with no subscription to
+             route events to it delivers nothing. -->
         <div class="subtab-bar">
             <button class="subtab-pill" :class="{ active: subTab === 'catalog' }" @click="switchSubTab('catalog')">
                 <n-icon size="16" class="subtab-icon"><LayoutGrid /></n-icon>
@@ -16,11 +18,11 @@
                 <n-icon size="16" class="subtab-icon"><ShieldCheck /></n-icon>
                 <span>PR Validation</span>
             </button>
-            <button v-if="showCiFeatures" class="subtab-pill" :class="{ active: subTab === 'subscriptions' }" @click="switchSubTab('subscriptions')">
+            <button class="subtab-pill" :class="{ active: subTab === 'subscriptions' }" @click="switchSubTab('subscriptions')">
                 <n-icon size="16" class="subtab-icon"><Bell /></n-icon>
                 <span>Subscriptions</span>
             </button>
-            <button v-if="showCiFeatures" class="subtab-pill" :class="{ active: subTab === 'channel-groups' }" @click="switchSubTab('channel-groups')">
+            <button class="subtab-pill" :class="{ active: subTab === 'channel-groups' }" @click="switchSubTab('channel-groups')">
                 <n-icon size="16" class="subtab-icon"><Users /></n-icon>
                 <span>Channel groups</span>
             </button>
@@ -84,7 +86,7 @@
                                     </template>
                                     Configured by an instance administrator in System Settings
                                 </n-tooltip>
-                                <n-button v-else size="small" :disabled="card.proOnly && !showCiFeatures" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
+                                <n-button v-else size="small" :disabled="cardLockedByEdition(card)" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
                                     <template #icon><n-icon><CirclePlus /></n-icon></template>
                                     {{ card.externalConfig ? 'Configure' : 'Add' }}
                                 </n-button>
@@ -128,7 +130,14 @@
                                                 @click="!testingChannels.has(ch.uuid) && sendChannelTest(ch)"
                                             ><Refresh v-if="testingChannels.has(ch.uuid)" /><Send v-else /></n-icon>
                                             <n-icon class="instance-icon" size="20" title="View delivery history for this channel" @click="viewChannelDeliveries(ch.uuid)"><History /></n-icon>
-                                            <n-icon class="instance-icon" size="20" :title="`Edit ${card.name} channel`" @click="openEditChannelForCard(card, ch)"><EditIcon /></n-icon>
+                                            <!-- Hidden when the edition cannot use this kind: a CE org
+                                                 holding an EMAIL/SENTINEL channel (seeded via API, or
+                                                 left by a downgrade) would otherwise open the full form
+                                                 and only learn at save that it needs a Pro licence --
+                                                 the "UI looser than backend" failure editionCapabilities
+                                                 warns about. Delete stays available so the row can be
+                                                 cleaned up. -->
+                                            <n-icon v-if="!cardLockedByEdition(card)" class="instance-icon" size="20" :title="`Edit ${card.name} channel`" @click="openEditChannelForCard(card, ch)"><EditIcon /></n-icon>
                                             <n-icon class="instance-icon danger" size="20" :title="`Delete ${card.name} channel`" @click="onDeleteChannel(card, ch)"><Trash /></n-icon>
                                         </div>
                                     </div>
@@ -187,8 +196,12 @@
                                 </template>
                             </div>
 
-                            <!-- + Add another for multi-instance only -->
-                            <button v-if="card.multiInstance" class="add-another" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
+                            <!-- + Add another for multi-instance only. Also honours the
+                                 edition lock: EMAIL/SENTINEL are multiInstance, so a CE
+                                 org that already has one (seeded via API, or left behind
+                                 by a downgrade) would otherwise show a live-looking
+                                 button whose click openAddForCard silently discards. -->
+                            <button v-if="card.multiInstance && !cardLockedByEdition(card)" class="add-another" @click="openAddForCard(card)" :data-testid="`add-channel-${card.id}`">
                                 <n-icon size="14"><CirclePlus /></n-icon>
                                 <span>Add another {{ card.name }}</span>
                             </button>
@@ -197,14 +210,15 @@
                         <!-- Once a messaging channel is configured, events only
                              reach it when a subscription routes them there.
                              Applies to every channel card (Slack/Teams/Email/
-                             Webhook/Sentinel). Gated on Pro so the OSS catalog
-                             stays the same. -->
+                             Webhook/Sentinel) on every edition -- the dead-end
+                             this prevents is worse on CE, where Slack is the
+                             first channel most operators configure. -->
                         <div
-                            v-if="showCiFeatures && isChannelCard(card) && isCardConfigured(card)"
-                            class="card-pro-hint"
+                            v-if="isChannelCard(card) && isCardConfigured(card)"
+                            class="card-route-hint"
                         >
                             Events are delivered when a
-                            <a class="pro-hint-link" @click="switchSubTab('subscriptions')">subscription</a>
+                            <a class="route-hint-link" @click="switchSubTab('subscriptions')">subscription</a>
                             routes them to this channel →
                         </div>
                     </div>
@@ -262,7 +276,7 @@
         </div>
 
         <!-- ============================== SUBSCRIPTIONS ============================== -->
-        <div v-if="subTab === 'subscriptions' && showCiFeatures" class="subscriptions-pane-wrap">
+        <div v-if="subTab === 'subscriptions'" class="subscriptions-pane-wrap">
             <div class="info-banner">
                 <n-icon size="20"><Bell /></n-icon>
                 <div>
@@ -276,7 +290,7 @@
         </div>
 
         <!-- ============================== CHANNEL GROUPS ============================== -->
-        <div v-if="subTab === 'channel-groups' && showCiFeatures" class="channel-groups-pane-wrap">
+        <div v-if="subTab === 'channel-groups'" class="channel-groups-pane-wrap">
             <div class="info-banner">
                 <n-icon size="20"><Users /></n-icon>
                 <div>
@@ -863,6 +877,12 @@ import WebhooksOfOrg from './WebhooksOfOrg.vue'
 import OrgGlobalPrValidationRules from './OrgGlobalPrValidationRules.vue'
 import SubscriptionsOfOrg from './SubscriptionsOfOrg.vue'
 import ChannelGroupsOfOrg from './ChannelGroupsOfOrg.vue'
+import {
+    isChannelTypeAvailable,
+    isProEdition,
+    isIntegrationsSubTabAvailable,
+    type IntegrationsSubTab,
+} from '../utils/editionCapabilities'
 import { useNotification, NotificationType } from 'naive-ui'
 
 const props = defineProps<{
@@ -893,18 +913,35 @@ const notify = (type: NotificationType, title: string, content: string) => {
     notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
 }
 
-const showCiFeatures = computed(() => props.installationType !== 'OSS')
+// Strictly the CI/SCM surface: GitHub/GitLab/Jenkins/ADO cards, inbound PR
+// Webhooks, PR Validation rules.
+//
+// It used to gate the notifications surface too, which was wrong -- CE ships
+// the entire notification stack (fan-out, delivery worker, Slack/Teams/Webhook
+// dispatchers, subscriptions, channel groups) and the backend allows all of it.
+// The edition predicates now live in utils/editionCapabilities so they are
+// unit-tested; the channel-type list there is additionally checked against the
+// backend's own gate. This flag is still read directly by the CI-surface
+// conditionals below, which is what it is for.
+const showCiFeatures = computed(() => isProEdition(props.installationType))
 const orguuid = computed(() => props.orguuid)
 const isOrgAdmin = computed(() => props.isOrgAdmin)
 const isGlobalAdmin = computed(() => props.isGlobalAdmin)
 const isWritable = computed(() => props.isWritable)
 
 // ---- Sub-tab state, URL-synced ---------------------------------------------
-type SubTab = 'catalog' | 'webhooks' | 'pr-validation' | 'subscriptions' | 'channel-groups'
-const subTab = ref<SubTab>((route.query.integrationsTab as SubTab) || 'catalog')
+type SubTab = IntegrationsSubTab
+
+function isSubTabAccessible(t: unknown): t is SubTab {
+    return isIntegrationsSubTabAvailable(t, props.installationType)
+}
+
+const subTab = ref<SubTab>(
+    isSubTabAccessible(route.query.integrationsTab) ? route.query.integrationsTab : 'catalog',
+)
 
 async function switchSubTab(t: SubTab) {
-    if (t !== 'catalog' && !showCiFeatures.value) return
+    if (!isSubTabAccessible(t)) return
     subTab.value = t
     await router.push({ query: { ...route.query, integrationsTab: t } })
 }
@@ -1058,9 +1095,6 @@ interface CardConfig {
     logoMark?: string
     iconComponent?: any
     multiInstance: boolean
-    // Pro-only kinds still show in the OSS catalog, but with a "Pro"
-    // pill and a disabled Add button instead of being hidden.
-    proOnly?: boolean
     // Instance-wide config that lives outside this per-org surface (e.g.
     // SendGrid, configured in System Settings). The card's action routes
     // to that page instead of opening a per-org modal, and its footer
@@ -1070,9 +1104,9 @@ interface CardConfig {
 
 const CARDS: CardConfig[] = [
     // Messaging
-    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Send security and operational notifications to a Slack channel via an incoming-webhook URL.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: true, proOnly: true },
-    { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Send security and operational notifications to a Microsoft Teams channel via a Power Automate Workflows webhook URL.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: true, proOnly: true },
-    { id: 'EMAIL', name: 'Email', vendor: 'Reliza', category: 'messaging', description: 'Send security and operational notifications to a list of email recipients, batched into periodic digest emails.', logoBg: '#2D8F4E', iconComponent: Mail, multiInstance: true, proOnly: true },
+    { id: 'SLACK', name: 'Slack', vendor: 'Slack Technologies', category: 'messaging', description: 'Send security and operational notifications to a Slack channel via an incoming-webhook URL.', logoBg: '#4A154B', iconComponent: BrandSlack, multiInstance: true },
+    { id: 'MSTEAMS', name: 'Microsoft Teams', vendor: 'Microsoft', category: 'messaging', description: 'Send security and operational notifications to a Microsoft Teams channel via a Power Automate Workflows webhook URL.', logoBg: '#4B53BC', logoMark: 'T', multiInstance: true },
+    { id: 'EMAIL', name: 'Email', vendor: 'Reliza', category: 'messaging', description: 'Send security and operational notifications to a list of email recipients, batched into periodic digest emails.', logoBg: '#2D8F4E', iconComponent: Mail, multiInstance: true },
     // SendGrid is not a per-org notification channel — it is the
     // instance-wide email delivery provider (EmailSendType.SENDGRID),
     // configured in System Settings → Email Sending Configuration. The
@@ -1081,8 +1115,8 @@ const CARDS: CardConfig[] = [
     // channel modal. The Email card above is the per-org recipient/digest
     // channel that rides on top of whichever provider this configures.
     { id: 'SENDGRID', name: 'SendGrid', vendor: 'Twilio SendGrid', category: 'messaging', description: 'Instance-wide email delivery provider used to send Email channel notifications and account emails. Configured in System Settings.', logoBg: '#1A82E2', logoMark: 'SG', multiInstance: false, externalConfig: true },
-    { id: 'WEBHOOK', name: 'Notification Webhook', vendor: 'Reliza', category: 'messaging', description: 'POST notification events to any HTTPS endpoint — PagerDuty, Opsgenie, Splunk, or in-house receivers — with optional bearer-token or HMAC-SHA256 signing.', logoBg: '#37474F', iconComponent: PlugConnected, multiInstance: true, proOnly: true },
-    { id: 'SENTINEL', name: 'Microsoft Sentinel', vendor: 'Microsoft', category: 'messaging', description: 'Stream notification events to Microsoft Sentinel (Azure Log Analytics) via the Logs Ingestion API.', logoBg: '#0078D4', iconComponent: ShieldCheck, multiInstance: true, proOnly: true },
+    { id: 'WEBHOOK', name: 'Notification Webhook', vendor: 'Reliza', category: 'messaging', description: 'POST notification events to any HTTPS endpoint — PagerDuty, Opsgenie, Splunk, or in-house receivers — with optional bearer-token or HMAC-SHA256 signing.', logoBg: '#37474F', iconComponent: PlugConnected, multiInstance: true },
+    { id: 'SENTINEL', name: 'Microsoft Sentinel', vendor: 'Microsoft', category: 'messaging', description: 'Stream notification events to Microsoft Sentinel (Azure Log Analytics) via the Logs Ingestion API.', logoBg: '#0078D4', iconComponent: ShieldCheck, multiInstance: true },
     // CI/CD & Source Control
     { id: 'GITHUB', name: 'GitHub', vendor: 'GitHub', category: 'ci', description: 'GitHub App for PR validation, inbound webhooks, and repository_dispatch.', logoBg: '#1F2328', iconComponent: BrandGithub, multiInstance: true },
     { id: 'GITLAB', name: 'GitLab', vendor: 'GitLab', category: 'ci', description: 'Trigger GitLab pipelines.', logoBg: '#FC6D26', iconComponent: BrandGitlab, multiInstance: true },
@@ -1125,6 +1159,24 @@ function channelTypeForCard(card: CardConfig): string {
     return card.id === 'MSTEAMS' ? 'MS_TEAMS' : card.id
 }
 
+/**
+ * Card visible in the catalog but unusable on this edition -- renders a "Pro"
+ * pill and a disabled Add button rather than being hidden, so the operator can
+ * still see the capability exists.
+ *
+ * Channel cards derive this from the single tested constant in
+ * utils/editionCapabilities, which mirrors the backend's licence check. That
+ * indirection is deliberate: the previous hand-maintained per-card flag drifted
+ * and marked CE-available Slack / Teams / Webhook as Pro.
+ *
+ * Non-channel cards are never edition-locked today -- the Pro-only CI kinds are
+ * hidden wholesale by visibleSections instead.
+ */
+function cardLockedByEdition(card: CardConfig): boolean {
+    if (!isChannelCard(card)) return false
+    return !isChannelTypeAvailable(channelTypeForCard(card), props.installationType)
+}
+
 function channelRowsForCard(card: CardConfig): ChannelCatalogRow[] {
     const t = channelTypeForCard(card)
     return notificationChannelRows.value.filter(c => c.type === t)
@@ -1149,7 +1201,7 @@ function ciInstancesForCard(card: CardConfig): any[] {
 }
 
 function cardStatusLabel(card: CardConfig): string {
-    if (card.proOnly && !showCiFeatures.value) return 'Pro'
+    if (cardLockedByEdition(card)) return 'Pro'
     if (!isCardConfigured(card)) return 'Available'
     if (isChannelCard(card)) {
         const n = channelRowsForCard(card).length
@@ -1177,7 +1229,7 @@ function cardName(id: CardConfig['id']): string {
 // point to where the setting actually lives instead.
 function cardFootHint(card: CardConfig): string {
     if (card.externalConfig) return 'Set in System Settings'
-    if (card.proOnly && !showCiFeatures.value) return 'Available in ReARM Pro'
+    if (cardLockedByEdition(card)) return 'Available in ReARM Pro'
     return 'Not configured'
 }
 
@@ -1218,7 +1270,7 @@ function kindLabel(t: string): string {
 
 // ---- Modal openers ---------------------------------------------------------
 function openAddForCard(card: CardConfig) {
-    if (card.proOnly && !showCiFeatures.value) return
+    if (cardLockedByEdition(card)) return
     if (card.id === 'SLACK') { openAddSlackChannel(); return }
     if (card.id === 'EMAIL') { openAddEmailChannel(); return }
     // SendGrid is instance-wide config, not a per-org channel — send the
@@ -2419,9 +2471,9 @@ const CATALOG_CHANNELS_FULL = gql`
     }`
 
 async function loadNotificationChannels(useCache: boolean) {
-    // Channel queries are a Pro surface — skip on OSS, where the
-    // EMAIL / WEBHOOK / SENTINEL cards render in their "Pro" state instead.
-    if (!showCiFeatures.value) return
+    // Runs on every edition. CE can create Slack / Teams / Webhook channels, so
+    // skipping this left those cards permanently "Available" even with channels
+    // configured -- and the Add button opening a form whose result never showed.
     const cachePolicy: FetchPolicy = useCache ? 'cache-first' : 'network-only'
     try {
         const { data, degraded } = await loadWithSchemaDriftFallback(
@@ -2632,18 +2684,18 @@ watch(() => props.orguuid, async () => {
 }
 .muted-12 { font-size: 12px; color: var(--muted); }
 
-.card-pro-hint {
+.card-route-hint {
     margin-top: 10px;
     font-size: 11.5px;
     color: var(--muted);
     line-height: 1.4;
 }
-.pro-hint-link {
+.route-hint-link {
     color: var(--n-color-primary, #2080f0);
     cursor: pointer;
     text-decoration: none;
 }
-.pro-hint-link:hover { text-decoration: underline; }
+.route-hint-link:hover { text-decoration: underline; }
 
 /* ---- instance rows ------------------------------------------------------ */
 .instance-list {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1149,7 +1149,10 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
                     <n-tab-pane name="downloadLog" tab="Download Log">
                         <DownloadLogView />
                     </n-tab-pane>
-                    <n-tab-pane name="deliveryHistory" tab="Delivery History" v-if="myUser.installationType !== 'OSS'">
+                    <!-- Every edition: CE delivers to Slack / Teams / Webhook, and
+                         this is the only surface that answers "did it actually
+                         send?". The channel cards deep-link straight here. -->
+                    <n-tab-pane name="deliveryHistory" tab="Delivery History">
                         <NotificationHistory
                             :orguuid="orgResolved"
                             :initial-channel-uuid="(route.query.historyChannel as string) || null"
@@ -1526,7 +1529,7 @@ const currentTab = ref(isTabAccessible(requestedTab) ? requestedTab : defaultTab
 const DEFAULT_POLICY_SUBTAB = 'approvalPoliciesInner'
 const DEFAULT_AUDIT_SUBTAB = 'downloadLog'
 const policySubTab = ref(route.query.policyTab as string || DEFAULT_POLICY_SUBTAB)
-// Audit sub-tab: Download Log (all editions) + Delivery History (Pro).
+// Audit sub-tab: Download Log + Delivery History, both on all editions.
 const auditSubTab = ref(route.query.auditTab as string || DEFAULT_AUDIT_SUBTAB)
 
 // Keep the tab selection in sync when the URL query changes while OrgSettings

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -154,7 +154,13 @@
                                             />
                                         </n-form-item>
                                     </n-gi>
-                                    <n-gi :span="22" :offset="0">
+                                    <!-- Hidden when there is nothing to offer. Covers both "this org
+                                         has no teams" and "this backend has no team channels" (a CE
+                                         backend, where loadTeams soft-fails to []): an empty picker
+                                         under copy promising a feature that cannot work is worse
+                                         than no picker. teamOptions still keeps ghosts for teams
+                                         already saved on the route, so those stay removable. -->
+                                    <n-gi v-if="teamOptions.length" :span="22" :offset="0">
                                         <n-form-item :label="i === 0 ? 'Teams (optional)' : ''" :show-feedback="false">
                                             <n-select
                                                 v-model:value="r.teams"
@@ -273,7 +279,8 @@ import {
     LIST_CHANNELS_QUERY, LIST_GROUPS_CORE_QUERY,
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
     extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType,
-    buildNotificationFilterInput
+    buildNotificationFilterInput,
+    buildNotificationRouteInput
 } from '@/utils/notificationsCommon'
 import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 
@@ -614,7 +621,11 @@ async function saveSubscription (): Promise<void> {
         && (r.teams || []).length === 0
     )
     if (emptyRouteIdx >= 0) {
-        subModalError.value = `Route ${emptyRouteIdx + 1} has no channels, groups or teams — pick at least one.`
+        // Don't name a target the operator has no way to pick: on a backend
+        // without team channels the Teams picker is hidden, so "or teams"
+        // would send them hunting for a control that isn't there.
+        const targets = teamOptions.value.length ? 'channels, groups or teams' : 'channels or groups'
+        subModalError.value = `Route ${emptyRouteIdx + 1} has no ${targets} — pick at least one.`
         return
     }
     // Build the filter input from ONLY the fields NotificationFilterInput
@@ -630,17 +641,9 @@ async function saveSubscription (): Promise<void> {
         status: f.status,
         eventTypes: f.eventTypes,
         filter: filterInput,
-        // Spread the original route's still-unmodelled fields (andEnvIn,
-        // andLifecycleIn) so an Edit → Save round-trip doesn't silently
-        // strip them. The modeled fields overlay last and win.
-        routes: f.routes.map(r => ({
-            ...(r._raw || {}),
-            whenSeverityAtLeast: r.whenSeverityAtLeast,
-            channels: r.channels,
-            channelGroups: r.channelGroups,
-            teams: r.teams,
-            perspectives: r.perspectives,
-        })),
+        // Preserves the route's unmodelled fields and drops the Pro-only ones a
+        // CE backend would reject. See buildNotificationRouteInput.
+        routes: f.routes.map(r => buildNotificationRouteInput(r)),
         dedupWindowMinutes: f.dedupWindowMinutes,
     }
     if (f.rateLimitMaxPerWindow && f.rateLimitWindowMinutes) {
@@ -883,10 +886,17 @@ const subscriptionColumns = computed(() => [
             })
             return h(NSpace, { size: 'small' }, {
                 default: () => [
+                    // Disabled on a DEGRADED load. The core query omits filter /
+                    // routes / dedupWindowMinutes / rateLimit, so the editor
+                    // would open showing defaults for all of them, and saving
+                    // REPLACES the subscription wholesale -- silently wiping the
+                    // CEL expression, every route but one, and the rate limit.
+                    // The banner alone is not enough: the destructive action has
+                    // to be unavailable, not merely discouraged. Add is fine.
                     h(NButton, {
                         size: 'tiny', secondary: true,
                         onClick: () => openEditSubscription(row),
-                        disabled: !canWrite.value,
+                        disabled: !canWrite.value || subscriptionsDegraded.value,
                         'data-testid': 'edit-subscription',
                     }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
                     h(NButton, {

--- a/ui/src/utils/editionCapabilities.spec.ts
+++ b/ui/src/utils/editionCapabilities.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import {
+    isProEdition,
+    isChannelTypeAvailable,
+    isIntegrationsSubTabAvailable,
+    PRO_ONLY_CHANNEL_TYPES,
+    INTEGRATIONS_SUBTABS,
+} from './editionCapabilities'
+
+describe('isProEdition', () => {
+    it('treats only the literal OSS build as CE', () => {
+        expect(isProEdition('OSS')).toBe(false)
+        // The whole InstallationType enum, minus OSS.
+        for (const t of ['SAAS', 'DEMO', 'MANAGED_SERVICE']) {
+            expect(isProEdition(t)).toBe(true)
+        }
+    })
+
+    it('treats an unloaded installationType as Pro (permissive default)', () => {
+        // Documented as safe only because every caller mounts behind a loaded
+        // user. If that ever stops being true this is the line to revisit.
+        expect(isProEdition(undefined)).toBe(true)
+        expect(isProEdition(null)).toBe(true)
+    })
+})
+
+describe('isChannelTypeAvailable', () => {
+    it('allows Slack / Teams / Webhook on CE -- the backend does', () => {
+        // MS_TEAMS is the backend type name; the catalog card id is MSTEAMS.
+        for (const t of ['SLACK', 'MS_TEAMS', 'WEBHOOK']) {
+            expect(isChannelTypeAvailable(t, 'OSS')).toBe(true)
+        }
+    })
+
+    it('blocks EMAIL and SENTINEL on CE -- the backend rejects them on save', () => {
+        expect(isChannelTypeAvailable('EMAIL', 'OSS')).toBe(false)
+        expect(isChannelTypeAvailable('SENTINEL', 'OSS')).toBe(false)
+    })
+
+    it('allows everything on a licensed edition', () => {
+        for (const t of ['SLACK', 'MS_TEAMS', 'WEBHOOK', 'EMAIL', 'SENTINEL']) {
+            expect(isChannelTypeAvailable(t, 'SAAS')).toBe(true)
+        }
+    })
+
+    it('does not block an unknown type on CE (backend decides, UI does not invent gates)', () => {
+        expect(isChannelTypeAvailable('SOMETHING_NEW', 'OSS')).toBe(true)
+    })
+})
+
+// The point of PRO_ONLY_CHANNEL_TYPES is to agree with the backend, so assert
+// against the BACKEND SOURCE rather than a literal in this file -- a literal
+// would only ever detect someone editing the constant, never the drift the
+// constant exists to prevent. Same in-repo-path + existsSync convention as
+// notificationInboxSchemaDrift.spec.ts.
+const GATE_SRC_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/java/io/reliza/service/NotificationChannelService.java',
+    import.meta.url))
+
+describe('PRO_ONLY_CHANNEL_TYPES vs the CE backend gate', () => {
+    it('has the backend source available', () => {
+        expect(existsSync(GATE_SRC_PATH)).toBe(true)
+    })
+
+    it('lists exactly the types validateSeed rejects on the OSS edition', () => {
+        if (!existsSync(GATE_SRC_PATH)) return
+        const src = readFileSync(GATE_SRC_PATH, 'utf8')
+        // Scope to validateSeed FIRST. isOssEdition() is used freely across this
+        // codebase, so an unanchored search would silently repoint at whichever
+        // gate happens to appear first if another is ever added above this one.
+        const from = src.indexOf('validateSeed')
+        expect(from, 'validateSeed not found -- method renamed?').toBeGreaterThan(-1)
+        const body = src.slice(from)
+        // The gate reads:
+        //   if (LicensingConstants.isOssEdition()
+        //           && (seed.getType() == IntegrationType.EMAIL
+        //               || seed.getType() == IntegrationType.SENTINEL)) {
+        const gate = body.match(/isOssEdition\(\)([\s\S]{0,400}?)\)\)\s*\{/)
+        expect(gate, 'could not locate the isOssEdition gate in validateSeed').not.toBeNull()
+        const gated = [...(gate![1].matchAll(/IntegrationType\.(\w+)/g))].map(m => m[1]).sort()
+        expect(gated).toEqual([...PRO_ONLY_CHANNEL_TYPES].sort())
+    })
+})
+
+describe('isIntegrationsSubTabAvailable', () => {
+    it('offers catalog, subscriptions and channel groups on every edition', () => {
+        for (const t of ['catalog', 'subscriptions', 'channel-groups']) {
+            expect(isIntegrationsSubTabAvailable(t, 'OSS')).toBe(true)
+            expect(isIntegrationsSubTabAvailable(t, 'SAAS')).toBe(true)
+        }
+    })
+
+    it('keeps the CI sub-tabs on Pro only', () => {
+        for (const t of ['webhooks', 'pr-validation']) {
+            expect(isIntegrationsSubTabAvailable(t, 'OSS')).toBe(false)
+            expect(isIntegrationsSubTabAvailable(t, 'SAAS')).toBe(true)
+        }
+    })
+
+    it('rejects an unknown tab on every edition -- it would render a blank body', () => {
+        for (const edition of ['OSS', 'SAAS']) {
+            expect(isIntegrationsSubTabAvailable('bogus', edition)).toBe(false)
+            expect(isIntegrationsSubTabAvailable('', edition)).toBe(false)
+            expect(isIntegrationsSubTabAvailable(undefined, edition)).toBe(false)
+        }
+    })
+
+    it('rejects the ARRAY vue-router yields for a repeated query param', () => {
+        // ?integrationsTab=catalog&integrationsTab=webhooks
+        expect(isIntegrationsSubTabAvailable(['catalog', 'webhooks'], 'SAAS')).toBe(false)
+        expect(isIntegrationsSubTabAvailable(['catalog'], 'SAAS')).toBe(false)
+    })
+
+    it('every declared sub-tab is reachable on Pro', () => {
+        // Guards a tab being added to the type but forgotten in the list.
+        for (const t of INTEGRATIONS_SUBTABS) {
+            expect(isIntegrationsSubTabAvailable(t, 'SAAS')).toBe(true)
+        }
+    })
+})

--- a/ui/src/utils/editionCapabilities.ts
+++ b/ui/src/utils/editionCapabilities.ts
@@ -1,0 +1,116 @@
+// Edition (CE vs Pro) availability policy for the Integrations page: which
+// notification channel types this edition may create, and which sub-tabs it may
+// open. Both are edition questions asked by OrgIntegrations.vue; keeping them
+// together is what lets the component hold no edition logic of its own.
+//
+// WHAT THE UI ACTUALLY KNOWS. The backend's licence gate is
+// LicensingConstants.isOssEdition(), a COMPILE-TIME constant baked into the
+// build (the CE jar returns literal `true`; the Pro jar compares an embedded
+// PEM). That value is never served to the browser. The only edition signals on
+// the GraphQL User type are `installationType` and `isLicenseValid`, so this
+// file uses `installationType` as a PROXY for the edition.
+//
+// The two signals are independent and CAN disagree -- a Pro build configured
+// with RELIZAPROP_INSTALLATION_TYPE=OSS reports OSS to the UI while still
+// accepting Pro-only channels. That is safe in practice because the CE Helm
+// chart hardcodes `RELIZAPROP_INSTALLATION_TYPE: "OSS"` (not templated, so a CE
+// deployment cannot report anything else), and a mismatch fails in the harmless
+// direction: the UI hides a capability the backend would have allowed. Do not
+// rely on this to be exact; a served capability field would be the real fix.
+//
+// WHY IT IS CENTRALISED. The backend rejects EMAIL and SENTINEL on CE in
+// NotificationChannelService.validateSeed:
+//
+//     // CE/Pro split: EMAIL and SENTINEL destinations are Pro-only.
+//     // Slack / Teams / Webhook are available on the CE (OSS) edition.
+//     if (LicensingConstants.isOssEdition()
+//             && (seed.getType() == IntegrationType.EMAIL
+//                 || seed.getType() == IntegrationType.SENTINEL)) { throw ... }
+//
+// Drift in EITHER direction is a bug the UI alone can produce:
+//   - UI stricter than backend -> a capability the customer already has is
+//     invisible. That is the complaint that prompted this file: CE shipped
+//     working Slack/Teams/Webhook dispatchers behind a "Pro" pill.
+//   - UI looser than backend -> the card is enabled, the operator fills in the
+//     whole form, and the save fails with a licence error. Worse than hiding it.
+//
+// Keeping the policy in one tested module is what makes the next channel type a
+// one-line decision instead of a grep across template conditionals.
+
+/** Channel types the backend rejects on the CE (OSS) edition. */
+export const PRO_ONLY_CHANNEL_TYPES: readonly string[] = ['EMAIL', 'SENTINEL']
+
+/**
+ * `NotificationRouteInput` fields that exist ONLY in the Pro schema.
+ *
+ * A different failure mode from the channel list above, and a nastier one:
+ * GraphQL input coercion rejects unknown keys outright, so sending one of these
+ * from a CE UI fails the WHOLE subscription mutation -- including saves that do
+ * not use the field at all. See buildNotificationRouteInput in
+ * notificationsCommon, which strips them, and routeInputSchemaDrift.spec.ts,
+ * which coerces the result against both real schemas.
+ */
+export const PRO_ONLY_ROUTE_FIELDS: readonly string[] = ['teams']
+
+/**
+ * Pro (licensed) edition, as far as the UI can tell. Every non-OSS
+ * installationType -- SAAS, DEMO, MANAGED_SERVICE -- is licensed; only the
+ * literal 'OSS' value marks CE. (Those four are the whole InstallationType
+ * enum, CommonVariables.InstallationType.)
+ *
+ * An absent installationType is treated as Pro, matching the
+ * `installationType !== 'OSS'` idiom used throughout this UI. That is the
+ * PERMISSIVE default -- it shows paid affordances rather than hiding them -- so
+ * it is only safe where the caller guarantees the user record is loaded. Every
+ * current caller does: OrgSettings mounts these surfaces behind `isOrgAdmin`,
+ * which already requires a loaded user.
+ */
+export function isProEdition (installationType: string | undefined | null): boolean {
+    return installationType !== 'OSS'
+}
+
+/**
+ * Is this notification channel type creatable on this edition?
+ *
+ * @param channelType the BACKEND type name (IntegrationType), not the catalog
+ *                    card id -- they differ for Teams (card 'MSTEAMS' vs type
+ *                    'MS_TEAMS'). Callers must map through channelTypeForCard.
+ */
+export function isChannelTypeAvailable (channelType: string, installationType: string | undefined | null): boolean {
+    if (isProEdition(installationType)) return true
+    return !PRO_ONLY_CHANNEL_TYPES.includes(channelType)
+}
+
+// ---- Integrations sub-tabs -------------------------------------------------
+
+export type IntegrationsSubTab =
+    'catalog' | 'webhooks' | 'pr-validation' | 'subscriptions' | 'channel-groups'
+
+export const INTEGRATIONS_SUBTABS: readonly IntegrationsSubTab[] =
+    ['catalog', 'webhooks', 'pr-validation', 'subscriptions', 'channel-groups']
+
+/**
+ * Sub-tabs that need the CI/SCM surface (inbound PR webhooks, PR validation
+ * rules). Everything else -- including subscriptions and channel groups -- is
+ * available on CE, because a channel with no subscription routing events to it
+ * delivers nothing.
+ */
+export const CI_ONLY_SUBTABS: readonly IntegrationsSubTab[] = ['webhooks', 'pr-validation']
+
+/**
+ * Accepts a sub-tab only if it is REAL and this edition can render it.
+ *
+ * Both halves matter, and for the same reason: anything else leaves a blank
+ * body. An unknown value (`?integrationsTab=bogus`) matches no pane's `v-if`
+ * and highlights no pill; so does a CI tab on CE. vue-router yields an ARRAY
+ * for a repeated query param, so this tests membership rather than trusting a
+ * cast.
+ */
+export function isIntegrationsSubTabAvailable (
+    tab: unknown,
+    installationType: string | undefined | null,
+): tab is IntegrationsSubTab {
+    if (!INTEGRATIONS_SUBTABS.includes(tab as IntegrationsSubTab)) return false
+    if (!CI_ONLY_SUBTABS.includes(tab as IntegrationsSubTab)) return true
+    return isProEdition(installationType)
+}

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -7,6 +7,7 @@
 
 import gql from 'graphql-tag'
 import commonFunctions from '@/utils/commonFunctions'
+import { PRO_ONLY_ROUTE_FIELDS } from '@/utils/editionCapabilities'
 
 export type NaiveTagType = 'success' | 'warning' | 'error' | 'info' | 'default'
 
@@ -318,6 +319,59 @@ function buildSubscriptionsQuery (fields: string) {
 }
 export const LIST_SUBSCRIPTIONS_QUERY = buildSubscriptionsQuery(`${SUBSCRIPTION_CORE_FIELDS} ${SUBSCRIPTION_ENRICHMENT_FIELDS}`)
 export const LIST_SUBSCRIPTIONS_CORE_QUERY = buildSubscriptionsQuery(SUBSCRIPTION_CORE_FIELDS)
+
+/**
+ * Build one `NotificationRouteInput` from a modeled route row.
+ *
+ * Same hazard as buildNotificationFilterInput below, one level down: GraphQL
+ * input coercion REJECTS unknown keys outright, so any field the server's
+ * NotificationRouteInput does not declare fails the whole mutation rather than
+ * being ignored.
+ *
+ * The offending fields are listed in PRO_ONLY_ROUTE_FIELDS (currently `teams`).
+ * Sending `teams: []` from a CE UI makes every subscription save -- including
+ * ones that use no teams at all -- fail with
+ *   `Field "teams" is not defined by type "NotificationRouteInput"`.
+ * Omitting the key when empty keeps CE saving while losing nothing on Pro, where
+ * an absent list and an empty list mean the same thing.
+ */
+export interface NotificationRouteInput {
+    whenSeverityAtLeast?: string | null
+    channels?: string[]
+    channelGroups?: string[]
+    perspectives?: string[]
+    teams?: string[]
+    // Unmodelled passthrough carried verbatim from `_raw` (andEnvIn,
+    // andLifecycleIn, rate-limit fields the editor does not surface yet).
+    [passthrough: string]: unknown
+}
+
+export function buildNotificationRouteInput (route: Record<string, any>): NotificationRouteInput {
+    const raw = { ...(route._raw || {}) }
+    // Strip the Pro-only fields from the passthrough as well.
+    //
+    // DEFENSIVE, not currently load-bearing: openEditSubscription models `teams`
+    // explicitly alongside `_raw`, so today the re-add below always restores
+    // whatever `_raw` carried and this loop changes nothing. It matters the
+    // moment a Pro-only field stops being modelled -- `_raw` becomes its only
+    // carrier, and without this the field would flow straight through to a CE
+    // backend and 400 every save. Kept because the failure it prevents is
+    // silent and total, and the cost is one shallow copy.
+    for (const f of PRO_ONLY_ROUTE_FIELDS) delete raw[f]
+    const out: NotificationRouteInput = {
+        ...raw,
+        whenSeverityAtLeast: route.whenSeverityAtLeast,
+        channels: route.channels,
+        channelGroups: route.channelGroups,
+        perspectives: route.perspectives,
+    }
+    // Send a Pro-only field only when it actually carries a value, so a CE
+    // backend never sees the key at all.
+    for (const f of PRO_ONLY_ROUTE_FIELDS) {
+        if ((route[f] || []).length > 0) out[f] = route[f]
+    }
+    return out
+}
 
 /**
  * Build the payload for `NotificationFilterInput` from the modeled UI fields

--- a/ui/src/utils/routeInputSchemaDrift.spec.ts
+++ b/ui/src/utils/routeInputSchemaDrift.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, coerceInputValue, type GraphQLSchema, type GraphQLInputType } from 'graphql'
+
+// notificationsCommon imports commonFunctions, which boots the graphql client
+// + keycloak as an import side effect. Same stub as notificationsCommon.spec.ts
+// -- buildNotificationRouteInput itself touches none of it.
+vi.mock('@/utils/commonFunctions', () => ({
+    default: { dateDisplay: (s: string) => `ABS:${s}` },
+}))
+
+const { buildNotificationRouteInput } = await import('./notificationsCommon')
+
+// buildNotificationRouteInput vs the REAL schemas, not a hand-copied field list.
+//
+// GraphQL input coercion rejects unknown keys outright, so a route field the
+// server does not declare fails the entire subscription mutation. `teams` is
+// Pro-only; a CE UI that sends `teams: []` cannot save ANY subscription. That
+// path became reachable when the CE UI stopped hiding the Subscriptions tab.
+//
+// Same convention as notificationInboxSchemaDrift.spec.ts: the CE mirror ships
+// in this repo so its checks always run; the Pro schema lives in the sibling
+// rearm-core checkout and is skipped (not failed) when absent.
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+/** Coercion errors for `value` against input type `typeName`, [] if it is valid. */
+function coerceErrors (schema: GraphQLSchema, typeName: string, value: unknown): string[] {
+    const type = schema.getType(typeName) as GraphQLInputType
+    const errors: string[] = []
+    coerceInputValue(value, type, (_path, _invalidValue, error) => {
+        errors.push(error.message)
+    })
+    return errors
+}
+
+// A fully-populated route as the editor models it, including the `_raw`
+// passthrough of an edit loaded from a Pro backend.
+const ROUTE_WITH_TEAMS = {
+    _raw: { andEnvIn: ['prod'], andLifecycleIn: ['GENERAL_AVAILABILITY'], teams: ['team-1'] },
+    whenSeverityAtLeast: 'HIGH',
+    channels: ['ch-1'],
+    channelGroups: [],
+    perspectives: [],
+    teams: ['team-1'],
+}
+
+const ROUTE_NO_TEAMS = { ...ROUTE_WITH_TEAMS, teams: [], _raw: { andEnvIn: ['prod'] } }
+
+describe('buildNotificationRouteInput vs the CE mirror schema (in-repo, always runs)', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema).not.toBeNull()
+    })
+
+    it('CE really does lack `teams` -- the premise of the omission', () => {
+        if (!ceSchema) return
+        // Guards against "fixed" meaning "CE caught up and we forgot". If CE
+        // gains `teams`, this fails and the omission can be simplified away.
+        const errs = coerceErrors(ceSchema, 'NotificationRouteInput', {
+            channels: ['ch-1'], teams: ['team-1'],
+        })
+        expect(errs.join(' ')).toMatch(/teams/)
+    })
+
+    it('a route with NO teams coerces cleanly on CE', () => {
+        if (!ceSchema) return
+        expect(coerceErrors(ceSchema, 'NotificationRouteInput', buildNotificationRouteInput(ROUTE_NO_TEAMS)))
+            .toEqual([])
+    })
+
+    it('never leaks `teams` in through the _raw spread when it is not modelled', () => {
+        // Exercises the passthrough strip SPECIFICALLY: `_raw` carries teams
+        // while the modelled field is empty, which is the only shape in which
+        // the strip is load-bearing. A fixture whose `_raw` has no teams would
+        // pass with the strip deleted and prove nothing.
+        const unmodelled = { _raw: { andEnvIn: ['prod'], teams: ['team-1'] }, channels: ['ch-1'] }
+        const built = buildNotificationRouteInput(unmodelled)
+        expect(built).not.toHaveProperty('teams')
+        if (ceSchema) {
+            expect(coerceErrors(ceSchema, 'NotificationRouteInput', built)).toEqual([])
+        }
+    })
+
+    it('drops nothing else while stripping teams', () => {
+        const unmodelled = { _raw: { andEnvIn: ['prod'], teams: ['team-1'] }, channels: ['ch-1'] }
+        expect(buildNotificationRouteInput(unmodelled).andEnvIn).toEqual(['prod'])
+    })
+
+    it('omits `teams` when the modelled list is empty', () => {
+        expect(buildNotificationRouteInput(ROUTE_NO_TEAMS)).not.toHaveProperty('teams')
+    })
+
+    it('preserves the unmodelled passthrough fields', () => {
+        const out = buildNotificationRouteInput(ROUTE_WITH_TEAMS)
+        expect(out.andEnvIn).toEqual(['prod'])
+        expect(out.andLifecycleIn).toEqual(['GENERAL_AVAILABILITY'])
+    })
+})
+
+// runIf, not an early return: an early return REPORTS PASSED when rearm-core is
+// absent, which makes the describe title a lie and hides that Pro went unchecked.
+describe('buildNotificationRouteInput vs the Pro schema (skipped when rearm-core is absent)', () => {
+    it.runIf(proSchema)('a route WITH teams coerces cleanly on Pro', () => {
+        expect(coerceErrors(proSchema!, 'NotificationRouteInput', buildNotificationRouteInput(ROUTE_WITH_TEAMS)))
+            .toEqual([])
+    })
+
+    it.runIf(proSchema)('a route with no teams coerces cleanly on Pro too', () => {
+        expect(coerceErrors(proSchema!, 'NotificationRouteInput', buildNotificationRouteInput(ROUTE_NO_TEAMS)))
+            .toEqual([])
+    })
+
+    it('carries the team targets through on Pro -- the omission is CE-only', () => {
+        // Pure function, no schema needed -- always runs.
+        expect(buildNotificationRouteInput(ROUTE_WITH_TEAMS).teams).toEqual(['team-1'])
+    })
+})


### PR DESCRIPTION
## Problem

A customer reported that Slack and Teams integrations are blocked in the CE UI while the CE backend allows them. Investigating, the gap was wider than reported.

The CE (OSS) backend ships the **entire** notification stack -- fan-out, delivery worker, Slack/Teams/Webhook dispatchers, subscriptions, channel groups -- and carries exactly **one** licence gate, in `NotificationChannelService.validateSeed`:

```java
// CE/Pro split: EMAIL and SENTINEL destinations are Pro-only.
// Slack / Teams / Webhook are available on the CE (OSS) edition.
if (LicensingConstants.isOssEdition()
        && (seed.getType() == IntegrationType.EMAIL
            || seed.getType() == IntegrationType.SENTINEL)) { throw ... }
```

The UI marked all five channel cards "Pro", **and** hid the Subscriptions + Channel groups sub-tabs, skipped `loadNotificationChannels` entirely, and gated Delivery History. `showCiFeatures` (`installationType !== 'OSS'`) conflated the CI/SCM surface with the notifications surface.

Un-marking the three cards alone would not have fixed it: a channel with no subscription routing events to it delivers nothing, and Delivery History is the only surface that answers "did it actually send?" -- which the channel cards deep-link to.

**Product call (@rhythm):** subscriptions and channel groups are available on CE too, not just the three channel types.

## Approach

`showCiFeatures` is now strictly the CI/SCM surface. The edition policy moved into one unit-tested module, `ui/src/utils/editionCapabilities.ts`, replacing the hand-maintained per-card `proOnly` flag. That flag is what drifted, and it could not have been right in principle: the policy is keyed on channel **type**, while the card id differs from it (`MSTEAMS` vs `MS_TEAMS`) -- a mismatch a per-card boolean cannot catch. Its spec parses the backend's own gate, so drift fails loudly rather than silently.

### Blocker found in review

`SubscriptionsOfOrg` sent `teams` in every `NotificationRouteInput` -- a field the CE schema does not declare. GraphQL rejects unknown input keys outright, so on CE **every** subscription save, including ones using no teams at all, would have failed with `Field "teams" is not defined by type "NotificationRouteInput"`. Exposed rather than caused by this change: the tab was previously hidden, so the path was unreachable.

Fixed by extracting `buildNotificationRouteInput`, which omits Pro-only route fields when empty and strips them from the `_raw` passthrough. `routeInputSchemaDrift.spec.ts` coerces its output against **both** real `.graphqls` files.

### Also fixed (same blast radius)

- **Degraded-load Edit could silently destroy data.** The core fallback query omits `filter routes dedupWindowMinutes rateLimit`, and save replaces wholesale -- opening Edit during a degraded load and saving would wipe the CEL expression, every route but one, and the rate limit. Now disabled while degraded; the banner alone wasn't enough.
- **Edit and "Add another" bypassed the edition lock**, letting a CE org fill in a Pro-only channel form and only fail at save -- the "UI looser than backend" failure mode.
- **The sub-tab clamp accepted unknown values** and the array vue-router yields for a repeated param, rendering the blank body it exists to prevent.

## Validation

Verified against a sandbox flipped to report `OSS`:

| | pre-fix UI | this branch |
|---|---|---|
| CE arm | **7 of 12 fail** | 12/12 pass |
| Pro arm | -- | 12/12 pass |

- Unit: 22 new tests. Each guard in `buildNotificationRouteInput` independently pinned (removing only the `_raw` strip fails 1 test; removing only the empty-omit fails 3).
- E2E through the real browser: a Pro-shaped subscription (team targets + unmodelled `andEnvIn`) re-saved via the UI comes back **byte-identical**.
- Delivery e2e: injected KEV event reached `FANNED_OUT`, teams-only route delivered `SENT`.
- `npm run validate:graphql`: 0 Pro failures, same 4 pre-existing CE drift warnings.
- Zero new lint errors.

Harness changes are in relizaio/rearm-playwright (`tests/notifications/editionParity.spec.ts`).

## Reviewer notes

- **Scope of the CE arm.** The UI proxies the edition via `installationType`; the backend's real gate is a compile-time constant in its own jar, never served to the browser. Flipping `RELIZAPROP_INSTALLATION_TYPE` changes only the UI's belief. UI-vs-backend agreement is therefore pinned in the unit suite, which reads the backend source -- not in the browser suite. Safe in practice because the CE Helm chart hardcodes `RELIZAPROP_INSTALLATION_TYPE: "OSS"` untemplated.
- **The CE arm is a manual gate** -- it needs a sandbox reporting OSS. More broadly, `.github/workflows/github_actions.yml` has no test job at all (no vitest, no eslint, no `validate:graphql`), so none of these tests run automatically. Worth fixing separately.
- **`npm test` is red on `main` already**, unrelated to this PR: `notificationInboxSchemaDrift.spec.ts` fails because the CE mirror caught up and its "split is load-bearing" assertion is now stale. Confirmed by stashing this branch's changes. It blocks adding a CI test job and should be resolved first.
- `.card-pro-hint` -> `.card-route-hint` (it renders on every edition now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)