### PR TITLE
fix(ui): wrap long lines in the VEX proposal's original-statement JSON

### DIFF
--- a/ui/src/components/VexProposalReview.vue
+++ b/ui/src/components/VexProposalReview.vue
@@ -16,7 +16,11 @@
             <n-grid :cols="2" x-gap="24">
                 <n-gi>
                     <n-h4>Original VEX statement</n-h4>
-                    <n-code language="json" :code="formatJson(proposal.sourceStatementJson)" />
+                    <!-- word-wrap: the statement JSON routinely carries long single-line
+                         string values (analysis.detail); without wrapping the pre keeps
+                         white-space: pre and overflows the grid cell, running underneath
+                         the proposed-analysis column. -->
+                    <n-code language="json" :code="formatJson(proposal.sourceStatementJson)" word-wrap />
                 </n-gi>
                 <n-gi>
                     <n-h4>


### PR DESCRIPTION
Fixes the overlap in the VEX Proposal review view (screenshot in report): the original-statement JSON carries long single-line string values — `analysis.detail` in particular — and `n-code` renders `white-space: pre`, so the `<pre>` expanded past its `n-grid` cell and ran underneath the Proposed ReARM analysis column.

One-attribute fix: naive-ui's `word-wrap` prop on `n-code` (applies `pre-wrap` + `break-word`), keeping the JSON inside its own column at any viewport width. This is the only `n-code` usage in the UI, so no sibling occurrences.

Build passes. Verification note: reproduces with any proposal whose `detail` exceeds the column width — the dev instance data from the report is a direct check post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)