### PR TITLE
Changelog re-scan visibility (UI): over-time changes in NONE mode, arrival-dated attribution, baseline label

### DIFF
--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -195,6 +195,7 @@
                             :branch-uuid="entry.branch.branchUuid"
                             :branch-name="entry.branch.branchName"
                         />
+                        <p v-if="entry.release.baselineRelease" class="baseline-note">Baseline release — the component's first release, so there is no earlier release to diff against.</p>
                         <SbomChangesDisplay :sbom-changes="entry.release.sbomChanges" />
                     </div>
                 </div>
@@ -250,7 +251,19 @@
                             :branch-uuid="entry.branch.branchUuid"
                             :branch-name="entry.branch.branchName"
                         />
+                        <p v-if="entry.release.baselineRelease" class="baseline-note">Baseline release — the component's first release, so there is no earlier release to diff against; its findings are listed under re-scan changes below when they were detected later.</p>
                         <FindingChangesDisplay :finding-changes="entry.release.findingChanges" :org-uuid="changelog.orgUuid" />
+                    </div>
+                    <!-- Re-scan-driven changes (e.g. a newly published advisory matching an
+                         already-shipped release) never show in the pairwise per-release diffs
+                         above - the affected releases' CURRENT metrics both carry the finding,
+                         so consecutive diffs cancel out. Surface them from the event stream. -->
+                    <div v-if="changelog.overTimeFindingChanges && changelog.overTimeFindingChanges.length > 0" class="over-time-section">
+                        <h3 class="over-time-heading">Changes detected by re-scans</h3>
+                        <OverTimeFindingChanges
+                            :over-time-finding-changes="changelog.overTimeFindingChanges"
+                            :org-uuid="changelog.orgUuid"
+                        />
                     </div>
                 </div>
 
@@ -312,7 +325,8 @@ import {
     ReleaseHeader,
     ProductReleaseHeader,
     ChangelogControls,
-    SeverityFilter
+    SeverityFilter,
+    OverTimeFindingChanges
 } from './changelog'
 import {
     fetchComponentChangelogByDate,
@@ -562,5 +576,18 @@ function handleExportPdf() {
 <style scoped lang="scss">
 .product-release-group {
     margin-bottom: 20px;
+}
+.baseline-note {
+    margin: 4px 0 8px;
+    font-style: italic;
+    color: #888;
+}
+.over-time-section {
+    margin-top: 24px;
+    padding-top: 12px;
+    border-top: 1px solid #e0e0e0;
+}
+.over-time-heading {
+    margin-bottom: 4px;
 }
 </style>

--- a/ui/src/components/ChangelogView.vue
+++ b/ui/src/components/ChangelogView.vue
@@ -11,10 +11,14 @@
                 <span v-if="props.branchprop && changelog.branches && changelog.branches.length === 1"> ({{ changelog.branches[0].branchName }}) - Changes</span>
                 <span v-else> - Component-wide Changes</span>
             </h2>
+            <!-- Toggle whenever a changelog came back at all: an AGGREGATED payload with no
+                 branch changes can still have a non-empty NONE view (e.g. a component whose
+                 only release is the baseline), so gating on branches.length locked users
+                 out of the NONE mode exactly when it was the only view with content. -->
             <ChangelogControls
                 v-model:dateRange="dateRange"
                 v-model:aggregationType="aggregationType"
-                :show-aggregation="!!(changelog && changelog.branches && changelog.branches.length > 0)"
+                :show-aggregation="!!changelog"
                 @apply="getAggregatedChangelog"
             />
         </div>

--- a/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
+++ b/ui/src/components/changelog/FindingChangesDisplayWithAttribution.vue
@@ -226,7 +226,8 @@ import type {
     VulnerabilityWithAttribution,
     ViolationWithAttribution,
     WeaknessWithAttribution,
-    OrgLevelContext
+    OrgLevelContext,
+    ComponentAttribution
 } from '../../types/changelog-attribution'
 import type { MetricsRevisionFindingChange } from '../../types/changelog-sealed'
 
@@ -463,6 +464,9 @@ type NormalizedFinding = {
     isStillPresent: boolean
     orgContext?: OrgLevelContext
     analysisState?: string | null
+    scanArrivalDate?: string | null
+    earliestCarrier?: ComponentAttribution | null
+    latestCarrier?: ComponentAttribution | null
 }
 
 const sortBySeverity = (findings: NormalizedFinding[]) => {
@@ -492,7 +496,10 @@ const normalizeVulnerability = (vuln: VulnerabilityWithAttribution): NormalizedF
     isNetResolved: vuln.isNetResolved,
     isStillPresent: vuln.isStillPresent,
     orgContext: vuln.orgContext,
-    analysisState: vuln.analysisState
+    analysisState: vuln.analysisState,
+    scanArrivalDate: vuln.scanArrivalDate,
+    earliestCarrier: vuln.earliestCarrier,
+    latestCarrier: vuln.latestCarrier
 })
 
 const normalizeViolation = (violation: ViolationWithAttribution): NormalizedFinding => ({
@@ -511,7 +518,10 @@ const normalizeViolation = (violation: ViolationWithAttribution): NormalizedFind
     isNetResolved: violation.isNetResolved,
     isStillPresent: violation.isStillPresent,
     orgContext: violation.orgContext,
-    analysisState: violation.analysisState
+    analysisState: violation.analysisState,
+    scanArrivalDate: violation.scanArrivalDate,
+    earliestCarrier: violation.earliestCarrier,
+    latestCarrier: violation.latestCarrier
 })
 
 const normalizeWeakness = (weakness: WeaknessWithAttribution): NormalizedFinding => ({
@@ -531,7 +541,10 @@ const normalizeWeakness = (weakness: WeaknessWithAttribution): NormalizedFinding
     isNetResolved: weakness.isNetResolved,
     isStillPresent: weakness.isStillPresent,
     orgContext: weakness.orgContext,
-    analysisState: weakness.analysisState
+    analysisState: weakness.analysisState,
+    scanArrivalDate: weakness.scanArrivalDate,
+    earliestCarrier: weakness.earliestCarrier,
+    latestCarrier: weakness.latestCarrier
 })
 
 const allFindings = computed(() => {
@@ -659,9 +672,39 @@ function getEarliestRelease(finding: NormalizedFinding): { version: string, rele
     return { version: sorted[0].releaseVersion, releaseUuid: sorted[0].releaseUuid }
 }
 
+function formatArrivalDate(iso: string): string {
+    const d = new Date(iso)
+    if (isNaN(d.getTime())) return iso
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+function carrierSegment(carrier: ComponentAttribution): AttributionSegment {
+    const version = carrier.releaseVersion || ''
+    const text = carrier.componentName ? `${carrier.componentName}@${version}`
+        : carrier.branchName ? `${carrier.branchName} ${version}` : `@${version}`
+    return { text, releaseUuid: carrier.releaseUuid }
+}
+
 function getAppearedContextSegments(finding: NormalizedFinding): AttributionSegment[] {
     if (finding.appearedIn.length === 0) return []
-    
+
+    // Re-scan-dated appearance: the finding-change event pins WHEN the finding
+    // was first detected, and earliest/latest carrier bound the releases whose
+    // current metrics carry it. Rendering the anchor release as "Appeared in
+    // <endpoint> (first occurrence...)" would misattribute a late advisory that
+    // also affects earlier releases, so this replaces the anchor list entirely.
+    if (finding.scanArrivalDate && finding.earliestCarrier) {
+        const segments: AttributionSegment[] = [
+            { text: `First detected ${formatArrivalDate(finding.scanArrivalDate)} — affects ` },
+            carrierSegment(finding.earliestCarrier)
+        ]
+        if (finding.latestCarrier && finding.latestCarrier.releaseUuid !== finding.earliestCarrier.releaseUuid) {
+            segments.push({ text: ' – ' })
+            segments.push(carrierSegment(finding.latestCarrier))
+        }
+        return segments
+    }
+
     if (finding.orgContext) {
         const segments: AttributionSegment[] = [{ text: 'Appeared in ' }]
         finding.appearedIn.forEach((a, i) => {

--- a/ui/src/components/changelog/OverTimeFindingChanges.vue
+++ b/ui/src/components/changelog/OverTimeFindingChanges.vue
@@ -1,5 +1,8 @@
 <template>
-    <div class="over-time-finding-changes">
+    <!-- finding-changes: the shared _finding-common.scss rules (row gap, in-label,
+         severity palette) are all nested under it; without it the finding rows
+         render with no spacing ("CVE-XinPkg"). -->
+    <div class="over-time-finding-changes finding-changes">
         <div v-if="dateBuckets.length > 0">
             <p class="over-time-note">
                 Finding changes detected by re-scans over the selected period, grouped by the date the change was observed.

--- a/ui/src/types/changelog-attribution.ts
+++ b/ui/src/types/changelog-attribution.ts
@@ -80,6 +80,13 @@ export interface VulnerabilityWithAttribution {
     isStillPresent: boolean  // Org-wide: still present in some releases
     orgContext?: OrgLevelContext  // Optional org-level semantic context (only for multi-component views)
     analysisState?: string | null  // Analysis state: EXPLOITABLE, IN_TRIAGE, FALSE_POSITIVE, NOT_AFFECTED
+    // Re-scan arrival context (additive; absent on backends without the fields and
+    // on findings whose appearance has no finding-change event in the window).
+    // When set, the appearance is dated by the scan that detected it and
+    // earliest/latest carrier bound the releases whose CURRENT metrics carry it.
+    scanArrivalDate?: string | null
+    earliestCarrier?: ComponentAttribution | null
+    latestCarrier?: ComponentAttribution | null
 }
 
 /**
@@ -100,6 +107,10 @@ export interface ViolationWithAttribution {
     isStillPresent: boolean
     orgContext?: OrgLevelContext  // Optional org-level semantic context (only for multi-component views)
     analysisState?: string | null  // Analysis state: EXPLOITABLE, IN_TRIAGE, FALSE_POSITIVE, NOT_AFFECTED
+    // Re-scan arrival context - see VulnerabilityWithAttribution.
+    scanArrivalDate?: string | null
+    earliestCarrier?: ComponentAttribution | null
+    latestCarrier?: ComponentAttribution | null
 }
 
 /**
@@ -122,6 +133,10 @@ export interface WeaknessWithAttribution {
     isStillPresent: boolean
     orgContext?: OrgLevelContext  // Optional org-level semantic context (only for multi-component views)
     analysisState?: string | null  // Analysis state: EXPLOITABLE, IN_TRIAGE, FALSE_POSITIVE, NOT_AFFECTED
+    // Re-scan arrival context - see VulnerabilityWithAttribution.
+    scanArrivalDate?: string | null
+    earliestCarrier?: ComponentAttribution | null
+    latestCarrier?: ComponentAttribution | null
 }
 
 /**

--- a/ui/src/types/changelog-sealed.ts
+++ b/ui/src/types/changelog-sealed.ts
@@ -125,6 +125,10 @@ export interface NoneReleaseChanges {
     commits: CodeCommit[]
     sbomChanges: ReleaseSbomChanges
     findingChanges: ReleaseFindingChanges
+    // True when this is the component's first release EVER: its empty SBOM/finding
+    // diffs mean "nothing to compare against", not "no changes". Optional so a
+    // backend without the field (CE mirror lag) degrades to no label.
+    baselineRelease?: boolean
 }
 
 /**

--- a/ui/src/utils/changelogPdfExport.ts
+++ b/ui/src/utils/changelogPdfExport.ts
@@ -298,7 +298,44 @@ function buildFindingNoneTable(changelog: any): { headers: string[]; rows: PdfRo
     for (const { branchLabel, release } of flattenNoneReleases(changelog)) {
         rows.push(...emitFinding(branchLabel, release))
     }
+    rows.push(...buildOverTimeRows(changelog, headers.length))
     return { headers, rows, widths }
+}
+
+// Re-scan-driven changes (already-shipped releases hit by a later advisory) never
+// appear in the pairwise per-release rows above; mirror the on-screen
+// "Changes detected by re-scans" section from the event stream.
+function buildOverTimeRows(changelog: any, columnCount: number): PdfRow[] {
+    const events = changelog.overTimeFindingChanges
+    if (!events || events.length === 0) return []
+    const kindLabel: Record<string, string> = {
+        APPEARED: 'New',
+        RESOLVED: 'Resolved',
+        SEVERITY_INCREASED: 'Severity increased',
+        SEVERITY_DECREASED: 'Severity decreased',
+        KEV_ADDED: 'KEV listed',
+        KEV_REMOVED: 'KEV removed'
+    }
+    const rows: PdfRow[] = [sectionHeaderRow('Changes detected by re-scans', columnCount)]
+    for (const ev of events) {
+        const f = ev.vulnerability || ev.violation || ev.weakness
+        if (!f) continue
+        const type = ev.vulnerability ? 'Vulnerability' : ev.violation ? 'Violation' : 'Weakness'
+        const issueId = ev.vulnerability ? (f.vulnId || '') : ev.violation ? (f.type || '') : (f.cweId || f.ruleId || '')
+        const location = ev.weakness ? (f.location || '') : (f.purl || '')
+        const date = ev.changeDate ? new Date(ev.changeDate).toLocaleDateString('en-CA') : ''
+        const status = kindLabel[ev.changeKind] || ev.changeKind || ''
+        rows.push({ cells: [
+            { text: ev.componentName ? `${ev.componentName} / ${ev.branchName || ''}` : (ev.branchName || '') },
+            { text: date ? `${ev.version || ''} (${date})` : (ev.version || '') },
+            { text: status, color: getStatusColor(status) },
+            { text: type },
+            { text: issueId },
+            { text: location },
+            { text: f.severity || '', color: f.severity ? getSeverityColor(f.severity) : undefined }
+        ]})
+    }
+    return rows
 }
 
 function addNoneFindingRows(rows: PdfRow[], branchName: string, version: string, fc: any) {
@@ -375,7 +412,8 @@ function buildFindingAggregatedTable(changelog: any): { headers: string[]; rows:
     const widths = ['auto', 'auto', 'auto', '*', 'auto', 'auto']
     const rows: PdfRow[] = []
 
-    const fc = changelog.findingChanges
+    // Prefer the window posture-diff when present, matching the on-screen view.
+    const fc = changelog.postureFindingChanges ?? changelog.findingChanges
     if (!fc) return { headers, rows, widths }
 
     const allFindings: { finding: any; type: string; statusOrder: number }[] = []
@@ -441,7 +479,22 @@ function formatAttribution(addedIn: any[], removedIn: any[], addedInCount?: numb
     return parts.join('; ')
 }
 
+function carrierLabel(carrier: any): string {
+    return `${carrier.componentName || ''}@${carrier.releaseVersion || ''}`
+}
+
 function formatFindingAttribution(finding: any): string {
+    // Re-scan-dated appearance: date the detection and bound the carrier
+    // releases instead of implying the window-end anchor introduced it
+    // (mirrors getAppearedContextSegments in FindingChangesDisplayWithAttribution).
+    if (finding.scanArrivalDate && finding.earliestCarrier) {
+        const date = new Date(finding.scanArrivalDate).toLocaleDateString('en-CA')
+        let range = carrierLabel(finding.earliestCarrier)
+        if (finding.latestCarrier && finding.latestCarrier.releaseUuid !== finding.earliestCarrier.releaseUuid) {
+            range += ` – ${carrierLabel(finding.latestCarrier)}`
+        }
+        return `First detected ${date} — affects ${range}`
+    }
     const parts: string[] = []
     if (finding.appearedIn && finding.appearedIn.length > 0) {
         parts.push(finding.appearedIn.map((a: any) => `${a.componentName || ''}@${a.releaseVersion || ''}`).join(', ') + moreSuffix(finding.appearedInCount, finding.appearedIn))

--- a/ui/src/utils/changelogQueries.ts
+++ b/ui/src/utils/changelogQueries.ts
@@ -5,372 +5,27 @@
 import { gql } from '@apollo/client/core'
 import graphqlClient from './graphql'
 import { ComponentChangelog, OrganizationChangelog } from '../types/changelog-sealed'
+import { isSchemaDriftError } from './graphqlDriftFallback'
+import {
+    stripAdditiveFields,
+    COMPONENT_CHANGELOG_QUERY,
+    COMPONENT_CHANGELOG_BY_DATE_QUERY,
+    ORGANIZATION_CHANGELOG_BY_DATE_QUERY,
+    COMPONENT_ATTRIBUTION_FRAGMENT,
+    OVER_TIME_FINDING_CHANGES_FRAGMENT
+} from './changelogQueryTexts'
 
-// Fragments selecting vulnerability findings inline the knownExploited field
-// so the KEV flag rides the main changelog query (cheaper than a mirror
-// query on top of the already-expensive changelog computation).
-
-// ========== GraphQL Field Fragments ==========
-
-const RELEASE_INFO_FRAGMENT = `
-    __typename
-    uuid
-    version
-    lifecycle
-`
-
-const CODE_COMMIT_FRAGMENT = `
-    commitId
-    commitUri
-    message
-    author
-    email
-    changeType
-`
-
-const RELEASE_SBOM_CHANGES_FRAGMENT = `
-    addedArtifacts {
-        purl
-        name
-        version
+// Try the full document first; if the deployed schema rejects it (CE mirror
+// lag), strip the #additive-field-tagged lines and retry. See
+// changelogQueryTexts.ts for the tagging rule and the drift spec pinning it.
+async function queryWithAdditiveFallback(queryText: string, variables: Record<string, any>): Promise<any> {
+    try {
+        return await graphqlClient.query({ query: gql(queryText), variables, fetchPolicy: 'no-cache' })
+    } catch (err) {
+        if (!isSchemaDriftError(err)) throw err
+        return await graphqlClient.query({ query: gql(stripAdditiveFields(queryText)), variables, fetchPolicy: 'no-cache' })
     }
-    removedArtifacts {
-        purl
-        name
-        version
-    }
-`
-
-const RELEASE_FINDING_CHANGES_FRAGMENT = `
-    appearedCount
-    resolvedCount
-    appearedVulnerabilities {
-        vulnId
-        purl
-        severity
-        aliases {
-            aliasId
-        }
-        analysisState
-        knownExploited
-    }
-    resolvedVulnerabilities {
-        vulnId
-        purl
-        severity
-        aliases {
-            aliasId
-        }
-        analysisState
-        knownExploited
-    }
-    appearedViolations {
-        type
-        purl
-        analysisState
-    }
-    resolvedViolations {
-        type
-        purl
-        analysisState
-    }
-    appearedWeaknesses {
-        cweId
-        severity
-        ruleId
-        location
-        analysisState
-    }
-    resolvedWeaknesses {
-        cweId
-        severity
-        ruleId
-        location
-        analysisState
-    }
-`
-
-// Over-time finding changes: flat list of re-scan-driven MetricsRevisionFindingChange
-// records. Exactly one of vulnerability/violation/weakness is non-null per record;
-// previousSeverity is set for SEVERITY_INCREASED and SEVERITY_DECREASED. Selects analysisState on each
-// nested finding for parity with the per-release finding-change fragments (so
-// suppressed/FALSE_POSITIVE findings render correctly in the drill-down drawer).
-const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
-    changeDate
-    changeKind
-    releaseUuid
-    version
-    componentUuid
-    componentName
-    branchUuid
-    branchName
-    previousSeverity
-    vulnerability {
-        vulnId
-        purl
-        severity
-        aliases {
-            aliasId
-        }
-        analysisState
-        knownExploited
-    }
-    violation {
-        type
-        purl
-        analysisState
-    }
-    weakness {
-        cweId
-        severity
-        ruleId
-        location
-        analysisState
-    }
-`
-
-const NONE_RELEASE_CHANGES_FRAGMENT = `
-    releaseUuid
-    version
-    lifecycle
-    createdDate
-    commits {
-        ${CODE_COMMIT_FRAGMENT}
-    }
-    sbomChanges {
-        ${RELEASE_SBOM_CHANGES_FRAGMENT}
-    }
-    findingChanges {
-        ${RELEASE_FINDING_CHANGES_FRAGMENT}
-    }
-`
-
-const COMMITS_BY_TYPE_FRAGMENT = `
-    changeType
-    commits {
-        ${CODE_COMMIT_FRAGMENT}
-    }
-`
-
-const COMPONENT_ATTRIBUTION_FRAGMENT = `
-    componentUuid
-    componentName
-    releaseUuid
-    releaseVersion
-    branchUuid
-    branchName
-`
-
-const ORG_LEVEL_CONTEXT_FRAGMENT = `
-    isNewToOrganization
-    wasPreviouslyReported
-    isPartiallyResolved
-    isFullyResolved
-    isInheritedInAllComponents
-    componentCount
-    affectedComponentNames
-    isNewlyKev
-    isSeverityIncreased
-    previousSeverity
-`
-
-const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
-    totalAdded
-    totalRemoved
-    artifacts {
-        purl
-        name
-        version
-        isNetAdded
-        isNetRemoved
-        addedInCount
-        removedInCount
-        addedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        removedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-    }
-`
-
-const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
-    totalAppeared
-    totalResolved
-    totalNewlyKev
-    totalSeverityIncreased
-    vulnerabilities {
-        findingKey
-        vulnId
-        purl
-        severity
-        aliases {
-            aliasId
-        }
-        knownExploited
-        isNetAppeared
-        isNetResolved
-        isStillPresent
-        appearedInCount
-        resolvedInCount
-        presentInCount
-        appearedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        resolvedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        presentIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        orgContext {
-            ${ORG_LEVEL_CONTEXT_FRAGMENT}
-        }
-        analysisState
-    }
-    violations {
-        findingKey
-        type
-        purl
-        isNetAppeared
-        isNetResolved
-        isStillPresent
-        appearedInCount
-        resolvedInCount
-        presentInCount
-        appearedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        resolvedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        presentIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        orgContext {
-            ${ORG_LEVEL_CONTEXT_FRAGMENT}
-        }
-        analysisState
-    }
-    weaknesses {
-        findingKey
-        cweId
-        severity
-        ruleId
-        location
-        isNetAppeared
-        isNetResolved
-        isStillPresent
-        appearedInCount
-        resolvedInCount
-        presentInCount
-        appearedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        resolvedIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        presentIn {
-            ${COMPONENT_ATTRIBUTION_FRAGMENT}
-        }
-        orgContext {
-            ${ORG_LEVEL_CONTEXT_FRAGMENT}
-        }
-        analysisState
-    }
-`
-
-// ========== Shared Component Changelog Fragments ==========
-
-const NONE_BRANCH_CHANGES_FRAGMENT = `
-    branchUuid
-    branchName
-    componentUuid
-    componentName
-    changeType
-    releases {
-        ${NONE_RELEASE_CHANGES_FRAGMENT}
-    }
-`
-
-const NONE_CHANGELOG_FIELDS = `
-    componentUuid
-    componentName
-    orgUuid
-    firstRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    lastRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    branches {
-        ${NONE_BRANCH_CHANGES_FRAGMENT}
-    }
-    overTimeFindingChanges {
-        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
-    }
-`
-
-const NONE_PRODUCT_CHANGELOG_FIELDS = `
-    componentUuid
-    componentName
-    orgUuid
-    firstRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    lastRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    productReleases {
-        releaseUuid
-        version
-        lifecycle
-        createdDate
-        branches {
-            ${NONE_BRANCH_CHANGES_FRAGMENT}
-        }
-    }
-`
-
-const AGGREGATED_CHANGELOG_FIELDS = `
-    componentUuid
-    componentName
-    orgUuid
-    firstRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    lastRelease {
-        ${RELEASE_INFO_FRAGMENT}
-    }
-    branches {
-        branchUuid
-        branchName
-        componentUuid
-        componentName
-        firstReleaseUuid
-        firstVersion
-        lastReleaseUuid
-        lastVersion
-        changeType
-        commitsByType {
-            ${COMMITS_BY_TYPE_FRAGMENT}
-        }
-    }
-    sbomChanges {
-        ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
-    }
-    findingChanges {
-        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
-    }
-    postureFindingChanges {
-        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
-    }
-    overTimeFindingChanges {
-        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
-    }
-`
-
-// ========== Query Functions ==========
+}
 
 /**
  * Fetch component changelog between two releases
@@ -382,43 +37,12 @@ export async function fetchComponentChangelog(params: {
     aggregated: 'NONE' | 'AGGREGATED'
     timeZone?: string
 }): Promise<ComponentChangelog> {
-    const response = await graphqlClient.query({
-        query: gql`
-            query FetchComponentChangelog(
-                $release1: ID!
-                $release2: ID!
-                $org: ID!
-                $aggregated: AggregationType!
-                $timeZone: String
-            ) {
-                componentChangelog(
-                    release1: $release1
-                    release2: $release2
-                    orgUuid: $org
-                    aggregated: $aggregated
-                    timeZone: $timeZone
-                ) {
-                    __typename
-                    ... on NoneChangelog {
-                        ${NONE_CHANGELOG_FIELDS}
-                    }
-                    ... on NoneProductChangelog {
-                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
-                    }
-                    ... on AggregatedChangelog {
-                        ${AGGREGATED_CHANGELOG_FIELDS}
-                    }
-                }
-            }
-        `,
-        variables: {
-            release1: params.release1,
-            release2: params.release2,
-            org: params.org,
-            aggregated: params.aggregated,
-            timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone
-        },
-        fetchPolicy: 'no-cache'
+    const response = await queryWithAdditiveFallback(COMPONENT_CHANGELOG_QUERY, {
+        release1: params.release1,
+        release2: params.release2,
+        org: params.org,
+        aggregated: params.aggregated,
+        timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone
     })
 
     return (response.data as any).componentChangelog as ComponentChangelog
@@ -436,49 +60,14 @@ export async function fetchComponentChangelogByDate(params: {
     dateFrom: string
     dateTo: string
 }): Promise<ComponentChangelog> {
-    const response = await graphqlClient.query({
-        query: gql`
-            query FetchComponentChangelogByDate(
-                $componentUuid: ID!
-                $branchUuid: ID
-                $org: ID!
-                $aggregated: AggregationType!
-                $timeZone: String
-                $dateFrom: DateTime!
-                $dateTo: DateTime!
-            ) {
-                componentChangelogByDate(
-                    componentUuid: $componentUuid
-                    branchUuid: $branchUuid
-                    orgUuid: $org
-                    aggregated: $aggregated
-                    timeZone: $timeZone
-                    dateFrom: $dateFrom
-                    dateTo: $dateTo
-                ) {
-                    __typename
-                    ... on NoneChangelog {
-                        ${NONE_CHANGELOG_FIELDS}
-                    }
-                    ... on NoneProductChangelog {
-                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
-                    }
-                    ... on AggregatedChangelog {
-                        ${AGGREGATED_CHANGELOG_FIELDS}
-                    }
-                }
-            }
-        `,
-        variables: {
-            componentUuid: params.componentUuid,
-            branchUuid: params.branchUuid || null,
-            org: params.org,
-            aggregated: params.aggregated,
-            timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
-            dateFrom: params.dateFrom,
-            dateTo: params.dateTo
-        },
-        fetchPolicy: 'no-cache'
+    const response = await queryWithAdditiveFallback(COMPONENT_CHANGELOG_BY_DATE_QUERY, {
+        componentUuid: params.componentUuid,
+        branchUuid: params.branchUuid || null,
+        org: params.org,
+        aggregated: params.aggregated,
+        timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+        dateFrom: params.dateFrom,
+        dateTo: params.dateTo
     })
 
     return (response.data as any).componentChangelogByDate as ComponentChangelog
@@ -495,71 +84,13 @@ export async function fetchOrganizationChangelogByDate(params: {
     aggregated: 'NONE' | 'AGGREGATED'
     timeZone?: string
 }): Promise<OrganizationChangelog> {
-    const response = await graphqlClient.query({
-        query: gql`
-            query FetchOrganizationChangelogByDate(
-                $orgUuid: ID!
-                $perspectiveUuid: ID
-                $dateFrom: DateTime!
-                $dateTo: DateTime!
-                $aggregated: AggregationType!
-                $timeZone: String
-            ) {
-                organizationChangelogByDate(
-                    orgUuid: $orgUuid
-                    perspectiveUuid: $perspectiveUuid
-                    dateFrom: $dateFrom
-                    dateTo: $dateTo
-                    aggregated: $aggregated
-                    timeZone: $timeZone
-                ) {
-                    __typename
-                    ... on NoneOrganizationChangelog {
-                        orgUuid
-                        dateFrom
-                        dateTo
-                        components {
-                            __typename
-                            ... on NoneChangelog {
-                                ${NONE_CHANGELOG_FIELDS}
-                            }
-                        }
-                        overTimeFindingChanges {
-                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
-                        }
-                    }
-                    ... on AggregatedOrganizationChangelog {
-                        orgUuid
-                        dateFrom
-                        dateTo
-                        components {
-                            __typename
-                            ... on AggregatedChangelog {
-                                ${AGGREGATED_CHANGELOG_FIELDS}
-                            }
-                        }
-                        sbomChanges {
-                            ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
-                        }
-                        findingChanges {
-                            ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
-                        }
-                        overTimeFindingChanges {
-                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
-                        }
-                    }
-                }
-            }
-        `,
-        variables: {
-            orgUuid: params.orgUuid,
-            perspectiveUuid: params.perspectiveUuid || null,
-            dateFrom: params.dateFrom,
-            dateTo: params.dateTo,
-            aggregated: params.aggregated,
-            timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone
-        },
-        fetchPolicy: 'no-cache'
+    const response = await queryWithAdditiveFallback(ORGANIZATION_CHANGELOG_BY_DATE_QUERY, {
+        orgUuid: params.orgUuid,
+        perspectiveUuid: params.perspectiveUuid || null,
+        dateFrom: params.dateFrom,
+        dateTo: params.dateTo,
+        aggregated: params.aggregated,
+        timeZone: params.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone
     })
 
     return (response.data as any).organizationChangelogByDate as OrganizationChangelog
@@ -740,3 +271,4 @@ export async function fetchFindingChangeTimeline(params: {
     })
     return (response.data as any).findingChangeTimelineByDate as MetricsRevisionFindingChangePage
 }
+

--- a/ui/src/utils/changelogQueryTexts.ts
+++ b/ui/src/utils/changelogQueryTexts.ts
@@ -1,0 +1,522 @@
+/**
+ * Changelog GraphQL document texts (fragments + full query strings).
+ *
+ * Deliberately free of any Apollo-client / runtime import so the vitest
+ * schema-drift spec (changelogSchemaDrift.spec.ts) can load it in a plain
+ * node environment; changelogQueries.ts owns the client-facing fetchers.
+ */
+// Fields newer than the oldest supported CE-mirror backend are declared on
+// single lines tagged with this GraphQL comment. When the deployed schema
+// rejects the full document (mirror lag), the tagged lines are stripped and
+// the query retried - same FULL->CORE degradation as notificationInboxQuery,
+// but derived from one source instead of hand-maintained fragment pairs.
+// RULE: a tagged selection must be self-contained on its one line (inline the
+// object body, no multi-line fragment interpolation).
+const ADDITIVE_FIELD_MARKER = '#additive-field'
+
+export function stripAdditiveFields(queryText: string): string {
+    return queryText.split('\n').filter((line) => !line.includes(ADDITIVE_FIELD_MARKER)).join('\n')
+}
+
+// One-line ComponentAttribution selection for marker-tagged carrier fields
+// (the multi-line COMPONENT_ATTRIBUTION_FRAGMENT cannot sit on a tagged line).
+const ATTRIBUTION_INLINE = 'componentUuid componentName releaseUuid releaseVersion branchUuid branchName'
+
+// Fragments selecting vulnerability findings inline the knownExploited field
+// so the KEV flag rides the main changelog query (cheaper than a mirror
+// query on top of the already-expensive changelog computation).
+
+// ========== GraphQL Field Fragments ==========
+
+const RELEASE_INFO_FRAGMENT = `
+    __typename
+    uuid
+    version
+    lifecycle
+`
+
+const CODE_COMMIT_FRAGMENT = `
+    commitId
+    commitUri
+    message
+    author
+    email
+    changeType
+`
+
+const RELEASE_SBOM_CHANGES_FRAGMENT = `
+    addedArtifacts {
+        purl
+        name
+        version
+    }
+    removedArtifacts {
+        purl
+        name
+        version
+    }
+`
+
+const RELEASE_FINDING_CHANGES_FRAGMENT = `
+    appearedCount
+    resolvedCount
+    appearedVulnerabilities {
+        vulnId
+        purl
+        severity
+        aliases {
+            aliasId
+        }
+        analysisState
+        knownExploited
+    }
+    resolvedVulnerabilities {
+        vulnId
+        purl
+        severity
+        aliases {
+            aliasId
+        }
+        analysisState
+        knownExploited
+    }
+    appearedViolations {
+        type
+        purl
+        analysisState
+    }
+    resolvedViolations {
+        type
+        purl
+        analysisState
+    }
+    appearedWeaknesses {
+        cweId
+        severity
+        ruleId
+        location
+        analysisState
+    }
+    resolvedWeaknesses {
+        cweId
+        severity
+        ruleId
+        location
+        analysisState
+    }
+`
+
+// Over-time finding changes: flat list of re-scan-driven MetricsRevisionFindingChange
+// records. Exactly one of vulnerability/violation/weakness is non-null per record;
+// previousSeverity is set for SEVERITY_INCREASED and SEVERITY_DECREASED. Selects analysisState on each
+// nested finding for parity with the per-release finding-change fragments (so
+// suppressed/FALSE_POSITIVE findings render correctly in the drill-down drawer).
+export const OVER_TIME_FINDING_CHANGES_FRAGMENT = `
+    changeDate
+    changeKind
+    releaseUuid
+    version
+    componentUuid
+    componentName
+    branchUuid
+    branchName
+    previousSeverity
+    vulnerability {
+        vulnId
+        purl
+        severity
+        aliases {
+            aliasId
+        }
+        analysisState
+        knownExploited
+    }
+    violation {
+        type
+        purl
+        analysisState
+    }
+    weakness {
+        cweId
+        severity
+        ruleId
+        location
+        analysisState
+    }
+`
+
+const NONE_RELEASE_CHANGES_FRAGMENT = `
+    releaseUuid
+    version
+    lifecycle
+    createdDate
+    baselineRelease #additive-field
+    commits {
+        ${CODE_COMMIT_FRAGMENT}
+    }
+    sbomChanges {
+        ${RELEASE_SBOM_CHANGES_FRAGMENT}
+    }
+    findingChanges {
+        ${RELEASE_FINDING_CHANGES_FRAGMENT}
+    }
+`
+
+const COMMITS_BY_TYPE_FRAGMENT = `
+    changeType
+    commits {
+        ${CODE_COMMIT_FRAGMENT}
+    }
+`
+
+export const COMPONENT_ATTRIBUTION_FRAGMENT = `
+    componentUuid
+    componentName
+    releaseUuid
+    releaseVersion
+    branchUuid
+    branchName
+`
+
+const ORG_LEVEL_CONTEXT_FRAGMENT = `
+    isNewToOrganization
+    wasPreviouslyReported
+    isPartiallyResolved
+    isFullyResolved
+    isInheritedInAllComponents
+    componentCount
+    affectedComponentNames
+    isNewlyKev
+    isSeverityIncreased
+    previousSeverity
+`
+
+const SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
+    totalAdded
+    totalRemoved
+    artifacts {
+        purl
+        name
+        version
+        isNetAdded
+        isNetRemoved
+        addedInCount
+        removedInCount
+        addedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        removedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+    }
+`
+
+const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
+    totalAppeared
+    totalResolved
+    totalNewlyKev
+    totalSeverityIncreased
+    vulnerabilities {
+        findingKey
+        vulnId
+        purl
+        severity
+        aliases {
+            aliasId
+        }
+        knownExploited
+        isNetAppeared
+        isNetResolved
+        isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
+        appearedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        resolvedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        presentIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        orgContext {
+            ${ORG_LEVEL_CONTEXT_FRAGMENT}
+        }
+        analysisState
+        scanArrivalDate #additive-field
+        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+    }
+    violations {
+        findingKey
+        type
+        purl
+        isNetAppeared
+        isNetResolved
+        isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
+        appearedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        resolvedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        presentIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        orgContext {
+            ${ORG_LEVEL_CONTEXT_FRAGMENT}
+        }
+        analysisState
+        scanArrivalDate #additive-field
+        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+    }
+    weaknesses {
+        findingKey
+        cweId
+        severity
+        ruleId
+        location
+        isNetAppeared
+        isNetResolved
+        isStillPresent
+        appearedInCount
+        resolvedInCount
+        presentInCount
+        appearedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        resolvedIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        presentIn {
+            ${COMPONENT_ATTRIBUTION_FRAGMENT}
+        }
+        orgContext {
+            ${ORG_LEVEL_CONTEXT_FRAGMENT}
+        }
+        analysisState
+        scanArrivalDate #additive-field
+        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+    }
+`
+
+// ========== Shared Component Changelog Fragments ==========
+
+const NONE_BRANCH_CHANGES_FRAGMENT = `
+    branchUuid
+    branchName
+    componentUuid
+    componentName
+    changeType
+    releases {
+        ${NONE_RELEASE_CHANGES_FRAGMENT}
+    }
+`
+
+const NONE_CHANGELOG_FIELDS = `
+    componentUuid
+    componentName
+    orgUuid
+    firstRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    lastRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    branches {
+        ${NONE_BRANCH_CHANGES_FRAGMENT}
+    }
+    overTimeFindingChanges {
+        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+    }
+`
+
+const NONE_PRODUCT_CHANGELOG_FIELDS = `
+    componentUuid
+    componentName
+    orgUuid
+    firstRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    lastRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    productReleases {
+        releaseUuid
+        version
+        lifecycle
+        createdDate
+        branches {
+            ${NONE_BRANCH_CHANGES_FRAGMENT}
+        }
+    }
+`
+
+const AGGREGATED_CHANGELOG_FIELDS = `
+    componentUuid
+    componentName
+    orgUuid
+    firstRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    lastRelease {
+        ${RELEASE_INFO_FRAGMENT}
+    }
+    branches {
+        branchUuid
+        branchName
+        componentUuid
+        componentName
+        firstReleaseUuid
+        firstVersion
+        lastReleaseUuid
+        lastVersion
+        changeType
+        commitsByType {
+            ${COMMITS_BY_TYPE_FRAGMENT}
+        }
+    }
+    sbomChanges {
+        ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+    }
+    findingChanges {
+        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+    }
+    postureFindingChanges {
+        ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+    }
+    overTimeFindingChanges {
+        ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+    }
+`
+
+// ========== Query Functions ==========
+
+// Query texts are module-level (and exported for the schema-drift spec, which
+// asserts the full text validates against Pro and the additive-stripped text
+// against the CE mirror). Exported via __changelogQueryTestables below.
+
+export const COMPONENT_CHANGELOG_QUERY = `
+            query FetchComponentChangelog(
+                $release1: ID!
+                $release2: ID!
+                $org: ID!
+                $aggregated: AggregationType!
+                $timeZone: String
+            ) {
+                componentChangelog(
+                    release1: $release1
+                    release2: $release2
+                    orgUuid: $org
+                    aggregated: $aggregated
+                    timeZone: $timeZone
+                ) {
+                    __typename
+                    ... on NoneChangelog {
+                        ${NONE_CHANGELOG_FIELDS}
+                    }
+                    ... on NoneProductChangelog {
+                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
+                    }
+                    ... on AggregatedChangelog {
+                        ${AGGREGATED_CHANGELOG_FIELDS}
+                    }
+                }
+            }
+        `
+
+export const COMPONENT_CHANGELOG_BY_DATE_QUERY = `
+            query FetchComponentChangelogByDate(
+                $componentUuid: ID!
+                $branchUuid: ID
+                $org: ID!
+                $aggregated: AggregationType!
+                $timeZone: String
+                $dateFrom: DateTime!
+                $dateTo: DateTime!
+            ) {
+                componentChangelogByDate(
+                    componentUuid: $componentUuid
+                    branchUuid: $branchUuid
+                    orgUuid: $org
+                    aggregated: $aggregated
+                    timeZone: $timeZone
+                    dateFrom: $dateFrom
+                    dateTo: $dateTo
+                ) {
+                    __typename
+                    ... on NoneChangelog {
+                        ${NONE_CHANGELOG_FIELDS}
+                    }
+                    ... on NoneProductChangelog {
+                        ${NONE_PRODUCT_CHANGELOG_FIELDS}
+                    }
+                    ... on AggregatedChangelog {
+                        ${AGGREGATED_CHANGELOG_FIELDS}
+                    }
+                }
+            }
+        `
+
+export const ORGANIZATION_CHANGELOG_BY_DATE_QUERY = `
+            query FetchOrganizationChangelogByDate(
+                $orgUuid: ID!
+                $perspectiveUuid: ID
+                $dateFrom: DateTime!
+                $dateTo: DateTime!
+                $aggregated: AggregationType!
+                $timeZone: String
+            ) {
+                organizationChangelogByDate(
+                    orgUuid: $orgUuid
+                    perspectiveUuid: $perspectiveUuid
+                    dateFrom: $dateFrom
+                    dateTo: $dateTo
+                    aggregated: $aggregated
+                    timeZone: $timeZone
+                ) {
+                    __typename
+                    ... on NoneOrganizationChangelog {
+                        orgUuid
+                        dateFrom
+                        dateTo
+                        components {
+                            __typename
+                            ... on NoneChangelog {
+                                ${NONE_CHANGELOG_FIELDS}
+                            }
+                        }
+                        overTimeFindingChanges {
+                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+                        }
+                    }
+                    ... on AggregatedOrganizationChangelog {
+                        orgUuid
+                        dateFrom
+                        dateTo
+                        components {
+                            __typename
+                            ... on AggregatedChangelog {
+                                ${AGGREGATED_CHANGELOG_FIELDS}
+                            }
+                        }
+                        sbomChanges {
+                            ${SBOM_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+                        }
+                        findingChanges {
+                            ${FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT}
+                        }
+                        overTimeFindingChanges {
+                            ${OVER_TIME_FINDING_CHANGES_FRAGMENT}
+                        }
+                    }
+                }
+            }
+        `
+

--- a/ui/src/utils/changelogSchemaDrift.spec.ts
+++ b/ui/src/utils/changelogSchemaDrift.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, parse, validate, type GraphQLSchema } from 'graphql'
+import {
+    stripAdditiveFields,
+    COMPONENT_CHANGELOG_QUERY,
+    COMPONENT_CHANGELOG_BY_DATE_QUERY,
+    ORGANIZATION_CHANGELOG_BY_DATE_QUERY
+} from './changelogQueryTexts'
+
+// The changelog queries carry #additive-field-tagged selections (re-scan
+// arrival attribution + baseline flag) that exist on Pro before the CE mirror
+// catches up. At runtime queryWithAdditiveFallback strips the tagged lines and
+// retries when the deployed schema rejects the full document. This spec pins
+// that contract the same way notificationInboxSchemaDrift.spec.ts pins the
+// inbox split: the STRIPPED text must always validate against the CE mirror
+// (in-repo, unconditional), the FULL text against Pro (skipped when the
+// sibling rearm-core checkout is absent, e.g. in this repo's own CI).
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+const queryEntries: [string, string][] = [
+    ['COMPONENT_CHANGELOG_QUERY', COMPONENT_CHANGELOG_QUERY],
+    ['COMPONENT_CHANGELOG_BY_DATE_QUERY', COMPONENT_CHANGELOG_BY_DATE_QUERY],
+    ['ORGANIZATION_CHANGELOG_BY_DATE_QUERY', ORGANIZATION_CHANGELOG_BY_DATE_QUERY]
+]
+
+describe('changelog stripped selections vs the CE mirror schema (in-repo, always runs)', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    // The load-bearing invariant: the fallback document every CE install
+    // degrades to must validate there, or the changelog blanks for CE users.
+    for (const [name, text] of queryEntries) {
+        it(`${name} stripped of additive fields is valid against the CE mirror`, () => {
+            if (!ceSchema) return
+            expect(validate(ceSchema, parse(stripAdditiveFields(text))).map(e => e.message)).toEqual([])
+        })
+    }
+
+    // Once the CE mirror catches up (full documents validate clean there), the
+    // tagged lines should be untagged and the fallback retired for these
+    // fields -- this test surfacing as a failure is that reminder.
+    it('at least one full document is INVALID against the CE mirror (fallback is load-bearing)', () => {
+        if (!ceSchema) return
+        const anyRejected = queryEntries.some(([, text]) => validate(ceSchema, parse(text)).length > 0)
+        expect(anyRejected).toBe(true)
+    })
+})
+
+describe('changelog full selections vs the Pro schema (skipped if rearm-core absent)', () => {
+    for (const [name, text] of queryEntries) {
+        it.runIf(proSchema)(`${name} full document is valid against Pro (source of truth)`, () => {
+            expect(validate(proSchema as GraphQLSchema, parse(text)).map(e => e.message)).toEqual([])
+        })
+    }
+})


### PR DESCRIPTION
UI half of the changelog re-scan visibility fix (backend: relizaio/rearm-saas#382). Late-advisory findings arriving via re-scans were invisible in the NONE changelog and misattributed in the AGGREGATED one.

- **NONE mode**: renders the over-time finding-change events (already selected by the query and populated by the backend, previously never displayed) in a "Changes detected by re-scans" section, using the existing `OverTimeFindingChanges` component; PDF export gains the matching section.
- **AGGREGATED attribution**: when the backend stamps `scanArrivalDate` + `earliestCarrier`/`latestCarrier` on an appeared finding, the attribution line becomes "First detected <date> — affects <earliest> – <latest>" (links to both releases; single link when they coincide) instead of the misleading anchor-release list; the PDF formatter matches, and the aggregated PDF now prefers `postureFindingChanges` like the on-screen view.
- **Baseline**: the component's first-ever release is labeled as the baseline on the NONE SBOM/finding tabs instead of showing empty diffs.
- **Schema-drift safety**: the new fields ride single-line selections tagged `#additive-field`; when a deployed backend rejects the full document (CE mirror lag — the backend is NOT being merged to CE yet), the tagged lines are stripped and the query retried (`isSchemaDriftError`, same contract as the notification inbox FULL/CORE split). Query texts move to client-free `changelogQueryTexts.ts`; new `changelogSchemaDrift.spec.ts` pins stripped-vs-CE-mirror and full-vs-Pro validity.

Validation: `npm run build` green, vitest 113/114 (the 1 failure is the pre-existing `notificationInboxSchemaDrift` "split is load-bearing" canary — the CE mirror caught up with the inbox enrichment fields, unrelated to this PR), new drift spec 8/8, `validate:graphql --strict` 0 Pro failures, eslint delta vs base: none (273 pre-existing errors on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Follow-up commit:** `OverTimeFindingChanges` root now also carries the `finding-changes` class — the shared `_finding-common.scss` rules (finding-row gap, in-label, severity palette) are nested under it, so the newly-prominent re-scan section rendered its rows unspaced ('CVE-2099-7777inpkg:npm/...') without it.

**Live verification on psclaude** (branch backend + this UI, synthetic late-advisory data — two releases scanned clean, CVE-bearing VDR re-scan later): AGGREGATED renders 'First detected August 1, 2026 — affects changelog-rescan-demo@0.0.1 – changelog-rescan-demo@0.0.2' with release links; NONE renders the 'Changes detected by re-scans' section with the per-release APPEARED events. Browser probe green, no new console errors.

**Second follow-up:** the date-based component header gated the Aggregation toggle on aggregated `branches.length > 0`, which locked users out of NONE mode exactly when it was the only view with content (a component whose only release is the baseline). Gate on the changelog's presence instead. Verified live: single-first-ever-release component now shows the toggle and renders the 'Baseline release' card in NONE mode.