### PR TITLE
feat(ui): KEV series support + series filter on findings-over-time charts

### DIFF
--- a/ui/src/components/FindingsOverTimeChart.vue
+++ b/ui/src/components/FindingsOverTimeChart.vue
@@ -12,16 +12,52 @@
                     <ArrowExpand20Regular />
                 </n-icon>
             </router-link>
-            <n-icon 
-                class="clickable" 
-                size="20" 
+            <n-icon
+                class="clickable"
+                size="20"
                 title="View Organization Changelog"
                 @click="showOrgChangelogModal = true"
             >
                 <AppsList20Regular />
             </n-icon>
+            <n-popover trigger="click" placement="bottom-start">
+                <template #trigger>
+                    <n-icon class="clickable" size="20" title="Filter chart series">
+                        <Filter20Regular />
+                    </n-icon>
+                </template>
+                <div class="series-filter-list">
+                    <n-checkbox
+                        v-for="s in seriesOptions"
+                        :key="s.name"
+                        :checked="selectedSeries.includes(s.name)"
+                        @update:checked="(val: boolean) => toggleSeries(s.name, val)"
+                    >
+                        <span class="series-color-dot" :style="{ backgroundColor: s.color }"></span>{{ s.name }}
+                    </n-checkbox>
+                </div>
+            </n-popover>
         </div>
-        <h3 v-else class="chart-title">Findings Over Time</h3>
+        <div v-else style="display: flex; align-items: center; gap: 8px;">
+            <h3 class="chart-title" style="margin: 0;">Findings Over Time</h3>
+            <n-popover trigger="click" placement="bottom-start">
+                <template #trigger>
+                    <n-icon class="clickable" size="20" title="Filter chart series">
+                        <Filter20Regular />
+                    </n-icon>
+                </template>
+                <div class="series-filter-list">
+                    <n-checkbox
+                        v-for="s in seriesOptions"
+                        :key="s.name"
+                        :checked="selectedSeries.includes(s.name)"
+                        @update:checked="(val: boolean) => toggleSeries(s.name, val)"
+                    >
+                        <span class="series-color-dot" :style="{ backgroundColor: s.color }"></span>{{ s.name }}
+                    </n-checkbox>
+                </div>
+            </n-popover>
+        </div>
         <n-skeleton v-if="isLoading" height="220px" :sharp="false" />
         <n-empty v-else-if="hasNoData" style="height: 220px;" :description="`No findings reported for the last ${props.daysBack} days`" size="large" />
         <div v-else id="findingsOverTimeVis"></div>
@@ -65,7 +101,7 @@ export default {
 import { ref, Ref, computed, onMounted, onBeforeUnmount, watch, toRaw, nextTick } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute } from 'vue-router'
-import { NSkeleton, NEmpty, NModal, useNotification, NotificationType } from 'naive-ui'
+import { NSkeleton, NEmpty, NModal, NPopover, NCheckbox, useNotification, NotificationType } from 'naive-ui'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import { processMetricsData } from '@/utils/metrics'
@@ -73,7 +109,7 @@ import constants from '@/utils/constants'
 import * as vegaEmbed from 'vega-embed'
 import VulnerabilityModal from './VulnerabilityModal.vue'
 import OrganizationChangelogView from './OrganizationChangelogView.vue'
-import { AppsList20Regular, ArrowExpand20Regular } from '@vicons/fluent'
+import { AppsList20Regular, ArrowExpand20Regular, Filter20Regular } from '@vicons/fluent'
 import { NIcon } from 'naive-ui'
 
 const props = withDefaults(defineProps<{
@@ -117,6 +153,50 @@ const notify = (type: NotificationType, title: string, content: string) => {
 
 const orgUuid = computed(() => props.orgUuid || myorg.value?.uuid || '')
 const isLoading = ref(true)
+
+// Series filter: raw values as fetched; the chart renders only selected
+// series. Everything is checked by default; a series stays unchecked across
+// refetches once the user unchecks it (seenSeries tracks which types have
+// already been defaulted, so only genuinely new series get auto-checked).
+const rawChartValues: Ref<any[]> = ref([])
+const selectedSeries: Ref<string[]> = ref([])
+const seenSeries = new Set<string>()
+
+const seriesOptions = computed(() => {
+    const present = new Set(rawChartValues.value.map((v: any) => v.type))
+    const domain: string[] = constants.FindingsChartColors.domain
+    const range: string[] = constants.FindingsChartColors.range
+    return domain
+        .map((name: string, i: number) => ({ name, color: range[i] }))
+        .filter(s => present.has(s.name))
+})
+
+function syncSeriesSelection() {
+    const present = new Set(rawChartValues.value.map((v: any) => v.type))
+    // default-check series never seen before; keep the user's unchecks
+    for (const t of present) {
+        if (!seenSeries.has(t)) {
+            seenSeries.add(t)
+            selectedSeries.value.push(t)
+        }
+    }
+    selectedSeries.value = selectedSeries.value.filter(t => present.has(t))
+}
+
+function applySeriesFilter() {
+    analyticsMetrics.value.data.values = rawChartValues.value.filter(
+        (v: any) => selectedSeries.value.includes(v.type))
+}
+
+function toggleSeries(name: string, checked: boolean) {
+    if (checked && !selectedSeries.value.includes(name)) {
+        selectedSeries.value = [...selectedSeries.value, name]
+    } else if (!checked) {
+        selectedSeries.value = selectedSeries.value.filter(t => t !== name)
+    }
+    applySeriesFilter()
+    renderChart()
+}
 const isMounted = ref(true)
 const hasNoData = ref(false)
 
@@ -303,7 +383,9 @@ const analyticsMetrics: Ref<any> = ref({
             as: "dateStr"
         },
         {
-            calculate: "datum.type && indexof(datum.type, 'Vulnerabilities') >= 0 ? upper(split(datum.type, ' ')[0]) : ''",
+            // 'KEV Vulnerabilities' deliberately yields no severity param: KEV is
+            // not a severity, and severity=KEV would filter the day view to nothing.
+            calculate: "datum.type === 'KEV Vulnerabilities' ? '' : (datum.type && indexof(datum.type, 'Vulnerabilities') >= 0 ? upper(split(datum.type, ' ')[0]) : '')",
             as: "severityParam"
         },
         {
@@ -604,7 +686,12 @@ async function fetchVulnerabilityViolationAnalytics() {
         }
         
         isLoading.value = false
-        hasNoData.value = !analyticsMetrics.value.data.values || analyticsMetrics.value.data.values.length === 0
+        // hasNoData is judged on the RAW fetch result: an empty chart caused by
+        // the user unchecking every series must not swap in the no-data state.
+        rawChartValues.value = analyticsMetrics.value.data.values || []
+        hasNoData.value = rawChartValues.value.length === 0
+        syncSeriesSelection()
+        applySeriesFilter()
         await nextTick()
         if (!hasNoData.value) {
             renderChart()
@@ -636,7 +723,12 @@ function renderChart() {
                 const datum = item.datum
                 let severity = ''
                 let typeParam = ''
-                if (datum.type && datum.type.indexOf('Vulnerabilities') >= 0) {
+                if (datum.type === 'KEV Vulnerabilities') {
+                    // KEV is not a severity, so a severity filter of 'KEV' would
+                    // match nothing in the per-day table. Open the day unfiltered;
+                    // the table flags known-exploited findings individually.
+                    typeParam = 'Vulnerability'
+                } else if (datum.type && datum.type.indexOf('Vulnerabilities') >= 0) {
                     severity = datum.type.split(' ')[0].toUpperCase()
                     typeParam = 'Vulnerability'
                 } else if (datum.type && datum.type.indexOf('Violations') >= 0) {
@@ -687,5 +779,19 @@ watch(showFindingsPerDay, (newVal) => {
 <style scoped lang="scss">
 .findingsOverTimeChart {
     display: grid;
+}
+
+.series-filter-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.series-color-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
 }
 </style>

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -16,10 +16,14 @@ const VIOLATION_COLORS = {
     OPERATIONAL: 'grey'
 }
 
+// KEV (known-exploited) series color: deliberately outside the severity
+// palette -- KEV is an exploitation signal, not a severity level.
+const KEV_SERIES_COLOR = '#7c3aed'
+
 // Combined findings colors for charts (domain/range arrays for Vega-Lite)
 const FINDINGS_CHART_COLORS = {
-    domain: ['Critical Vulnerabilities', 'High Vulnerabilities', 'Medium Vulnerabilities', 'Low Vulnerabilities', 'Unassigned Vulnerabilities', 'License Violations', 'Security Violations', 'Operational Violations'],
-    range: [VULNERABILITY_COLORS.CRITICAL, VULNERABILITY_COLORS.HIGH, VULNERABILITY_COLORS.MEDIUM, VULNERABILITY_COLORS.LOW, VULNERABILITY_COLORS.UNASSIGNED, VIOLATION_COLORS.LICENSE, VIOLATION_COLORS.SECURITY, VIOLATION_COLORS.OPERATIONAL]
+    domain: ['Critical Vulnerabilities', 'High Vulnerabilities', 'Medium Vulnerabilities', 'Low Vulnerabilities', 'Unassigned Vulnerabilities', 'KEV Vulnerabilities', 'License Violations', 'Security Violations', 'Operational Violations'],
+    range: [VULNERABILITY_COLORS.CRITICAL, VULNERABILITY_COLORS.HIGH, VULNERABILITY_COLORS.MEDIUM, VULNERABILITY_COLORS.LOW, VULNERABILITY_COLORS.UNASSIGNED, KEV_SERIES_COLOR, VIOLATION_COLORS.LICENSE, VIOLATION_COLORS.SECURITY, VIOLATION_COLORS.OPERATIONAL]
 }
 
 const PACKAGE_TYPES = ['MAVEN', 'NPM', 'NUGET', 'GEM', 'PYPI', 'CONTAINER']


### PR DESCRIPTION
CE side of the **KEV Vulnerabilities** chart series (backend: relizaio/rearm-saas#383), plus a series filter.

## KEV series

- `FINDINGS_CHART_COLORS` gains the ninth domain entry, colored violet (`#7c3aed`) — deliberately outside the severity palette, since KEV is an exploitation signal, not a severity. Without this the unknown series wrapped d3's ordinal scale to `range[0]` and rendered in the same red as Critical.
- Clicking a KEV point opens the per-day findings view **unfiltered** (KEV is not a severity; `severity=KEV` would filter the table to nothing) — special-cased in both the click handler and the vega `url` transform. The table's per-row KEV flags carry the signal from there.

## Series filter (widget + full-page)

A funnel icon next to the chart title — in both header variants, so it appears on the AppHome/ComponentView widgets and the full-page view alike — opens a checkbox list of the series present in the data, each with its chart color dot:

- everything checked by default
- unchecking hides that line — e.g. leave only the KEV line visible
- selections survive refetches (date-range changes); genuinely new series default to checked
- the no-data empty state is judged on the **raw** fetch result, so unchecking every series yields an empty chart, not a false "no findings reported"

## Verification

`npm run build` clean; deployed as a dev image to the agent-scully sandbox alongside the backend branch build, with synthesized KEV history in one org — series renders in violet, the filter toggles lines in both widget and full-page modes, KEV point click opens the day view unfiltered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)