### PR TITLE
Backend sync-up with ReARM Pro + retire caught-up UI schema-drift fallbacks

### DIFF
--- a/backend/src/main/java/io/reliza/common/Utils.java
+++ b/backend/src/main/java/io/reliza/common/Utils.java
@@ -90,6 +90,8 @@ public class Utils {
 	// names (Spring Boot 4 keeps `-parameters` on by default) — that's
 	// what makes our many @Data @Builder DTOs round-trip without us
 	// having to annotate every single one with @NoArgsConstructor.
+	// DO NOT bind org.cyclonedx.model.* with this mapper -- use CDX_OM below.
+	// See the CDX_OM javadoc for why; both directions are affected.
 	public static final ObjectMapper OM = JsonMapper.builder()
 			.changeDefaultVisibility(vc -> vc.withCreatorVisibility(
 					com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NON_PRIVATE))
@@ -97,6 +99,50 @@ public class Utils {
 			.enable(tools.jackson.databind.cfg.DateTimeFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
 			.enable(tools.jackson.databind.cfg.DateTimeFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
 			.build();
+
+	/**
+	 * The ONLY mapper that may bind {@code org.cyclonedx.model.*} types.
+	 *
+	 * <p>cyclonedx-core-java is a <b>Jackson 2</b> library and {@link #OM} is
+	 * Jackson 3 ({@code tools.jackson}). Annotations themselves are not the
+	 * problem -- {@code com.fasterxml.jackson.annotation.*} was never renamed, so
+	 * {@code @JsonProperty("bom-ref")} and friends still apply. What Jackson 3
+	 * cannot honour is {@code @JsonSerialize/@JsonDeserialize(using = ...)}
+	 * pointing at handlers that extend Jackson 2 databind classes, which 25 of the
+	 * library's model types rely on. Both directions break, differently:
+	 *
+	 * <ul>
+	 *   <li>Reading: {@code LicenseChoice} is a single object in Java but an ARRAY
+	 *       on the wire, bridged by {@code LicenseDeserializer}. Binding with OM
+	 *       threw MismatchedInputException on the first component carrying
+	 *       licenses -- loud, and fixed in ReleaseService.buildVdrBom.</li>
+	 *   <li>Writing: date fields are bridged by {@code CustomDateSerializer}.
+	 *       Binding with OM does NOT throw -- it silently emits epoch millis
+	 *       ({@code "published":1750000000000}) where the spec requires
+	 *       ISO-8601 ({@code "published":"2025-06-15T15:06:40Z"}), because OM
+	 *       enables WRITE_DATES_AS_TIMESTAMPS. Silent, so it survived far longer.</li>
+	 * </ul>
+	 *
+	 * <p>Upgrading the library does not remove the need for this: 13.0.0 is still
+	 * Jackson 2, and upstream has no Jackson 3 migration open.
+	 *
+	 * <p>Configured to match what the library's own {@code BomJsonGenerator}
+	 * emits: NON_NULL inclusion, plus {@code LicenseChoiceSerializer} so nested
+	 * licenses serialize as the wire array rather than the default bean shape.
+	 * ({@link CdxLicenseUtil} keeps its own narrower mapper on purpose -- it
+	 * round-trips license arrays through {@code convertValue}, where NON_NULL
+	 * would change the stored shape.)
+	 */
+	public static final com.fasterxml.jackson.databind.ObjectMapper CDX_OM;
+	static {
+		CDX_OM = new com.fasterxml.jackson.databind.ObjectMapper();
+		CDX_OM.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+		com.fasterxml.jackson.databind.module.SimpleModule cdxModule =
+				new com.fasterxml.jackson.databind.module.SimpleModule();
+		cdxModule.addSerializer(org.cyclonedx.model.LicenseChoice.class,
+				new org.cyclonedx.util.serializer.LicenseChoiceSerializer(false, org.cyclonedx.Version.VERSION_16));
+		CDX_OM.registerModule(cdxModule);
+	}
 	
 	public static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
 	public static final ZoneOffset UTC_ZONE_OFFSET = ZoneOffset.of("Z");

--- a/backend/src/main/java/io/reliza/dto/ChangelogRecords.java
+++ b/backend/src/main/java/io/reliza/dto/ChangelogRecords.java
@@ -241,7 +241,12 @@ public final class ChangelogRecords {
 		List<CodeCommit> commits,
 		ReleaseSbomChanges sbomChanges,
 		ReleaseFindingChanges findingChanges,
-		ZonedDateTime createdDate
+		ZonedDateTime createdDate,
+		// ADDITIVE (changelog re-scan visibility): true when this is the component's first release
+		// EVER (no predecessor exists at all, in-window or before it). Its finding/SBOM sections are
+		// empty because there is no baseline to diff against, NOT because nothing changed -- the UI
+		// labels the card instead of rendering a silently empty section.
+		boolean baselineRelease
 	) {}
 	
 	/**

--- a/backend/src/main/java/io/reliza/dto/ViolationWithAttribution.java
+++ b/backend/src/main/java/io/reliza/dto/ViolationWithAttribution.java
@@ -35,5 +35,20 @@ public record ViolationWithAttribution(
     OrgLevelContext orgContext,
     
     // Analysis state (FALSE_POSITIVE, NOT_AFFECTED, etc.)
-    AnalysisState analysisState
-) {}
+    AnalysisState analysisState,
+
+    // ADDITIVE (changelog re-scan visibility): when this finding ARRIVED inside the window per
+    // finding_change_events (APPEARED), the earliest in-window event date. Lets the UI say WHEN a
+    // finding was first detected instead of implying the endpoint-anchor release introduced it.
+    java.time.ZonedDateTime scanArrivalDate,
+    // Earliest / latest in-window releases (by creation) whose CURRENT metrics carry this finding --
+    // the honest carrier RANGE for an arrival, replacing the misleading single endpoint anchor.
+    ComponentAttribution earliestCarrier,
+    ComponentAttribution latestCarrier
+) {
+	/** Copy with the scan-arrival decoration set; every other field is preserved verbatim. */
+	public ViolationWithAttribution withScanArrival(java.time.ZonedDateTime arrivalDate,
+			ComponentAttribution earliest, ComponentAttribution latest) {
+		return new ViolationWithAttribution(findingKey(), type(), purl(), resolvedIn(), appearedIn(), presentIn(), resolvedInCount(), appearedInCount(), presentInCount(), isNetResolved(), isNetAppeared(), isStillPresent(), orgContext(), analysisState(), arrivalDate, earliest, latest);
+	}
+}

--- a/backend/src/main/java/io/reliza/dto/VulnerabilityWithAttribution.java
+++ b/backend/src/main/java/io/reliza/dto/VulnerabilityWithAttribution.java
@@ -41,5 +41,20 @@ public record VulnerabilityWithAttribution(
     OrgLevelContext orgContext,
     
     // Analysis state (FALSE_POSITIVE, NOT_AFFECTED, etc.)
-    AnalysisState analysisState
-) {}
+    AnalysisState analysisState,
+
+    // ADDITIVE (changelog re-scan visibility): when this finding ARRIVED inside the window per
+    // finding_change_events (APPEARED), the earliest in-window event date. Lets the UI say WHEN a
+    // finding was first detected instead of implying the endpoint-anchor release introduced it.
+    java.time.ZonedDateTime scanArrivalDate,
+    // Earliest / latest in-window releases (by creation) whose CURRENT metrics carry this finding --
+    // the honest carrier RANGE for an arrival, replacing the misleading single endpoint anchor.
+    ComponentAttribution earliestCarrier,
+    ComponentAttribution latestCarrier
+) {
+	/** Copy with the scan-arrival decoration set; every other field is preserved verbatim. */
+	public VulnerabilityWithAttribution withScanArrival(java.time.ZonedDateTime arrivalDate,
+			ComponentAttribution earliest, ComponentAttribution latest) {
+		return new VulnerabilityWithAttribution(findingKey(), vulnId(), severity(), purl(), aliases(), resolvedIn(), appearedIn(), presentIn(), resolvedInCount(), appearedInCount(), presentInCount(), isNetResolved(), isNetAppeared(), isStillPresent(), orgContext(), analysisState(), arrivalDate, earliest, latest);
+	}
+}

--- a/backend/src/main/java/io/reliza/dto/WeaknessWithAttribution.java
+++ b/backend/src/main/java/io/reliza/dto/WeaknessWithAttribution.java
@@ -37,5 +37,20 @@ public record WeaknessWithAttribution(
     OrgLevelContext orgContext,
     
     // Analysis state (FALSE_POSITIVE, NOT_AFFECTED, etc.)
-    AnalysisState analysisState
-) {}
+    AnalysisState analysisState,
+
+    // ADDITIVE (changelog re-scan visibility): when this finding ARRIVED inside the window per
+    // finding_change_events (APPEARED), the earliest in-window event date. Lets the UI say WHEN a
+    // finding was first detected instead of implying the endpoint-anchor release introduced it.
+    java.time.ZonedDateTime scanArrivalDate,
+    // Earliest / latest in-window releases (by creation) whose CURRENT metrics carry this finding --
+    // the honest carrier RANGE for an arrival, replacing the misleading single endpoint anchor.
+    ComponentAttribution earliestCarrier,
+    ComponentAttribution latestCarrier
+) {
+	/** Copy with the scan-arrival decoration set; every other field is preserved verbatim. */
+	public WeaknessWithAttribution withScanArrival(java.time.ZonedDateTime arrivalDate,
+			ComponentAttribution earliest, ComponentAttribution latest) {
+		return new WeaknessWithAttribution(findingKey(), cweId(), severity(), ruleId(), location(), resolvedIn(), appearedIn(), presentIn(), resolvedInCount(), appearedInCount(), presentInCount(), isNetResolved(), isNetAppeared(), isStillPresent(), orgContext(), analysisState(), arrivalDate, earliest, latest);
+	}
+}

--- a/backend/src/main/java/io/reliza/model/FlowControl.java
+++ b/backend/src/main/java/io/reliza/model/FlowControl.java
@@ -61,6 +61,11 @@ public record FlowControl(
         String autoIntegrateRequestedAt,
         String autoIntegrateSkipUntil,
         Integer autoIntegrateFailureCount,
+        // Stamped by claimAutoIntegrate when a worker takes the lease. The
+        // post-run conditional clear compares it against autoIntegrateRequestedAt:
+        // a request newer than the claim arrived mid-run and must survive the
+        // clear (lost-wakeup guard), so only the lease/bookkeeping is dropped.
+        String autoIntegrateClaimedAt,
         // Metrics-compute backoff fence (mirrors the sbomReconcile*/autoIntegrate*
         // skip pattern). Set when a scannable release's metrics compute ends
         // incomplete (own BOM or a child release still unscanned) or throws, so

--- a/backend/src/main/java/io/reliza/model/OrganizationData.java
+++ b/backend/src/main/java/io/reliza/model/OrganizationData.java
@@ -335,6 +335,62 @@ public class OrganizationData extends RelizaDataParent implements RelizaObject {
 		private UUID approvalPolicy;
 	}
 
+	/**
+	 * Org-wide team-assignment rule: assign a durable owner team to every
+	 * component whose name matches a pattern, instead of picking one by hand on
+	 * each component (RFC Phase 5 / T2). Deliberately shaped after
+	 * {@link GlobalApprovalPolicyRule} -- same anchoring, same type filter, same
+	 * first-match-wins contract -- so operators learn one rule model, not two.
+	 *
+	 * <p>A matching rule SETS the component's durable owner (DECIDED 2026-07-29):
+	 * there is exactly one answer to "who owns this", and a per-component owner
+	 * always wins over a rule. Deliberately NOT a second "assigned team" field --
+	 * two fields both answering that question is the ambiguity retiring
+	 * {@code leads} removed.
+	 *
+	 * <p>Resolution happens at READ time in
+	 * {@code ComponentOwnershipService.resolveOwnership}; nothing is written onto
+	 * the component. So editing a pattern takes effect immediately, a rule and a
+	 * stored value can never drift apart, and no bulk write can corrupt an
+	 * inventory. The resulting {@code ComponentOwnership} carries
+	 * {@code derived=true} plus the rule name in its reason, which is how the UI
+	 * distinguishes "someone chose this" from "a pattern matched".
+	 *
+	 * <p>The filter {@code componentType} value {@code ANY} matches both
+	 * {@code COMPONENT} and {@code PRODUCT} (there is no {@code ANY}-typed
+	 * component entity itself -- it's only a rule-side filter value).
+	 */
+	@Data
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class GlobalTeamAssignmentRule {
+		/** Display name; unique within the org. */
+		@JsonProperty
+		private String name;
+		/**
+		 * Java regex matched against {@code ComponentData.name} via
+		 * {@code Pattern.matcher(name).matches()} -- fully anchored, same
+		 * convention as {@code DependencyPatternService} and
+		 * {@link GlobalApprovalPolicyRule}. Operators write {@code frontend-.*}
+		 * (no leading {@code ^}, no trailing {@code $}).
+		 */
+		@JsonProperty
+		private String namePattern;
+		/**
+		 * Type filter. {@code COMPONENT} / {@code PRODUCT} restrict the match;
+		 * {@code ANY} (the default when null) matches both concrete types.
+		 */
+		@JsonProperty
+		private ComponentData.ComponentType componentType;
+		/**
+		 * Referenced owner team ({@code UserGroup}) UUID. Validation rejects
+		 * rules whose team doesn't exist or belongs to another org at write
+		 * time; the resolver re-checks at read time, so a team deleted later
+		 * degrades the component to ORPHANED rather than silently vanishing.
+		 */
+		@JsonProperty
+		private UUID ownerTeam;
+	}
+
 	public static class InvitedObject {
 		@JsonProperty(CommonVariables.SECRET_FIELD)
 		private String secret;
@@ -398,6 +454,13 @@ public class OrganizationData extends RelizaDataParent implements RelizaObject {
 	 */
 	@JsonProperty
 	private List<GlobalApprovalPolicyRule> globalApprovalPolicyRules = new LinkedList<>();
+	/**
+	 * Org-wide team-assignment rules -- see {@link GlobalTeamAssignmentRule}.
+	 * Empty/null means "no org-wide assignments"; per-component owners behave
+	 * exactly as before. List order is the priority order (first match wins).
+	 */
+	@JsonProperty
+	private List<GlobalTeamAssignmentRule> globalTeamAssignmentRules = new LinkedList<>();
 
 
 	public void removeInvitee(String email, UUID whoInvited){

--- a/backend/src/main/java/io/reliza/model/ReleaseData.java
+++ b/backend/src/main/java/io/reliza/model/ReleaseData.java
@@ -181,6 +181,18 @@ public class ReleaseData extends RelizaDataParent implements RelizaObject, Gener
 	@Setter(AccessLevel.PRIVATE)
 	private UUID branch = null; // project parent
 
+	/**
+	 * Re-parent this release under another component/branch. Exists SOLELY for
+	 * the duplicate-component repair (ComponentDuplicateRepairService), which
+	 * folds a duplicate's releases under the surviving leader: component and
+	 * branch are identity-adjacent and deliberately keep private setters, so
+	 * ordinary mutation paths cannot move a release between components.
+	 */
+	public void repointToComponentBranch(UUID componentUuid, UUID branchUuid) {
+		this.component = componentUuid;
+		this.branch = branchUuid;
+	}
+
 	@JsonProperty(CommonVariables.PARENT_RELEASES_FIELD)
 	private List<ParentRelease> parentReleases = new LinkedList<>();
 	

--- a/backend/src/main/java/io/reliza/model/TeamRole.java
+++ b/backend/src/main/java/io/reliza/model/TeamRole.java
@@ -1,0 +1,30 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.model;
+
+/**
+ * The role a member plays on a Team (the {@link UserGroup} primitive).
+ *
+ * <p><strong>A role is an addressing LABEL and never grants access.</strong> It
+ * answers "who on this team do I escalate a KEV finding to?", not "who may write
+ * this component". Membership stays decoupled from RBAC (RFC sec. 4.1): a team
+ * may additionally be granted a permission, but that is a separate, explicit
+ * choice that no role here implies. Nothing in the authorization path reads this
+ * enum -- it feeds notification/escalation targeting only.
+ *
+ * <p>{@code CUSTOM} is the escape hatch for org-defined roles: the operator's
+ * label travels alongside in {@code customRole} rather than widening this enum,
+ * so the known set stays a closed vocabulary (house rule: enums over magic
+ * strings) while orgs are not boxed in.
+ */
+public enum TeamRole {
+	TEAM_LEAD,
+	SECURITY_SPECIALIST,
+	DEVELOPER,
+	QA,
+	PROJECT_MANAGER,
+	PRODUCT_MANAGER,
+	CUSTOM;
+}

--- a/backend/src/main/java/io/reliza/model/UserGroupData.java
+++ b/backend/src/main/java/io/reliza/model/UserGroupData.java
@@ -7,10 +7,16 @@ package io.reliza.model;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -29,7 +35,75 @@ import io.reliza.model.dto.UserGroupPermissionDto;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UserGroupData extends RelizaDataParent implements RelizaObject {
-	
+
+	/**
+	 * An addressing role attached to a registered ReARM user already on this
+	 * team's roster ({@link #getAllUsers()}). This is a pure annotation -- it
+	 * does NOT add anyone to the team, so the roster keeps exactly one source of
+	 * truth ({@code users} + {@code manualUsers}) and SSO sync stays untouched.
+	 * A {@code userRef} with no matching roster entry is rejected on write.
+	 *
+	 * <p>{@code customRole} carries the operator's label when {@code role} is
+	 * {@link TeamRole#CUSTOM}, and is null otherwise. See {@link TeamRole} --
+	 * roles never grant access.
+	 */
+	public record TeamMemberRole (UUID userRef, TeamRole role, String customRole) {}
+
+	/**
+	 * A team member who is not a registered ReARM user, reachable only by a
+	 * freeform contact (email / Slack handle) -- the team-level analogue of
+	 * {@code ComponentData.FreeformContact}, plus a role. Both freeform fields
+	 * are operator-supplied and are HTML-sanitized via
+	 * {@link #sanitizeExternalMembers} before persistence, since they render
+	 * back into the team UI.
+	 *
+	 * <p><strong>External members deliberately do NOT count toward the durability
+	 * bar</strong> (DECIDED 2026-07-28): they live outside {@code users} /
+	 * {@code manualUsers}, so {@link #getAllUsers()} -- and therefore
+	 * {@code ComponentOwnershipService.isTeamDurable} -- ignores them by
+	 * construction. Durability means "survives a departure", which needs
+	 * accountable, lifecycle-managed accounts; an external contact is
+	 * addressable but confers no durability.
+	 */
+	public record ExternalTeamMember (String name, String contact, TeamRole role, String customRole) {}
+
+	/**
+	 * Returns a sanitized copy of {@code externalMembers} with each freeform
+	 * field run through jsoup {@code Safelist.basic()} -- the same safelist the
+	 * component contact path uses for operator-supplied text. Null input yields
+	 * null; null individual fields are preserved as null. Role fields are
+	 * enum/label data and are passed through untouched apart from the label,
+	 * which is operator text and so is sanitized too.
+	 */
+	/**
+	 * Returns a sanitized copy of {@code memberRoles}. Only {@code customRole} is
+	 * operator-supplied free text ({@code userRef} is a UUID and {@code role} an
+	 * enum), but it is the same class of label as
+	 * {@link ExternalTeamMember#customRole} and renders into the same team UI, so
+	 * it gets the same treatment -- sanitize-on-write applies to the WHOLE new
+	 * surface, not just the external half.
+	 */
+	public static List<TeamMemberRole> sanitizeMemberRoles (List<TeamMemberRole> memberRoles) {
+		if (null == memberRoles) return null;
+		return memberRoles.stream()
+				.map(mr -> new TeamMemberRole(
+						mr.userRef(),
+						mr.role(),
+						StringUtils.isEmpty(mr.customRole()) ? mr.customRole() : Jsoup.clean(mr.customRole(), Safelist.basic())))
+				.collect(Collectors.toList());
+	}
+
+	public static List<ExternalTeamMember> sanitizeExternalMembers (List<ExternalTeamMember> externalMembers) {
+		if (null == externalMembers) return null;
+		return externalMembers.stream()
+				.map(m -> new ExternalTeamMember(
+						StringUtils.isEmpty(m.name()) ? m.name() : Jsoup.clean(m.name(), Safelist.basic()),
+						StringUtils.isEmpty(m.contact()) ? m.contact() : Jsoup.clean(m.contact(), Safelist.basic()),
+						m.role(),
+						StringUtils.isEmpty(m.customRole()) ? m.customRole() : Jsoup.clean(m.customRole(), Safelist.basic())))
+				.collect(Collectors.toList());
+	}
+
 	private UUID uuid;
 	@JsonProperty(CommonVariables.NAME_FIELD)
 	private String name;
@@ -47,6 +121,23 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 	private Set<UUID> manualUsers = new LinkedHashSet<>(); // manually added users (not managed by SSO sync)
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups = new LinkedHashSet<>(); // SSO groups connected to this user group
+	/** Addressing roles for roster users; annotation only -- never a roster of its own. */
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles = new LinkedList<>();
+	/** Non-ReARM team members; addressable, but excluded from durability by design. */
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers = new LinkedList<>();
+	/**
+	 * Notification channels this team is reachable on (T3) -- e.g. its Slack
+	 * channel. Held as DIRECT channel refs rather than a
+	 * {@code NotificationChannelGroup} reference on purpose: the operator's model
+	 * is "this team has a channel", and routing them through a separate named
+	 * group would add a second entity and a second screen for no user benefit.
+	 * Channel groups remain the org-level bundling concept for subscriptions;
+	 * this is the team's own address.
+	 */
+	@JsonProperty("notificationChannels")
+	private Set<UUID> notificationChannels = new LinkedHashSet<>();
 	@JsonProperty
 	private UUID resourceGroup = CommonVariables.DEFAULT_RESOURCE_GROUP;
 
@@ -128,6 +219,50 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 		return allUsers;
 	}
 	
+	public List<TeamMemberRole> getMemberRoles() {
+		return new LinkedList<>(memberRoles);
+	}
+
+	private void setMemberRoles(Collection<TeamMemberRole> memberRoles) {
+		this.memberRoles = new LinkedList<>(memberRoles);
+	}
+
+	public List<ExternalTeamMember> getExternalMembers() {
+		return new LinkedList<>(externalMembers);
+	}
+
+	private void setExternalMembers(Collection<ExternalTeamMember> externalMembers) {
+		this.externalMembers = new LinkedList<>(externalMembers);
+	}
+
+	/**
+	 * The addressing role recorded for a roster user, if any. Used by the
+	 * escalation path ("notify the security specialist on this component's owner
+	 * team"); absence means the user is on the team with no declared role.
+	 *
+	 * <p>Deliberately re-checks {@link #hasUser} rather than trusting the stored
+	 * annotation: a role can outlive its member. Write-time validation only fires
+	 * when the caller sends {@code memberRoles}, so an update that shrinks the
+	 * roster with {@code memberRoles} omitted -- and SSO-driven removals via
+	 * {@code UserGroupService.removeUserFromGroupInternal}, which never touches
+	 * this field -- both leave a role pointing at an ex-member. Filtering on read
+	 * closes every such path by construction, so escalation can never target
+	 * someone who has left the team.
+	 */
+	@JsonIgnore
+	public Optional<TeamMemberRole> getRoleForUser(UUID userUuid) {
+		if (!hasUser(userUuid)) return Optional.empty();
+		return memberRoles.stream().filter(mr -> null != mr.userRef() && mr.userRef().equals(userUuid)).findFirst();
+	}
+
+	public Set<UUID> getNotificationChannels() {
+		return new LinkedHashSet<>(notificationChannels);
+	}
+
+	private void setNotificationChannels(Collection<UUID> notificationChannels) {
+		this.notificationChannels = new LinkedHashSet<>(notificationChannels);
+	}
+
 	public Set<String> getConnectedSsoGroups() {
 		return new LinkedHashSet<>(connectedSsoGroups);
 	}
@@ -254,7 +389,30 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 		} else {
 			updatedUserGroupData.setConnectedSsoGroups(ugd.getConnectedSsoGroups());
 		}
-		
+
+		// Sanitize on write, not on read: the freeform custom-label / name /
+		// contact fields are operator text rendered back into the team UI. Both
+		// member lists get it -- sanitizing only the external half would leave
+		// memberRoles[].customRole as an unescaped sink.
+
+		if (null != updateUgd.getMemberRoles()) {
+			updatedUserGroupData.setMemberRoles(sanitizeMemberRoles(updateUgd.getMemberRoles()));
+		} else {
+			updatedUserGroupData.setMemberRoles(ugd.getMemberRoles());
+		}
+
+		if (null != updateUgd.getExternalMembers()) {
+			updatedUserGroupData.setExternalMembers(sanitizeExternalMembers(updateUgd.getExternalMembers()));
+		} else {
+			updatedUserGroupData.setExternalMembers(ugd.getExternalMembers());
+		}
+
+		if (null != updateUgd.getNotificationChannels()) {
+			updatedUserGroupData.setNotificationChannels(updateUgd.getNotificationChannels());
+		} else {
+			updatedUserGroupData.setNotificationChannels(ugd.getNotificationChannels());
+		}
+
 		return updatedUserGroupData;
 	}
 	
@@ -288,6 +446,9 @@ public class UserGroupData extends RelizaDataParent implements RelizaObject {
 				.users(ugd.getUsers())
 				.manualUsers(ugd.getManualUsers())
 				.connectedSsoGroups(ugd.getConnectedSsoGroups())
+				.memberRoles(ugd.getMemberRoles())
+				.externalMembers(ugd.getExternalMembers())
+				.notificationChannels(ugd.getNotificationChannels())
 				.build();
 	}
 

--- a/backend/src/main/java/io/reliza/model/dto/ComponentDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/ComponentDto.java
@@ -112,4 +112,13 @@ public class ComponentDto {
 	/** Durable owner to set on the component (RFC Phase 4b); validated on write. Null = no change. */
 	@JsonProperty
 	private ComponentOwner owner;
+	/**
+	 * Explicitly remove the stored owner (T2). Needed because {@code owner} null
+	 * already means "no change", so there is no way to express "clear it" with
+	 * that field alone. Clearing hands the component back to org team-assignment
+	 * rules -- without this, a manually-set owner could never return to
+	 * rule-based assignment.
+	 */
+	@JsonProperty
+	private Boolean clearOwner;
 }

--- a/backend/src/main/java/io/reliza/model/dto/ReleaseMetricsDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/ReleaseMetricsDto.java
@@ -1482,12 +1482,29 @@ public class ReleaseMetricsDto implements Cloneable {
 	}
 
 	public List<VulnViolationsChartDto> convertToChartDto (ZonedDateTime createdDate) {
+		return convertToChartDto(createdDate, true);
+	}
+
+	/**
+	 * {@code includeKevSeries=false} is for callers rehydrating from stored
+	 * numeric-metrics maps written before the {@code kevCount} key existed:
+	 * such a map cannot distinguish "0 KEV findings" from "not measured", so
+	 * the point is omitted and the series starts where the data starts.
+	 */
+	public List<VulnViolationsChartDto> convertToChartDto (ZonedDateTime createdDate, boolean includeKevSeries) {
 		List<VulnViolationsChartDto> vulnViolDtos = new LinkedList<>();
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getCritical(), "Critical Vulnerabilities"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getHigh(), "High Vulnerabilities"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getMedium(), "Medium Vulnerabilities"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getLow(), "Low Vulnerabilities"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getUnassigned(), "Unassigned Vulnerabilities"));
+		if (includeKevSeries) {
+			// kevCount is stamped by ReleaseMetricsComputeService and kept fresh by
+			// the KEV catalog sync (which re-stamps affected releases without a
+			// rescan), so as-of-now KEV membership is correct even for historical
+			// releases.
+			vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getKevCount(), "KEV Vulnerabilities"));
+		}
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getPolicyViolationsLicenseTotal(), "License Violations"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getPolicyViolationsOperationalTotal(), "Operational Violations"));
 		vulnViolDtos.add(new VulnViolationsChartDto(createdDate, this.getPolicyViolationsSecurityTotal(), "Security Violations"));

--- a/backend/src/main/java/io/reliza/model/dto/UpdateComponentDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/UpdateComponentDto.java
@@ -158,6 +158,9 @@ public class UpdateComponentDto {
 	/** Durable owner to set (RFC Phase 4b); validated server-side against the component's org. Null = unchanged. */
 	@JsonProperty
 	private ComponentOwner owner;
+	/** Explicitly remove the stored owner; see {@code ComponentDto.clearOwner}. */
+	@JsonProperty
+	private Boolean clearOwner;
 
 	public static ReleaseOutputEvent convertReleaseOutputEventFromInput (ReleaseOutputEventInput roei,
 			IntegrationType it) throws DatabindException, JacksonException {
@@ -234,6 +237,7 @@ public class UpdateComponentDto {
 								.leads(ucd.getLeads())
 								.contacts(ucd.getContacts())
 								.owner(ucd.getOwner())
+								.clearOwner(ucd.getClearOwner())
 								.build();
 		return cdto;
 	}

--- a/backend/src/main/java/io/reliza/model/dto/UpdateUserGroupDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/UpdateUserGroupDto.java
@@ -5,6 +5,7 @@
 package io.reliza.model.dto;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -12,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.reliza.common.CommonVariables;
 import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import lombok.Builder;
 import lombok.Data;
 
@@ -36,4 +39,11 @@ public class UpdateUserGroupDto {
 	private UserGroupStatus status;
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups;
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles;
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers;
+	/** Channels this team is reachable on (T3). */
+	@JsonProperty("notificationChannels")
+	private Set<UUID> notificationChannels;
 }

--- a/backend/src/main/java/io/reliza/model/dto/UserGroupWebDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/UserGroupWebDto.java
@@ -4,6 +4,7 @@
 
 package io.reliza.model.dto;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -11,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.reliza.common.CommonVariables;
 import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.UserPermission.Permissions;
 import lombok.Builder;
 import lombok.Data;
@@ -36,4 +39,11 @@ public class UserGroupWebDto {
 	private Set<UUID> manualUsers;
 	@JsonProperty("connectedSsoGroups")
 	private Set<String> connectedSsoGroups;
+	@JsonProperty("memberRoles")
+	private List<TeamMemberRole> memberRoles;
+	@JsonProperty("externalMembers")
+	private List<ExternalTeamMember> externalMembers;
+	/** Channels this team is reachable on (T3). */
+	@JsonProperty("notificationChannels")
+	private Set<UUID> notificationChannels;
 }

--- a/backend/src/main/java/io/reliza/model/dto/notifications/NotificationSubscriptionData.java
+++ b/backend/src/main/java/io/reliza/model/dto/notifications/NotificationSubscriptionData.java
@@ -83,7 +83,27 @@ public record NotificationSubscriptionData(
              * pre-13b read semantics. Treat null and empty identically
              * at the consumer site (the fan-out helper does).
              */
-            List<UUID> channelGroups) {
+            List<UUID> channelGroups,
+            /*
+             * T3 -- team targeting. A route may name Teams (UserGroups);
+             * at fan-out time each team's own {@code notificationChannels}
+             * are resolved and merged into the route's channel set. Lets an
+             * operator say "tell the Payments Team" without knowing which
+             * Slack channel that is today, and keeps the answer correct when
+             * the team later changes channel.
+             *
+             * <p><b>null is load-bearing</b> exactly as for
+             * {@code channelGroups}: pre-T3 JSONB rows do not carry this key,
+             * and the back-compat constructors below default it to null so
+             * existing routes keep their "channels only" semantics on read.
+             * Treat null and empty identically at the consumer site.
+             *
+             * <p>Scope note: this expands to team CHANNELS only. It does not
+             * push rows into members' inboxes -- inbox visibility already has
+             * its own component-team / perspective arms, and adding a third
+             * targeting path would risk duplicate inbox rows for one event.
+             */
+            List<UUID> teams) {
 
         /**
          * Backwards-compat constructor for callers (tests, older
@@ -105,7 +125,7 @@ public record NotificationSubscriptionData(
                 List<String> andEnvIn,
                 List<ReleaseLifecycle> andLifecycleIn,
                 List<UUID> channels) {
-            this(whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, null, null);
+            this(whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, null, null, null);
         }
 
         /**
@@ -119,7 +139,21 @@ public record NotificationSubscriptionData(
                 List<ReleaseLifecycle> andLifecycleIn,
                 List<UUID> channels,
                 List<UUID> perspectives) {
-            this(whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, perspectives, null);
+            this(whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, perspectives, null, null);
+        }
+
+        /**
+         * Phase 13b back-compat constructor -- for callers that pre-date the
+         * T3 {@code teams} field but already pass {@code channelGroups}.
+         * Defaults {@code teams} to null (= no team expansion).
+         */
+        public RouteConfig(NotificationSeverity whenSeverityAtLeast,
+                List<String> andEnvIn,
+                List<ReleaseLifecycle> andLifecycleIn,
+                List<UUID> channels,
+                List<UUID> perspectives,
+                List<UUID> channelGroups) {
+            this(whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, perspectives, channelGroups, null);
         }
     }
 

--- a/backend/src/main/java/io/reliza/model/dto/notifications/NotificationSubscriptionInput.java
+++ b/backend/src/main/java/io/reliza/model/dto/notifications/NotificationSubscriptionInput.java
@@ -71,7 +71,15 @@ public record NotificationSubscriptionInput(
              * NotificationSubscriptionService: every UUID must resolve
              * to a group in the same org as the subscription.
              */
-            List<UUID> channelGroups) {
+            List<UUID> channelGroups,
+            /*
+             * T3 -- UUIDs of Teams (user groups) whose own
+             * notificationChannels are merged into this route at fan-out
+             * time. Null / empty = no team expansion. Resolved late, at
+             * fan-out rather than save, so retargeting a team's channel
+             * takes effect without editing every subscription naming it.
+             */
+            List<UUID> teams) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/backend/src/main/java/io/reliza/repositories/ComponentRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ComponentRepository.java
@@ -66,6 +66,11 @@ public interface ComponentRepository extends CrudRepository<Component, UUID> {
 			value = VariableQueries.FIND_COMPONENT_BY_VCS_AND_PATH,
 			nativeQuery = true)
 	List<Component> findAllComponentsByVcsAndPath(String vcsUuidAsString, String orgUuidAsString, String repoPath);
+
+	@Query(
+			value = VariableQueries.FIND_LIVE_VCS_COMPONENTS_OF_ORG,
+			nativeQuery = true)
+	List<Component> findLiveVcsComponentsOfOrg(String orgUuidAsString);
 	
 	@Query(
 			value = VariableQueries.FIND_COMPONENTS_BY_VCS,

--- a/backend/src/main/java/io/reliza/repositories/ReleaseRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/ReleaseRepository.java
@@ -654,12 +654,19 @@ public interface ReleaseRepository extends CrudRepository<Release, UUID> {
 	// silently dropped. No migration: flow_control is JSONB.
 	// ---------------------------------------------------------------------
 
-	/** First-write-wins marker; idempotent re-marks are no-ops while queued. */
+	/**
+	 * Always bumps {@code autoIntegrateRequestedAt}. This used to be first-write-wins, which
+	 * combined with the unconditional clear below into a lost wake-up: a re-trigger arriving
+	 * while a worker held the lease was a no-op here, the claim was lost to the lease, and the
+	 * in-flight worker's clear then erased the queue entry -- the re-trigger was dropped
+	 * entirely (no scheduler retry). Bumping the timestamp lets the clear detect that a request
+	 * arrived after the claim and preserve it.
+	 */
 	@Transactional
 	@Modifying
 	@Query(value = "UPDATE rearm.releases "
 			+ "SET flow_control = jsonb_set(coalesce(flow_control, '{}'::jsonb), '{autoIntegrateRequestedAt}', to_jsonb(now()), true) "
-			+ "WHERE uuid = :uuid AND (flow_control->>'autoIntegrateRequestedAt') IS NULL", nativeQuery = true)
+			+ "WHERE uuid = :uuid", nativeQuery = true)
 	void markAutoIntegrateRequested(@Param("uuid") UUID uuid);
 
 	/**
@@ -676,8 +683,10 @@ public interface ReleaseRepository extends CrudRepository<Release, UUID> {
 	@Transactional
 	@Modifying
 	@Query(value = "UPDATE rearm.releases "
-			+ "SET flow_control = jsonb_set(coalesce(flow_control, '{}'::jsonb), '{autoIntegrateSkipUntil}', "
-			+ "    to_jsonb((now() + (:leaseSeconds || ' seconds')::interval)::text), true) "
+			+ "SET flow_control = jsonb_set(jsonb_set(coalesce(flow_control, '{}'::jsonb), "
+			+ "    '{autoIntegrateSkipUntil}', "
+			+ "    to_jsonb((now() + (:leaseSeconds || ' seconds')::interval)::text), true), "
+			+ "    '{autoIntegrateClaimedAt}', to_jsonb(now()), true) "
 			+ "WHERE uuid = :uuid AND (flow_control->>'autoIntegrateRequestedAt') IS NOT NULL "
 			+ "AND ((flow_control->>'autoIntegrateSkipUntil') IS NULL "
 			+ "     OR (flow_control->>'autoIntegrateSkipUntil')::timestamptz < now())", nativeQuery = true)
@@ -692,12 +701,21 @@ public interface ReleaseRepository extends CrudRepository<Release, UUID> {
 			+ "LIMIT :batchLimit", nativeQuery = true)
 	List<UUID> findUuidsOfReleasesPendingAutoIntegrate(@Param("batchLimit") int batchLimit);
 
-	/** Clear the marker after every feature set integrated (or no-op). */
+	/**
+	 * Clear the markers after every feature set integrated (or no-op) -- UNLESS a new request
+	 * arrived after this run's claim (requestedAt > claimedAt): then keep the queue entry and
+	 * drop only the lease/bookkeeping, so the scheduler drain re-processes on its next tick
+	 * instead of the re-trigger being silently lost. A NULL claimedAt (legacy in-flight rows)
+	 * compares as unknown and falls through to the full clear (pre-fix behavior).
+	 */
 	@Transactional
 	@Modifying
 	@Query(value = "UPDATE rearm.releases "
 			+ "SET flow_control = NULLIF("
-			+ "    flow_control - 'autoIntegrateRequestedAt' - 'autoIntegrateSkipUntil' - 'autoIntegrateFailureCount', "
+			+ "    CASE WHEN (flow_control->>'autoIntegrateRequestedAt')::timestamptz > (flow_control->>'autoIntegrateClaimedAt')::timestamptz "
+			+ "         THEN flow_control - 'autoIntegrateSkipUntil' - 'autoIntegrateFailureCount' - 'autoIntegrateClaimedAt' "
+			+ "         ELSE flow_control - 'autoIntegrateRequestedAt' - 'autoIntegrateSkipUntil' - 'autoIntegrateFailureCount' - 'autoIntegrateClaimedAt' "
+			+ "    END, "
 			+ "    '{}'::jsonb) "
 			+ "WHERE uuid = :uuid", nativeQuery = true)
 	void clearAutoIntegrateRequested(@Param("uuid") UUID uuid);

--- a/backend/src/main/java/io/reliza/repositories/VariableQueries.java
+++ b/backend/src/main/java/io/reliza/repositories/VariableQueries.java
@@ -1101,6 +1101,14 @@ class VariableQueries {
 			(v.record_data->>'uri' = :uri or v.record_data->>'uri' = 'https://' || :uri or v.record_data->>'uri' = 'http://' || :uri)
 			""";
 	
+	protected static final String FIND_LIVE_VCS_COMPONENTS_OF_ORG = """
+			select * from rearm.components c
+			where c.record_data->>'org' = :orgUuidAsString
+			and c.record_data->>'vcs' is not null
+			and c.record_data->>'type' = 'COMPONENT'
+			and (c.record_data->>'status' != 'ARCHIVED' or c.record_data->>'status' is null)
+			""";
+
 	protected static final String FIND_COMPONENTS_BY_VCS = """
 			select * from rearm.components c
 			where c.record_data->>'vcs' = :vcsUuidAsString
@@ -1306,6 +1314,7 @@ class VariableQueries {
 				COALESCE((am.numeric_metrics->>'medium')::int, 0) as medium,
 				COALESCE((am.numeric_metrics->>'low')::int, 0) as low,
 				COALESCE((am.numeric_metrics->>'unassigned')::int, 0) as unassigned,
+				(am.numeric_metrics->>'kevCount')::int as kevCount,
 				COALESCE((am.numeric_metrics->>'policyViolationsLicenseTotal')::int, 0) as licenseViolations,
 				COALESCE((am.numeric_metrics->>'policyViolationsOperationalTotal')::int, 0) as operationalViolations,
 				COALESCE((am.numeric_metrics->>'policyViolationsSecurityTotal')::int, 0) as securityViolations
@@ -1339,6 +1348,7 @@ class VariableQueries {
 				COALESCE((am.numeric_metrics->>'medium')::int, 0) as medium,
 				COALESCE((am.numeric_metrics->>'low')::int, 0) as low,
 				COALESCE((am.numeric_metrics->>'unassigned')::int, 0) as unassigned,
+				(am.numeric_metrics->>'kevCount')::int as kevCount,
 				COALESCE((am.numeric_metrics->>'policyViolationsLicenseTotal')::int, 0) as licenseViolations,
 				COALESCE((am.numeric_metrics->>'policyViolationsOperationalTotal')::int, 0) as operationalViolations,
 				COALESCE((am.numeric_metrics->>'policyViolationsSecurityTotal')::int, 0) as securityViolations

--- a/backend/src/main/java/io/reliza/repositories/dao/VulnViolationsChartDao.java
+++ b/backend/src/main/java/io/reliza/repositories/dao/VulnViolationsChartDao.java
@@ -10,6 +10,9 @@ public interface VulnViolationsChartDao {
 	Integer getMedium();
 	Integer getLow();
 	Integer getUnassigned();
+	/** Null on rows seeded before the kevCount key existed -- the read side
+	 * omits the KEV point rather than drawing a false zero. */
+	Integer getKevCount();
 	Integer getLicenseViolations();
 	Integer getOperationalViolations();
 	Integer getSecurityViolations();

--- a/backend/src/main/java/io/reliza/service/AnalyticsMetricsService.java
+++ b/backend/src/main/java/io/reliza/service/AnalyticsMetricsService.java
@@ -96,7 +96,7 @@ public class AnalyticsMetricsService {
 	private List<VulnViolationsChartDto> mapChartDaoToChartDtos(VulnViolationsChartDao row, java.time.ZoneId zone) {
 		LocalDate localDate = LocalDate.parse(row.getDateKey());
 		ZonedDateTime date = localDate.atStartOfDay(zone);
-		return List.of(
+		List<VulnViolationsChartDto> dtos = new LinkedList<>(List.of(
 			new VulnViolationsChartDto(date, row.getCritical(), "Critical Vulnerabilities"),
 			new VulnViolationsChartDto(date, row.getHigh(), "High Vulnerabilities"),
 			new VulnViolationsChartDto(date, row.getMedium(), "Medium Vulnerabilities"),
@@ -105,7 +105,15 @@ public class AnalyticsMetricsService {
 			new VulnViolationsChartDto(date, row.getLicenseViolations(), "License Violations"),
 			new VulnViolationsChartDto(date, row.getOperationalViolations(), "Operational Violations"),
 			new VulnViolationsChartDto(date, row.getSecurityViolations(), "Security Violations")
-		);
+		));
+		// kevCount is deliberately NOT coalesced in the SQL: rows seeded before the
+		// key existed return null, and emitting 0 for them would draw a flat
+		// "no KEV exposure" line for days we simply have no data for. Omitting the
+		// point makes the series start where the data starts.
+		if (row.getKevCount() != null) {
+			dtos.add(new VulnViolationsChartDto(date, row.getKevCount(), "KEV Vulnerabilities"));
+		}
+		return dtos;
 	}
 	
 	public Optional<AnalyticsMetricsData> findAnalyticsMetricsByOrgPerspectiveDateKey(UUID org, UUID perspective, String dateKey) {
@@ -435,6 +443,7 @@ public class AnalyticsMetricsService {
 		nm.put("medium", metricInt(m.getMedium()));
 		nm.put("low", metricInt(m.getLow()));
 		nm.put("unassigned", metricInt(m.getUnassigned()));
+		nm.put("kevCount", metricInt(m.getKevCount()));
 		nm.put("weaknesses", metricInt(m.getWeaknesses()));
 		nm.put("policyViolationsTotal", metricInt(m.getPolicyViolationsTotal()));
 		nm.put("policyViolationsLicenseTotal", metricInt(m.getPolicyViolationsLicenseTotal()));
@@ -544,6 +553,7 @@ public class AnalyticsMetricsService {
 		m.setMedium(numOrZero(nm.get("medium")));
 		m.setLow(numOrZero(nm.get("low")));
 		m.setUnassigned(numOrZero(nm.get("unassigned")));
+		m.setKevCount(numOrZero(nm.get("kevCount")));
 		m.setWeaknesses(numOrZero(nm.get("weaknesses")));
 		m.setPolicyViolationsTotal(numOrZero(nm.get("policyViolationsTotal")));
 		m.setPolicyViolationsLicenseTotal(numOrZero(nm.get("policyViolationsLicenseTotal")));
@@ -673,7 +683,10 @@ public class AnalyticsMetricsService {
 		List<VulnViolationsChartDto> out = new LinkedList<>();
 		for (ComponentAnalyticsMetrics row : rows) {
 			ZonedDateTime date = LocalDate.parse(row.getDateKey()).atStartOfDay(zone);
-			out.addAll(metricsFromNumericMap(row.getNumericMetrics()).convertToChartDto(date));
+			// Rows written before the kevCount key existed cannot distinguish
+			// "0 KEV" from "not measured" -- omit the KEV point for those days.
+			boolean hasKev = row.getNumericMetrics() != null && row.getNumericMetrics().containsKey("kevCount");
+			out.addAll(metricsFromNumericMap(row.getNumericMetrics()).convertToChartDto(date, hasKev));
 		}
 		return out;
 	}
@@ -766,7 +779,7 @@ public class AnalyticsMetricsService {
 		Map<String, Object> metricsMap = (Map<String, Object>) recordData.get("metrics");
 		if (metricsMap != null) {
 			Map<String, Object> nm = new java.util.LinkedHashMap<>();
-			for (String field : List.of("critical", "high", "medium", "low", "unassigned",
+			for (String field : List.of("critical", "high", "medium", "low", "unassigned", "kevCount",
 					"policyViolationsLicenseTotal", "policyViolationsOperationalTotal",
 					"policyViolationsSecurityTotal")) {
 				Object v = metricsMap.get(field);

--- a/backend/src/main/java/io/reliza/service/CdxVexParser.java
+++ b/backend/src/main/java/io/reliza/service/CdxVexParser.java
@@ -125,10 +125,18 @@ public class CdxVexParser implements VexFormatParser {
                 responses.add(AnalysisResponse.valueOf(r.name()));
             }
         }
+        // Utils.CDX_OM, never Utils.OM: this is a cyclonedx model type, and the
+        // Jackson 3 mapper cannot apply the library's CustomDateSerializer. It
+        // does not fail -- it silently writes epoch millis
+        // ("published":1750000000000) where the spec requires ISO-8601
+        // ("published":"2025-06-15T15:06:40Z"), because Utils.OM enables
+        // WRITE_DATES_AS_TIMESTAMPS. That wrong shape was persisted as the VEX
+        // statement's provenance record AND hashed as its dedup key.
         String stmtJson;
         try {
-            stmtJson = Utils.OM.writeValueAsString(v);
-        } catch (JacksonException e) {
+            stmtJson = Utils.CDX_OM.writeValueAsString(v);
+        } catch (com.fasterxml.jackson.core.JacksonException e) {
+            log.error("Failed to serialize VEX statement {} for provenance: {}", v.getId(), e.getMessage(), e);
             stmtJson = "{}";
         }
         VulnerabilitySeverity severity = highestSeverity(v);

--- a/backend/src/main/java/io/reliza/service/ChangeLogService.java
+++ b/backend/src/main/java/io/reliza/service/ChangeLogService.java
@@ -117,7 +117,13 @@ public class ChangeLogService {
 		ReleaseData globalLast,
 		Map<UUID, String> branchNameMap,
 		String userTimeZone,
-		List<VcsRepositoryData> vcsRepoDataList
+		List<VcsRepositoryData> vcsRepoDataList,
+		// Date-window semantics (getComponentChangelogByDate / org changelog): show EVERY release in
+		// the window -- the oldest diffs against the branch's latest OUT-OF-WINDOW predecessor, and
+		// carries baselineRelease=true when no predecessor exists (the branch's first release ever).
+		// false = release1/release2 comparison semantics: globalFirst is the comparison base and is
+		// excluded from display.
+		boolean dateWindowSemantics
 	) {}
 	
 	/**
@@ -557,8 +563,8 @@ public class ChangeLogService {
 		List<VcsRepositoryData> vcsRepoDataList = vcsRepositoryService.listVcsRepoDataByOrg(org);
 		ChangelogContext ctx = new ChangelogContext(
 			releasesByBranch, component, org, globalFirst, globalLast,
-			branchNameMap, userTimeZone, vcsRepoDataList);
-		
+			branchNameMap, userTimeZone, vcsRepoDataList, false);
+
 		if (aggregationType == AggregationType.NONE) {
 			return computeNoneChangelog(ctx);
 		}
@@ -723,7 +729,7 @@ public class ChangeLogService {
 		List<VcsRepositoryData> vcsRepoDataList = vcsRepositoryService.listVcsRepoDataByOrg(org);
 		ChangelogContext ctx = new ChangelogContext(
 			releasesByBranch, component, org, globalFirstRelease, globalLastRelease,
-			branchNameMap, userTimeZone, vcsRepoDataList);
+			branchNameMap, userTimeZone, vcsRepoDataList, true);
 
 		List<ReleaseData> allReleases = releasesByBranch.values().stream().flatMap(List::stream).toList();
 
@@ -1274,7 +1280,7 @@ public class ChangeLogService {
 				
 				ChangelogContext ctx = new ChangelogContext(
 					releasesByBranch, component, orgUuid, globalFirst, globalLast,
-					branchNameMap, userTimeZone, vcsRepoDataList);
+					branchNameMap, userTimeZone, vcsRepoDataList, true);
 				
 				// Pre-fetch acollections once for all releases (used by both component-level and org-level SBOM)
 				Map<UUID, List<AcollectionData>> releaseAcollectionsMap = (aggregationType == AggregationType.AGGREGATED)
@@ -1649,14 +1655,16 @@ public class ChangeLogService {
 				continue;
 			}
 			
-			// Exclude baseline release from changelog - only show releases after baseline
+			// Comparison semantics (release1/release2): globalFirst is the comparison base and is
+			// excluded from display. Date-window semantics: show EVERY release in the window -- the
+			// oldest one diffs against the branch's out-of-window predecessor (fetched below).
 			UUID baselineUuid = ctx.globalFirst().getUuid();
-			
-			// Filter out baseline release by UUID
-			List<ReleaseData> releasesToShow = branchReleases.stream()
-				.filter(r -> !r.getUuid().equals(baselineUuid))
-				.collect(Collectors.toList());
-			
+			List<ReleaseData> releasesToShow = ctx.dateWindowSemantics()
+				? branchReleases
+				: branchReleases.stream()
+					.filter(r -> !r.getUuid().equals(baselineUuid))
+					.collect(Collectors.toList());
+
 			// Early return if no releases to show after excluding baseline
 			if (releasesToShow.isEmpty()) {
 				continue;  // Skip this branch - no changes to display
@@ -1676,19 +1684,31 @@ public class ChangeLogService {
 				}
 			}
 			
-			// IMPORTANT: Also fetch baseline release acollection for SBOM/finding comparison
-			// Although baseline is excluded from display, we need its acollection to compute
-			// SBOM and finding changes for the oldest release in releasesToShow (which compares against baseline)
-			// See computeSbomChangesFromAcollections and computeFindingChangesForRelease below
-			ReleaseData baselineRelease = ctx.globalFirst();
-			AcollectionData baselineAc = acollectionService.getLatestCollectionDataOfRelease(baselineRelease.getUuid());
-			if (baselineAc != null) {
-				acollectionByRelease.put(baselineRelease.getUuid(), baselineAc);
+			// Diff base for the OLDEST release in releasesToShow. Comparison semantics: globalFirst
+			// (excluded from display above). Date-window semantics: the branch's latest release
+			// created strictly before the oldest shown one -- null when none exists, i.e. the
+			// oldest shown release is the branch's first release EVER and renders as the baseline
+			// (empty diffs + baselineRelease=true) instead of being silently suppressed.
+			ReleaseData baselineRelease;
+			if (ctx.dateWindowSemantics()) {
+				ReleaseData oldestShown = releasesToShow.get(releasesToShow.size() - 1);
+				// minusNanos(1000): AtOrBefore is inclusive and Postgres stores microseconds; step
+				// one microsecond back so the oldest shown release cannot resolve as its own base.
+				baselineRelease = sharedReleaseService.getBranchLatestReleaseAtOrBeforeDate(
+					branchId, oldestShown.getCreatedDate().minusNanos(1000)).orElse(null);
 			} else {
-				// DEFENSIVE: Log warning if baseline acollection is missing
-				// This could cause incorrect SBOM/finding diffs for the first release after baseline
-				log.warn("Baseline acollection not found for release {} - SBOM/finding changes may be incomplete", 
-					baselineRelease.getUuid());
+				baselineRelease = ctx.globalFirst();
+			}
+			if (baselineRelease != null) {
+				AcollectionData baselineAc = acollectionService.getLatestCollectionDataOfRelease(baselineRelease.getUuid());
+				if (baselineAc != null) {
+					acollectionByRelease.put(baselineRelease.getUuid(), baselineAc);
+				} else {
+					// DEFENSIVE: Log warning if baseline acollection is missing
+					// This could cause incorrect SBOM/finding diffs for the first release after baseline
+					log.warn("Baseline acollection not found for release {} - SBOM/finding changes may be incomplete",
+						baselineRelease.getUuid());
+				}
 			}
 			
 			List<NoneReleaseChanges> releaseChangesList = new ArrayList<>();
@@ -1724,7 +1744,8 @@ public class ChangeLogService {
 					sbomChanges,
 					findingChanges,
 					currentRelease.getCreatedDate()
-				));
+				,
+					previousRelease == null));
 			}
 			
 			if (!releaseChangesList.isEmpty()) {
@@ -2312,7 +2333,7 @@ public class ChangeLogService {
 						if (aggregationType == AggregationType.NONE) {
 							allNoneBranchChanges.add(new NoneBranchChanges(
 								branchId, branchName, componentUuid, componentData.getName(),
-								List.of(new NoneReleaseChanges(targetReleaseUuid, targetRelease.getDecoratedVersionString(userTimeZone), targetRelease.getLifecycle(), List.of(), EMPTY_SBOM_CHANGES, EMPTY_FINDING_CHANGES, targetRelease.getCreatedDate())),
+								List.of(new NoneReleaseChanges(targetReleaseUuid, targetRelease.getDecoratedVersionString(userTimeZone), targetRelease.getLifecycle(), List.of(), EMPTY_SBOM_CHANGES, EMPTY_FINDING_CHANGES, targetRelease.getCreatedDate(), false)),
 								ChangeType.ADDED));
 						} else {
 							allAggregatedBranchChanges.add(new AggregatedBranchChanges(
@@ -2344,7 +2365,7 @@ public class ChangeLogService {
 						if (aggregationType == AggregationType.NONE) {
 							allNoneBranchChanges.add(new NoneBranchChanges(
 								branchId, branchName, componentUuid, componentData.getName(),
-								List.of(new NoneReleaseChanges(baselineReleaseUuid, baselineRelease.getDecoratedVersionString(userTimeZone), baselineRelease.getLifecycle(), List.of(), EMPTY_SBOM_CHANGES, EMPTY_FINDING_CHANGES, baselineRelease.getCreatedDate())),
+								List.of(new NoneReleaseChanges(baselineReleaseUuid, baselineRelease.getDecoratedVersionString(userTimeZone), baselineRelease.getLifecycle(), List.of(), EMPTY_SBOM_CHANGES, EMPTY_FINDING_CHANGES, baselineRelease.getCreatedDate(), false)),
 								ChangeType.REMOVED));
 						} else {
 							allAggregatedBranchChanges.add(new AggregatedBranchChanges(
@@ -2414,7 +2435,7 @@ public class ChangeLogService {
 				
 				ChangelogContext ctx = new ChangelogContext(
 					releasesByBranch, componentData, org, compFirst, compLast,
-					branchNameMap, userTimeZone, vcsRepoDataList);
+					branchNameMap, userTimeZone, vcsRepoDataList, false);
 				
 				// Pre-fetch acollections once for AGGREGATED mode
 				Map<UUID, List<AcollectionData>> releaseAcollectionsMap = (aggregationType == AggregationType.AGGREGATED)

--- a/backend/src/main/java/io/reliza/service/ComponentDuplicateRepairService.java
+++ b/backend/src/main/java/io/reliza/service/ComponentDuplicateRepairService.java
@@ -1,0 +1,325 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.reliza.common.CommonVariables.StatusEnum;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.Branch;
+import io.reliza.model.BranchData;
+import io.reliza.model.Component;
+import io.reliza.model.ComponentData;
+import io.reliza.model.OrganizationData;
+import io.reliza.model.Release;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.WhoUpdated;
+import io.reliza.service.oss.OssReleaseService;
+
+/**
+ * Feature-gated repair for DUPLICATE component registrations: several
+ * non-archived COMPONENT-type components of one org bound to the same
+ * (vcs, repoPath) AND carrying the same name. Name equality is required even
+ * though resolution is name-blind -- the incident loop derives the identical
+ * name on every duplicate, while a name mismatch signals possibly-intentional
+ * distinct components, which are never auto-merged (and deliberately not
+ * reported: operator direction, 2026-07-30 -- only the repairable count is
+ * logged, one line per org).
+ *
+ * <p>How they arise: the resolve and create sides of VCS-based resolution used
+ * to canonicalize URIs differently, and create-on-missing callers treated every
+ * resolution failure -- including "multiple found" -- as absence. A first-build
+ * race seeds two; each CI run then minted another (30+ observed in prod, one
+ * per run). The resolution fixes stop NEW duplicates; this sweep repairs the
+ * accumulated estate, which otherwise keeps every affected CI red with
+ * "Multiple components found ... Please use component UUID instead."
+ *
+ * <p>Repair contract (per duplicate group): the OLDEST component is the leader
+ * -- it is the one the org's history accreted around. For every other
+ * component: when its release versions do not collide with versions already
+ * under the leader, its releases are FOLDED under the leader (moved to the
+ * leader's same-named branch, auto-created when absent), then the duplicate's
+ * branches and the duplicate itself are archived. On any version collision the
+ * duplicate is archived WITHOUT folding -- its releases stay attached to the
+ * archived component, preserved and recoverable, rather than risking two
+ * different releases claiming one version slot under the leader.
+ *
+ * <p>Release moves save with considerTriggers=false: a repair must not fire
+ * lifecycle triggers, notifications or auto-integrate.
+ *
+ * <p>Gated by {@code relizaprops.enforceUniqueComponents} (helm:
+ * {@code enforceUniqueComponents}, default false). When enabled the sweep runs
+ * once per boot, asynchronously, after the application is ready. It is also
+ * exposed per-org through the {@code repairDuplicateComponents} mutation (org
+ * ADMIN) so operators can repair a single org on demand -- and so e2e tests can
+ * drive it without a server restart.
+ */
+@Service
+public class ComponentDuplicateRepairService {
+
+	private static final Logger log = LoggerFactory.getLogger(ComponentDuplicateRepairService.class);
+
+	@Autowired private ComponentService componentService;
+	@Autowired private BranchService branchService;
+	@Autowired private ReleaseService releaseService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private OrganizationService organizationService;
+
+	// Self-proxy so per-group @Transactional applies on internal calls.
+	@Lazy @Autowired private ComponentDuplicateRepairService self;
+
+	@Value("${relizaprops.enforceUniqueComponents:false}")
+	private boolean enforceUniqueComponents;
+
+	public record RepairSummary(
+			int groupsExamined,
+			int releasesFolded,
+			int componentsArchived,
+			int branchesArchived,
+			int conflictGroups) {
+		public static RepairSummary empty() { return new RepairSummary(0, 0, 0, 0, 0); }
+		public RepairSummary plus(RepairSummary o) {
+			return new RepairSummary(
+					groupsExamined + o.groupsExamined,
+					releasesFolded + o.releasesFolded,
+					componentsArchived + o.componentsArchived,
+					branchesArchived + o.branchesArchived,
+					conflictGroups + o.conflictGroups);
+		}
+	}
+
+	/** Duplicate census for one org: same-name group count + excess (repairable) components. */
+	public record DuplicateCount(int groups, int excessComponents) {}
+
+	/**
+	 * Startup pass across every organization, async so a large estate never
+	 * blocks boot. The CENSUS always runs: every boot counts existing
+	 * duplicates by the exact sweep identity (COMPONENT type, vcs + normalized
+	 * repoPath + NAME) and reports any findings at error, so an affected
+	 * instance is visible without any flag. The SWEEP itself stays gated by
+	 * enforceUniqueComponents so plain upgrades never mutate data.
+	 */
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationReady() {
+		CompletableFuture.runAsync(() -> {
+			try {
+				int orgsWithDups = 0, totalGroups = 0, totalExcess = 0;
+				RepairSummary total = RepairSummary.empty();
+				for (OrganizationData od : organizationService.listAllOrganizationData()) {
+					// Archived orgs run no CI; their estate cannot page anyone and
+					// must not generate boot noise. The org-scoped ADMIN mutation can
+					// still target one explicitly if ever needed.
+					if (od.getStatus() == StatusEnum.ARCHIVED) continue;
+					try {
+						DuplicateCount count = countDuplicates(od.getUuid());
+						if (count.groups() > 0) {
+							orgsWithDups++;
+							totalGroups += count.groups();
+							totalExcess += count.excessComponents();
+							// One line per org: the count of components an actual repair
+							// would act on (fold or archive), nothing else.
+							log.error("[DUP-COMPONENT-REPAIR] org {}: {} component(s) in scope for repair "
+									+ "across {} duplicate group(s)",
+									od.getUuid(), count.excessComponents(), count.groups());
+						}
+						if (enforceUniqueComponents) {
+							total = total.plus(repairOrganization(od.getUuid(), WhoUpdated.getAutoWhoUpdated()));
+						}
+					} catch (Exception e) {
+						log.error("Duplicate-component startup pass failed for org {}", od.getUuid(), e);
+					}
+				}
+				if (enforceUniqueComponents) {
+					log.error("[DUP-COMPONENT-REPAIR] startup sweep complete: groups={}, releasesFolded={}, "
+							+ "componentsArchived={}, branchesArchived={}, conflictGroups={}",
+							total.groupsExamined(), total.releasesFolded(), total.componentsArchived(),
+							total.branchesArchived(), total.conflictGroups());
+				} else if (totalGroups > 0) {
+					log.error("[DUP-COMPONENT-REPAIR] startup census: {} duplicate group(s) / {} excess "
+							+ "component(s) across {} org(s); enforceUniqueComponents=false so NOTHING was "
+							+ "repaired -- enable the flag or run repairDuplicateComponents per org",
+							totalGroups, totalExcess, orgsWithDups);
+				} else {
+					// Positive confirmation (operator request): a clean boot prints
+					// exactly one line, so "checked and clean" is distinguishable
+					// from "census never ran".
+					log.error("[DUP-COMPONENT-REPAIR] startup census clean: no duplicate components in scope for repair");
+				}
+			} catch (Exception e) {
+				log.error("Duplicate-component startup pass failed", e);
+			}
+		});
+	}
+
+	/**
+	 * Count same-name duplicate groups for one org, using EXACTLY the sweep's
+	 * grouping (shared code path) -- the census can never drift from what the
+	 * sweep would repair. Read-only.
+	 */
+	public DuplicateCount countDuplicates(UUID orgUuid) {
+		int groups = 0, excess = 0;
+		for (List<Component> group : sameNameDuplicateGroups(orgUuid).values()) {
+			groups++;
+			excess += group.size() - 1;
+		}
+		return new DuplicateCount(groups, excess);
+	}
+
+	/**
+	 * Repair one organization: group its live VCS-bound components by
+	 * (vcs, repoPath) and repair every group holding more than one.
+	 */
+	public RepairSummary repairOrganization(UUID orgUuid, WhoUpdated wu) {
+		RepairSummary summary = RepairSummary.empty();
+		for (Map.Entry<String, List<Component>> group : sameNameDuplicateGroups(orgUuid).entrySet()) {
+			try {
+				summary = summary.plus(self.repairGroup(orgUuid, group.getValue(), wu));
+			} catch (Exception e) {
+				// Per-group isolation: one failed group must not abort the org.
+				log.error("Duplicate-component repair failed for org {} group {}", orgUuid, group.getKey(), e);
+			}
+		}
+		if (summary.groupsExamined() > 0) {
+			log.error("[DUP-COMPONENT-REPAIR] org {}: groups={}, releasesFolded={}, componentsArchived={}, "
+					+ "branchesArchived={}, conflictGroups={}",
+					orgUuid, summary.groupsExamined(), summary.releasesFolded(), summary.componentsArchived(),
+					summary.branchesArchived(), summary.conflictGroups());
+		}
+		return summary;
+	}
+
+	/**
+	 * Repair identity: (vcs, repoPath, NAME), COMPONENT type only (the query
+	 * filters type). repoPath normalizes null / '' / '.' into one root bucket,
+	 * mirroring FIND_COMPONENT_BY_VCS_AND_PATH (a UI-created component stores
+	 * null where CI stores '.'). NAME is deliberately REQUIRED to match even
+	 * though resolution is name-blind: the incident loop derives the identical
+	 * name on every duplicate registration (same URI, same path -> same derived
+	 * name, verified empirically), while a name MISMATCH on one (vcs, repoPath)
+	 * signals possibly-intentional distinct components -- those are never
+	 * auto-merged (resolution for them stays ambiguous; surfacing that is left
+	 * to the resolution error itself, per operator direction).
+	 *
+	 * <p>Returns only groups with 2+ members. Shared by the startup census, the
+	 * startup sweep and the mutation, so counting and repairing can never
+	 * disagree about what a duplicate is.
+	 */
+	private Map<String, List<Component>> sameNameDuplicateGroups(UUID orgUuid) {
+		Map<String, List<Component>> groups = new LinkedHashMap<>();
+		for (Component c : componentService.listLiveVcsComponentsOfOrg(orgUuid)) {
+			ComponentData cd = ComponentData.dataFromRecord(c);
+			if (cd.getVcs() == null) continue;
+			String vcsPathKey = cd.getVcs() + "|" + normalizeRepoPath(cd.getRepoPath());
+			groups.computeIfAbsent(vcsPathKey + "|" + cd.getName(), k -> new ArrayList<>()).add(c);
+		}
+		groups.values().removeIf(g -> g.size() < 2);
+		return groups;
+	}
+
+	/** Root-identity normalization, mirroring FIND_COMPONENT_BY_VCS_AND_PATH. */
+	private static String normalizeRepoPath(String repoPath) {
+		return (repoPath == null || repoPath.isEmpty() || ".".equals(repoPath)) ? "" : repoPath;
+	}
+
+	/**
+	 * Repair a single duplicate group atomically: either the whole group's
+	 * folds + archivals commit, or none do (the group is retried on the next
+	 * startup / manual run).
+	 */
+	@Transactional
+	public RepairSummary repairGroup(UUID orgUuid, List<Component> components, WhoUpdated wu) throws RelizaException {
+		List<Component> ordered = new ArrayList<>(components);
+		ordered.sort((a, b) -> a.getCreatedDate().compareTo(b.getCreatedDate()));
+		Component leader = ordered.get(0);
+
+		// Version slots already occupied under the leader; grows as folds land so
+		// a version can never be claimed twice within one group repair.
+		Set<String> leaderVersions = new HashSet<>();
+		for (Release r : releaseService.listReleasesByComponent(leader.getUuid())) {
+			ReleaseData rd = ReleaseData.dataFromRecord(r);
+			if (rd.getVersion() != null) leaderVersions.add(rd.getVersion());
+		}
+
+		int releasesFolded = 0;
+		int componentsArchived = 0;
+		int branchesArchived = 0;
+		int conflictGroups = 0;
+
+		for (Component dup : ordered.subList(1, ordered.size())) {
+			List<Release> dupReleases = releaseService.listReleasesByComponent(dup.getUuid());
+
+			boolean conflict = dupReleases.stream()
+					.map(r -> ReleaseData.dataFromRecord(r).getVersion())
+					.anyMatch(v -> v != null && leaderVersions.contains(v));
+
+			if (conflict) {
+				conflictGroups++;
+				log.error("[DUP-COMPONENT-REPAIR] org {}: component {} conflicts with leader {} on at least one "
+						+ "release version -- archiving WITHOUT folding ({} release(s) stay on the archived component)",
+						orgUuid, dup.getUuid(), leader.getUuid(), dupReleases.size());
+			} else {
+				for (Release r : dupReleases) {
+					moveReleaseToLeader(r, leader.getUuid(), wu);
+					ReleaseData rd = ReleaseData.dataFromRecord(r);
+					if (rd.getVersion() != null) leaderVersions.add(rd.getVersion());
+					releasesFolded++;
+				}
+			}
+
+			// archiveComponent cascades to ALL branches (including BASE, which the
+			// standalone archiveBranch guard rightly refuses for live components).
+			long liveBranches = branchService.listBranchesOfComponent(dup.getUuid(), null).stream()
+					.map(BranchData::branchDataFromDbRecord)
+					.filter(bd -> bd.getStatus() != StatusEnum.ARCHIVED)
+					.count();
+			componentService.archiveComponent(dup.getUuid(), wu);
+			branchesArchived += (int) liveBranches;
+			componentsArchived++;
+			log.error("[DUP-COMPONENT-REPAIR] org {}: archived duplicate component {} (leader {}), folded={}",
+					orgUuid, dup.getUuid(), leader.getUuid(), !conflict);
+		}
+
+		return new RepairSummary(1, releasesFolded, componentsArchived, branchesArchived, conflictGroups);
+	}
+
+	/**
+	 * Move one release under the leader, into the leader's branch of the same
+	 * name (auto-created when the leader has no such branch). Saved with
+	 * considerTriggers=false -- a repair must not fire triggers, notifications
+	 * or auto-integrate.
+	 */
+	private void moveReleaseToLeader(Release r, UUID leaderUuid, WhoUpdated wu) throws RelizaException {
+		ReleaseData rd = ReleaseData.dataFromRecord(r);
+		String branchName = branchService.getBranchData(rd.getBranch())
+				.map(BranchData::getName)
+				.orElseThrow(() -> new RelizaException(
+						"Branch " + rd.getBranch() + " of release " + rd.getUuid() + " not found"));
+		Optional<Branch> leaderBranch = branchService.findBranchByName(leaderUuid, branchName, true, wu);
+		if (leaderBranch.isEmpty()) {
+			throw new RelizaException("Could not resolve or create branch '" + branchName
+					+ "' on leader component " + leaderUuid);
+		}
+		rd.repointToComponentBranch(leaderUuid, leaderBranch.get().getUuid());
+		ossReleaseService.saveRelease(r, rd, wu, false);
+	}
+}

--- a/backend/src/main/java/io/reliza/service/ComponentOwnershipService.java
+++ b/backend/src/main/java/io/reliza/service/ComponentOwnershipService.java
@@ -18,6 +18,7 @@ import io.reliza.model.ComponentData;
 import io.reliza.model.ComponentData.ComponentOwner;
 import io.reliza.model.ComponentOwnerType;
 import io.reliza.model.ComponentOwnershipStatus;
+import io.reliza.model.OrganizationData;
 import io.reliza.model.UserGroupData;
 import io.reliza.model.UserPermission.PermissionScope;
 import io.reliza.model.UserPermission.PermissionType;
@@ -52,6 +53,12 @@ public class ComponentOwnershipService {
 	@Autowired
 	private ComponentTeamService componentTeamService;
 
+	@Autowired
+	private GetOrganizationService getOrganizationService;
+
+	@Autowired
+	private OrgTeamAssignmentRuleService teamAssignmentRuleService;
+
 	/**
 	 * Convenience overload for the per-component read path. Skips the org-group
 	 * fetch entirely when a stored owner is present (the common case once ownership
@@ -59,10 +66,13 @@ public class ComponentOwnershipService {
 	 * stored-owner component costs no {@code getUserGroupsByOrganization}.
 	 */
 	public ComponentOwnership resolveOwnership (ComponentData cd) {
-		List<UserGroupData> orgGroups = hasStoredOwner(cd.getOwner())
+		boolean stored = hasStoredOwner(cd.getOwner());
+		List<UserGroupData> orgGroups = stored
 				? List.of()
 				: userGroupService.getUserGroupsByOrganization(cd.getOrg());
-		return resolveOwnership(cd, orgGroups);
+		// A stored owner short-circuits everything, so skip the org fetch too.
+		OrganizationData od = stored ? null : getOrganizationService.getOrganizationData(cd.getOrg()).orElse(null);
+		return resolveOwnership(cd, orgGroups, od);
 	}
 
 	/**
@@ -70,9 +80,50 @@ public class ComponentOwnershipService {
 	 * avoid an N+1 group fetch per component; sec. 10.5). {@code orgGroups} is only
 	 * consulted on the suggestion path (no stored owner).
 	 */
-	public ComponentOwnership resolveOwnership (ComponentData cd, List<UserGroupData> orgGroups) {
+	/**
+	 * Full form: also takes the org record so a batch caller can hoist BOTH the
+	 * group list and the org (which carries the team-assignment rules) out of the
+	 * per-component loop.
+	 *
+	 * <p>Precedence, highest first (T2, DECIDED 2026-07-29):
+	 * <ol>
+	 *   <li><b>Stored owner</b> -- someone chose it on this component; a rule
+	 *       never overrides a deliberate human choice.</li>
+	 *   <li><b>Team-assignment rule</b> -- first matching rule in org order. Sets
+	 *       the owner (not a parallel field), flagged {@code derived}.</li>
+	 *   <li><b>Candidate suggestion</b> -- no owner at all; suggest one.</li>
+	 * </ol>
+	 */
+	public ComponentOwnership resolveOwnership (ComponentData cd, List<UserGroupData> orgGroups,
+			OrganizationData od) {
 		ComponentOwner owner = cd.getOwner();
-		return hasStoredOwner(owner) ? resolveStored(cd, owner) : suggestFromCandidates(cd, orgGroups);
+		if (hasStoredOwner(owner)) return resolveStored(cd, owner);
+		var ruleMatch = teamAssignmentRuleService.matchFor(cd, od, orgGroups);
+		if (ruleMatch.isPresent()) return fromRule(ruleMatch.get());
+		return suggestFromCandidates(cd, orgGroups);
+	}
+
+	/**
+	 * A rule-assigned owner is a real owner -- same durability arithmetic as a
+	 * stored one, so a rule pointing at a one-person team is honestly reported
+	 * NON_DURABLE rather than laundering it into OWNED. {@code derived=true} plus
+	 * the rule name in the reason is how the UI shows provenance without a second
+	 * stored field.
+	 */
+	private ComponentOwnership fromRule (OrgTeamAssignmentRuleService.TeamAssignmentMatch match) {
+		UserGroupData team = match.team();
+		String via = " (via rule '" + match.rule().getName() + "')";
+		if (team.getStatus() != UserGroupStatus.ACTIVE) {
+			return new ComponentOwnership(ComponentOwnerType.TEAM, team.getUuid(), false,
+					ComponentOwnershipStatus.DEGRADED, true, "Owner team is archived/inactive" + via);
+		}
+		boolean durable = isTeamDurable(team);
+		return new ComponentOwnership(ComponentOwnerType.TEAM, team.getUuid(), durable,
+				durable ? ComponentOwnershipStatus.OWNED : ComponentOwnershipStatus.NON_DURABLE, true,
+				durable
+						? "Assigned by rule '" + match.rule().getName() + "'"
+						: "Owner team has fewer than " + DURABLE_MIN_MEMBERS
+								+ " members and is not SSO-backed" + via);
 	}
 
 	/**
@@ -87,9 +138,12 @@ public class ComponentOwnershipService {
 	 */
 	public List<ComponentOwnershipReportRow> ownershipReport (UUID orgUuid, List<ComponentData> components) {
 		List<UserGroupData> orgGroups = userGroupService.getUserGroupsByOrganization(orgUuid);
+		// Hoisted for the same reason as orgGroups: the org record carries the
+		// team-assignment rules, and re-fetching it per component would be an N+1.
+		OrganizationData od = getOrganizationService.getOrganizationData(orgUuid).orElse(null);
 		List<ComponentOwnershipReportRow> rows = new ArrayList<>();
 		for (ComponentData cd : components) {
-			ComponentOwnership o = resolveOwnership(cd, orgGroups);
+			ComponentOwnership o = resolveOwnership(cd, orgGroups, od);
 			if (o.status() != ComponentOwnershipStatus.OWNED) {
 				rows.add(new ComponentOwnershipReportRow(cd.getUuid(), cd.getName(), cd.getType(), o));
 			}

--- a/backend/src/main/java/io/reliza/service/ComponentService.java
+++ b/backend/src/main/java/io/reliza/service/ComponentService.java
@@ -511,7 +511,12 @@ public class ComponentService {
 			// Durable owner (RFC Phase 4b): validate the ref synchronously (no DB
 			// FK backs it) against the component's org before storing. Null = no
 			// change; an invalid ref throws before any save.
-			if (null != cdto.getOwner()) {
+			// clearOwner wins over owner: an explicit "remove it" should not be
+			// silently ignored because a stale owner object rode along in the
+			// same payload.
+			if (Boolean.TRUE.equals(cdto.getClearOwner())) {
+				cd.setOwner(null);
+			} else if (null != cdto.getOwner()) {
 				componentOwnershipService.validateOwner(cdto.getOwner(), cd.getOrg());
 				cd.setOwner(cdto.getOwner());
 			}
@@ -728,37 +733,77 @@ public class ComponentService {
 	}
 	
 	/**
-	 * Find component data by VCS repository UUID and repository path within an organization.
-	 * Throws RelizaException if component not found or if multiple components match (ambiguous).
-	 * 
-	 * @param vcsUuid VCS repository UUID
-	 * @param orgUuid Organization UUID
-	 * @param repoPath Repository path (can be null for root)
-	 * @return ComponentData matching the VCS and repoPath
-	 * @throws RelizaException if component not found or multiple components found
+	 * Outcome of VCS-based component resolution, modeled as data rather than
+	 * exceptions so callers that may CREATE on absence can tell the three cases
+	 * apart without catch-based control flow. The prod failure mode this
+	 * prevents: a caller holding createComponentIfMissing caught EVERY
+	 * resolution exception as "not found" -- including AMBIGUOUS -- so once two
+	 * duplicate registrations existed, every CI run minted another (30+
+	 * observed, one per run). AMBIGUOUS is an operator problem to surface,
+	 * never a license to create component N+1.
 	 */
-	public ComponentData findComponentDataByVcsAndPath(UUID vcsUuid, UUID orgUuid, String repoPath) throws RelizaException {
+	public static enum ComponentResolutionStatus { FOUND, NOT_FOUND, AMBIGUOUS }
+
+	public static record ComponentResolution(ComponentResolutionStatus status, UUID componentId, String detail) {
+		public static ComponentResolution found(UUID componentId) {
+			return new ComponentResolution(ComponentResolutionStatus.FOUND, componentId, null);
+		}
+		public static ComponentResolution notFound(String detail) {
+			return new ComponentResolution(ComponentResolutionStatus.NOT_FOUND, null, detail);
+		}
+		public static ComponentResolution ambiguous(String detail) {
+			return new ComponentResolution(ComponentResolutionStatus.AMBIGUOUS, null, detail);
+		}
+	}
+
+	/**
+	 * Tri-state component lookup by VCS repository UUID and repo path within an
+	 * organization. Never throws for a resolution outcome.
+	 */
+	private ComponentResolution componentResolutionByVcsAndPath(UUID vcsUuid, UUID orgUuid, String repoPath) {
 		List<Component> components = repository.findAllComponentsByVcsAndPath(vcsUuid.toString(), orgUuid.toString(), repoPath);
-		
+
 		log.debug("Found {} components for vcsUuid={}, orgUuid={}, repoPath={}", components.size(), vcsUuid, orgUuid, repoPath);
-		
+
 		if (components.isEmpty()) {
-			throw new RelizaException(String.format(
+			return ComponentResolution.notFound(String.format(
 				"Component not found for VCS UUID '%s' and repo path '%s'", vcsUuid, repoPath));
 		}
-		
+
 		if (components.size() > 1) {
 			String componentIds = components.stream()
 				.map(c -> c.getUuid().toString())
 				.collect(java.util.stream.Collectors.joining(", "));
 			log.error("Multiple components found (ambiguous): vcsUuid={}, orgUuid={}, repoPath={}, count={}, componentIds={}", 
 				vcsUuid, orgUuid, repoPath, components.size(), componentIds);
-			throw new RelizaException(String.format(
+			return ComponentResolution.ambiguous(String.format(
 				"Multiple components found for VCS UUID '%s' and repo path '%s'. Component IDs: %s. Please use component UUID instead.", 
 				vcsUuid, repoPath, componentIds));
 		}
-		
-		return ComponentData.dataFromRecord(components.get(0));
+
+		return ComponentResolution.found(components.get(0).getUuid());
+	}
+
+	/**
+	 * Every live (non-archived) component of the org that is bound to a VCS
+	 * repository -- the candidate universe for duplicate-registration repair.
+	 */
+	public List<Component> listLiveVcsComponentsOfOrg(UUID orgUuid) {
+		return repository.findLiveVcsComponentsOfOrg(orgUuid.toString());
+	}
+
+	/**
+	 * Throwing convenience over {@link #componentResolutionByVcsAndPath} for
+	 * callers with no create-on-missing semantics (e.g. versionFeatureSet
+	 * override resolution): NOT_FOUND and AMBIGUOUS both surface as errors.
+	 */
+	public ComponentData findComponentDataByVcsAndPath(UUID vcsUuid, UUID orgUuid, String repoPath) throws RelizaException {
+		ComponentResolution resolution = componentResolutionByVcsAndPath(vcsUuid, orgUuid, repoPath);
+		if (resolution.status() != ComponentResolutionStatus.FOUND) {
+			throw new RelizaException(resolution.detail());
+		}
+		return getComponentService.getComponentData(resolution.componentId())
+				.orElseThrow(() -> new RelizaException("Component " + resolution.componentId() + " not found"));
 	}
 	
 	/**
@@ -773,6 +818,21 @@ public class ComponentService {
 	 * @throws RelizaException if component resolution fails
 	 */
 	public UUID resolveComponentIdFromInput(Map<String, Object> inputMap, ProgrammaticAuthContext authCtx) throws RelizaException {
+		ComponentResolution resolution = resolveComponentResolutionFromInput(inputMap, authCtx);
+		if (resolution.status() == ComponentResolutionStatus.FOUND) return resolution.componentId();
+		throw new RelizaException(resolution.detail());
+	}
+
+	/**
+	 * Tri-state variant of {@link #resolveComponentIdFromInput} for callers that
+	 * may CREATE the component when it does not exist (addRelease / getNewVersion
+	 * with {@code createComponentIfMissing}). Resolution outcomes come back as
+	 * data -- creation is only legitimate on {@code NOT_FOUND}, and {@code
+	 * AMBIGUOUS} (duplicate registrations for the same VCS + repoPath) must fail
+	 * the call rather than mint another duplicate. Genuine errors that are not
+	 * resolution outcomes (wrong key type, VCS/component mismatch) still throw.
+	 */
+	public ComponentResolution resolveComponentResolutionFromInput(Map<String, Object> inputMap, ProgrammaticAuthContext authCtx) throws RelizaException {
 		CommonVariables.AuthHeaderParse ahp = authCtx == null ? null : authCtx.ahp();
 		UUID orgUuid = authCtx == null ? null : authCtx.orgUuid();
 		String vcsUri = Utils.normalizeVcsUri((String) inputMap.get("vcsUri"));
@@ -801,17 +861,16 @@ public class ComponentService {
 					}
 				}
 			}
-			return componentId;
+			return ComponentResolution.found(componentId);
 		}
 
 		// Only attempt VCS-based resolution if componentId is not provided
 		if (vcsUri != null) {
-			if (orgUuid == null) throw new RelizaException("Component not found");
-			ComponentData componentData = resolveComponentByVcsUriAndPath(orgUuid, vcsUri, repoPath);
-			return componentData.getUuid();
+			if (orgUuid == null) return ComponentResolution.notFound("Component not found");
+			return resolveComponentResolutionByVcsUriAndPath(orgUuid, vcsUri, repoPath);
 		}
 
-		throw new RelizaException("Component not found");
+		return ComponentResolution.notFound("Component not found");
 	}
 	
 	/**
@@ -837,8 +896,10 @@ public class ComponentService {
 
 	public ComponentData createComponentFromVcsUri(UUID orgUuid, String vcsUri, String repoPath, String vcsDisplayName, VcsType vcsType,
 			String versionSchema, String featureBranchVersionSchema, String componentNameOverride, WhoUpdated wu) throws RelizaException {
-		// Strip username from URI if present (e.g., https://relizaio@dev.azure.com/ -> https://dev.azure.com/)
-		String cleanVcsUri = Utils.normalizeVcsUri(vcsUri);
+		// Full canonical form (scheme, user@, git@, trailing .git, scp colon): the
+		// VCS row is stored in this form, and deriving the component NAME from a
+		// lesser form leaked '.git' into names (e.g. 'repo.git-alpha').
+		String cleanVcsUri = Utils.cleanVcsUri(Utils.normalizeVcsUri(vcsUri));
 
 		// Find or create VCS repository
 		VcsType effectiveVcsType = (vcsType != null) ? vcsType : VcsType.GIT;
@@ -889,33 +950,31 @@ public class ComponentService {
 	 * @return ComponentData matching the VCS URI and repoPath
 	 * @throws RelizaException if VCS not found, component not found, or multiple components found
 	 */
-	public ComponentData resolveComponentByVcsUriAndPath(UUID orgUuid, String vcsUri, String repoPath) throws RelizaException {
+	public ComponentResolution resolveComponentResolutionByVcsUriAndPath(UUID orgUuid, String vcsUri, String repoPath) {
+		// Full canonicalization happens inside getVcsRepositoryDataByUri, matching
+		// the form rows are stored in (see that method for the prod incident this
+		// alignment fixes -- the resolve side used to canonicalize LESS than the
+		// create side, so '.git'-suffixed CI URIs never resolved and re-created).
+		String cleanVcsUri = Utils.cleanVcsUri(Utils.normalizeVcsUri(vcsUri));
 
-		String cleanVcsUri = Utils.normalizeVcsUri(vcsUri);
-		
 		log.debug("VCS-based component resolution : vcsUri={}, repoPath={}, orgUuid={}", cleanVcsUri, repoPath, orgUuid);
-		
+
 		// Find VCS repository within organization
 		Optional<VcsRepositoryData> vcsRepoData = vcsRepositoryService.getVcsRepositoryDataByUri(orgUuid, cleanVcsUri);
 		if (!vcsRepoData.isPresent()) {
 			log.warn("VCS repository not found : vcsUri={}, orgUuid={}", vcsUri, orgUuid);
-			throw new RelizaException("VCS repository " + cleanVcsUri + " not found in this organization");
+			return ComponentResolution.notFound("VCS repository " + cleanVcsUri + " not found in this organization");
 		}
-		
+
 		log.debug("VCS repository found : uuid={}, name={}", 
 		 vcsRepoData.get().getUuid(), vcsRepoData.get().getName());
-		
-		// Find component by VCS UUID + orgUuid + repoPath (org-scoped)
-		try {
-			ComponentData componentData = findComponentDataByVcsAndPath(vcsRepoData.get().getUuid(), orgUuid, repoPath);
-			log.debug("Component resolved : componentId={}, componentName={}, repoPath={}",
-			 componentData.getUuid(), componentData.getName(), repoPath);
-			return componentData;
-		} catch (RelizaException e) {
+
+		ComponentResolution resolution = componentResolutionByVcsAndPath(vcsRepoData.get().getUuid(), orgUuid, repoPath);
+		if (resolution.status() != ComponentResolutionStatus.FOUND) {
 			log.error("Component resolution failed : vcsUri={}, repoPath={}, vcsUuid={}, orgUuid={}, error={}",
-			 vcsUri, repoPath, vcsRepoData.get().getUuid(), orgUuid, e.getMessage());
-			throw e;
+			 vcsUri, repoPath, vcsRepoData.get().getUuid(), orgUuid, resolution.detail());
 		}
+		return resolution;
 	}
 
 	/**

--- a/backend/src/main/java/io/reliza/service/FindingComparisonService.java
+++ b/backend/src/main/java/io/reliza/service/FindingComparisonService.java
@@ -744,7 +744,8 @@ public class FindingComparisonService {
 					fa.resolvedInCount(), fa.appearedInCount(), fa.presentInCount(),
 					flags.isNetResolved(), flags.isNetAppeared(), flags.isStillPresent(),
 					flags.orgContext(),
-					fa.finding.analysisState()
+					fa.finding.analysisState(),
+					null, null, null
 				);
 			})
 			.collect(Collectors.toList());
@@ -761,7 +762,8 @@ public class FindingComparisonService {
 					fa.resolvedInCount(), fa.appearedInCount(), fa.presentInCount(),
 					flags.isNetResolved(), flags.isNetAppeared(), flags.isStillPresent(),
 					flags.orgContext(),
-					fa.finding.analysisState()
+					fa.finding.analysisState(),
+					null, null, null
 				);
 			})
 			.collect(Collectors.toList());
@@ -780,7 +782,8 @@ public class FindingComparisonService {
 					fa.resolvedInCount(), fa.appearedInCount(), fa.presentInCount(),
 					flags.isNetResolved(), flags.isNetAppeared(), flags.isStillPresent(),
 					flags.orgContext(),
-					fa.finding.analysisState()
+					fa.finding.analysisState(),
+					null, null, null
 				);
 			})
 			.collect(Collectors.toList());
@@ -1308,7 +1311,8 @@ public class FindingComparisonService {
 		// ONE horizon per request: reuse the prefetch's snapshot so the degrade decision and the clamp
 		// disclosure share the same instant (no false clamp at the exact boundary, no extra org lookup).
 		ZonedDateTime horizon = prefetch != null ? prefetch.retentionHorizon() : retentionHorizon(org);
-		return assembleFromFoldedMaps(org, maps, inheritedInComponents, escalations,
+		return assembleFromFoldedMaps(componentReleases, componentNames, branchNameCache,
+			org, maps, inheritedInComponents, escalations,
 			allReleaseUuids, totalComponents, from, to, horizon);
 	}
 
@@ -1326,6 +1330,9 @@ public class FindingComparisonService {
 	 *                        so {@code isInheritedInAllComponents} degrades correctly per scope.
 	 */
 	private FindingChangesWithAttribution assembleFromFoldedMaps(
+			Map<UUID, List<ReleaseData>> scopeReleases,
+			Map<UUID, String> componentNames,
+			Map<UUID, String> branchNameCache,
 			UUID org,
 			AttributionMaps maps,
 			Map<String, Set<UUID>> inheritedInComponents,
@@ -1347,6 +1354,12 @@ public class FindingComparisonService {
 				flags = suppressCrossComponentInheritedNew(key, flags, inheritedInComponents);
 				return decorateWithOverlay(key, flags, overlay);
 			});
+
+		// Changelog re-scan visibility: stamp appeared findings that ARRIVED via an in-window
+		// finding_change_event with the arrival date and the earliest/latest in-window releases
+		// currently carrying them -- the honest carrier range, replacing the misleading
+		// single endpoint-anchor attribution ("first occurrence") for late-scan arrivals.
+		base = decorateScanArrivals(base, overlay.appearedAtByKey(), scopeReleases, componentNames, branchNameCache);
 
 		// DISCLOSURE: the from-endpoint degrades to current metrics for EVERY release when `from` predates
 		// the org's event-retention horizon (older events purged -> not reverse-reconstructable). That is a
@@ -1479,7 +1492,8 @@ public class FindingComparisonService {
 		}
 
 		int totalConstituents = allComponents.size();
-		return assembleFromFoldedMaps(org, maps, inheritedInComponents, escalations,
+		return assembleFromFoldedMaps(constituentReleases, java.util.Collections.emptyMap(), new HashMap<>(),
+			org, maps, inheritedInComponents, escalations,
 			allReleaseUuids, totalConstituents, from, to, prefetch.retentionHorizon());
 	}
 
@@ -1917,10 +1931,98 @@ public class FindingComparisonService {
 	 * so the badge count is legitimately lower than the raw KEV_ADDED / SEVERITY_INCREASED event count. The UI
 	 * labels/tooltips say "open findings ... in this period" to convey this.
 	 */
+	/**
+	 * Stamp scan-arrival facts onto appeared findings (changelog re-scan visibility).
+	 *
+	 * <p>For every finding key with an in-window APPEARED event (still-present at the window
+	 * end -- the overlay pre-filters), find the earliest and latest in-scope releases whose
+	 * CURRENT metrics carry the finding (membership by the same FROZEN key extractors the
+	 * attribution maps use) and copy the finding with {@code scanArrivalDate} + the carrier
+	 * range. Release-borne appearances also get stamped -- for them the earliest carrier IS
+	 * the introducing release, so the UI can distinguish the two arrival modes by comparing
+	 * the earliest carrier to the appearedIn anchor without any threshold heuristics.
+	 */
+	private FindingChangesWithAttribution decorateScanArrivals(
+			FindingChangesWithAttribution base,
+			Map<String, ZonedDateTime> appearedAtByKey,
+			Map<UUID, List<ReleaseData>> scopeReleases,
+			Map<UUID, String> componentNames,
+			Map<UUID, String> branchNameCache) {
+		if (appearedAtByKey == null || appearedAtByKey.isEmpty() || scopeReleases == null || scopeReleases.isEmpty()) {
+			return base;
+		}
+
+		record Carrier(UUID componentUuid, ReleaseData release) {}
+		Map<String, Carrier> earliest = new HashMap<>();
+		Map<String, Carrier> latest = new HashMap<>();
+		for (Map.Entry<UUID, List<ReleaseData>> entry : scopeReleases.entrySet()) {
+			UUID componentUuid = entry.getKey();
+			for (ReleaseData rd : entry.getValue()) {
+				if (rd == null || rd.getMetrics() == null || rd.getCreatedDate() == null) continue;
+				ReleaseMetricsDto m = rd.getMetrics();
+				List<String> keys = new ArrayList<>();
+				for (VulnerabilityDto v : nullSafe(m.getVulnerabilityDetails())) keys.add(VULN_KEY.apply(v));
+				for (ViolationDto v : nullSafe(m.getViolationDetails())) keys.add(VIOLATION_KEY.apply(v));
+				for (WeaknessDto w : nullSafe(m.getWeaknessDetails())) keys.add(WEAKNESS_KEY.apply(w));
+				for (String key : keys) {
+					if (!appearedAtByKey.containsKey(key)) continue;
+					Carrier c = new Carrier(componentUuid, rd);
+					earliest.merge(key, c, (a, b) ->
+							a.release().getCreatedDate().isBefore(b.release().getCreatedDate()) ? a : b);
+					latest.merge(key, c, (a, b) ->
+							a.release().getCreatedDate().isAfter(b.release().getCreatedDate()) ? a : b);
+				}
+			}
+		}
+
+		java.util.function.BiFunction<String, ZonedDateTime, ComponentAttribution[]> carriersOf = (key, at) -> {
+			Carrier e = earliest.get(key);
+			Carrier l = latest.get(key);
+			return new ComponentAttribution[] {
+				e == null ? null : toCarrierAttribution(e.componentUuid(), e.release(), componentNames, branchNameCache),
+				l == null ? null : toCarrierAttribution(l.componentUuid(), l.release(), componentNames, branchNameCache)
+			};
+		};
+
+		List<VulnerabilityWithAttribution> vulns = base.vulnerabilities().stream().map(v -> {
+			ZonedDateTime at = v.appearedInCount() > 0 ? appearedAtByKey.get(v.findingKey()) : null;
+			if (at == null) return v;
+			ComponentAttribution[] c = carriersOf.apply(v.findingKey(), at);
+			return v.withScanArrival(at, c[0], c[1]);
+		}).collect(Collectors.toList());
+		List<ViolationWithAttribution> viols = base.violations().stream().map(v -> {
+			ZonedDateTime at = v.appearedInCount() > 0 ? appearedAtByKey.get(v.findingKey()) : null;
+			if (at == null) return v;
+			ComponentAttribution[] c = carriersOf.apply(v.findingKey(), at);
+			return v.withScanArrival(at, c[0], c[1]);
+		}).collect(Collectors.toList());
+		List<WeaknessWithAttribution> weaks = base.weaknesses().stream().map(w -> {
+			ZonedDateTime at = w.appearedInCount() > 0 ? appearedAtByKey.get(w.findingKey()) : null;
+			if (at == null) return w;
+			ComponentAttribution[] c = carriersOf.apply(w.findingKey(), at);
+			return w.withScanArrival(at, c[0], c[1]);
+		}).collect(Collectors.toList());
+
+		return new FindingChangesWithAttribution(vulns, viols, weaks,
+				base.totalAppeared(), base.totalResolved(), base.totalNewlyKev(), base.totalSeverityIncreased(),
+				base.reconstructionClampedSince(), base.postureDiffApplied());
+	}
+
+	private ComponentAttribution toCarrierAttribution(UUID componentUuid, ReleaseData rd,
+			Map<UUID, String> componentNames, Map<UUID, String> branchNameCache) {
+		String componentName = componentNames != null ? componentNames.getOrDefault(componentUuid, "") : "";
+		UUID branchUuid = rd.getBranch();
+		String branchName = branchUuid != null ? cachedBranchName(branchUuid, branchNameCache) : null;
+		return new ComponentAttribution(componentUuid, componentName, rd.getUuid(), rd.getVersion(), branchUuid, branchName);
+	}
+
 	private record WorsenedOverlay(
 			Set<String> newlyKevKeys,
 			Set<String> severityIncreasedKeys,
-			Map<String, String> previousSeverityByKey) {}
+			Map<String, String> previousSeverityByKey,
+			// key -> earliest in-window APPEARED event date, present-at-to filtered. Feeds the
+			// scan-arrival decoration on appeared findings (changelog re-scan visibility).
+			Map<String, ZonedDateTime> appearedAtByKey) {}
 
 	private WorsenedOverlay buildWorsenedOverlay(
 			UUID org,
@@ -1933,9 +2035,10 @@ public class FindingComparisonService {
 		Set<String> newlyKev = new HashSet<>();
 		Set<String> sevInc = new HashSet<>();
 		Map<String, String> prevSevByKey = new HashMap<>();
+		Map<String, ZonedDateTime> appearedAt = new HashMap<>();
 
 		if (org == null || releaseUuids == null || releaseUuids.isEmpty()) {
-			return new WorsenedOverlay(newlyKev, sevInc, prevSevByKey);
+			return new WorsenedOverlay(newlyKev, sevInc, prevSevByKey, appearedAt);
 		}
 
 		// present-at-to keys: any finding key that has at least one presentIn attribution.
@@ -1967,11 +2070,21 @@ public class FindingComparisonService {
 							prevSevByKey.putIfAbsent(key, prevSev);
 						}
 					}
-					default -> { /* APPEARED / RESOLVED: not a worsened annotation */ }
+					case APPEARED -> {
+						// Earliest in-window arrival per key (still-present keys only, via the
+						// presentAtTo gate above): the date the finding was first DETECTED in the
+						// window, which the UI renders instead of implying the endpoint-anchor
+						// release introduced it.
+						if (ev.getChangeDate() != null) {
+							appearedAt.merge(key, ev.getChangeDate(),
+									(a, b) -> a.isBefore(b) ? a : b);
+						}
+					}
+					default -> { /* RESOLVED: not a worsened annotation */ }
 				}
 			}
 		}
-		return new WorsenedOverlay(newlyKev, sevInc, prevSevByKey);
+		return new WorsenedOverlay(newlyKev, sevInc, prevSevByKey, appearedAt);
 	}
 
 	private static <T> void collectPresentKeys(Map<String, FindingAttribution<T>> findingMap, Set<String> out) {

--- a/backend/src/main/java/io/reliza/service/NotificationFanOutService.java
+++ b/backend/src/main/java/io/reliza/service/NotificationFanOutService.java
@@ -129,6 +129,9 @@ public class NotificationFanOutService {
     @Autowired
     private NotificationChannelGroupService channelGroupService;
 
+    @Autowired
+    private UserGroupService userGroupService;
+
     // Defence-in-depth org guard (S-5). The save-time invariant
     // (channel.org == subscription.org checked at upsert) already
     // ensures fan-out can't write a cross-tenant delivery via the
@@ -305,12 +308,12 @@ public class NotificationFanOutService {
             if (!severityGateMatches(route, eventSeverity)) continue;
             if (!perspectiveGateMatches(route, event)) continue;
             // Phase 13b: expand channelGroups, then merge with direct
-            // channels. Dedup is first-seen across the merged list, so a
-            // channel referenced both directly and via a group still
-            // produces exactly one delivery row.
-            List<UUID> resolvedChannels = mergeRouteChannels(route);
+            // channels; T3 adds team expansion. Dedup is first-seen across the
+            // merged list, so a channel referenced directly, via a group AND via
+            // a team still produces exactly one delivery row.
+            List<UUID> resolvedChannels = mergeRouteChannels(route, event.getOrg());
             if (resolvedChannels.isEmpty()) {
-                // No direct channels AND no resolvable groups — log + skip.
+                // No direct channels, no resolvable groups, no team channels -- log + skip.
                 // Distinct from "all channels resolved but every one was
                 // dedup-suppressed" (that path still fires the insertDelivery
                 // dedup check). A zero-channel route is a save-time validation
@@ -327,14 +330,15 @@ public class NotificationFanOutService {
     }
 
     /**
-     * Phase 13b merge helper. Returns the deduplicated, first-seen-order
-     * union of {@code route.channels} and the channel UUIDs resolved
-     * from {@code route.channelGroups}. Direct channels are visited
+     * Merge helper. Returns the deduplicated, first-seen-order union of
+     * {@code route.channels}, the channel UUIDs resolved from
+     * {@code route.channelGroups} (Phase 13b), and the channels of the teams
+     * named in {@code route.teams} (T3). Direct channels are visited
      * first so an operator who explicitly listed a channel sees it
      * preserved even if a group later also contains it. Null entries
      * on either side are silently skipped.
      */
-    private List<UUID> mergeRouteChannels(RouteConfig route) {
+    private List<UUID> mergeRouteChannels(RouteConfig route, UUID eventOrg) {
         Set<UUID> seen = new HashSet<>();
         List<UUID> out = new ArrayList<>();
         if (route.channels() != null) {
@@ -345,6 +349,14 @@ public class NotificationFanOutService {
         if (route.channelGroups() != null && !route.channelGroups().isEmpty()) {
             List<UUID> expanded = channelGroupService.resolveChannelUuids(route.channelGroups());
             for (UUID ch : expanded) {
+                if (ch != null && seen.add(ch)) out.add(ch);
+            }
+        }
+        // T3: a route may target Teams; each contributes its own channels.
+        // Resolved late (here, not at save time) so retargeting a team's Slack
+        // channel takes effect without touching every subscription that names it.
+        if (route.teams() != null && !route.teams().isEmpty()) {
+            for (UUID ch : userGroupService.resolveTeamChannelUuids(route.teams(), eventOrg)) {
                 if (ch != null && seen.add(ch)) out.add(ch);
             }
         }

--- a/backend/src/main/java/io/reliza/service/NotificationSubscriptionService.java
+++ b/backend/src/main/java/io/reliza/service/NotificationSubscriptionService.java
@@ -13,12 +13,14 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.reliza.common.CommonVariables.TableName;
 import io.reliza.common.Utils;
+import io.reliza.model.UserGroupData;
 import io.reliza.exceptions.RelizaException;
 import io.reliza.model.Integration;
 import io.reliza.model.IntegrationData;
@@ -78,6 +80,10 @@ public class NotificationSubscriptionService {
 
     @Autowired
     private NotificationSubscriptionRepository subscriptionRepo;
+
+    @Autowired
+    @Lazy
+    private UserGroupService userGroupService;
 
     @Autowired
     private IntegrationRepository integrationRepo;
@@ -249,13 +255,19 @@ public class NotificationSubscriptionService {
     private void validateRoutes(UUID org, List<RouteConfig> routes) throws RelizaException {
         Set<UUID> referencedChannels = new HashSet<>();
         Set<UUID> referencedGroups = new HashSet<>();
+        Set<UUID> referencedTeams = new HashSet<>();
         for (RouteConfig route : routes) {
             if (route == null) continue;
+            // T3: a teams-only route is legitimate -- naming a team INSTEAD of a
+            // channel is the whole point (the team's channel is resolved at
+            // fan-out). Omitting teams from this gate made the Teams target
+            // unusable without also naming a channel, defeating the feature.
             boolean hasChannels = route.channels() != null && !route.channels().isEmpty();
             boolean hasGroups = route.channelGroups() != null && !route.channelGroups().isEmpty();
-            if (!hasChannels && !hasGroups) {
+            boolean hasTeams = route.teams() != null && !route.teams().isEmpty();
+            if (!hasChannels && !hasGroups && !hasTeams) {
                 throw new RelizaException(
-                        "route must reference at least one channel or channelGroup");
+                        "route must reference at least one channel, channelGroup or team");
             }
             if (route.channels() != null) {
                 for (UUID channelUuid : route.channels()) {
@@ -267,13 +279,19 @@ public class NotificationSubscriptionService {
                     if (groupUuid != null) referencedGroups.add(groupUuid);
                 }
             }
+            if (route.teams() != null) {
+                for (UUID teamUuid : route.teams()) {
+                    if (teamUuid != null) referencedTeams.add(teamUuid);
+                }
+            }
         }
-        if (referencedChannels.isEmpty() && referencedGroups.isEmpty()) {
+        if (referencedChannels.isEmpty() && referencedGroups.isEmpty() && referencedTeams.isEmpty()) {
             throw new RelizaException(
-                    "subscription routes must reference at least one channel or channelGroup");
+                    "subscription routes must reference at least one channel, channelGroup or team");
         }
         validateReferencedChannels(org, referencedChannels);
         validateReferencedGroups(org, referencedGroups);
+        validateReferencedTeams(org, referencedTeams);
     }
 
     /**
@@ -306,6 +324,46 @@ public class NotificationSubscriptionService {
         }
         if (!wrongOrg.isEmpty()) {
             throw new RelizaException("Routes reference channels in a different org: " + wrongOrg);
+        }
+    }
+
+    /**
+     * T3 -- same contract as {@link #validateReferencedGroups}: a route may only
+     * name teams that exist and belong to this org. Without this the fan-out's
+     * cross-org channel guard was the SOLE control, and that guard is conditional
+     * (a channel with a null org passes it) -- so this restores the two-layer
+     * property channels and groups already have.
+     *
+     * <p><b>Deliberately does NOT reject a DEACTIVATED team.</b> Writes are
+     * whole-list replace, so rejecting one would lock the operator out of the
+     * subscription entirely: they could neither keep the team (rejected here) nor
+     * drop it (an emptied route is rejected above), with no error hinting at the
+     * only escape. A deactivated team is already harmless --
+     * {@code UserGroupService.resolveTeamChannelUuids} skips non-ACTIVE teams so
+     * nothing is delivered, and the route editor labels it "(deactivated)" so it
+     * can be seen and removed. Verified live: the rejection made
+     * deactivate-then-clean-up impossible.
+     */
+    private void validateReferencedTeams(UUID org, Set<UUID> referenced) throws RelizaException {
+        if (referenced.isEmpty()) return;
+        List<UUID> notFound = new ArrayList<>();
+        List<UUID> wrongOrg = new ArrayList<>();
+        for (UUID teamUuid : referenced) {
+            Optional<UserGroupData> ougd = userGroupService.getUserGroupData(teamUuid);
+            if (ougd.isEmpty()) {
+                notFound.add(teamUuid);
+                continue;
+            }
+            UserGroupData ugd = ougd.get();
+            if (ugd.getOrg() == null || !ugd.getOrg().equals(org)) {
+                wrongOrg.add(teamUuid);
+            }
+        }
+        if (!notFound.isEmpty()) {
+            throw new RelizaException("Routes reference unknown teams: " + notFound);
+        }
+        if (!wrongOrg.isEmpty()) {
+            throw new RelizaException("Routes reference teams in a different org: " + wrongOrg);
         }
     }
 

--- a/backend/src/main/java/io/reliza/service/OrgTeamAssignmentRuleService.java
+++ b/backend/src/main/java/io/reliza/service/OrgTeamAssignmentRuleService.java
@@ -1,0 +1,258 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.ComponentData;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.OrganizationData;
+import io.reliza.model.OrganizationData.GlobalTeamAssignmentRule;
+import io.reliza.model.UserGroupData;
+import io.reliza.model.WhoUpdated;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Org-wide team-assignment rules (RFC Phase 5 / T2): assign a durable owner team
+ * by pattern instead of picking one by hand on every component.
+ *
+ * <p>Deliberately shaped after {@code OrgApprovalPolicyService} -- same
+ * fully-anchored regex convention, same {@code ANY} type filter, same
+ * first-match-wins priority contract -- so operators learn one rule model rather
+ * than two subtly different ones.
+ *
+ * <p><strong>Precedence</strong> (DECIDED 2026-07-29, "Option A"): a per-component
+ * stored owner always wins; only when there is none does the rule list decide.
+ * A match SETS the owner rather than living in a parallel "assigned team" field,
+ * so there is exactly one answer to "who owns this".
+ *
+ * <p>Resolution is pure and read-time -- nothing is written onto the component.
+ * Editing a pattern therefore takes effect immediately, a rule and a stored value
+ * can never drift apart, and no bulk write can corrupt an inventory.
+ */
+@Slf4j
+@Service
+public class OrgTeamAssignmentRuleService {
+
+	/**
+	 * Longest pattern we will accept. A cap alone does not stop catastrophic
+	 * backtracking, but it bounds how much rope an operator gets and keeps the
+	 * cache keys small.
+	 */
+	public static final int MAX_PATTERN_LENGTH = 512;
+
+	/**
+	 * Match-step budget. Guards against catastrophic backtracking: a pattern like
+	 * {@code (.*a){20}} is perfectly valid and compiles fine, but can run for
+	 * minutes on a short input. Since rules are evaluated on EVERY ownership read
+	 * of EVERY component in the org, an unbounded match would let one saved rule
+	 * burn request threads indefinitely -- a denial of service that an org admin
+	 * could trigger for the whole instance. The budget makes a pathological
+	 * pattern fail fast (and loudly) instead.
+	 */
+	private static final int MATCH_STEP_BUDGET = 200_000;
+
+	/**
+	 * Compiled-pattern cache. Without it every rule is recompiled for every
+	 * component on the report path. Bounded by (orgs x rules) and keyed by the
+	 * pattern text, so identical patterns across orgs share one entry.
+	 */
+	private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
+
+	@Autowired
+	private UserGroupService userGroupService;
+
+	@Autowired
+	private OrganizationService organizationService;
+
+	/** A rule that matched, together with the team it resolves to. */
+	public record TeamAssignmentMatch (GlobalTeamAssignmentRule rule, UserGroupData team) {}
+
+	/** Raised when a pattern exceeds {@link #MATCH_STEP_BUDGET} steps. */
+	private static final class MatchBudgetExceededException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+	}
+
+	/**
+	 * A CharSequence that counts reads and aborts once the budget is spent.
+	 * java.util.regex has no timeout, but it interrogates the input through
+	 * charAt() -- so counting those reads is the standard way to bound a match
+	 * without spawning a watchdog thread per evaluation.
+	 */
+	private static final class BudgetedCharSequence implements CharSequence {
+		private final CharSequence delegate;
+		private int budget;
+		BudgetedCharSequence (CharSequence delegate, int budget) {
+			this.delegate = delegate;
+			this.budget = budget;
+		}
+		@Override public int length () { return delegate.length(); }
+		@Override public char charAt (int index) {
+			if (--budget < 0) throw new MatchBudgetExceededException();
+			return delegate.charAt(index);
+		}
+		@Override public CharSequence subSequence (int start, int end) {
+			return new BudgetedCharSequence(delegate.subSequence(start, end), budget);
+		}
+		@Override public String toString () { return delegate.toString(); }
+	}
+
+	/** Compile once (cached) and match under a step budget. */
+	private boolean matchesSafely (String pattern, String name, String ruleName, UUID orgUuid) {
+		Pattern p;
+		try {
+			p = patternCache.computeIfAbsent(pattern, Pattern::compile);
+		} catch (PatternSyntaxException e) {
+			// Defensive -- writes validate the regex, but bad data on read must
+			// not kill the whole ownership resolver.
+			log.warn("Bad regex in org team-assignment rule '{}' (org {}): {}", ruleName, orgUuid, e.getMessage());
+			return false;
+		}
+		try {
+			return p.matcher(new BudgetedCharSequence(name, MATCH_STEP_BUDGET)).matches();
+		} catch (MatchBudgetExceededException e) {
+			log.warn("Team-assignment rule '{}' (org {}) exceeded the match budget on name '{}'"
+					+ " -- treating as no match; simplify the pattern", ruleName, orgUuid, name);
+			return false;
+		}
+	}
+
+	/**
+	 * The first rule (in list order) that matches this component AND still
+	 * resolves to a live team in the same org. A rule whose team was deleted is
+	 * skipped rather than winning-and-orphaning, so one stale rule cannot mask
+	 * every rule behind it.
+	 */
+	public Optional<TeamAssignmentMatch> matchFor (ComponentData cd, OrganizationData od) {
+		return matchFor(cd, od, List.of());
+	}
+
+	/**
+	 * As above, but resolving the rule's team from an already-loaded org group
+	 * list when possible. Callers that loop over components (the ownership
+	 * report) hoist that list once; without this the rule path would go back to
+	 * the DB per component per rule -- reintroducing exactly the N+1 the hoisting
+	 * exists to prevent.
+	 */
+	public Optional<TeamAssignmentMatch> matchFor (ComponentData cd, OrganizationData od,
+			List<UserGroupData> orgGroups) {
+		if (null == cd || null == od || null == od.getGlobalTeamAssignmentRules()) return Optional.empty();
+		String name = StringUtils.defaultString(cd.getName(), "");
+		ComponentType cType = cd.getType();
+		for (GlobalTeamAssignmentRule rule : od.getGlobalTeamAssignmentRules()) {
+			if (null == rule || StringUtils.isBlank(rule.getNamePattern())) continue;
+			if (!typeFilterMatches(rule.getComponentType(), cType)) continue;
+			if (!matchesSafely(rule.getNamePattern(), name, rule.getName(), od.getUuid())) continue;
+			UserGroupData team = resolveTeam(rule, od.getUuid(), orgGroups);
+			if (null == team) continue;
+			return Optional.of(new TeamAssignmentMatch(rule, team));
+		}
+		return Optional.empty();
+	}
+
+	private boolean typeFilterMatches (ComponentType ruleType, ComponentType componentType) {
+		// Rule's type filter -- null and ANY both mean "match any".
+		if (null == ruleType || ComponentType.ANY == ruleType) return true;
+		return ruleType == componentType;
+	}
+
+	/**
+	 * The rule's team if it still exists in this org. An INACTIVE (archived) team
+	 * is deliberately still returned: ownership resolution reports that as
+	 * DEGRADED, which is more useful than silently falling through to the next
+	 * rule and hiding that the intended owner was archived.
+	 */
+	private UserGroupData resolveTeam (GlobalTeamAssignmentRule rule, UUID orgUuid,
+			List<UserGroupData> orgGroups) {
+		if (null == rule.getOwnerTeam()) return null;
+		if (null != orgGroups) {
+			Optional<UserGroupData> hoisted = orgGroups.stream()
+					.filter(g -> rule.getOwnerTeam().equals(g.getUuid())).findFirst();
+			if (hoisted.isPresent()) {
+				return orgUuid.equals(hoisted.get().getOrg()) ? hoisted.get() : null;
+			}
+		}
+		Optional<UserGroupData> ougd = userGroupService.getUserGroupData(rule.getOwnerTeam());
+		if (ougd.isEmpty()) return null;
+		UserGroupData ugd = ougd.get();
+		if (!orgUuid.equals(ugd.getOrg())) return null;
+		return ugd;
+	}
+
+	/**
+	 * Write-time validation. Mirrors the approval-policy rule contract: named,
+	 * uniquely named, compilable regex, and a team that actually exists in this
+	 * org. Rejecting here keeps the read path free of surprises.
+	 */
+	/**
+	 * Validate + persist in one call, mirroring {@code OrgApprovalPolicyService.setRules}.
+	 * Keeping this the ONLY write entry point means a future caller (CLI, import,
+	 * bulk tooling) cannot reach the persist step without validation -- which is
+	 * why {@link #validate} is private.
+	 */
+	@Transactional
+	public OrganizationData setRules (UUID orgUuid, List<GlobalTeamAssignmentRule> rules, WhoUpdated wu)
+			throws RelizaException {
+		List<GlobalTeamAssignmentRule> normalized = (null == rules) ? new LinkedList<>() : rules;
+		validate(orgUuid, normalized);
+		return organizationService.setGlobalTeamAssignmentRules(orgUuid, new LinkedList<>(normalized), wu);
+	}
+
+	void validate (UUID orgUuid, List<GlobalTeamAssignmentRule> rules) throws RelizaException {
+		if (null == rules) return;
+		LinkedHashSet<String> seenLowerNames = new LinkedHashSet<>();
+		for (int i = 0; i < rules.size(); i++) {
+			GlobalTeamAssignmentRule r = rules.get(i);
+			String idx = "[" + i + "]";
+			if (null == r) throw new RelizaException("Rule " + idx + " is null");
+			if (StringUtils.isBlank(r.getName())) {
+				throw new RelizaException("Rule " + idx + " has a blank name");
+			}
+			if (!seenLowerNames.add(r.getName().toLowerCase())) {
+				throw new RelizaException("Duplicate rule name (case-insensitive): '" + r.getName() + "'");
+			}
+			if (StringUtils.isBlank(r.getNamePattern())) {
+				throw new RelizaException("Rule '" + r.getName() + "' has a blank namePattern");
+			}
+			if (r.getNamePattern().length() > MAX_PATTERN_LENGTH) {
+				throw new RelizaException("Rule '" + r.getName() + "' namePattern exceeds "
+						+ MAX_PATTERN_LENGTH + " characters");
+			}
+			try {
+				Pattern.compile(r.getNamePattern());
+			} catch (PatternSyntaxException e) {
+				throw new RelizaException("Rule '" + r.getName() + "' has an invalid regex: " + e.getMessage());
+			}
+			if (null == r.getOwnerTeam()) {
+				throw new RelizaException("Rule '" + r.getName() + "' has no ownerTeam set");
+			}
+			UserGroupData team = resolveTeam(r, orgUuid, List.of());
+			if (null == team) {
+				throw new RelizaException("Rule '" + r.getName()
+						+ "' ownerTeam is missing or belongs to a different org");
+			}
+			if (UserGroupStatus.INACTIVE == team.getStatus()) {
+				throw new RelizaException("Rule '" + r.getName()
+						+ "' points at an archived team; restore the team or pick another");
+			}
+			// Type filter is permissive -- null/ANY both mean "match any".
+		}
+	}
+}

--- a/backend/src/main/java/io/reliza/service/OrganizationService.java
+++ b/backend/src/main/java/io/reliza/service/OrganizationService.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -161,6 +162,20 @@ public class OrganizationService {
 				.orElseThrow(() -> new RelizaException("Organization not found: " + orgUuid));
 		OrganizationData od = OrganizationData.orgDataFromDbRecord(org);
 		od.setGlobalApprovalPolicyRules(validatedRules == null ? new java.util.LinkedList<>() : validatedRules);
+		Organization saved = saveOrganization(org, Utils.dataToRecord(od), wu);
+		return OrganizationData.orgDataFromDbRecord(saved);
+	}
+
+	/** Persist validated team-assignment rules (T2). Validation lives in
+	 *  {@code OrgTeamAssignmentRuleService}; this only stores. */
+	@Transactional
+	public OrganizationData setGlobalTeamAssignmentRules(UUID orgUuid,
+			List<OrganizationData.GlobalTeamAssignmentRule> validatedRules, WhoUpdated wu)
+			throws RelizaException {
+		Organization org = getOrganizationService.getOrganization(orgUuid)
+				.orElseThrow(() -> new RelizaException("Organization not found: " + orgUuid));
+		OrganizationData od = OrganizationData.orgDataFromDbRecord(org);
+		od.setGlobalTeamAssignmentRules(validatedRules == null ? new LinkedList<>() : validatedRules);
 		Organization saved = saveOrganization(org, Utils.dataToRecord(od), wu);
 		return OrganizationData.orgDataFromDbRecord(saved);
 	}

--- a/backend/src/main/java/io/reliza/service/UserGroupService.java
+++ b/backend/src/main/java/io/reliza/service/UserGroupService.java
@@ -5,12 +5,18 @@
 package io.reliza.service;
 
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
@@ -23,9 +29,13 @@ import io.reliza.common.CommonVariables.TableName;
 import io.reliza.common.CommonVariables.UserGroupStatus;
 import io.reliza.common.Utils;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.model.IntegrationData;
+import io.reliza.model.TeamRole;
 import io.reliza.model.UserData;
 import io.reliza.model.UserGroup;
 import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.UserPermission;
 import io.reliza.model.UserPermission.PermissionFunction;
 import io.reliza.model.UserPermission.PermissionType;
@@ -33,7 +43,9 @@ import io.reliza.model.dto.CreateUserGroupDto;
 import io.reliza.model.dto.UpdateUserGroupDto;
 import io.reliza.model.WhoUpdated;
 import io.reliza.repositories.UserGroupRepository;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @Transactional
 public class UserGroupService {
@@ -51,6 +63,10 @@ public class UserGroupService {
 	@Autowired
 	@Lazy
 	private UserService userService;
+
+	@Autowired
+	@Lazy
+	private NotificationChannelService notificationChannelService;
 	
 	
 	public Optional<UserGroup> getUserGroup(UUID groupUuid) {
@@ -144,6 +160,19 @@ public class UserGroupService {
 			}
 		}
 		
+		// Team-member validation lives here, next to the other domain rules
+		// (name uniqueness / restore conflict) rather than in the data fetcher,
+		// so every caller of this method is held to the invariant -- not just the
+		// GraphQL one. Sanitize BEFORE validating so the checks see exactly what
+		// will persist: a customRole of "<script>x</script>" is non-empty on the
+		// way in but sanitizes to "", which is precisely the state the CUSTOM
+		// rule exists to reject.
+		updateUserGroupDto.setMemberRoles(UserGroupData.sanitizeMemberRoles(updateUserGroupDto.getMemberRoles()));
+		updateUserGroupDto.setExternalMembers(UserGroupData.sanitizeExternalMembers(updateUserGroupDto.getExternalMembers()));
+		validateMemberRoles(updateUserGroupDto.getMemberRoles(), effectiveRoster(ugd, updateUserGroupDto));
+		validateExternalMembers(updateUserGroupDto.getExternalMembers());
+		validateNotificationChannels(updateUserGroupDto.getNotificationChannels(), ugd.getOrg());
+
 		UserGroupData updatedUgd = UserGroupData.updateUserGroupData(ugd, updateUserGroupDto);
 
 		// check if group permissions are being elevated from read to write
@@ -183,6 +212,163 @@ public class UserGroupService {
 			}
 		}
 		return count;
+	}
+
+	/**
+	 * The deduplicated channels of the given teams, first-seen order (T3). Used
+	 * by the fan-out to expand a route's {@code teams} target. A team that no
+	 * longer exists, belongs to another org, or has been deactivated contributes
+	 * nothing rather than failing the whole fan-out -- one stale reference must
+	 * not silence every other route target.
+	 */
+	public List<UUID> resolveTeamChannelUuids(Iterable<UUID> teamUuids, UUID expectedOrg) {
+		if (null == teamUuids) return Collections.emptyList();
+		// Fail CLOSED on a missing org: a conditional guard that a caller can
+		// silently switch off is the shape the previous review criticised in
+		// channelEligibleForDelivery. No production caller passes null today, and
+		// none should be able to start.
+		if (null == expectedOrg) return Collections.emptyList();
+		List<UUID> out = new ArrayList<>();
+		Set<UUID> seen = new HashSet<>();
+		for (UUID teamUuid : teamUuids) {
+			if (null == teamUuid) continue;
+			UserGroupData ugd;
+			try {
+				Optional<UserGroupData> ougd = getUserGroupData(teamUuid);
+				if (ougd.isEmpty()) continue;
+				ugd = ougd.get();
+			} catch (RuntimeException e) {
+				// dataFromRecord throws on an unsupported schemaVersion or malformed
+				// record_data. This runs inside the fan-out, so letting it escape
+				// would kill the whole pass for one bad row -- the opposite of what
+				// this method promises. Reads tolerate dangling references.
+				log.warn("Skipping unreadable team {} while resolving route channels: {}",
+						teamUuid, e.getMessage());
+				continue;
+			}
+			// Org guard even though writes validate: this is the read side of a
+			// cross-tenant path, and relying solely on the fan-out's channel-org
+			// check would leave one conditional guard between a stale route and
+			// another org's team record.
+			if (!expectedOrg.equals(ugd.getOrg())) continue;
+			// A deactivated team is not a target. The picker hides INACTIVE teams,
+			// so an operator who deactivates one reasonably expects notifications
+			// to stop; without this an already-saved route keeps firing forever.
+			if (UserGroupStatus.ACTIVE != ugd.getStatus()) continue;
+			for (UUID ch : ugd.getNotificationChannels()) {
+				if (null != ch && seen.add(ch)) out.add(ch);
+			}
+		}
+		return out;
+	}
+
+	/**
+	 * The roster this update will LAND on -- mirrors
+	 * {@code UserGroupData.updateUserGroupData}'s merge (null means keep
+	 * existing, non-null replaces), so adding a user and giving them a role in
+	 * the same call works. Package-private for test access.
+	 */
+	static Set<UUID> effectiveRoster(UserGroupData existing, UpdateUserGroupDto dto) {
+		Set<UUID> roster = new LinkedHashSet<>(
+				null != dto.getUsers() ? dto.getUsers() : existing.getUsers());
+		roster.addAll(null != dto.getManualUsers() ? dto.getManualUsers() : existing.getManualUsers());
+		return roster;
+	}
+
+	/**
+	 * A role annotates an EXISTING roster member -- it must never be a back door
+	 * for adding someone to a team, which would fork the roster into two sources
+	 * of truth. Note this only fires when the caller SENDS memberRoles; a role
+	 * can still go stale when the roster shrinks separately, which is why
+	 * {@code UserGroupData.getRoleForUser} re-checks membership on read.
+	 */
+	static void validateMemberRoles(List<TeamMemberRole> memberRoles, Set<UUID> roster) throws RelizaException {
+		if (null == memberRoles) return;
+		Set<UUID> seen = new LinkedHashSet<>();
+		for (TeamMemberRole mr : memberRoles) {
+			if (null == mr.userRef() || !roster.contains(mr.userRef())) {
+				throw new RelizaException(
+						"A team role can only be assigned to an existing team member: " + mr.userRef());
+			}
+			if (!seen.add(mr.userRef())) {
+				// getRoleForUser returns a single Optional, so a second entry for
+				// the same user would be silently dropped -- reject instead of
+				// persisting a role that never takes effect.
+				throw new RelizaException("Duplicate team role for member: " + mr.userRef());
+			}
+			validateCustomRole(mr.role(), mr.customRole());
+		}
+	}
+
+	/** External members carry no roster identity, so identity/reachability is all we can check. */
+	static void validateExternalMembers(List<ExternalTeamMember> externalMembers) throws RelizaException {
+		if (null == externalMembers) return;
+		for (ExternalTeamMember em : externalMembers) {
+			// Checked post-sanitization: GraphQL String! rejects null but not "",
+			// and a pure-markup value sanitizes down to "". An external member
+			// without a contact is unreachable, which defeats the point of storing
+			// one at all.
+			if (StringUtils.isBlank(em.name()) || StringUtils.isBlank(em.contact())) {
+				throw new RelizaException("An external team member requires a non-blank name and contact");
+			}
+			validateCustomRole(em.role(), em.customRole());
+		}
+	}
+
+
+	/**
+	 * A team's channels must exist, belong to the same org, and actually be
+	 * notification channels -- the same three checks as
+	 * {@code NotificationChannelGroupService.validateSeed}. A reference to a
+	 * deleted, cross-org or non-channel integration is a save-time error, not a
+	 * fan-out-time surprise. Package-private for test access.
+	 */
+	void validateNotificationChannels(Set<UUID> channels, UUID orgUuid) throws RelizaException {
+		if (null == channels) return;
+		for (UUID channelUuid : channels) {
+			if (null == channelUuid) throw new RelizaException("Team channels cannot contain null entries");
+			var oc = notificationChannelService.getChannel(channelUuid);
+			if (oc.isEmpty()) {
+				throw new RelizaException("Notification channel not found: " + channelUuid
+						+ ". Remove it from this team's channels to continue.");
+			}
+			IntegrationData idata;
+			try {
+				idata = IntegrationData.dataFromRecord(oc.get());
+			} catch (RuntimeException e) {
+				// Tolerant parse, matching the channel-group validator: malformed
+				// record_data is a validation error, not an unwrapped 500.
+				throw new RelizaException("Notification channel " + channelUuid + " is unreadable");
+			}
+			if (null == idata || null == idata.getOrg() || !idata.getOrg().equals(orgUuid)) {
+				throw new RelizaException("Notification channel " + channelUuid
+						+ " does not belong to this organization");
+			}
+			// Must actually BE a notification channel. Without this a same-org CI
+			// integration (DTrack, GitHub, Jira...) can be attached as a team
+			// channel; fan-out then writes a delivery row per event that the
+			// worker terminates FAILED ("no dispatcher") -- exactly the
+			// fan-out-time surprise this validation exists to prevent.
+			if (null == idata.getName()
+					|| !IntegrationData.NOTIFICATION_DESTINATION_TYPES.contains(idata.getType())) {
+				throw new RelizaException("Integration " + channelUuid
+						+ " is not a notification channel");
+			}
+		}
+	}
+
+	/**
+	 * These are malformed-input errors, not authorization failures, so they go
+	 * through {@link RelizaException} -- the domain validation channel
+	 * {@code GraphQLExceptionHandlers.handleReliza} surfaces as BAD_REQUEST with
+	 * the actual message. Throwing AccessDeniedException here would flatten every
+	 * one of them to a generic "Not authorized", misleading both the operator
+	 * fixing their request and anyone reading the logs.
+	 */
+	static void validateCustomRole(TeamRole role, String customRole) throws RelizaException {
+		if (TeamRole.CUSTOM == role && StringUtils.isBlank(customRole)) {
+			throw new RelizaException("A CUSTOM team role requires a customRole label");
+		}
 	}
 
 	private boolean hasWritePermissions(UserGroupData ugd) {

--- a/backend/src/main/java/io/reliza/service/VcsRepositoryService.java
+++ b/backend/src/main/java/io/reliza/service/VcsRepositoryService.java
@@ -94,6 +94,13 @@ public class VcsRepositoryService {
 	 * @return Optional of VcsRepositoryData
 	 */
 	public Optional<VcsRepositoryData> getVcsRepositoryDataByUri(UUID orgUuid, String uri) {
+		// Same canonicalization as the createIfMissing lookup below: rows are STORED
+		// in the cleaned form (no scheme/user@/git@/.git/scp-colon), so a read with
+		// the raw form -- notably the ordinary '.git' clone URL every CI passes --
+		// misses the row the create path finds. That split is what minted a new
+		// component per CI run against the same VCS row (30+ observed in prod):
+		// resolution never found the VCS, creation always did.
+		uri = Utils.cleanVcsUri(Utils.normalizeVcsUri(uri));
 		Optional<VcsRepositoryData> vcsData = Optional.empty();
 		Optional<VcsRepository> vr = findVcsRepositoryByOrgAndUri(orgUuid, uri);
 		if (vr.isPresent()) {

--- a/backend/src/main/java/io/reliza/ws/ComponentDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ComponentDataFetcher.java
@@ -130,6 +130,9 @@ public class ComponentDataFetcher {
 	private OrganizationService organizationService;
 
 	@Autowired
+	private io.reliza.service.ComponentDuplicateRepairService componentDuplicateRepairService;
+
+	@Autowired
 	private OssPerspectiveService ossPerspectiveService;
 
 	@Autowired
@@ -253,17 +256,27 @@ public class ComponentDataFetcher {
 
 		Map<String, Object> getNewVersionInput = dfe.getArgument("newVersionInput");
 
-		// First, try to resolve component normally
+		// Tri-state resolution: creation is legitimate ONLY on NOT_FOUND. The
+		// previous catch-based flow treated EVERY resolution failure as "not
+		// found" when createComponentIfMissing was set -- including AMBIGUOUS
+		// (duplicate registrations for the same VCS + repoPath) -- so once two
+		// duplicates existed, every CI run minted another instead of surfacing
+		// the operator problem (30+ observed in prod, one per run).
 		UUID componentId = null;
-		try {
-			componentId = componentService.resolveComponentIdFromInput(getNewVersionInput, authCtx);
-		} catch (RelizaException e) {
-			Boolean createComponentIfMissing = (Boolean) getNewVersionInput.get("createComponentIfMissing");
-			if (Boolean.TRUE.equals(createComponentIfMissing)) {
-				// Will create component after authorization is established
-				log.info("Component not found, will create due to createComponentIfMissing flag");
-			} else {
-				throw new RelizaException("Component cannot be resolved: " + e.getMessage());
+		ComponentService.ComponentResolution componentResolution =
+				componentService.resolveComponentResolutionFromInput(getNewVersionInput, authCtx);
+		switch (componentResolution.status()) {
+			case FOUND -> componentId = componentResolution.componentId();
+			case AMBIGUOUS -> throw new RelizaException("Component cannot be resolved: " + componentResolution.detail());
+			case NOT_FOUND -> {
+				Boolean createComponentIfMissing = (Boolean) getNewVersionInput.get("createComponentIfMissing");
+				if (Boolean.TRUE.equals(createComponentIfMissing)) {
+					// Will create component after authorization is established
+					log.info("Component not found ({}), will create due to createComponentIfMissing flag",
+							componentResolution.detail());
+				} else {
+					throw new RelizaException("Component cannot be resolved: " + componentResolution.detail());
+				}
 			}
 		}
 
@@ -743,4 +756,23 @@ public class ComponentDataFetcher {
 				.filter(Objects::nonNull)
 				.toList();
 	}
+	/**
+	 * Org-ADMIN on-demand repair of duplicate component registrations. Same
+	 * routine the enforceUniqueComponents startup sweep runs, scoped to one org
+	 * -- lets an operator repair a known-affected org without a restart, and
+	 * lets e2e tests drive the sweep deterministically.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "repairDuplicateComponents")
+	public io.reliza.service.ComponentDuplicateRepairService.RepairSummary repairDuplicateComponents(
+			@InputArgument("orgUuid") UUID orgUuid) throws RelizaException {
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		var od = getOrganizationService.getOrganizationData(orgUuid);
+		RelizaObject ro = od.isPresent() ? od.get() : null;
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.ADMIN);
+		return componentDuplicateRepairService.repairOrganization(orgUuid, WhoUpdated.getWhoUpdated(oud.get()));
+	}
+
 }

--- a/backend/src/main/java/io/reliza/ws/NotificationDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/NotificationDataFetcher.java
@@ -816,7 +816,11 @@ public class NotificationDataFetcher {
 						// Phase 13b: channelGroups passes through as-is.
 						// Null preserves "no group expansion" on routes
 						// authored without the field.
-						r.channelGroups()))
+						r.channelGroups(),
+						// T3: teams passes through as-is. Null preserves
+						// "no team expansion" on routes authored without
+						// the field.
+						r.teams()))
 				.toList();
 	}
 

--- a/backend/src/main/java/io/reliza/ws/OrgTeamAssignmentRuleDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/OrgTeamAssignmentRuleDataFetcher.java
@@ -1,0 +1,80 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.ws;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsData;
+import com.netflix.graphql.dgs.InputArgument;
+
+import io.reliza.common.CommonVariables.CallType;
+import io.reliza.common.Utils;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.OrganizationData;
+import io.reliza.model.OrganizationData.GlobalTeamAssignmentRule;
+import io.reliza.model.RelizaObject;
+import io.reliza.model.UserPermission.PermissionFunction;
+import io.reliza.model.UserPermission.PermissionScope;
+import io.reliza.model.WhoUpdated;
+import io.reliza.service.AuthorizationService;
+import io.reliza.service.GetOrganizationService;
+import io.reliza.service.OrgTeamAssignmentRuleService;
+import io.reliza.service.UserService;
+
+/**
+ * Write surface for org-wide team-assignment rules (T2). Mirrors the
+ * approval-policy rule fetcher: org-admin only, whole-list replace, validated
+ * before persistence.
+ *
+ * <p>The list is replaced wholesale rather than patched per rule because ORDER
+ * is the priority contract -- a per-rule edit API would make reordering an
+ * awkward multi-call dance and invite races between two admins.
+ */
+@DgsComponent
+public class OrgTeamAssignmentRuleDataFetcher {
+
+	@Autowired
+	private AuthorizationService authorizationService;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private GetOrganizationService getOrganizationService;
+
+	@Autowired
+	private OrgTeamAssignmentRuleService teamAssignmentRuleService;
+
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "setGlobalTeamAssignmentRules")
+	public OrganizationData setGlobalTeamAssignmentRules(
+			@InputArgument("orgUuid") UUID orgUuid,
+			@InputArgument("rules") List<Object> rules) throws RelizaException {
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		Optional<OrganizationData> od = getOrganizationService.getOrganizationData(orgUuid);
+		RelizaObject ro = od.isPresent() ? od.get() : null;
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.ADMIN);
+		WhoUpdated wu = WhoUpdated.getWhoUpdated(oud.get());
+		List<GlobalTeamAssignmentRule> typedRules = new LinkedList<>();
+		if (null != rules) {
+			for (Object raw : rules) {
+				typedRules.add(Utils.OM.convertValue(raw, GlobalTeamAssignmentRule.class));
+			}
+		}
+		// Single entry point: validate-and-persist is encapsulated in the service
+		// so no caller can reach the write without validation.
+		return teamAssignmentRuleService.setRules(orgUuid, typedRules, wu);
+	}
+}

--- a/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
+++ b/backend/src/main/java/io/reliza/ws/ReleaseDatafetcher.java
@@ -1090,17 +1090,27 @@ public class ReleaseDatafetcher {
 			}
 		}
 
-		// First, try to resolve component normally
+		// Tri-state resolution: creation is legitimate ONLY on NOT_FOUND. The
+		// previous catch-based flow treated EVERY resolution failure as "not
+		// found" when createComponentIfMissing was set -- including AMBIGUOUS
+		// (duplicate registrations for the same VCS + repoPath) -- so once two
+		// duplicates existed, every CI run minted another instead of surfacing
+		// the operator problem (30+ observed in prod, one per run).
 		UUID componentId = null;
-		try {
-			componentId = componentService.resolveComponentIdFromInput(progReleaseInput, authCtx);
-		} catch (RelizaException e) {
-			Boolean createComponentIfMissing = (Boolean) progReleaseInput.get("createComponentIfMissing");
-			if (Boolean.TRUE.equals(createComponentIfMissing)) {
-				// Will create component after authorization is established
-				log.info("Component not found, will create due to createComponentIfMissing flag");
-			} else {
-				throw new RelizaException("Component cannot be resolved: " + e.getMessage());
+		ComponentService.ComponentResolution componentResolution =
+				componentService.resolveComponentResolutionFromInput(progReleaseInput, authCtx);
+		switch (componentResolution.status()) {
+			case FOUND -> componentId = componentResolution.componentId();
+			case AMBIGUOUS -> throw new RelizaException("Component cannot be resolved: " + componentResolution.detail());
+			case NOT_FOUND -> {
+				Boolean createComponentIfMissing = (Boolean) progReleaseInput.get("createComponentIfMissing");
+				if (Boolean.TRUE.equals(createComponentIfMissing)) {
+					// Will create component after authorization is established
+					log.info("Component not found ({}), will create due to createComponentIfMissing flag",
+							componentResolution.detail());
+				} else {
+					throw new RelizaException("Component cannot be resolved: " + componentResolution.detail());
+				}
 			}
 		}
 

--- a/backend/src/main/java/io/reliza/ws/UserGroupDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/UserGroupDataFetcher.java
@@ -103,7 +103,10 @@ public class UserGroupDataFetcher {
 
 		validateUsersInOrganization(userGroupInput.getUsers(), ugd.get().getOrg(), groupUuid);
 		validateUsersInOrganization(userGroupInput.getManualUsers(), ugd.get().getOrg(), groupUuid);
-		
+		// Team-member roles / external members are sanitized and validated inside
+		// UserGroupService.updateUserGroupComprehensive, so every caller of that
+		// service method is held to the same invariant, not just this fetcher.
+
 		var approvals = userGroupInput.getApprovals();
 		OrganizationData od = getOrganizationService.getOrganizationData(ugd.get().getOrg()).get();
 		

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -476,6 +476,14 @@ type Query {
 	kevRecordDetails(orgUuid: ID!, cveId: String!): KevRecordDetails
 }
 
+type DuplicateComponentRepairSummary {
+	groupsExamined: Int!
+	releasesFolded: Int!
+	componentsArchived: Int!
+	branchesArchived: Int!
+	conflictGroups: Int!
+}
+
 type Mutation {
 	# user management
 	acceptUserPolicies(tosAccepted: Boolean!, marketingAccepted: Boolean!, email: String): User
@@ -584,6 +592,15 @@ type Mutation {
 	send the rules in the order you want first-match-wins to honour.
 	"""
 	setGlobalPrValidationTriggerRules(orgUuid: ID!, rules: [GlobalPrValidationTriggerRuleInput!]!): Organization
+	"""
+	Replace the org's team-assignment rules wholesale. Each rule needs a name
+	(unique within the org, case-insensitive), a compilable regex no longer than
+	512 characters, and an ownerTeam that exists, is ACTIVE and belongs to this
+	org. List order is the priority order; send the rules in the order you want
+	first-match-wins to honour. Pass an empty list to clear all rules.
+	Org-admin only.
+	"""
+	setGlobalTeamAssignmentRules(orgUuid: ID!, rules: [GlobalTeamAssignmentRuleInput!]!): Organization
 	"""
 	Replace the org's global approval-policy assignment rules
 	atomically. Each input rule must (a) carry a non-blank, org-unique
@@ -722,6 +739,15 @@ type Mutation {
 	# (e.g. an earlier async reconcile failed). Returns true on success; throws on failure so the
 	# caller sees the underlying error.
 	reconcileReleaseSbomComponents(releaseUuid: ID!): Boolean
+	"""
+	Org-ADMIN repair for duplicate component registrations: several live
+	COMPONENT-type components on one (vcs, repoPath) carrying the SAME name.
+	Folds non-conflicting releases under the oldest component and archives the
+	duplicates; on version conflicts archives without folding. Same-vcs groups
+	with differing names are reported but never auto-merged. Same routine the
+	enforceUniqueComponents startup sweep runs.
+	"""
+	repairDuplicateComponents(orgUuid: ID!): DuplicateComponentRepairSummary
 
 	# Programmatic
 	setApprovalsOnApiKey(apiKeyUuid: ID!, approvals: [String], notes: String): ApiKey
@@ -1314,9 +1340,10 @@ type NotificationSubscriptionResult {
 	# JSON-stringified filter config: { mode, presetConfig, celExpression }.
 	filter: String
 	# JSON-stringified route table:
-	# [{ whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, perspectives, channelGroups }].
+	# [{ whenSeverityAtLeast, andEnvIn, andLifecycleIn, channels, perspectives, channelGroups, teams }].
 	# perspectives is the Phase 12 list of UUIDs gating the route -- null/empty = no gate.
 	# channelGroups is the Phase 13b list of group UUIDs expanded to member channels at fan-out.
+	# teams is the T3 list of team UUIDs whose own channels are merged in at fan-out.
 	routes: String
 	dedupWindowMinutes: Int
 	# JSON-stringified rate limit config: { maxPerWindow, windowMinutes }. Nullable.
@@ -1647,6 +1674,15 @@ input NotificationRouteInput {
 	# Same null/[] equivalence as perspectives: both treated as "no group
 	# expansion."
 	channelGroups: [ID!]
+	# T3 team targeting. UUIDs of Teams (user groups) whose own
+	# notificationChannels are merged into this route at fan-out time. Lets an
+	# operator say "tell the Payments Team" without knowing which Slack channel
+	# that is today, and keeps it correct when the team later changes channel.
+	# Teams are resolved at fan-out, not at save: a team that no longer exists
+	# contributes nothing rather than failing the route. Expands to team
+	# CHANNELS only -- it does not push rows into members' inboxes, which have
+	# their own visibility arms. Same null/[] equivalence as the fields above.
+	teams: [ID!]
 }
 
 input NotificationRateLimitInput {
@@ -1937,6 +1973,43 @@ type Organization {
 	clean-up. SAAS-only.
 	"""
 	globalApprovalPolicyRules: [GlobalApprovalPolicyRule]
+	"""
+	Org-wide team-assignment rules. Each rule maps a regex over
+	{@code Component.name} (matched fully-anchored) plus a
+	{@code componentType} filter to an owner team. When a component has no
+	per-component owner, the resolver walks this list in order and the first
+	matching rule's team becomes the component's durable owner -- the result
+	is flagged derived and names the rule, so the UI can distinguish "someone
+	chose this" from "a pattern matched". A per-component owner always wins.
+	List order is the priority order -- first match wins.
+	"""
+	globalTeamAssignmentRules: [GlobalTeamAssignmentRule]
+}
+
+"""
+Org-wide team-assignment rule (T2). See
+{@link Organization.globalTeamAssignmentRules} for the priority contract.
+"""
+type GlobalTeamAssignmentRule {
+	"""Display name; unique within the org."""
+	name: String
+	"""
+	Java regex matched against {@code ComponentData.name} via
+	{@code Pattern.matcher(name).matches()} -- fully anchored. Operators write
+	{@code frontend-.*} (no leading {@code ^}, no trailing {@code $}).
+	"""
+	namePattern: String
+	"""Type filter; ANY (or null) matches both COMPONENT and PRODUCT."""
+	componentType: ComponentType
+	"""Owner team (UserGroup) UUID; must exist and be active in this org."""
+	ownerTeam: ID
+}
+
+input GlobalTeamAssignmentRuleInput {
+	name: String!
+	namePattern: String!
+	componentType: ComponentType
+	ownerTeam: ID!
 }
 
 """
@@ -2193,8 +2266,48 @@ type UserGroupWebDto {
 	permissions: Permissions
 	status: UserGroupStatus
 	connectedSsoGroups: [String]
+	# Addressing roles for roster users (annotation only -- a role never grants
+	# access, and listing a user here does NOT add them to the team).
+	memberRoles: [TeamMemberRole]
+	# Team members who are not registered ReARM users. Addressable for
+	# notification/escalation, but excluded from the durability bar by design.
+	externalMembers: [ExternalTeamMember]
+	"""
+	Notification channels this team is reachable on (e.g. its Slack channel).
+	Direct channel references rather than a channel-group reference: a team
+	having its own channel is one idea, and routing it through a separate named
+	group would add an entity and a screen for no benefit. Channel groups remain
+	the org-level bundling concept for subscriptions.
+	"""
+	notificationChannels: [ID]
 	createdDate: DateTime
 	lastUpdatedBy: ID
+}
+
+# The role a member plays on a Team. An addressing LABEL only -- never grants
+# access (membership stays decoupled from RBAC). CUSTOM carries an org-defined
+# label alongside in customRole.
+enum TeamRole {
+	TEAM_LEAD
+	SECURITY_SPECIALIST
+	DEVELOPER
+	QA
+	PROJECT_MANAGER
+	PRODUCT_MANAGER
+	CUSTOM
+}
+
+type TeamMemberRole {
+	userRef: ID
+	role: TeamRole
+	customRole: String
+}
+
+type ExternalTeamMember {
+	name: String
+	contact: String
+	role: TeamRole
+	customRole: String
 }
 
 type EmailObject {
@@ -2360,6 +2473,8 @@ type NoneReleaseChanges {
 	sbomChanges: ReleaseSbomChanges!
 	findingChanges: ReleaseFindingChanges!
 	createdDate: DateTime!
+	"ADDITIVE (changelog re-scan visibility): true when this is the component's first release EVER -- its finding/SBOM sections are empty because there is no baseline to diff against, not because nothing changed."
+	baselineRelease: Boolean!
 }
 
 type CodeCommit {
@@ -2544,6 +2659,12 @@ type VulnerabilityWithAttribution {
 	analysisState: AnalysisState
 	"True when this vulnerability (by CVE id or alias) is in the CISA KEV catalog"
 	knownExploited: Boolean
+	"ADDITIVE (changelog re-scan visibility): earliest in-window APPEARED finding_change_event date for this finding; null when the appearance is not event-backed."
+	scanArrivalDate: DateTime
+	"ADDITIVE: earliest in-window release (by creation) whose current metrics carry this finding."
+	earliestCarrier: ComponentAttribution
+	"ADDITIVE: latest in-window release (by creation) whose current metrics carry this finding."
+	latestCarrier: ComponentAttribution
 }
 
 type VulnerabilityAlias {
@@ -2610,6 +2731,12 @@ type ViolationWithAttribution {
 	isStillPresent: Boolean!
 	orgContext: OrgLevelContext
 	analysisState: AnalysisState
+	"ADDITIVE (changelog re-scan visibility): earliest in-window APPEARED finding_change_event date for this finding; null when the appearance is not event-backed."
+	scanArrivalDate: DateTime
+	"ADDITIVE: earliest in-window release (by creation) whose current metrics carry this finding."
+	earliestCarrier: ComponentAttribution
+	"ADDITIVE: latest in-window release (by creation) whose current metrics carry this finding."
+	latestCarrier: ComponentAttribution
 }
 
 type WeaknessWithAttribution {
@@ -2631,6 +2758,12 @@ type WeaknessWithAttribution {
 	isStillPresent: Boolean!
 	orgContext: OrgLevelContext
 	analysisState: AnalysisState
+	"ADDITIVE (changelog re-scan visibility): earliest in-window APPEARED finding_change_event date for this finding; null when the appearance is not event-backed."
+	scanArrivalDate: DateTime
+	"ADDITIVE: earliest in-window release (by creation) whose current metrics carry this finding."
+	earliestCarrier: ComponentAttribution
+	"ADDITIVE: latest in-window release (by creation) whose current metrics carry this finding."
+	latestCarrier: ComponentAttribution
 }
 
 type OrgLevelContext {
@@ -4005,6 +4138,12 @@ input UpdateComponentInput {
 	component's org (no DB FK). Null leaves the existing owner unchanged.
 	"""
 	owner: ComponentOwnerInput
+	"""
+	Explicitly remove the stored owner. Needed because owner: null already means
+	"no change", so it cannot express removal. Clearing hands the component back
+	to org team-assignment rules. Takes precedence over owner when both are sent.
+	"""
+	clearOwner: Boolean
 }
 
 input ComponentContactInput {
@@ -4482,6 +4621,27 @@ input UpdateUserGroupInput {
 	approvals: [String]
 	status: UserGroupStatus
 	connectedSsoGroups: [String]
+	# Each userRef must already be on the roster (users + manualUsers); a role
+	# annotates an existing member, it never adds one.
+	memberRoles: [TeamMemberRoleInput]
+	externalMembers: [ExternalTeamMemberInput]
+	# Channels must exist and belong to this org; validated on save.
+	notificationChannels: [ID]
+}
+
+input TeamMemberRoleInput {
+	userRef: ID!
+	role: TeamRole!
+	# Required when role is CUSTOM, ignored otherwise.
+	customRole: String
+}
+
+input ExternalTeamMemberInput {
+	name: String!
+	contact: String!
+	role: TeamRole!
+	# Required when role is CUSTOM, ignored otherwise.
+	customRole: String
 }
 
 input UserGroupPermissionInput {

--- a/backend/src/test/java/io/reliza/common/CdxMapperContractTest.java
+++ b/backend/src/test/java/io/reliza/common/CdxMapperContractTest.java
@@ -1,0 +1,102 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.vulnerability.Vulnerability;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the rule that {@code org.cyclonedx.model.*} is bound with
+ * {@link Utils#CDX_OM} (Jackson 2) and never {@link Utils#OM} (Jackson 3).
+ *
+ * <p>cyclonedx-core-java is a Jackson 2 library. Annotations are not the issue --
+ * {@code com.fasterxml.jackson.annotation.*} was never renamed -- but
+ * {@code @JsonSerialize/@JsonDeserialize(using = ...)} handlers extend Jackson 2
+ * databind classes that Jackson 3 cannot apply. Both directions break, and the
+ * write direction breaks SILENTLY, which is why it went unnoticed longer than the
+ * read direction.
+ */
+public class CdxMapperContractTest {
+
+	/** A VEX statement whose dates exercise the library's CustomDateSerializer. */
+	private static Vulnerability vulnerabilityWithDates() {
+		Vulnerability v = new Vulnerability();
+		v.setBomRef("v-1");
+		v.setId("CVE-2020-7598");
+		v.setPublished(new Date(1750000000000L));
+		Vulnerability.Analysis a = new Vulnerability.Analysis();
+		a.setState(Vulnerability.Analysis.State.NOT_AFFECTED);
+		a.setFirstIssued(new Date(1750000000000L));
+		v.setAnalysis(a);
+		return v;
+	}
+
+	/**
+	 * WRITE: the spec types dates as ISO-8601 strings. This is what
+	 * CdxVexParser persists as a VEX statement's provenance record and hashes as
+	 * its dedup key, so the shape is durable, not cosmetic.
+	 */
+	@Test
+	public void cdxMapperWritesSpecDatesAsIsoStrings() throws Exception {
+		String json = Utils.CDX_OM.writeValueAsString(vulnerabilityWithDates());
+
+		assertTrue(json.contains("\"published\":\"2025-06-15T15:06:40Z\""),
+				"published must be an ISO-8601 string, got: " + json);
+		assertTrue(json.contains("\"firstIssued\":\"2025-06-15T15:06:40Z\""),
+				"analysis.firstIssued must be an ISO-8601 string, got: " + json);
+		// bom-ref proves the annotation-driven rename still applies.
+		assertTrue(json.contains("\"bom-ref\":\"v-1\""), "bom-ref key must survive: " + json);
+	}
+
+	/**
+	 * The guard rail for the write direction. Utils.OM emits epoch millis here --
+	 * a JSON number where the spec demands a string -- and does NOT throw. If this
+	 * ever starts matching CDX_OM, the workaround can be revisited; until then
+	 * this is what stops someone "simplifying" CdxVexParser back to Utils.OM.
+	 */
+	@Test
+	public void jackson3MapperSilentlyWritesNonSpecDates() throws Exception {
+		String viaJackson3 = Utils.OM.writeValueAsString(vulnerabilityWithDates());
+		String viaCdx = Utils.CDX_OM.writeValueAsString(vulnerabilityWithDates());
+
+		assertFalse(viaJackson3.equals(viaCdx),
+				"if these now agree, Utils.OM may be safe for cyclonedx writes -- re-evaluate");
+		assertTrue(viaJackson3.contains("\"published\":1750000000000"),
+				"Utils.OM is expected to emit epoch millis (the bug being guarded), got: " + viaJackson3);
+	}
+
+	/** READ: the licenses ARRAY binds through CDX_OM. */
+	@Test
+	public void cdxMapperReadsLicensesArray() throws Exception {
+		String bomJson = """
+				{"bomFormat":"CycloneDX","specVersion":"1.6","version":1,
+				 "components":[{"type":"library","name":"minimist","version":"1.2.0",
+				   "purl":"pkg:npm/minimist@1.2.0","bom-ref":"pkg:npm/minimist@1.2.0",
+				   "licenses":[{"license":{"id":"MIT"}}]}]}
+				""";
+		Bom bom = new JsonParser().parse(bomJson.getBytes(StandardCharsets.UTF_8));
+		Component c = bom.getComponents().get(0);
+		assertNotNull(c.getLicenses(), "licenses must bind");
+		assertEquals("MIT", c.getLicenses().getLicenses().get(0).getId());
+
+		// And the same document must still defeat the Jackson 3 mapper.
+		assertThrows(Exception.class, () -> {
+			var tree = Utils.OM.readTree(bomJson);
+			Utils.OM.treeToValue(tree.get("components").get(0), Component.class);
+		}, "Utils.OM must not be able to bind org.cyclonedx.model types");
+	}
+}

--- a/backend/src/test/java/io/reliza/model/UserGroupTeamMembersTest.java
+++ b/backend/src/test/java/io/reliza/model/UserGroupTeamMembersTest.java
@@ -1,0 +1,189 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.common.Utils;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
+import io.reliza.model.dto.UpdateUserGroupDto;
+
+/**
+ * Pins the Team-primitive additions (T1: member roles + external members) at the
+ * model layer, where the JSONB round-trip actually happens.
+ *
+ * <p>The headline invariant is the durability one: <strong>external (non-ReARM)
+ * members must not count toward the {@code DURABLE_MIN_MEMBERS} bar</strong>
+ * (DECIDED 2026-07-28). That holds by construction because externals live
+ * outside {@code users}/{@code manualUsers} and {@code getAllUsers()} -- which
+ * {@code ComponentOwnershipService.isTeamDurable} counts -- never sees them.
+ * It is pinned here so a future refactor that folds externals into the roster
+ * fails loudly instead of silently making one-person teams look durable.
+ */
+class UserGroupTeamMembersTest {
+
+	private static final UUID USER_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final UUID USER_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+	private static UserGroupData fromJson(String json) {
+		return Utils.OM.readValue(json, UserGroupData.class);
+	}
+
+	// ---------- durability: externals are addressable but never durable ----------
+
+	@Test
+	void externalMembersDoNotCountTowardTheDurabilityRoster() {
+		// One real member + two externals. A naive "count everyone" rule would
+		// read 3 and call this durable; the roster must still report exactly 1.
+		UserGroupData ugd = fromJson("""
+				{"name":"Docs Team","manualUsers":["%s"],
+				 "externalMembers":[
+				   {"name":"Ext One","contact":"ext1@vendor.example","role":"SECURITY_SPECIALIST"},
+				   {"name":"Ext Two","contact":"ext2@vendor.example","role":"DEVELOPER"}]}
+				""".formatted(USER_A));
+		assertEquals(2, ugd.getExternalMembers().size(), "externals must still be stored and addressable");
+		assertEquals(1, ugd.getAllUsers().size(),
+				"getAllUsers -- what the durability bar counts -- must exclude external members");
+		assertTrue(ugd.getAllUsers().contains(USER_A));
+	}
+
+	@Test
+	void rosterUsersStillCountNormally() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","users":["%s"],"manualUsers":["%s"]}
+				""".formatted(USER_A, USER_B));
+		assertEquals(2, ugd.getAllUsers().size(), "SSO + manual users both count toward durability");
+	}
+
+	// ---------- roles are annotations on the roster ----------
+
+	@Test
+	void roleLookupResolvesForARosterUserAndIsEmptyOtherwise() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"TEAM_LEAD"}]}
+				""".formatted(USER_A, USER_A));
+		var role = ugd.getRoleForUser(USER_A);
+		assertTrue(role.isPresent());
+		assertEquals(TeamRole.TEAM_LEAD, role.get().role());
+		assertTrue(ugd.getRoleForUser(USER_B).isEmpty(), "no role recorded -> empty, not a default role");
+	}
+
+	@Test
+	void roleIsNotReadableForSomeoneNoLongerOnTheRoster() {
+		// A role can outlive its member: write-time validation only fires when the
+		// caller sends memberRoles, and SSO-driven removals never touch the field.
+		// Read-side filtering is what stops escalation targeting an ex-member.
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"SECURITY_SPECIALIST"}]}
+				""".formatted(USER_A, USER_B));
+		assertTrue(ugd.getRoleForUser(USER_B).isEmpty(),
+				"a stale role for a departed member must not resolve");
+		assertEquals(1, ugd.getMemberRoles().size(),
+				"the stored annotation is left intact -- only the read is filtered");
+	}
+
+	@Test
+	void memberRoleCustomLabelIsSanitized() {
+		// The external half is not the only freeform sink: memberRoles[].customRole
+		// is operator text too and renders into the same team UI.
+		List<TeamMemberRole> sanitized = UserGroupData.sanitizeMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.CUSTOM, "<script>alert(1)</script>Release Captain")));
+		assertFalse(sanitized.get(0).customRole().contains("<script"));
+		assertTrue(sanitized.get(0).customRole().contains("Release Captain"));
+	}
+
+	@Test
+	void customRoleCarriesItsOperatorLabel() {
+		UserGroupData ugd = fromJson("""
+				{"name":"Platform","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"CUSTOM","customRole":"Release Captain"}]}
+				""".formatted(USER_A, USER_A));
+		var role = ugd.getRoleForUser(USER_A).orElseThrow();
+		assertEquals(TeamRole.CUSTOM, role.role());
+		assertEquals("Release Captain", role.customRole());
+	}
+
+	// ---------- sanitization of operator-supplied freeform text ----------
+
+	@Test
+	void sanitizeExternalMembersStripsScriptMarkupButKeepsBenignText() {
+		List<ExternalTeamMember> sanitized = UserGroupData.sanitizeExternalMembers(List.of(
+				new ExternalTeamMember("<script>alert(1)</script>Vendor",
+						"<img src=x onerror=alert(1)>ops@vendor.example",
+						TeamRole.CUSTOM, "<script>x</script>On-call")));
+		ExternalTeamMember m = sanitized.get(0);
+		assertFalse(m.name().contains("<script"), "script markup must not survive into the team UI");
+		assertTrue(m.name().contains("Vendor"), "benign text survives");
+		assertFalse(m.contact().contains("onerror"));
+		assertTrue(m.contact().contains("ops@vendor.example"));
+		assertFalse(m.customRole().contains("<script"));
+		assertTrue(m.customRole().contains("On-call"));
+	}
+
+	@Test
+	void sanitizeExternalMembersIsNullSafe() {
+		assertNull(UserGroupData.sanitizeExternalMembers(null));
+		ExternalTeamMember m = UserGroupData.sanitizeExternalMembers(
+				List.of(new ExternalTeamMember(null, null, TeamRole.QA, null))).get(0);
+		assertNull(m.name(), "null fields are preserved, not coerced to empty");
+		assertNull(m.contact());
+		assertEquals(TeamRole.QA, m.role());
+	}
+
+	// ---------- update merge: null means keep, non-null means replace ----------
+
+	@Test
+	void updateKeepsExistingMembersWhenFieldsOmitted() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333","manualUsers":["%s"],
+				 "memberRoles":[{"userRef":"%s","role":"QA"}],
+				 "externalMembers":[{"name":"Ext","contact":"e@x.example","role":"DEVELOPER"}]}
+				""".formatted(USER_A, USER_A));
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder().name("Platform Renamed").build());
+		assertEquals("Platform Renamed", merged.getName());
+		assertEquals(1, merged.getMemberRoles().size(), "omitted memberRoles must be preserved");
+		assertEquals(1, merged.getExternalMembers().size(), "omitted externalMembers must be preserved");
+	}
+
+	@Test
+	void updateSanitizesExternalMembersOnWrite() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333"}
+				""");
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder()
+						.externalMembers(List.of(new ExternalTeamMember(
+								"<script>bad</script>Vendor", "ops@vendor.example", TeamRole.DEVELOPER, null)))
+						.build());
+		assertFalse(merged.getExternalMembers().get(0).name().contains("<script"),
+				"sanitization happens on the write path, not on read");
+	}
+
+	@Test
+	void updateReplacesMemberRolesWhenSupplied() {
+		UserGroupData existing = fromJson("""
+				{"name":"Platform","org":"33333333-3333-3333-3333-333333333333","manualUsers":["%s","%s"],
+				 "memberRoles":[{"userRef":"%s","role":"QA"}]}
+				""".formatted(USER_A, USER_B, USER_A));
+		UserGroupData merged = UserGroupData.updateUserGroupData(existing,
+				UpdateUserGroupDto.builder()
+						.memberRoles(List.of(new TeamMemberRole(USER_B, TeamRole.TEAM_LEAD, null)))
+						.build());
+		assertEquals(1, merged.getMemberRoles().size());
+		assertEquals(USER_B, merged.getMemberRoles().get(0).userRef(), "supplied list replaces wholesale");
+		assertTrue(merged.getRoleForUser(USER_A).isEmpty());
+	}
+}

--- a/backend/src/test/java/io/reliza/service/ChangelogBaselineVisibilityIntegrationTest.java
+++ b/backend/src/test/java/io/reliza/service/ChangelogBaselineVisibilityIntegrationTest.java
@@ -1,0 +1,144 @@
+/**
+* Copyright 2019 - 2026 Reliza Incorporated. Licensed under MIT License.
+* https://reliza.io
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.dto.ChangelogRecords.ComponentChangelog;
+import io.reliza.dto.ChangelogRecords.NoneChangelog;
+import io.reliza.dto.ChangelogRecords.NoneReleaseChanges;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.Branch;
+import io.reliza.model.BranchData.BranchType;
+import io.reliza.model.Component;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.Release;
+import io.reliza.model.ReleaseData.ReleaseLifecycle;
+import io.reliza.model.ReleaseData.ReleaseStatus;
+import io.reliza.model.WhoUpdated;
+import io.reliza.model.changelog.entry.AggregationType;
+import io.reliza.model.dto.ReleaseDto;
+import io.reliza.model.dto.ReleaseMetricsDto;
+import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilityDto;
+import io.reliza.model.dto.ReleaseMetricsDto.VulnerabilitySeverity;
+import io.reliza.service.oss.OssReleaseService;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Pins the date-window NONE changelog contract (changelog re-scan visibility, proposal 3):
+ * every release in the window is SHOWN -- the branch's first release EVER renders as a
+ * labeled baseline (baselineRelease=true, empty diffs) instead of being suppressed, and a
+ * window that starts after some releases diffs its oldest shown release against the
+ * out-of-window predecessor (baselineRelease=false).
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class ChangelogBaselineVisibilityIntegrationTest {
+
+	@Autowired private ComponentService componentService;
+	@Autowired private BranchService branchService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private SharedReleaseService sharedReleaseService;
+	@Autowired private ChangeLogService changeLogService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final String CVE = "CVE-2026-9002";
+	private static final String PURL = "pkg:npm/baseline-demo@1.0.0";
+
+	private static ReleaseMetricsDto metricsWith(VulnerabilityDto... vulns) {
+		ReleaseMetricsDto m = new ReleaseMetricsDto();
+		m.setVulnerabilityDetails(new LinkedList<>(List.of(vulns)));
+		m.setLastScanned(ZonedDateTime.now());
+		return m;
+	}
+
+	private static VulnerabilityDto vuln() {
+		return new VulnerabilityDto(PURL, CVE, VulnerabilitySeverity.HIGH, java.util.Set.of(),
+				java.util.Set.of(), java.util.Set.of(), null, null, ZonedDateTime.now(),
+				null, null, null, null, null, false);
+	}
+
+	private UUID createRelease(Component component, Branch branch, Organization org, String version,
+			ReleaseMetricsDto metrics) throws RelizaException {
+		ReleaseDto dto = ReleaseDto.builder()
+				.component(component.getUuid())
+				.branch(branch.getUuid())
+				.org(org.getUuid())
+				.status(ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseLifecycle.ASSEMBLED)
+				.version(version)
+				.build();
+		Release r = ossReleaseService.createRelease(dto, WhoUpdated.getTestWhoUpdated());
+		if (metrics != null) {
+			Release live = sharedReleaseService.getRelease(r.getUuid()).orElseThrow();
+			sharedReleaseService.saveReleaseMetrics(live, metrics);
+		}
+		return r.getUuid();
+	}
+
+	@Test
+	public void dateWindowNone_firstEverReleaseShownAsBaseline_laterWindowUsesPredecessor()
+			throws RelizaException, InterruptedException {
+		Organization org = testInitializer.obtainOrganization();
+		Component component = componentService.createComponent(
+				"comp_" + UUID.randomUUID(), org.getUuid(), ComponentType.COMPONENT,
+				"semver", "Branch.Micro", null, WhoUpdated.getTestWhoUpdated());
+		Branch branch = branchService.createBranch(
+				"main", component.getUuid(), BranchType.BASE, WhoUpdated.getTestWhoUpdated());
+
+		ZonedDateTime windowFrom = ZonedDateTime.now().minusMinutes(5);
+		createRelease(component, branch, org, "1.0.0", metricsWith());
+		Thread.sleep(50);
+		ZonedDateTime betweenReleases = ZonedDateTime.now();
+		Thread.sleep(50);
+		createRelease(component, branch, org, "1.1.0", metricsWith(vuln()));
+		ZonedDateTime windowTo = ZonedDateTime.now().plusMinutes(5);
+
+		// Full window: BOTH releases shown; the first-ever one is the labeled baseline.
+		ComponentChangelog cl = changeLogService.getComponentChangelogByDate(
+				component.getUuid(), null, org.getUuid(), AggregationType.NONE, "UTC", windowFrom, windowTo);
+		assertTrue(cl instanceof NoneChangelog, "NONE mode must return NoneChangelog");
+		List<NoneReleaseChanges> releases = ((NoneChangelog) cl).branches().get(0).releases();
+		assertEquals(2, releases.size(), "date-window NONE must show every release in the window");
+
+		NoneReleaseChanges newest = releases.get(0);
+		NoneReleaseChanges oldest = releases.get(1);
+		assertTrue(oldest.version().startsWith("1.0.0"), "oldest card must be the first release");
+		assertTrue(oldest.baselineRelease(), "first release EVER must carry baselineRelease=true");
+		assertEquals(0, oldest.findingChanges().appearedCount(),
+				"baseline card has no predecessor to diff against");
+		assertFalse(newest.baselineRelease(), "a release with a predecessor is not the baseline");
+		assertEquals(1, newest.findingChanges().appearedCount(),
+				"pairwise diff vs the shown predecessor must be intact");
+
+		// Narrow window (starts between the releases): only 1.1.0 in window, diffed against the
+		// OUT-OF-WINDOW predecessor 1.0.0 -- shown, not a baseline, diff intact.
+		ComponentChangelog clNarrow = changeLogService.getComponentChangelogByDate(
+				component.getUuid(), null, org.getUuid(), AggregationType.NONE, "UTC", betweenReleases, windowTo);
+		List<NoneReleaseChanges> narrowReleases = ((NoneChangelog) clNarrow).branches().get(0).releases();
+		assertEquals(1, narrowReleases.size(), "only the in-window release is shown");
+		NoneReleaseChanges narrowCard = narrowReleases.get(0);
+		assertTrue(narrowCard.version().startsWith("1.1.0"));
+		assertFalse(narrowCard.baselineRelease(),
+				"a release with an out-of-window predecessor is NOT the baseline");
+		assertEquals(1, narrowCard.findingChanges().appearedCount(),
+				"oldest in-window release must diff against the out-of-window predecessor");
+	}
+}

--- a/backend/src/test/java/io/reliza/service/ComponentDuplicateRepairTest.java
+++ b/backend/src/test/java/io/reliza/service/ComponentDuplicateRepairTest.java
@@ -1,0 +1,430 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.common.CommonVariables.StatusEnum;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.Branch;
+import io.reliza.model.BranchData;
+import io.reliza.model.Component;
+import io.reliza.model.ComponentData;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.VcsRepository;
+import io.reliza.model.WhoUpdated;
+import io.reliza.model.dto.CreateComponentDto;
+import io.reliza.model.dto.ReleaseDto;
+import io.reliza.service.ComponentDuplicateRepairService.RepairSummary;
+import io.reliza.service.oss.OssReleaseService;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Exercises the duplicate-component repair sweep
+ * ({@link ComponentDuplicateRepairService}) against real rows on the local test
+ * database: fold-under-oldest-leader, branch mapping (same-named merge +
+ * auto-create), version-conflict archival without folding, intra-group version
+ * competition, idempotency, and org scoping.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class ComponentDuplicateRepairTest {
+
+	@Autowired private ComponentService componentService;
+	@Autowired private GetComponentService getComponentService;
+	@Autowired private BranchService branchService;
+	@Autowired private ReleaseService releaseService;
+	@Autowired private SharedReleaseService sharedReleaseService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private VcsRepositoryService vcsRepositoryService;
+	@Autowired private ComponentDuplicateRepairService repairService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final WhoUpdated WU = WhoUpdated.getTestWhoUpdated();
+	private static final String REPO_PATH = "svc/app";
+
+	// ---- fixtures ----
+
+	private record Fx(Organization org, UUID vcsUuid) {}
+
+	private Fx fx() {
+		Organization org = testInitializer.obtainOrganization();
+		String slug = "it-duprepair-" + UUID.randomUUID().toString().substring(0, 8);
+		VcsRepository vcs = vcsRepositoryService.getVcsRepositoryByUri(
+				org.getUuid(), "github.com/it-dup/" + slug, null, null, true, WU).get();
+		return new Fx(org, vcs.getUuid());
+	}
+
+	/**
+	 * Component on the fixture VCS + shared repoPath + the SHARED name -- the
+	 * repair identity now requires name equality (the incident loop derives the
+	 * identical name on every duplicate), so group members must share it.
+	 */
+	private UUID comp(Fx fx, String name) throws RelizaException {
+		return compWithPath(fx, name, REPO_PATH);
+	}
+
+	private UUID compWithPath(Fx fx, String name, String repoPath) throws RelizaException {
+		CreateComponentDto dto = CreateComponentDto.builder()
+				.organization(fx.org().getUuid())
+				.name(name)
+				.type(ComponentType.COMPONENT)
+				.vcs(fx.vcsUuid())
+				.repoPath(repoPath)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build();
+		UUID uuid = componentService.createComponent(dto, WU).getUuid();
+		// created_date is the leader tiebreaker -- keep creation instants distinct.
+		try { Thread.sleep(10); } catch (InterruptedException ie) { Thread.currentThread().interrupt(); }
+		return uuid;
+	}
+
+	private UUID release(Fx fx, UUID component, String branchName, String version) throws RelizaException {
+		Branch branch = branchService.findBranchByName(component, branchName, true, WU).get();
+		ReleaseDto dto = ReleaseDto.builder()
+				.component(component)
+				.branch(branch.getUuid())
+				.org(fx.org().getUuid())
+				.status(ReleaseData.ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseData.ReleaseLifecycle.ASSEMBLED)
+				.version(version)
+				.build();
+		return ossReleaseService.createRelease(dto, WU).getUuid();
+	}
+
+	private Set<String> versionsOf(UUID component) {
+		return releaseService.listReleasesByComponent(component).stream()
+				.map(r -> ReleaseData.dataFromRecord(r).getVersion())
+				.collect(Collectors.toSet());
+	}
+
+	private StatusEnum componentStatus(UUID uuid) {
+		Component c = getComponentService.getComponent(uuid).orElseThrow();
+		return ComponentData.dataFromRecord(c).getStatus();
+	}
+
+	private ReleaseData releaseData(UUID uuid) {
+		return sharedReleaseService.getReleaseData(uuid).orElseThrow();
+	}
+
+	// ---- scenarios ----
+
+	@Test
+	public void noDuplicatesIsNoop() throws Exception {
+		Fx fx = fx();
+		comp(fx, "solo");
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(0, s.groupsExamined());
+		assertEquals(0, s.componentsArchived());
+	}
+
+	@Test
+	public void disjointVersionsFoldUnderOldestLeader() throws Exception {
+		Fx fx = fx();
+		UUID leader = comp(fx, "app");
+		UUID dupA = comp(fx, "app");
+		UUID dupB = comp(fx, "app");
+
+		UUID leaderRel = release(fx, leader, "main", "1.0.0");
+		UUID dupMainRel = release(fx, dupA, "main", "2.0.0");
+		UUID dupFeatRel = release(fx, dupA, "feat", "3.0.0");
+		// dupB carries no releases at all.
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+
+		assertEquals(1, s.groupsExamined());
+		assertEquals(2, s.releasesFolded());
+		assertEquals(2, s.componentsArchived());
+		assertEquals(0, s.conflictGroups());
+
+		// Leader owns every release; duplicates own none.
+		assertEquals(Set.of("1.0.0", "2.0.0", "3.0.0"), versionsOf(leader));
+		assertEquals(Set.of(), versionsOf(dupA));
+		assertEquals(Set.of(), versionsOf(dupB));
+
+		// Same-named branch merged: the moved release sits on the LEADER's main.
+		UUID leaderMain = releaseData(leaderRel).getBranch();
+		assertEquals(leaderMain, releaseData(dupMainRel).getBranch());
+		assertEquals(leader, releaseData(dupMainRel).getComponent());
+
+		// Unique-named branch auto-created on the leader and adopted the release.
+		ReleaseData featData = releaseData(dupFeatRel);
+		assertEquals(leader, featData.getComponent());
+		BranchData leaderFeat = branchService.getBranchData(featData.getBranch()).orElseThrow();
+		assertEquals("feat", leaderFeat.getName());
+		assertEquals(leader, leaderFeat.getComponent());
+		assertNotEquals(StatusEnum.ARCHIVED, leaderFeat.getStatus());
+
+		// Duplicates and their branches archived; leader stays live.
+		assertEquals(StatusEnum.ARCHIVED, componentStatus(dupA));
+		assertEquals(StatusEnum.ARCHIVED, componentStatus(dupB));
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(leader));
+		for (Branch b : branchService.listBranchesOfComponent(dupA, null)) {
+			assertEquals(StatusEnum.ARCHIVED, BranchData.branchDataFromDbRecord(b).getStatus(),
+					"duplicate branch must be archived: " + b.getUuid());
+		}
+	}
+
+	@Test
+	public void versionConflictArchivesWithoutFolding() throws Exception {
+		Fx fx = fx();
+		UUID leader = comp(fx, "app");
+		UUID dup = comp(fx, "app");
+
+		release(fx, leader, "main", "1.0.0");
+		UUID dupConflicting = release(fx, dup, "main", "1.0.0");
+		UUID dupExtra = release(fx, dup, "main", "2.0.0");
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+
+		assertEquals(1, s.groupsExamined());
+		assertEquals(0, s.releasesFolded());
+		assertEquals(1, s.conflictGroups());
+		assertEquals(1, s.componentsArchived());
+
+		// Nothing moved: the conflicted duplicate keeps BOTH its releases,
+		// preserved on the archived component rather than merged.
+		assertEquals(Set.of("1.0.0"), versionsOf(leader));
+		assertEquals(Set.of("1.0.0", "2.0.0"), versionsOf(dup));
+		assertEquals(dup, releaseData(dupConflicting).getComponent());
+		assertEquals(dup, releaseData(dupExtra).getComponent());
+		assertEquals(StatusEnum.ARCHIVED, componentStatus(dup));
+	}
+
+	@Test
+	public void secondDuplicateConflictsAfterFirstFolds() throws Exception {
+		Fx fx = fx();
+		UUID leader = comp(fx, "app");   // oldest; no releases of its own
+		UUID dupA = comp(fx, "app");
+		UUID dupB = comp(fx, "app");
+
+		release(fx, dupA, "main", "5.0.0");
+		UUID dupBRel = release(fx, dupB, "main", "5.0.0");
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+
+		// dupA folds 5.0.0 into the leader; dupB's 5.0.0 now collides with the
+		// freshly folded slot and must NOT fold -- the version set grows as the
+		// group repair progresses, never allowing one version to land twice.
+		assertEquals(1, s.releasesFolded());
+		assertEquals(1, s.conflictGroups());
+		assertEquals(2, s.componentsArchived());
+		assertEquals(Set.of("5.0.0"), versionsOf(leader));
+		assertEquals(dupB, releaseData(dupBRel).getComponent());
+	}
+
+	@Test
+	public void secondRunIsIdempotentNoop() throws Exception {
+		Fx fx = fx();
+		UUID leader = comp(fx, "app");
+		UUID dup = comp(fx, "app");
+		release(fx, leader, "main", "1.0.0");
+		release(fx, dup, "main", "2.0.0");
+
+		RepairSummary first = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(1, first.componentsArchived());
+
+		RepairSummary second = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(0, second.groupsExamined());
+		assertEquals(0, second.componentsArchived());
+		assertEquals(Set.of("1.0.0", "2.0.0"), versionsOf(leader));
+	}
+
+	@Test
+	public void repairIsScopedToTheRequestedOrg() throws Exception {
+		Fx fxA = fx();
+		Fx fxB = fx();
+		comp(fxA, "a-app");
+		comp(fxA, "a-app");
+		UUID bSolo = comp(fxB, "b-solo");
+
+		RepairSummary s = repairService.repairOrganization(fxA.org().getUuid(), WU);
+		assertEquals(1, s.groupsExamined());
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(bSolo));
+
+		RepairSummary sB = repairService.repairOrganization(fxB.org().getUuid(), WU);
+		assertEquals(0, sB.groupsExamined());
+	}
+
+	/** Duplicate groups are keyed by (vcs, repoPath) -- distinct paths never merge. */
+	@Test
+	public void distinctRepoPathsAreNotDuplicates() throws Exception {
+		Fx fx = fx();
+		comp(fx, "path-a");
+		CreateComponentDto other = CreateComponentDto.builder()
+				.organization(fx.org().getUuid())
+				.name("path-b")
+				.type(ComponentType.COMPONENT)
+				.vcs(fx.vcsUuid())
+				.repoPath("svc/other")
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build();
+		componentService.createComponent(other, WU);
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(0, s.groupsExamined());
+	}
+
+	/**
+	 * ROOT components can be registered with repoPath '.' (the CI default), ''
+	 * or null (UI-created) -- resolution's FIND_COMPONENT_BY_VCS_AND_PATH
+	 * equates all three, so a '.'-form + null-form pair is AMBIGUOUS to CI. The
+	 * sweep must group by the SAME identity, or precisely the estate it exists
+	 * to fix stays invisible (found empirically pre-fix: resolution AMBIGUOUS
+	 * while repairOrganization saw two singleton groups and did nothing).
+	 */
+	@Test
+	public void mixedRootRepoPathFormsAreOneDuplicateGroup() throws Exception {
+		Fx fx = fx();
+		UUID ciForm = compWithPath(fx, "rootapp", ".");
+		UUID uiForm = compWithPath(fx, "rootapp", null);
+
+		// Resolution's view first: this pair keeps CI red.
+		var before = componentService.resolveComponentResolutionByVcsUriAndPath(
+				fx.org().getUuid(), "github.com/it-dup/" + vcsSlug(fx), null);
+		assertEquals(ComponentService.ComponentResolutionStatus.AMBIGUOUS, before.status());
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(1, s.groupsExamined());
+		assertEquals(1, s.componentsArchived());
+
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(ciForm));
+		assertEquals(StatusEnum.ARCHIVED, componentStatus(uiForm));
+
+		// And CI recovers, whichever root form it passes.
+		for (String repoPath : new String[] { null, "", "." }) {
+			var after = componentService.resolveComponentResolutionByVcsUriAndPath(
+					fx.org().getUuid(), "github.com/it-dup/" + vcsSlug(fx), repoPath);
+			assertEquals(ComponentService.ComponentResolutionStatus.FOUND, after.status(),
+					"root form must resolve post-repair: " + repoPath);
+			assertEquals(ciForm, after.componentId());
+		}
+	}
+
+	/** The whole point, end to end: after repair, VCS-based resolution works again. */
+	@Test
+	public void resolutionRecoversAfterRepair() throws Exception {
+		Fx fx = fx();
+		UUID leader = comp(fx, "app");
+		comp(fx, "app");
+
+		var before = componentService.resolveComponentResolutionByVcsUriAndPath(
+				fx.org().getUuid(), "github.com/it-dup/" + vcsSlug(fx), REPO_PATH);
+		assertEquals(ComponentService.ComponentResolutionStatus.AMBIGUOUS, before.status());
+
+		repairService.repairOrganization(fx.org().getUuid(), WU);
+
+		var after = componentService.resolveComponentResolutionByVcsUriAndPath(
+				fx.org().getUuid(), "github.com/it-dup/" + vcsSlug(fx), REPO_PATH);
+		assertEquals(ComponentService.ComponentResolutionStatus.FOUND, after.status());
+		assertEquals(leader, after.componentId());
+	}
+
+	/**
+	 * Same (vcs, repoPath) but DIFFERENT names: possibly intentional distinct
+	 * components -- never auto-merged. Resolution stays ambiguous (name-blind),
+	 * which the sweep reports at error; repairing it is a manual decision.
+	 */
+	@Test
+	public void differentNamesAreNeverRepaired() throws Exception {
+		Fx fx = fx();
+		UUID a = comp(fx, "frontend");
+		UUID b = comp(fx, "backend");
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(0, s.groupsExamined());
+		assertEquals(0, s.componentsArchived());
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(a));
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(b));
+
+		// The deliberate leftover: resolution is still ambiguous for this pair.
+		var res = componentService.resolveComponentResolutionByVcsUriAndPath(
+				fx.org().getUuid(), "github.com/it-dup/" + vcsSlug(fx), REPO_PATH);
+		assertEquals(ComponentService.ComponentResolutionStatus.AMBIGUOUS, res.status());
+	}
+
+	/** Mixed group {app, app, other}: the same-named pair repairs, 'other' is untouched. */
+	@Test
+	public void mixedNamesRepairOnlyTheSameNamedSubset() throws Exception {
+		Fx fx = fx();
+		UUID appLeader = comp(fx, "app");
+		UUID appDup = comp(fx, "app");
+		UUID other = comp(fx, "other");
+
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(1, s.groupsExamined());
+		assertEquals(1, s.componentsArchived());
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(appLeader));
+		assertEquals(StatusEnum.ARCHIVED, componentStatus(appDup));
+		assertNotEquals(StatusEnum.ARCHIVED, componentStatus(other));
+	}
+
+	/**
+	 * The startup census counts with EXACTLY the sweep identity: same-name pairs
+	 * count, different-name pairs and PRODUCT pairs do not -- and after a repair
+	 * the census reads zero.
+	 */
+	@Test
+	public void censusCountsExactlyWhatTheSweepWouldRepair() throws Exception {
+		Fx fx = fx();
+		comp(fx, "app");
+		comp(fx, "app");            // same-name pair -> 1 group, 1 excess
+		comp(fx, "frontend");
+		comp(fx, "backend");        // different names -> not counted
+
+		var count = repairService.countDuplicates(fx.org().getUuid());
+		assertEquals(1, count.groups());
+		assertEquals(1, count.excessComponents());
+
+		repairService.repairOrganization(fx.org().getUuid(), WU);
+		var after = repairService.countDuplicates(fx.org().getUuid());
+		assertEquals(0, after.groups());
+		assertEquals(0, after.excessComponents());
+	}
+
+	/** PRODUCT-type components are outside the sweep entirely. */
+	@Test
+	public void productTypeComponentsAreIgnored() throws Exception {
+		Fx fx = fx();
+		for (int i = 0; i < 2; i++) {
+			CreateComponentDto dto = CreateComponentDto.builder()
+					.organization(fx.org().getUuid())
+					.name("bundle")
+					.type(ComponentType.PRODUCT)
+					.vcs(fx.vcsUuid())
+					.repoPath(REPO_PATH)
+					.versionSchema("semver")
+					.featureBranchVersioning("Branch.Micro")
+					.build();
+			componentService.createComponent(dto, WU);
+		}
+		RepairSummary s = repairService.repairOrganization(fx.org().getUuid(), WU);
+		assertEquals(0, s.groupsExamined());
+	}
+
+	private String vcsSlug(Fx fx) {
+		return vcsRepositoryService.getVcsRepositoryData(fx.vcsUuid()).orElseThrow()
+				.getUri().replace("github.com/it-dup/", "");
+	}
+
+}

--- a/backend/src/test/java/io/reliza/service/ComponentOwnershipServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/ComponentOwnershipServiceTest.java
@@ -27,10 +27,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import io.reliza.common.CommonVariables.UserGroupStatus;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.common.Utils;
 import io.reliza.model.ComponentData;
 import io.reliza.model.ComponentData.ComponentOwner;
 import io.reliza.model.ComponentOwnerType;
 import io.reliza.model.ComponentOwnershipStatus;
+import io.reliza.model.OrganizationData;
 import io.reliza.model.UserData;
 import io.reliza.model.UserGroupData;
 import io.reliza.model.UserPermission;
@@ -49,6 +51,8 @@ class ComponentOwnershipServiceTest {
 	private UserGroupService userGroupService;
 	private UserService userService;
 	private ComponentTeamService componentTeamService;
+	private GetOrganizationService getOrganizationService;
+	private OrgTeamAssignmentRuleService teamAssignmentRuleService;
 	private ComponentOwnershipService service;
 
 	private UUID org;
@@ -59,10 +63,20 @@ class ComponentOwnershipServiceTest {
 		userGroupService = mock(UserGroupService.class);
 		userService = mock(UserService.class);
 		componentTeamService = mock(ComponentTeamService.class);
+		getOrganizationService = mock(GetOrganizationService.class);
+		// Real rule service over a mocked group service: the matching logic is
+		// what these tests exercise, so stubbing it would test nothing.
+		teamAssignmentRuleService = new OrgTeamAssignmentRuleService();
+		ReflectionTestUtils.setField(teamAssignmentRuleService, "userGroupService", userGroupService);
 		service = new ComponentOwnershipService();
 		ReflectionTestUtils.setField(service, "userGroupService", userGroupService);
 		ReflectionTestUtils.setField(service, "userService", userService);
 		ReflectionTestUtils.setField(service, "componentTeamService", componentTeamService);
+		ReflectionTestUtils.setField(service, "getOrganizationService", getOrganizationService);
+		ReflectionTestUtils.setField(service, "teamAssignmentRuleService", teamAssignmentRuleService);
+		// Default: org resolves but carries no rules, so every pre-T2 test keeps
+		// its original meaning (stored owner / candidate suggestion only).
+		when(getOrganizationService.getOrganizationData(any())).thenReturn(Optional.empty());
 		org = UUID.randomUUID();
 		comp = UUID.randomUUID();
 	}
@@ -108,7 +122,7 @@ class ComponentOwnershipServiceTest {
 		UUID t = UUID.randomUUID();
 		UserGroupData tm = team(t, "Platform", org, UserGroupStatus.ACTIVE, 2, false, null);
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.OWNED, o.status());
 		assertTrue(o.durable());
 		assertFalse(o.derived());
@@ -120,8 +134,33 @@ class ComponentOwnershipServiceTest {
 		UUID t = UUID.randomUUID();
 		UserGroupData tm = team(t, "Solo", org, UserGroupStatus.ACTIVE, 1, false, null);
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status());
+		assertFalse(o.durable());
+	}
+
+	/**
+	 * End-to-end counterpart to {@code UserGroupTeamMembersTest}: uses a REAL
+	 * (non-mocked) UserGroupData so {@code getAllUsers()} is the production
+	 * implementation, proving external members never reach the durability count.
+	 * DECIDED 2026-07-28 -- externals are addressable but confer no durability,
+	 * so a 1-real-member team stays NON_DURABLE no matter how many externals it
+	 * carries. Mocking {@code getAllUsers} (as the helper above does) could not
+	 * catch a regression that folded externals into the roster.
+	 */
+	@Test
+	void storedTeamWithExternalMembersStaysNonDurableOnOneRealMember() {
+		UUID t = UUID.randomUUID();
+		UserGroupData realTeam = Utils.OM.readValue("""
+				{"name":"Docs Team","org":"%s","status":"ACTIVE","manualUsers":["%s"],
+				 "externalMembers":[
+				   {"name":"Ext One","contact":"e1@vendor.example","role":"SECURITY_SPECIALIST"},
+				   {"name":"Ext Two","contact":"e2@vendor.example","role":"DEVELOPER"}]}
+				""".formatted(org, UUID.randomUUID()), UserGroupData.class);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(realTeam));
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
+		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status(),
+				"two external members must not lift a one-person team over the durability bar");
 		assertFalse(o.durable());
 	}
 
@@ -131,7 +170,7 @@ class ComponentOwnershipServiceTest {
 		// 0 direct members but SSO-backed -> durable (IdP membership materializes at login).
 		UserGroupData tm = team(t, "IdP Team", org, UserGroupStatus.ACTIVE, 0, true, null);
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.OWNED, o.status());
 		assertTrue(o.durable());
 	}
@@ -141,7 +180,7 @@ class ComponentOwnershipServiceTest {
 		UUID t = UUID.randomUUID();
 		UserGroupData tm = team(t, "Archived", org, UserGroupStatus.INACTIVE, 5, false, null);
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.DEGRADED, o.status());
 		assertFalse(o.durable());
 	}
@@ -150,7 +189,7 @@ class ComponentOwnershipServiceTest {
 	void storedTeamMissingIsOrphaned() {
 		UUID t = UUID.randomUUID();
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.empty());
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 	}
 
@@ -159,7 +198,7 @@ class ComponentOwnershipServiceTest {
 		UUID t = UUID.randomUUID();
 		UserGroupData tm = team(t, "Other org", UUID.randomUUID(), UserGroupStatus.ACTIVE, 5, false, null);
 		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
-		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(teamOwner(t)), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 	}
 
@@ -170,7 +209,7 @@ class ComponentOwnershipServiceTest {
 		UUID u = UUID.randomUUID();
 		when(userService.getUserDataWithOrg(u, org)).thenReturn(Optional.of(mock(UserData.class)));
 		ComponentOwner owner = new ComponentOwner(ComponentOwnerType.USER, u);
-		ComponentOwnership o = service.resolveOwnership(component(owner), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(owner), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status());
 		assertFalse(o.durable());
 		assertEquals(ComponentOwnerType.USER, o.ownerType());
@@ -181,7 +220,7 @@ class ComponentOwnershipServiceTest {
 		UUID u = UUID.randomUUID();
 		when(userService.getUserDataWithOrg(u, org)).thenReturn(Optional.empty());
 		ComponentOwner owner = new ComponentOwner(ComponentOwnerType.USER, u);
-		ComponentOwnership o = service.resolveOwnership(component(owner), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(owner), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 	}
 
@@ -191,7 +230,7 @@ class ComponentOwnershipServiceTest {
 	void noOwnerWithOneCandidateTeamSuggestsItUnset() {
 		UUID t = UUID.randomUUID();
 		UserGroupData cand = team(t, "Writers", org, UserGroupStatus.ACTIVE, 3, false, PermissionType.READ_WRITE);
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of(cand));
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(cand), null);
 		assertEquals(ComponentOwnershipStatus.UNSET, o.status());
 		assertTrue(o.derived());
 		assertEquals(t, o.ownerRef());
@@ -204,7 +243,7 @@ class ComponentOwnershipServiceTest {
 		UUID big = UUID.randomUUID();
 		UserGroupData smallDurable = team(small, "Small", org, UserGroupStatus.ACTIVE, 2, false, PermissionType.READ_WRITE);
 		UserGroupData bigDurable = team(big, "Big", org, UserGroupStatus.ACTIVE, 9, false, PermissionType.ADMIN);
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of(smallDurable, bigDurable));
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(smallDurable, bigDurable), null);
 		assertEquals(ComponentOwnershipStatus.UNSET, o.status());
 		assertEquals(big, o.ownerRef(), "should suggest the largest durable candidate");
 	}
@@ -216,7 +255,7 @@ class ComponentOwnershipServiceTest {
 		UUID t = UUID.randomUUID();
 		UserGroupData readOnly = team(t, "Viewers", org, UserGroupStatus.ACTIVE, 4, false, PermissionType.READ_ONLY);
 		when(componentTeamService.deriveTeam(any(ComponentData.class))).thenReturn(List.of());
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of(readOnly));
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(readOnly), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 		assertNull(o.ownerRef());
 	}
@@ -225,7 +264,7 @@ class ComponentOwnershipServiceTest {
 	void noOwnerNoTeamButIndividualWritersSuggestsCreateTeam() {
 		when(componentTeamService.deriveTeam(any(ComponentData.class)))
 				.thenReturn(List.of(mock(UserData.class), mock(UserData.class)));
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.UNSET, o.status());
 		assertTrue(o.derived());
 		assertNull(o.ownerRef(), "no team to point at yet -- a create-team hint");
@@ -234,7 +273,7 @@ class ComponentOwnershipServiceTest {
 	@Test
 	void noOwnerNothingDerivableIsOrphaned() {
 		when(componentTeamService.deriveTeam(any(ComponentData.class))).thenReturn(List.of());
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 		assertFalse(o.derived());
 	}
@@ -255,7 +294,7 @@ class ComponentOwnershipServiceTest {
 		// falls through to the suggestion path rather than NPE-ing.
 		when(componentTeamService.deriveTeam(any(ComponentData.class))).thenReturn(List.of());
 		ComponentOwner malformed = new ComponentOwner(ComponentOwnerType.TEAM, null);
-		ComponentOwnership o = service.resolveOwnership(component(malformed), List.of());
+		ComponentOwnership o = service.resolveOwnership(component(malformed), List.of(), null);
 		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status());
 		assertFalse(o.derived());
 	}
@@ -270,7 +309,7 @@ class ComponentOwnershipServiceTest {
 				team(durableTeamUuid, "Durable", org, UserGroupStatus.ACTIVE, 2, false, PermissionType.READ_WRITE);
 		UserGroupData tiny =
 				team(tinyUuid, "Tiny", org, UserGroupStatus.ACTIVE, 1, false, PermissionType.READ_WRITE);
-		ComponentOwnership o = service.resolveOwnership(component(null), List.of(tiny, durableTeam));
+		ComponentOwnership o = service.resolveOwnership(component(null), List.of(tiny, durableTeam), null);
 		assertEquals(durableTeamUuid, o.ownerRef());
 		assertTrue(o.durable());
 	}
@@ -357,5 +396,125 @@ class ComponentOwnershipServiceTest {
 		when(userService.getUserDataWithOrg(u, org)).thenReturn(Optional.empty());
 		assertThrows(RelizaException.class,
 				() -> service.validateOwner(new ComponentOwner(ComponentOwnerType.USER, u), org));
+	}
+
+	// ---------- T2: team-assignment rules (Option A -- a rule SETS the owner) ----------
+
+	private OrganizationData orgWithRule(String ruleName, String pattern, UUID team) {
+		var r = new OrganizationData.GlobalTeamAssignmentRule();
+		r.setName(ruleName);
+		r.setNamePattern(pattern);
+		r.setOwnerTeam(team);
+		OrganizationData od = mock(OrganizationData.class);
+		when(od.getUuid()).thenReturn(org);
+		when(od.getGlobalTeamAssignmentRules()).thenReturn(List.of(r));
+		return od;
+	}
+
+	private ComponentData named(String name, ComponentOwner owner) {
+		ComponentData cd = component(owner);
+		cd.setName(name);
+		cd.setType(ComponentData.ComponentType.COMPONENT);
+		return cd;
+	}
+
+	@Test
+	void ruleAssignsOwnerWhenComponentHasNoStoredOwner() {
+		UUID t = UUID.randomUUID();
+		UserGroupData tm = team(t, "Rebom", org, UserGroupStatus.ACTIVE, 2, false, null);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
+		ComponentOwnership o = service.resolveOwnership(
+				named("rebom-backend", null), List.of(), orgWithRule("rebom", "rebom-.*", t));
+		assertEquals(ComponentOwnershipStatus.OWNED, o.status());
+		assertEquals(t, o.ownerRef());
+		assertTrue(o.derived(), "a rule-assigned owner is derived, not hand-picked");
+		assertTrue(o.reason().contains("rebom"), "the reason names the rule for provenance: " + o.reason());
+	}
+
+	@Test
+	void storedOwnerBeatsAMatchingRule() {
+		// The whole point of Option A's precedence: a rule never overrides a
+		// deliberate per-component choice.
+		UUID stored = UUID.randomUUID();
+		UUID ruleTeam = UUID.randomUUID();
+		UserGroupData storedTeam = team(stored, "Chosen", org, UserGroupStatus.ACTIVE, 2, false, null);
+		when(userGroupService.getUserGroupData(stored)).thenReturn(Optional.of(storedTeam));
+		ComponentOwnership o = service.resolveOwnership(
+				named("rebom-backend", teamOwner(stored)), List.of(), orgWithRule("rebom", "rebom-.*", ruleTeam));
+		assertEquals(stored, o.ownerRef());
+		assertFalse(o.derived(), "a stored owner is not derived");
+	}
+
+	@Test
+	void ruleAssignedOneMemberTeamIsStillReportedNonDurable() {
+		// A rule must not launder a one-person team into OWNED.
+		UUID t = UUID.randomUUID();
+		UserGroupData tm = team(t, "Solo", org, UserGroupStatus.ACTIVE, 1, false, null);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
+		ComponentOwnership o = service.resolveOwnership(
+				named("rebom-backend", null), List.of(), orgWithRule("rebom", "rebom-.*", t));
+		assertEquals(ComponentOwnershipStatus.NON_DURABLE, o.status());
+		assertFalse(o.durable());
+	}
+
+	@Test
+	void aMatchingRuleBeatsACandidateSuggestion() {
+		// Precedence tier 2 over tier 3: a durable candidate team exists AND a rule
+		// matches -- the rule must win, and the result must be OWNED (not an UNSET
+		// suggestion). Previously unverified.
+		UUID ruleTeam = UUID.randomUUID();
+		UserGroupData rt = team(ruleTeam, "Rule", org, UserGroupStatus.ACTIVE, 2, false, null);
+		when(userGroupService.getUserGroupData(ruleTeam)).thenReturn(Optional.of(rt));
+		UUID candidate = UUID.randomUUID();
+		UserGroupData cand = team(candidate, "Candidate", org, UserGroupStatus.ACTIVE, 3, false,
+				PermissionType.READ_WRITE);
+		ComponentOwnership o = service.resolveOwnership(
+				named("rebom-backend", null), List.of(cand), orgWithRule("rebom", "rebom-.*", ruleTeam));
+		assertEquals(ComponentOwnershipStatus.OWNED, o.status());
+		assertEquals(ruleTeam, o.ownerRef(), "the rule must win over a candidate suggestion");
+	}
+
+	@Test
+	void ruleTeamArchivedAfterTheRuleWasSavedReportsDegraded() {
+		// Writes reject archived teams, but a team can be archived later. The
+		// resolver must surface that as DEGRADED rather than silently skipping to
+		// the next rule -- an archived team is recoverable and worth telling the
+		// operator about.
+		UUID t = UUID.randomUUID();
+		UserGroupData tm = team(t, "Archived", org, UserGroupStatus.INACTIVE, 5, false, null);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
+		ComponentOwnership o = service.resolveOwnership(
+				named("rebom-backend", null), List.of(), orgWithRule("rebom", "rebom-.*", t));
+		assertEquals(ComponentOwnershipStatus.DEGRADED, o.status());
+		assertTrue(o.derived());
+		assertTrue(o.reason().contains("rebom"), "reason names the rule: " + o.reason());
+	}
+
+	@Test
+	void nonMatchingRuleFallsThroughToTheCandidateSuggestion() {
+		UUID t = UUID.randomUUID();
+		UserGroupData tm = team(t, "Rebom", org, UserGroupStatus.ACTIVE, 2, false, null);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
+		ComponentOwnership o = service.resolveOwnership(
+				named("unrelated-thing", null), List.of(), orgWithRule("rebom", "rebom-.*", t));
+		assertEquals(ComponentOwnershipStatus.ORPHANED, o.status(),
+				"no rule match and no candidate team -> orphaned, as before T2");
+	}
+
+	@Test
+	void clearingAStoredOwnerHandsTheComponentBackToTheRule() {
+		// The workflow clearOwner exists for: a component manually pinned to one
+		// team, then released back to org rules. Modeled here as owner -> null.
+		UUID t = UUID.randomUUID();
+		UserGroupData tm = team(t, "Rebom", org, UserGroupStatus.ACTIVE, 2, false, null);
+		when(userGroupService.getUserGroupData(t)).thenReturn(Optional.of(tm));
+		var od = orgWithRule("rebom", "rebom-.*", t);
+		ComponentData pinned = named("rebom-backend", teamOwner(UUID.randomUUID()));
+		assertFalse(service.resolveOwnership(pinned, List.of(), od).derived(),
+				"while pinned, the stored owner wins");
+		ComponentData cleared = named("rebom-backend", null);
+		ComponentOwnership after = service.resolveOwnership(cleared, List.of(), od);
+		assertTrue(after.derived(), "once cleared, the rule takes over again");
+		assertEquals(t, after.ownerRef());
 	}
 }

--- a/backend/src/test/java/io/reliza/service/ComponentPostureDiffTest.java
+++ b/backend/src/test/java/io/reliza/service/ComponentPostureDiffTest.java
@@ -370,4 +370,62 @@ public class ComponentPostureDiffTest {
                 "retired out-of-window from-baseline excluded -> absent at from, present at to -> net-appeared");
         assertEquals(1, result.totalAppeared());
     }
+    // ---- changelog re-scan visibility: arrival decoration ----
+
+    /**
+     * The prod case this feature exists for (mafia-express, 2026-08-01): a NEW ADVISORY lands via
+     * re-scan on packages present in EVERY release, so ALL in-window releases' current metrics carry
+     * it. The posture diff classifies it New (absent at from, present at to) -- and must now also
+     * stamp WHEN it arrived (earliest in-window APPEARED event) and the honest carrier RANGE
+     * (earliest/latest in-window release currently carrying it), instead of leaving only the
+     * endpoint-anchor attribution that reads as "0.0.4 introduced this".
+     */
+    @Test
+    void lateScanArrival_stampsArrivalDateAndCarrierRange() {
+        VulnerabilityDto cve = vuln("CVE-2024-10491", "pkg:npm/express@5.2.1", VulnerabilitySeverity.MEDIUM, false);
+        ReleaseData r3 = release(REL_FROM, BRANCH_A, "0.0.3",
+                ZonedDateTime.parse("2026-06-05T00:00:00Z"), metrics(cve));
+        ReleaseData r4 = release(REL_TO, BRANCH_A, "0.0.4",
+                ZonedDateTime.parse("2026-06-10T00:00:00Z"), metrics(cve));
+        ZonedDateTime arrival = ZonedDateTime.parse("2026-06-15T00:00:00Z");
+        lenient().when(findingDimBackfillService.hydrateInRangeV3(any(), any(), any(), any()))
+                .thenReturn(List.of(appeared(REL_TO, "CVE-2024-10491", "pkg:npm/express@5.2.1",
+                        VulnerabilitySeverity.MEDIUM, arrival)));
+
+        FindingChangesWithAttribution result = run(Map.of(COMPONENT_A, List.of(r3, r4)));
+
+        VulnerabilityWithAttribution v = findVuln(result, "CVE-2024-10491");
+        assertNotNull(v);
+        assertTrue(v.appearedInCount() > 0, "absent at from (event replays it away), present at to -> appeared");
+        assertEquals(arrival, v.scanArrivalDate(), "arrival = earliest in-window APPEARED event date");
+        assertNotNull(v.earliestCarrier());
+        assertNotNull(v.latestCarrier());
+        assertEquals(REL_FROM, v.earliestCarrier().releaseUuid(), "earliest carrier is 0.0.3, NOT the endpoint anchor");
+        assertEquals("0.0.3", v.earliestCarrier().releaseVersion());
+        assertEquals(REL_TO, v.latestCarrier().releaseUuid());
+        assertEquals("0.0.4", v.latestCarrier().releaseVersion());
+        assertEquals("comp-a", v.earliestCarrier().componentName());
+    }
+
+    /** Without an in-window APPEARED event the decoration stays null -- nothing fabricated. */
+    @Test
+    void noEvent_appearanceKeepsNullScanArrival() {
+        VulnerabilityDto cve = vuln("CVE-2026-7777", LODASH, VulnerabilitySeverity.HIGH, false);
+        // Only the newer release carries it; no events at all (release-borne appearance,
+        // from-anchor reconstructs identical to current -> the from-anchor release lacks it).
+        ReleaseData r1 = release(REL_FROM, BRANCH_A, "1.0",
+                ZonedDateTime.parse("2026-06-05T00:00:00Z"), metrics());
+        ReleaseData r2 = release(REL_TO, BRANCH_A, "2.0",
+                ZonedDateTime.parse("2026-06-10T00:00:00Z"), metrics(cve));
+        stubNoEvents();
+
+        FindingChangesWithAttribution result = run(Map.of(COMPONENT_A, List.of(r1, r2)));
+
+        VulnerabilityWithAttribution v = findVuln(result, "CVE-2026-7777");
+        assertNotNull(v);
+        assertTrue(v.appearedInCount() > 0);
+        assertNull(v.scanArrivalDate());
+        assertNull(v.earliestCarrier());
+        assertNull(v.latestCarrier());
+    }
 }

--- a/backend/src/test/java/io/reliza/service/ComponentVcsResolutionTest.java
+++ b/backend/src/test/java/io/reliza/service/ComponentVcsResolutionTest.java
@@ -1,0 +1,127 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.model.WhoUpdated;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.VcsRepository;
+import io.reliza.model.dto.CreateComponentDto;
+import io.reliza.service.ComponentService.ComponentResolution;
+import io.reliza.service.ComponentService.ComponentResolutionStatus;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Pins VCS-based component resolution against the duplicate-registration
+ * incident (30+ components for one (vcs, repoPath), +1 per CI run):
+ *
+ * <ol>
+ *   <li>URI-form stability: resolve and create must canonicalize identically.
+ *       The resolve side used to apply less canonicalization than the create
+ *       side, so the ordinary '.git' clone URL never resolved the component it
+ *       had just created -- while the create side kept finding the one VCS row
+ *       and minting a new component against it, silently, every build.</li>
+ *   <li>Tri-state outcomes: AMBIGUOUS is data, not an exception to be caught --
+ *       the create-on-missing callers used to treat every resolution failure as
+ *       "not found", turning two duplicates into N.</li>
+ * </ol>
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class ComponentVcsResolutionTest {
+
+	@Autowired private ComponentService componentService;
+	@Autowired private VcsRepositoryService vcsRepositoryService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final String REPO_PATH = "svc/alpha";
+
+	private record Fixture(UUID orgUuid, UUID vcsUuid, String rawGitUri, String bareUri) {}
+
+	/** One VCS row (stored canonical), created through the same path CI creation uses. */
+	private Fixture fixture() {
+		Organization org = testInitializer.obtainOrganization();
+		String slug = "it-dupres-" + UUID.randomUUID().toString().substring(0, 8);
+		String rawGitUri = "https://github.com/it-dup/" + slug + ".git";
+		VcsRepository vcs = vcsRepositoryService
+				.getVcsRepositoryByUri(org.getUuid(), rawGitUri, null, null, true, WhoUpdated.getTestWhoUpdated()).get();
+		return new Fixture(org.getUuid(), vcs.getUuid(), rawGitUri, "github.com/it-dup/" + slug);
+	}
+
+	private UUID createComponentOn(Fixture fx, String name) throws RelizaException {
+		CreateComponentDto dto = CreateComponentDto.builder()
+				.organization(fx.orgUuid())
+				.name(name)
+				.type(ComponentType.COMPONENT)
+				.vcs(fx.vcsUuid())
+				.repoPath(REPO_PATH)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build();
+		return componentService.createComponent(dto, WhoUpdated.getTestWhoUpdated()).getUuid();
+	}
+
+	/** Both the .git clone URL and the bare form must resolve the one component. */
+	@Test
+	public void gitSuffixedUriResolvesTheComponentItCreated() throws Exception {
+		Fixture fx = fixture();
+		UUID componentId = createComponentOn(fx, "resolves-either-form");
+
+		for (String uriForm : new String[] { fx.rawGitUri(), fx.bareUri(), "https://" + fx.bareUri() }) {
+			ComponentResolution resolution =
+					componentService.resolveComponentResolutionByVcsUriAndPath(fx.orgUuid(), uriForm, REPO_PATH);
+			assertEquals(ComponentResolutionStatus.FOUND, resolution.status(),
+					"uri form must resolve: " + uriForm + " -> " + resolution.detail());
+			assertEquals(componentId, resolution.componentId(), "wrong component for uri form " + uriForm);
+		}
+	}
+
+	/** An unknown VCS is NOT_FOUND -- the only status that may legitimize creation. */
+	@Test
+	public void unknownVcsIsNotFoundNotError() {
+		Fixture fx = fixture();
+		ComponentResolution resolution = componentService.resolveComponentResolutionByVcsUriAndPath(
+				fx.orgUuid(), "https://github.com/it-dup/never-created-" + UUID.randomUUID() + ".git", REPO_PATH);
+		assertEquals(ComponentResolutionStatus.NOT_FOUND, resolution.status());
+		assertNotNull(resolution.detail());
+	}
+
+	/** Duplicate registrations resolve AMBIGUOUS -- data, not a swallowed throw. */
+	@Test
+	public void duplicateRegistrationsResolveAmbiguous() throws Exception {
+		Fixture fx = fixture();
+		UUID first = createComponentOn(fx, "dup-a");
+		UUID second = createComponentOn(fx, "dup-b");
+
+		ComponentResolution resolution =
+				componentService.resolveComponentResolutionByVcsUriAndPath(fx.orgUuid(), fx.rawGitUri(), REPO_PATH);
+		assertEquals(ComponentResolutionStatus.AMBIGUOUS, resolution.status());
+		assertTrue(resolution.detail().contains("Multiple components found"),
+				"detail must carry the operator diagnostic: " + resolution.detail());
+		assertTrue(resolution.detail().contains(first.toString()) && resolution.detail().contains(second.toString()),
+				"detail must enumerate the duplicate component ids: " + resolution.detail());
+
+		// The throwing wrapper (no-create callers: synchronizeBranch, getLatestRelease,
+		// versionFeatureSet overrides) surfaces the same diagnostic as an error.
+		RelizaException ex = assertThrows(RelizaException.class,
+				() -> componentService.findComponentDataByVcsAndPath(fx.vcsUuid(), fx.orgUuid(), REPO_PATH));
+		assertTrue(ex.getMessage().contains("Multiple components found"));
+	}
+}

--- a/backend/src/test/java/io/reliza/service/KevSeriesChartTest.java
+++ b/backend/src/test/java/io/reliza/service/KevSeriesChartTest.java
@@ -1,0 +1,160 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.AnalyticsMetrics;
+import io.reliza.model.Branch;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.Release;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.WhoUpdated;
+import io.reliza.model.dto.AnalyticsDtos.VulnViolationsChartDto;
+import io.reliza.model.dto.CreateComponentDto;
+import io.reliza.model.dto.ReleaseDto;
+import io.reliza.model.dto.ReleaseMetricsDto;
+import io.reliza.repositories.AnalyticsMetricsRepository;
+import io.reliza.service.oss.OssReleaseService;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Pins the KEV series on the findings-over-time charts across its two data
+ * paths:
+ *
+ * <ol>
+ *   <li><b>Org path</b> (seeded {@code analytics_metrics} rows): the SQL reads
+ *       {@code kevCount} WITHOUT coalescing, so rows written before the key
+ *       existed yield null and the mapper omits the KEV point -- a legacy day
+ *       must not draw a false "0 KEV exposure" line, and the series starts
+ *       where the data starts.</li>
+ *   <li><b>Branch path</b> (computed from per-day latest release metrics):
+ *       {@code kevCount} is already maintained on release metrics (stamped at
+ *       compute, re-stamped by the KEV catalog sync), so the chart emits it
+ *       for every point.</li>
+ * </ol>
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class KevSeriesChartTest {
+
+	@Autowired private AnalyticsMetricsService analyticsMetricsService;
+	@Autowired private AnalyticsMetricsRepository analyticsMetricsRepository;
+	@Autowired private ComponentService componentService;
+	@Autowired private BranchService branchService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private SharedReleaseService sharedReleaseService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final WhoUpdated WU = WhoUpdated.getTestWhoUpdated();
+	private static final String KEV_SERIES = "KEV Vulnerabilities";
+
+	private void saveOrgRow(UUID org, String dateKey, Map<String, Object> numericMetrics) {
+		AnalyticsMetrics am = new AnalyticsMetrics();
+		am.setOrg(org);
+		am.setDateKey(dateKey);
+		am.setNumericMetrics(numericMetrics);
+		analyticsMetricsRepository.save(am);
+	}
+
+	private static Optional<VulnViolationsChartDto> kevPointOn(List<VulnViolationsChartDto> dtos, String dateKey) {
+		return dtos.stream()
+				.filter(d -> KEV_SERIES.equals(d.type()))
+				.filter(d -> d.createdDate().toLocalDate().toString().equals(dateKey))
+				.findFirst();
+	}
+
+	@Test
+	public void orgChartOmitsKevForLegacyRowsAndEmitsForNewOnes() {
+		Organization org = testInitializer.obtainOrganization();
+		ZonedDateTime now = ZonedDateTime.now();
+		String legacyKey = now.minusDays(3).toLocalDate().toString();
+		String currentKey = now.minusDays(2).toLocalDate().toString();
+
+		// Legacy row: seeded before the kevCount key existed.
+		saveOrgRow(org.getUuid(), legacyKey, Map.of(
+				"critical", 4, "high", 2, "medium", 1, "low", 0, "unassigned", 0,
+				"policyViolationsLicenseTotal", 0, "policyViolationsOperationalTotal", 0,
+				"policyViolationsSecurityTotal", 0));
+		// Current row: carries the key.
+		saveOrgRow(org.getUuid(), currentKey, Map.of(
+				"critical", 4, "high", 2, "medium", 1, "low", 0, "unassigned", 0, "kevCount", 3,
+				"policyViolationsLicenseTotal", 0, "policyViolationsOperationalTotal", 0,
+				"policyViolationsSecurityTotal", 0));
+
+		List<VulnViolationsChartDto> dtos = analyticsMetricsService.listChartDataByOrgDates(
+				org.getUuid(), now.minusDays(4), now.minusDays(1));
+
+		assertTrue(kevPointOn(dtos, legacyKey).isEmpty(),
+				"legacy row without kevCount must omit the KEV point, not draw a false zero");
+		Optional<VulnViolationsChartDto> current = kevPointOn(dtos, currentKey);
+		assertTrue(current.isPresent(), "row with kevCount must emit the KEV point");
+		assertEquals(3, current.get().num());
+
+		// The other eight series stay intact on BOTH days.
+		for (String key : List.of(legacyKey, currentKey)) {
+			long seriesOnDay = dtos.stream()
+					.filter(d -> d.createdDate().toLocalDate().toString().equals(key)).count();
+			assertEquals(key.equals(currentKey) ? 9 : 8, seriesOnDay,
+					"unexpected series count on " + key);
+		}
+	}
+
+	@Test
+	public void branchChartEmitsKevFromReleaseMetrics() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		String slug = "it-kev-" + UUID.randomUUID().toString().substring(0, 8);
+		UUID componentUuid = componentService.createComponent(CreateComponentDto.builder()
+				.organization(org.getUuid())
+				.name(slug)
+				.type(ComponentType.COMPONENT)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build(), WU).getUuid();
+		Branch branch = branchService.findBranchByName(componentUuid, "main", true, WU).get();
+		UUID releaseUuid = ossReleaseService.createRelease(ReleaseDto.builder()
+				.component(componentUuid)
+				.branch(branch.getUuid())
+				.org(org.getUuid())
+				.status(ReleaseData.ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseData.ReleaseLifecycle.ASSEMBLED)
+				.version("1.0.0")
+				.build(), WU).getUuid();
+
+		// Stamp metrics the way the compute service does, with KEV present.
+		Release r = sharedReleaseService.getRelease(releaseUuid).orElseThrow();
+		ReleaseMetricsDto rmd = new ReleaseMetricsDto();
+		rmd.setCritical(2);
+		rmd.setHigh(1);
+		rmd.setKevCount(1);
+		sharedReleaseService.saveReleaseMetrics(r, rmd);
+
+		ZonedDateTime now = ZonedDateTime.now();
+		List<VulnViolationsChartDto> dtos = analyticsMetricsService.getVulnViolationByBranchChartData(
+				branch.getUuid(), now.minusDays(1), now.plusDays(1));
+
+		String todayKey = now.toLocalDate().toString();
+		Optional<VulnViolationsChartDto> kev = kevPointOn(dtos, todayKey);
+		assertTrue(kev.isPresent(), "branch chart must emit the KEV series");
+		assertEquals(1, kev.get().num());
+		assertEquals(9, dtos.size(), "compute path emits all nine series");
+	}
+}

--- a/backend/src/test/java/io/reliza/service/NotificationSubscriptionServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/NotificationSubscriptionServiceTest.java
@@ -27,7 +27,9 @@ import org.mockito.ArgumentCaptor;
 
 import io.reliza.common.CommonVariables.TableName;
 import io.reliza.common.Utils;
+import io.reliza.common.CommonVariables.UserGroupStatus;
 import io.reliza.exceptions.RelizaException;
+import io.reliza.model.UserGroupData;
 import io.reliza.model.WhoUpdated;
 import io.reliza.model.Integration;
 import io.reliza.model.IntegrationData;
@@ -63,6 +65,7 @@ class NotificationSubscriptionServiceTest {
     private NotificationChannelGroupRepository channelGroupRepo;
     private AuditService auditService;
     private NotificationCelEvaluator celEvaluator;
+    private UserGroupService userGroupService;
     private NotificationSubscriptionService service;
 
     @BeforeEach
@@ -72,6 +75,7 @@ class NotificationSubscriptionServiceTest {
         channelGroupRepo = mock(NotificationChannelGroupRepository.class);
         auditService = mock(AuditService.class);
         celEvaluator = mock(NotificationCelEvaluator.class);
+        userGroupService = mock(UserGroupService.class);
         when(subRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         service = new NotificationSubscriptionService();
@@ -80,6 +84,7 @@ class NotificationSubscriptionServiceTest {
         inject("channelGroupRepo", channelGroupRepo);
         inject("auditService", auditService);
         inject("celEvaluator", celEvaluator);
+        inject("userGroupService", userGroupService);
     }
 
     private void inject(String field, Object value) throws Exception {
@@ -462,5 +467,89 @@ class NotificationSubscriptionServiceTest {
                 null, null);
         sub.setRecordData(Utils.OM.convertValue(data, Map.class));
         return sub;
+    }
+
+    // ---------- T3: team route targets ----------
+
+    /**
+     * Regression guard for a shipped-blocker: `teams` was missing from the
+     * route-emptiness gates, so a route naming ONLY a team was rejected at save.
+     * Naming a team INSTEAD of a channel is the entire point of the feature --
+     * its channel is resolved at fan-out -- so this must save.
+     */
+    @Test
+    void aTeamsOnlyRouteIsAccepted() throws Exception {
+        UUID orgUuid = UUID.randomUUID();
+        UUID teamUuid = UUID.randomUUID();
+        stubTeamInOrg(teamUuid, orgUuid, UserGroupStatus.ACTIVE);
+
+        NotificationSubscriptionData seed = subscriptionSeedWithTeams(orgUuid, List.of(), List.of(teamUuid));
+        NotificationSubscription saved = service.upsertSubscription(
+                null, seed, WhoUpdated.getApiWhoUpdated(UUID.randomUUID(), "test"));
+        assertNotNull(saved, "a route naming only a team must be savable");
+    }
+
+    @Test
+    void aRouteWithNoChannelGroupOrTeamIsStillRejected() {
+        UUID orgUuid = UUID.randomUUID();
+        NotificationSubscriptionData seed = subscriptionSeedWithTeams(orgUuid, List.of(), List.of());
+        assertThrows(RelizaException.class, () -> service.upsertSubscription(
+                null, seed, WhoUpdated.getApiWhoUpdated(UUID.randomUUID(), "test")));
+    }
+
+    @Test
+    void anUnknownTeamInARouteIsRejectedAtSave() {
+        UUID orgUuid = UUID.randomUUID();
+        UUID unknown = UUID.randomUUID();
+        when(userGroupService.getUserGroupData(unknown)).thenReturn(Optional.empty());
+        NotificationSubscriptionData seed = subscriptionSeedWithTeams(orgUuid, List.of(), List.of(unknown));
+        RelizaException e = assertThrows(RelizaException.class, () -> service.upsertSubscription(
+                null, seed, WhoUpdated.getApiWhoUpdated(UUID.randomUUID(), "test")));
+        assertTrue(e.getMessage().contains("unknown teams"), e.getMessage());
+    }
+
+    @Test
+    void aCrossOrgTeamInARouteIsRejectedAtSave() {
+        UUID orgUuid = UUID.randomUUID();
+        UUID foreign = UUID.randomUUID();
+        stubTeamInOrg(foreign, UUID.randomUUID(), UserGroupStatus.ACTIVE);
+        NotificationSubscriptionData seed = subscriptionSeedWithTeams(orgUuid, List.of(), List.of(foreign));
+        RelizaException e = assertThrows(RelizaException.class, () -> service.upsertSubscription(
+                null, seed, WhoUpdated.getApiWhoUpdated(UUID.randomUUID(), "test")));
+        assertTrue(e.getMessage().contains("different org"), e.getMessage());
+    }
+
+    /**
+     * A DEACTIVATED team must still SAVE. Rejecting it locked the operator out of
+     * the subscription: they could neither keep the team nor drop it (an emptied
+     * route is also rejected). Resolution skips non-ACTIVE teams, so nothing is
+     * delivered -- that is the real control.
+     */
+    @Test
+    void aDeactivatedTeamInARouteStillSavesSoItCanBeCleanedUp() throws Exception {
+        UUID orgUuid = UUID.randomUUID();
+        UUID teamUuid = UUID.randomUUID();
+        stubTeamInOrg(teamUuid, orgUuid, UserGroupStatus.INACTIVE);
+        NotificationSubscriptionData seed = subscriptionSeedWithTeams(orgUuid, List.of(), List.of(teamUuid));
+        assertNotNull(service.upsertSubscription(
+                null, seed, WhoUpdated.getApiWhoUpdated(UUID.randomUUID(), "test")));
+    }
+
+    private void stubTeamInOrg(UUID teamUuid, UUID orgUuid, UserGroupStatus status) {
+        UserGroupData ugd = mock(UserGroupData.class);
+        when(ugd.getUuid()).thenReturn(teamUuid);
+        when(ugd.getOrg()).thenReturn(orgUuid);
+        when(ugd.getStatus()).thenReturn(status);
+        when(userGroupService.getUserGroupData(teamUuid)).thenReturn(Optional.of(ugd));
+    }
+
+    private static NotificationSubscriptionData subscriptionSeedWithTeams(UUID org,
+            List<UUID> channels, List<UUID> teams) {
+        return new NotificationSubscriptionData(
+                org, null, "test-sub", NotificationSubscriptionStatus.ACTIVE,
+                List.of(NotificationEventType.NEW_VULN_AFFECTS_RELEASES),
+                null,
+                List.of(new RouteConfig(null, null, null, channels, null, null, teams)),
+                null, null);
     }
 }

--- a/backend/src/test/java/io/reliza/service/OrgTeamAssignmentRuleServiceTest.java
+++ b/backend/src/test/java/io/reliza/service/OrgTeamAssignmentRuleServiceTest.java
@@ -1,0 +1,250 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.ComponentData;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.OrganizationData;
+import io.reliza.model.OrganizationData.GlobalTeamAssignmentRule;
+import io.reliza.model.UserGroupData;
+
+/**
+ * Matching + validation for org-wide team-assignment rules (T2).
+ *
+ * <p>The contract mirrors {@code OrgApprovalPolicyService}: patterns are FULLY
+ * ANCHORED, the {@code componentType} filter treats null/ANY as "match any", and
+ * list order is priority order with first-match-wins.
+ */
+class OrgTeamAssignmentRuleServiceTest {
+
+	private UserGroupService userGroupService;
+	private OrgTeamAssignmentRuleService service;
+
+	private final UUID org = UUID.randomUUID();
+	private final UUID teamA = UUID.randomUUID();
+	private final UUID teamB = UUID.randomUUID();
+
+	@BeforeEach
+	void setUp() {
+		userGroupService = mock(UserGroupService.class);
+		service = new OrgTeamAssignmentRuleService();
+		ReflectionTestUtils.setField(service, "userGroupService", userGroupService);
+		ReflectionTestUtils.setField(service, "organizationService", mock(OrganizationService.class));
+		stubTeam(teamA, org, UserGroupStatus.ACTIVE);
+		stubTeam(teamB, org, UserGroupStatus.ACTIVE);
+	}
+
+	private void stubTeam(UUID uuid, UUID teamOrg, UserGroupStatus status) {
+		UserGroupData g = mock(UserGroupData.class);
+		when(g.getUuid()).thenReturn(uuid);
+		when(g.getOrg()).thenReturn(teamOrg);
+		when(g.getStatus()).thenReturn(status);
+		when(userGroupService.getUserGroupData(uuid)).thenReturn(Optional.of(g));
+	}
+
+	private static GlobalTeamAssignmentRule rule(String name, String pattern, ComponentType type, UUID team) {
+		GlobalTeamAssignmentRule r = new GlobalTeamAssignmentRule();
+		r.setName(name);
+		r.setNamePattern(pattern);
+		r.setComponentType(type);
+		r.setOwnerTeam(team);
+		return r;
+	}
+
+	private OrganizationData orgWith(GlobalTeamAssignmentRule... rules) {
+		OrganizationData od = mock(OrganizationData.class);
+		when(od.getUuid()).thenReturn(org);
+		when(od.getGlobalTeamAssignmentRules()).thenReturn(Arrays.asList(rules));
+		return od;
+	}
+
+	private static ComponentData component(String name, ComponentType type) {
+		ComponentData cd = new ComponentData();
+		cd.setName(name);
+		cd.setType(type);
+		return cd;
+	}
+
+	// ---------- matching ----------
+
+	@Test
+	void matchesAnchoredPattern() {
+		var m = service.matchFor(component("rebom-backend", ComponentType.COMPONENT),
+				orgWith(rule("rebom", "rebom-.*", null, teamA)));
+		assertTrue(m.isPresent());
+		assertEquals(teamA, m.get().team().getUuid());
+	}
+
+	@Test
+	void patternIsFullyAnchoredSoAPrefixDoesNotMatchALongerName() {
+		// "rebom-" would match as a substring but must NOT match the whole name --
+		// same anchoring convention as DependencyPatternService.
+		assertTrue(service.matchFor(component("rebom-backend", ComponentType.COMPONENT),
+				orgWith(rule("r", "rebom-", null, teamA))).isEmpty());
+	}
+
+	@Test
+	void firstMatchingRuleWinsInListOrder() {
+		var m = service.matchFor(component("rebom-backend", ComponentType.COMPONENT),
+				orgWith(rule("first", "rebom-.*", null, teamA),
+						rule("second", ".*backend", null, teamB)));
+		assertEquals(teamA, m.get().team().getUuid(), "list order is the priority order");
+		assertEquals("first", m.get().rule().getName());
+	}
+
+	@Test
+	void typeFilterRestrictsTheMatch() {
+		var od = orgWith(rule("products only", ".*", ComponentType.PRODUCT, teamA));
+		assertTrue(service.matchFor(component("anything", ComponentType.PRODUCT), od).isPresent());
+		assertTrue(service.matchFor(component("anything", ComponentType.COMPONENT), od).isEmpty());
+	}
+
+	@Test
+	void nullAndAnyTypeFilterMatchBothConcreteTypes() {
+		for (ComponentType filter : new ComponentType[] { null, ComponentType.ANY }) {
+			var od = orgWith(rule("any", ".*", filter, teamA));
+			assertTrue(service.matchFor(component("x", ComponentType.COMPONENT), od).isPresent());
+			assertTrue(service.matchFor(component("x", ComponentType.PRODUCT), od).isPresent());
+		}
+	}
+
+	@Test
+	void ruleWhoseTeamIsGoneIsSkippedSoLaterRulesStillApply() {
+		UUID missing = UUID.randomUUID();
+		when(userGroupService.getUserGroupData(missing)).thenReturn(Optional.empty());
+		var m = service.matchFor(component("rebom-backend", ComponentType.COMPONENT),
+				orgWith(rule("stale", "rebom-.*", null, missing),
+						rule("good", "rebom-.*", null, teamB)));
+		assertTrue(m.isPresent(), "one stale rule must not mask every rule behind it");
+		assertEquals(teamB, m.get().team().getUuid());
+	}
+
+	@Test
+	void crossOrgTeamIsNotUsable() {
+		UUID foreign = UUID.randomUUID();
+		stubTeam(foreign, UUID.randomUUID(), UserGroupStatus.ACTIVE);
+		assertTrue(service.matchFor(component("x", ComponentType.COMPONENT),
+				orgWith(rule("foreign", ".*", null, foreign))).isEmpty());
+	}
+
+	@Test
+	void badRegexOnReadIsSkippedNotThrown() {
+		// Writes validate the regex; bad data on read must not kill the resolver.
+		var m = service.matchFor(component("x", ComponentType.COMPONENT),
+				orgWith(rule("bad", "[unclosed", null, teamA),
+						rule("good", "x", null, teamB)));
+		assertEquals(teamB, m.get().team().getUuid());
+	}
+
+	@Test
+	void noRulesOrNullOrgYieldsNoMatch() {
+		assertTrue(service.matchFor(component("x", ComponentType.COMPONENT), orgWith()).isEmpty());
+		assertTrue(service.matchFor(component("x", ComponentType.COMPONENT), null).isEmpty());
+	}
+
+	// ---------- validation ----------
+
+	@Test
+	void validateAcceptsAWellFormedRule() throws Exception {
+		service.validate(org, List.of(rule("ok", "rebom-.*", ComponentType.COMPONENT, teamA)));
+	}
+
+	@Test
+	void validateRejectsBlankNameBlankPatternAndBadRegex() {
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("", "x", null, teamA))));
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", " ", null, teamA))));
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", "[unclosed", null, teamA))));
+	}
+
+	@Test
+	void validateRejectsDuplicateNamesCaseInsensitively() {
+		assertThrows(RelizaException.class, () -> service.validate(org,
+				List.of(rule("Rebom", "a.*", null, teamA), rule("rebom", "b.*", null, teamB))));
+	}
+
+	@Test
+	void validateRejectsMissingCrossOrgAndArchivedTeams() {
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", "x", null, null))));
+		UUID missing = UUID.randomUUID();
+		when(userGroupService.getUserGroupData(missing)).thenReturn(Optional.empty());
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", "x", null, missing))));
+		UUID archived = UUID.randomUUID();
+		stubTeam(archived, org, UserGroupStatus.INACTIVE);
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", "x", null, archived))));
+	}
+
+	@Test
+	void validateToleratesNullList() throws Exception {
+		service.validate(org, null);
+	}
+
+	// ---------- ReDoS / cost guards ----------
+
+	@Test
+	void catastrophicBacktrackingIsBudgetedNotHung() {
+		// (.*a){20} against a non-matching string does not terminate in any
+		// practical time under a plain matcher. Rules run on EVERY ownership read
+		// of EVERY component, so an unbounded match would let one saved rule burn
+		// request threads for the whole instance. The step budget must make this
+		// fail fast and report "no match" instead.
+		String evil = "(.*a){20}";
+		String name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!";
+		ComponentData cd = component(name, ComponentType.COMPONENT);
+		long start = System.nanoTime();
+		var m = service.matchFor(cd, orgWith(rule("evil", evil, null, teamA)));
+		long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+		assertTrue(m.isEmpty(), "a budget-exceeding pattern must not report a match");
+		assertTrue(elapsedMs < 10_000, "match must abort on budget, took " + elapsedMs + "ms");
+	}
+
+	@Test
+	void validateRejectsAnOverlongPattern() {
+		String tooLong = "a".repeat(OrgTeamAssignmentRuleService.MAX_PATTERN_LENGTH + 1);
+		assertThrows(RelizaException.class, () -> service.validate(org, List.of(rule("n", tooLong, null, teamA))));
+	}
+
+	// ---------- hoisted group list (N+1 avoidance) ----------
+
+	@Test
+	void hoistedOrgGroupsAreUsedInsteadOfARepositoryHit() {
+		UserGroupData hoisted = mock(UserGroupData.class);
+		when(hoisted.getUuid()).thenReturn(teamA);
+		when(hoisted.getOrg()).thenReturn(org);
+		when(hoisted.getStatus()).thenReturn(UserGroupStatus.ACTIVE);
+		var m = service.matchFor(component("x", ComponentType.COMPONENT),
+				orgWith(rule("r", "x", null, teamA)), List.of(hoisted));
+		assertTrue(m.isPresent());
+		// The whole point of hoisting: no per-component DB read for the team.
+		verify(userGroupService, never()).getUserGroupData(teamA);
+	}
+
+	@Test
+	void archivedTeamIsStillReturnedSoOwnershipCanReportDegraded() {
+		UUID archived = UUID.randomUUID();
+		stubTeam(archived, org, UserGroupStatus.INACTIVE);
+		var m = service.matchFor(component("x", ComponentType.COMPONENT),
+				orgWith(rule("r", "x", null, archived)));
+		assertTrue(m.isPresent(), "an archived team must surface as DEGRADED, not fall through");
+		assertEquals(UserGroupStatus.INACTIVE, m.get().team().getStatus());
+	}
+}

--- a/backend/src/test/java/io/reliza/service/ReleaseScanSelfHealTest.java
+++ b/backend/src/test/java/io/reliza/service/ReleaseScanSelfHealTest.java
@@ -199,7 +199,7 @@ public class ReleaseScanSelfHealTest {
 	}
 
 	private static FlowControl fcWithFailures(int failureCount) {
-		return new FlowControl(null, null, null, null, null, null, null, null, failureCount);
+		return new FlowControl(null, null, null, null, null, null, null, null, null, failureCount);
 	}
 
 	// ---- helpers (local, mirroring ReleaseMetricsFinderQueryTest's fixture style) ----

--- a/backend/src/test/java/io/reliza/service/TeamChannelRoutingTest.java
+++ b/backend/src/test/java/io/reliza/service/TeamChannelRoutingTest.java
@@ -1,0 +1,125 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.UUID;
+
+import tools.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.reliza.common.Utils;
+import io.reliza.common.CommonVariables.UserGroupStatus;
+import io.reliza.model.UserGroup;
+import io.reliza.repositories.UserGroupRepository;
+
+/**
+ * {@code UserGroupService.resolveTeamChannelUuids} -- what the fan-out calls to
+ * turn a route's {@code teams} target into channel UUIDs (T3).
+ *
+ * <p>Resolution is deliberately LATE (fan-out, not save) so retargeting a team's
+ * channel takes effect without editing every subscription that names it. That
+ * makes the read-side guards here load-bearing: cross-org and deactivated teams
+ * must be skipped even though writes also validate, because a route saved before
+ * a team changed must not keep delivering.
+ */
+class TeamChannelRoutingTest {
+
+	private UserGroupRepository repo;
+	private UserGroupService service;
+
+	private final UUID org = UUID.randomUUID();
+	private final UUID otherOrg = UUID.randomUUID();
+	private final UUID teamA = UUID.randomUUID();
+	private final UUID teamB = UUID.randomUUID();
+	private final UUID chan1 = UUID.randomUUID();
+	private final UUID chan2 = UUID.randomUUID();
+
+	@BeforeEach
+	void setUp() {
+		repo = mock(UserGroupRepository.class);
+		service = new UserGroupService();
+		ReflectionTestUtils.setField(service, "userGroupRepository", repo);
+	}
+
+	/** Stubs the repository so the REAL service method under test runs. */
+	private void stubTeam(UUID uuid, UUID teamOrg, UserGroupStatus status, UUID... channels) {
+		String chans = Arrays.stream(channels).map(c -> "\"" + c + "\"").collect(Collectors.joining(","));
+		UserGroup ug = new UserGroup();
+		ug.setUuid(uuid);
+		ug.setRecordData(Utils.OM.readValue(
+				"{\"name\":\"T\",\"org\":\"%s\",\"status\":\"%s\",\"notificationChannels\":[%s]}"
+						.formatted(teamOrg, status, chans),
+				new TypeReference<Map<String, Object>>() {}));
+		when(repo.findById(uuid)).thenReturn(Optional.of(ug));
+	}
+
+	@Test
+	void nullAndEmptyYieldNoChannels() {
+		assertTrue(service.resolveTeamChannelUuids(null, org).isEmpty());
+		assertTrue(service.resolveTeamChannelUuids(List.of(), org).isEmpty());
+	}
+
+	@Test
+	void teamChannelsAreResolvedDedupedInFirstSeenOrder() {
+		stubTeam(teamA, org, UserGroupStatus.ACTIVE, chan1, chan2);
+		stubTeam(teamB, org, UserGroupStatus.ACTIVE, chan2);
+		assertEquals(List.of(chan1, chan2), service.resolveTeamChannelUuids(List.of(teamA, teamB), org),
+				"a channel shared by two teams is delivered to once, in first-seen order");
+	}
+
+	@Test
+	void aMissingTeamContributesNothingRatherThanFailingTheRoute() {
+		when(repo.findById(teamA)).thenReturn(Optional.empty());
+		stubTeam(teamB, org, UserGroupStatus.ACTIVE, chan2);
+		assertEquals(List.of(chan2), service.resolveTeamChannelUuids(List.of(teamA, teamB), org),
+				"one stale team reference must not silence the rest of the route");
+	}
+
+	@Test
+	void aCrossOrgTeamIsSkipped() {
+		// Writes validate too, but a route saved before a change must not become a
+		// cross-tenant read/delivery path.
+		stubTeam(teamA, otherOrg, UserGroupStatus.ACTIVE, chan1);
+		assertTrue(service.resolveTeamChannelUuids(List.of(teamA), org).isEmpty());
+	}
+
+	@Test
+	void aDeactivatedTeamStopsReceivingNotifications() {
+		// The picker hides INACTIVE teams, so an operator who deactivates one
+		// expects delivery to stop; without this an already-saved route fires forever.
+		stubTeam(teamA, org, UserGroupStatus.INACTIVE, chan1);
+		assertTrue(service.resolveTeamChannelUuids(List.of(teamA), org).isEmpty());
+	}
+
+	@Test
+	void aTeamWithNoChannelsContributesNothing() {
+		stubTeam(teamA, org, UserGroupStatus.ACTIVE);
+		assertTrue(service.resolveTeamChannelUuids(List.of(teamA), org).isEmpty());
+	}
+
+	@Test
+	void aDeactivatedTeamIsHarmlessAtResolutionSoItNeedNotBeRejectedAtSave() {
+		// Regression guard for a lock-out found in live smoke: rejecting a
+		// DEACTIVATED team at SAVE made the subscription un-editable (the operator
+		// could neither keep the team nor drop it, since an emptied route is also
+		// rejected). Resolution skipping it is the real protection -- nothing is
+		// delivered -- so the save-time rejection was removed.
+		stubTeam(teamA, org, UserGroupStatus.INACTIVE, chan1);
+		stubTeam(teamB, org, UserGroupStatus.ACTIVE, chan2);
+		assertEquals(List.of(chan2), service.resolveTeamChannelUuids(List.of(teamA, teamB), org),
+				"the deactivated team contributes nothing while the active one still delivers");
+	}
+}

--- a/backend/src/test/java/io/reliza/service/UserGroupTeamValidationTest.java
+++ b/backend/src/test/java/io/reliza/service/UserGroupTeamValidationTest.java
@@ -1,0 +1,228 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.reliza.common.Utils;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.Integration;
+import io.reliza.model.TeamRole;
+import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
+import io.reliza.model.dto.UpdateUserGroupDto;
+
+/**
+ * Covers the Team-member write-path invariants enforced in
+ * {@link UserGroupService} (T1). These validators are the ONLY thing keeping
+ * {@code memberRoles} an annotation rather than a second roster, so they are
+ * pinned directly rather than through the GraphQL layer.
+ *
+ * <p>They live on the service (not the data fetcher) so that every caller of
+ * {@code updateUserGroupComprehensive} is held to them -- these tests exercise
+ * them at that boundary.
+ */
+class UserGroupTeamValidationTest {
+
+	private static final UUID USER_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final UUID USER_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+	private static final UUID STRANGER = UUID.fromString("99999999-9999-9999-9999-999999999999");
+
+	private static UserGroupData group(String json) {
+		return Utils.OM.readValue(json, UserGroupData.class);
+	}
+
+	// ---------- effectiveRoster mirrors the merge (null = keep, non-null = replace) ----------
+
+	@Test
+	void effectiveRosterFallsBackToStoredWhenUpdateOmitsMembers() {
+		UserGroupData existing = group("""
+				{"name":"T","manualUsers":["%s"],"users":["%s"]}""".formatted(USER_A, USER_B));
+		Set<UUID> roster = UserGroupService.effectiveRoster(existing, UpdateUserGroupDto.builder().build());
+		assertEquals(Set.of(USER_A, USER_B), roster);
+	}
+
+	@Test
+	void effectiveRosterUsesIncomingListWhenSupplied() {
+		UserGroupData existing = group("""
+				{"name":"T","manualUsers":["%s"]}""".formatted(USER_A));
+		Set<UUID> roster = UserGroupService.effectiveRoster(existing,
+				UpdateUserGroupDto.builder().manualUsers(Set.of(USER_B)).build());
+		assertTrue(roster.contains(USER_B));
+		assertTrue(!roster.contains(USER_A), "a replaced roster must not retain the old members");
+	}
+
+	// ---------- a role may only annotate an existing member ----------
+
+	@Test
+	void roleForNonRosterUserIsRejected() {
+		RelizaException e = assertThrows(RelizaException.class, () ->
+				UserGroupService.validateMemberRoles(
+						List.of(new TeamMemberRole(STRANGER, TeamRole.DEVELOPER, null)),
+						Set.of(USER_A)));
+		assertTrue(e.getMessage().contains(STRANGER.toString()),
+				"the message should name the offending user so the operator can fix it");
+	}
+
+	@Test
+	void roleForUserAddedInTheSameCallIsAccepted() {
+		// The roster is computed post-merge, so "add a member and give them a
+		// role in one mutation" must work -- otherwise the UI would need two round trips.
+		assertDoesNotThrow(() -> UserGroupService.validateMemberRoles(
+				List.of(new TeamMemberRole(USER_B, TeamRole.TEAM_LEAD, null)),
+				Set.of(USER_A, USER_B)));
+	}
+
+	@Test
+	void nullMemberRolesIsANoOp() {
+		assertDoesNotThrow(() -> UserGroupService.validateMemberRoles(null, Set.of()));
+	}
+
+	@Test
+	void duplicateRoleForSameUserIsRejected() {
+		// getRoleForUser returns a single Optional, so a second entry would be
+		// silently dropped -- reject rather than persist a role that never applies.
+		assertThrows(RelizaException.class, () -> UserGroupService.validateMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.QA, null),
+						new TeamMemberRole(USER_A, TeamRole.TEAM_LEAD, null)),
+				Set.of(USER_A)));
+	}
+
+	// ---------- CUSTOM requires a label, checked post-sanitization ----------
+
+	@Test
+	void customRoleWithoutLabelIsRejected() {
+		assertThrows(RelizaException.class, () -> UserGroupService.validateCustomRole(TeamRole.CUSTOM, null));
+		assertThrows(RelizaException.class, () -> UserGroupService.validateCustomRole(TeamRole.CUSTOM, ""));
+	}
+
+	@Test
+	void customRoleThatSanitizesToEmptyIsRejected() {
+		// The order matters: "<script>x</script>" is non-blank on the way in but
+		// sanitizes to "", which is exactly the state the CUSTOM rule forbids.
+		// Sanitizing first is what makes this reachable.
+		List<TeamMemberRole> sanitized = UserGroupData.sanitizeMemberRoles(
+				List.of(new TeamMemberRole(USER_A, TeamRole.CUSTOM, "<script>x</script>")));
+		assertThrows(RelizaException.class,
+				() -> UserGroupService.validateMemberRoles(sanitized, Set.of(USER_A)));
+	}
+
+	@Test
+	void nonCustomRoleNeedsNoLabel() {
+		assertDoesNotThrow(() -> UserGroupService.validateCustomRole(TeamRole.SECURITY_SPECIALIST, null));
+	}
+
+	// ---------- external members must stay reachable ----------
+
+	@Test
+	void externalMemberWithBlankContactIsRejected() {
+		assertThrows(RelizaException.class, () -> UserGroupService.validateExternalMembers(
+				List.of(new ExternalTeamMember("Vendor", "  ", TeamRole.DEVELOPER, null))));
+	}
+
+	@Test
+	void externalMemberThatSanitizesToBlankNameIsRejected() {
+		// GraphQL String! stops null but not a pure-markup value that sanitizes away.
+		List<ExternalTeamMember> sanitized = UserGroupData.sanitizeExternalMembers(
+				List.of(new ExternalTeamMember("<script>x</script>", "ops@vendor.example", TeamRole.QA, null)));
+		assertThrows(RelizaException.class, () -> UserGroupService.validateExternalMembers(sanitized));
+	}
+
+	@Test
+	void wellFormedExternalMemberIsAccepted() {
+		assertDoesNotThrow(() -> UserGroupService.validateExternalMembers(
+				List.of(new ExternalTeamMember("Vendor Ops", "ops@vendor.example", TeamRole.CUSTOM, "On-call"))));
+	}
+
+	private static final UUID ORG = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+	/** An Integration row whose record_data carries the given org. */
+	private static Integration channel(UUID uuid, UUID org) {
+		Integration i = new Integration();
+		i.setUuid(uuid);
+		// name + a destination type are both required now: the validator checks the
+		// integration really IS a notification channel, not just any same-org row.
+		i.setRecordData(Map.of("uuid", uuid.toString(), "org", org.toString(),
+				"identifier", "chan", "name", "Alerts", "type", "SLACK"));
+		return i;
+	}
+
+	/** Service with only the channel dependency wired -- that is all these checks touch. */
+	private static UserGroupService newServiceWithChannels(Integration found) {
+		NotificationChannelService ncs = mock(NotificationChannelService.class);
+		when(ncs.getChannel(any(UUID.class)))
+				.thenReturn(null == found ? Optional.empty() : Optional.of(found));
+		UserGroupService svc = new UserGroupService();
+		ReflectionTestUtils.setField(svc, "notificationChannelService", ncs);
+		return svc;
+	}
+
+	// ---------- T3: a team's own notification channels ----------
+
+	@Test
+	void nullChannelsIsANoOp() {
+		assertDoesNotThrow(() -> newServiceWithChannels(null).validateNotificationChannels(null, ORG));
+	}
+
+	@Test
+	void aChannelInTheSameOrgIsAccepted() {
+		UUID ch = UUID.randomUUID();
+		assertDoesNotThrow(() -> newServiceWithChannels(channel(ch, ORG))
+				.validateNotificationChannels(Set.of(ch), ORG));
+	}
+
+	@Test
+	void aMissingChannelIsRejectedAtSaveTimeNotFanOutTime() {
+		UUID ch = UUID.randomUUID();
+		RelizaException e = assertThrows(RelizaException.class,
+				() -> newServiceWithChannels(null).validateNotificationChannels(Set.of(ch), ORG));
+		assertTrue(e.getMessage().contains(ch.toString()), e.getMessage());
+	}
+
+	@Test
+	void aCrossOrgChannelIsRejected() {
+		UUID ch = UUID.randomUUID();
+		assertThrows(RelizaException.class, () -> newServiceWithChannels(channel(ch, UUID.randomUUID()))
+				.validateNotificationChannels(Set.of(ch), ORG));
+	}
+
+	@Test
+	void aNullChannelEntryIsRejected() {
+		Set<UUID> withNull = new LinkedHashSet<>();
+		withNull.add(null);
+		assertThrows(RelizaException.class,
+				() -> newServiceWithChannels(null).validateNotificationChannels(withNull, ORG));
+	}
+
+	@Test
+	void aNonChannelIntegrationCannotBeATeamChannel() {
+		// A same-org CI integration (DTrack/GitHub/Jira) must be refused: fan-out
+		// would otherwise write a delivery row per event that the worker
+		// terminates FAILED for want of a dispatcher.
+		UUID ch = UUID.randomUUID();
+		Integration ci = new Integration();
+		ci.setUuid(ch);
+		ci.setRecordData(Map.of("uuid", ch.toString(), "org", ORG.toString(),
+				"identifier", "dt", "name", "Dependency Track", "type", "DEPENDENCYTRACK"));
+		assertThrows(RelizaException.class,
+				() -> newServiceWithChannels(ci).validateNotificationChannels(Set.of(ch), ORG));
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/TeamRoleSchemaEnumSyncTest.java
+++ b/backend/src/test/java/io/reliza/ws/TeamRoleSchemaEnumSyncTest.java
@@ -1,0 +1,90 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.TeamRole;
+
+/**
+ * Regression guard for the Team-primitive role enum (sibling of
+ * {@code ComponentOwnershipSchemaEnumSyncTest} /
+ * {@code NotificationSchemaEnumSyncTest}).
+ *
+ * <p>{@code TeamRole} is declared in BOTH the Java model and
+ * {@code schema.graphqls}, and DGS binds the GraphQL enum to the Java enum of the
+ * same name -- so a value present on one side but not the other silently breaks
+ * binding. Adding an org-facing role is exactly the kind of change that lands on
+ * one side only, and the failure mode (a role that cannot be selected, or a
+ * deserialization error at request time) is invisible until runtime. This test
+ * parses the raw schema (no Spring / DGS) and asserts the value sets are equal.
+ */
+class TeamRoleSchemaEnumSyncTest {
+
+	/** "enum Foo { ... }" block -- captures the body between the braces. */
+	private static final Pattern ENUM_BLOCK = Pattern.compile(
+			"enum\\s+(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+	@Test
+	void teamRoleEnumIsInSync() {
+		assertEnumInSync("TeamRole",
+				Arrays.stream(TeamRole.values()).map(Enum::name)
+						.collect(Collectors.toCollection(TreeSet::new)));
+	}
+
+	private void assertEnumInSync(String schemaEnumName, Set<String> javaValues) {
+		Set<String> schemaValues = readSchemaEnum(schemaEnumName);
+		assertEquals(javaValues, schemaValues,
+				"GraphQL enum " + schemaEnumName + " drifted from Java enum;"
+						+ " missing in schema: " + diff(javaValues, schemaValues)
+						+ "; extra in schema: " + diff(schemaValues, javaValues));
+	}
+
+	private static Set<String> diff(Set<String> a, Set<String> b) {
+		Set<String> r = new LinkedHashSet<>(a);
+		r.removeAll(b);
+		return r;
+	}
+
+	private static Set<String> readSchemaEnum(String enumName) {
+		String schema = readSchema();
+		Matcher m = ENUM_BLOCK.matcher(schema);
+		while (m.find()) {
+			if (!enumName.equals(m.group(1))) continue;
+			Set<String> out = new TreeSet<>();
+			for (String raw : m.group(2).split("\\R")) {
+				String line = raw.trim();
+				int hash = line.indexOf('#');
+				if (hash >= 0) line = line.substring(0, hash).trim();
+				if (line.isEmpty()) continue;
+				out.add(line);
+			}
+			return out;
+		}
+		throw new AssertionError("Did not find enum " + enumName + " in schema.graphqls");
+	}
+
+	private static String readSchema() {
+		try (InputStream in = TeamRoleSchemaEnumSyncTest.class.getResourceAsStream(
+				"/schema/schema.graphqls")) {
+			if (in == null) throw new IllegalStateException("schema.graphqls not on test classpath");
+			return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/UserGroupTest.java
+++ b/backend/src/test/java/io/reliza/ws/UserGroupTest.java
@@ -24,7 +24,10 @@ import io.reliza.exceptions.RelizaException;
 import io.reliza.model.Organization;
 import io.reliza.model.User;
 import io.reliza.model.UserData;
+import io.reliza.model.TeamRole;
 import io.reliza.model.UserGroupData;
+import io.reliza.model.UserGroupData.ExternalTeamMember;
+import io.reliza.model.UserGroupData.TeamMemberRole;
 import io.reliza.model.WhoUpdated;
 import io.reliza.model.dto.CreateUserGroupDto;
 import io.reliza.model.dto.UpdateUserGroupDto;
@@ -501,6 +504,12 @@ public class UserGroupTest {
 				.groupId(created.getUuid())
 				.users(Set.of(testUser1, testUser2))
 				.connectedSsoGroups(Set.of("lifecycle-sso"))
+				// T1 Team fields: exercised through the real JSONB round-trip so a
+				// serialization-side break (record component or enum that fails to
+				// bind) is caught here rather than by hand-written fixture JSON.
+				.memberRoles(List.of(new TeamMemberRole(testUser1, TeamRole.TEAM_LEAD, null)))
+				.externalMembers(List.of(new ExternalTeamMember(
+						"Lifecycle Vendor", "vendor@lifecycle.example", TeamRole.CUSTOM, "On-call")))
 				.build();
 		userGroupService.updateUserGroupComprehensive(enrichDto, WhoUpdated.getTestWhoUpdated());
 
@@ -521,6 +530,17 @@ public class UserGroupTest {
 		Assertions.assertTrue(restored.getUsers().contains(testUser1));
 		Assertions.assertTrue(restored.getUsers().contains(testUser2));
 		Assertions.assertTrue(restored.getConnectedSsoGroups().contains("lifecycle-sso"));
+		// T1: roles + external members survive the deactivate/restore cycle
+		Assertions.assertEquals(1, restored.getMemberRoles().size());
+		Assertions.assertEquals(TeamRole.TEAM_LEAD, restored.getMemberRoles().get(0).role());
+		Assertions.assertEquals(testUser1, restored.getMemberRoles().get(0).userRef());
+		Assertions.assertTrue(restored.getRoleForUser(testUser1).isPresent(),
+				"the role must resolve for a user still on the roster");
+		Assertions.assertEquals(1, restored.getExternalMembers().size());
+		Assertions.assertEquals("Lifecycle Vendor", restored.getExternalMembers().get(0).name());
+		Assertions.assertEquals("On-call", restored.getExternalMembers().get(0).customRole());
+		Assertions.assertEquals(2, restored.getAllUsers().size(),
+				"the external member must not have joined the durability roster");
 	}
 
 	// ==================== T8: CREATE-AFTER-RESTORE CYCLE ====================

--- a/ui/src/utils/changelogQueryTexts.ts
+++ b/ui/src/utils/changelogQueryTexts.ts
@@ -12,14 +12,19 @@
 // but derived from one source instead of hand-maintained fragment pairs.
 // RULE: a tagged selection must be self-contained on its one line (inline the
 // object body, no multi-line fragment interpolation).
+// Currently NO line is tagged: the CE mirror caught up with the re-scan
+// visibility fields (scanArrivalDate/carriers/baselineRelease), so they were
+// untagged and the fallback is dormant. Tag future Pro-first fields the same
+// way to re-arm it; changelogSchemaDrift.spec.ts keeps the stripped documents
+// valid against the CE mirror either way.
 const ADDITIVE_FIELD_MARKER = '#additive-field'
 
 export function stripAdditiveFields(queryText: string): string {
     return queryText.split('\n').filter((line) => !line.includes(ADDITIVE_FIELD_MARKER)).join('\n')
 }
 
-// One-line ComponentAttribution selection for marker-tagged carrier fields
-// (the multi-line COMPONENT_ATTRIBUTION_FRAGMENT cannot sit on a tagged line).
+// One-line ComponentAttribution selection for single-line carrier fields
+// (a tagged line cannot interpolate the multi-line COMPONENT_ATTRIBUTION_FRAGMENT).
 const ATTRIBUTION_INLINE = 'componentUuid componentName releaseUuid releaseVersion branchUuid branchName'
 
 // Fragments selecting vulnerability findings inline the knownExploited field
@@ -150,7 +155,7 @@ const NONE_RELEASE_CHANGES_FRAGMENT = `
     version
     lifecycle
     createdDate
-    baselineRelease #additive-field
+    baselineRelease
     commits {
         ${CODE_COMMIT_FRAGMENT}
     }
@@ -244,9 +249,9 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
             ${ORG_LEVEL_CONTEXT_FRAGMENT}
         }
         analysisState
-        scanArrivalDate #additive-field
-        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
-        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        scanArrivalDate
+        earliestCarrier { ${ATTRIBUTION_INLINE} }
+        latestCarrier { ${ATTRIBUTION_INLINE} }
     }
     violations {
         findingKey
@@ -271,9 +276,9 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
             ${ORG_LEVEL_CONTEXT_FRAGMENT}
         }
         analysisState
-        scanArrivalDate #additive-field
-        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
-        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        scanArrivalDate
+        earliestCarrier { ${ATTRIBUTION_INLINE} }
+        latestCarrier { ${ATTRIBUTION_INLINE} }
     }
     weaknesses {
         findingKey
@@ -300,9 +305,9 @@ const FINDING_CHANGES_WITH_ATTRIBUTION_FRAGMENT = `
             ${ORG_LEVEL_CONTEXT_FRAGMENT}
         }
         analysisState
-        scanArrivalDate #additive-field
-        earliestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
-        latestCarrier { ${ATTRIBUTION_INLINE} } #additive-field
+        scanArrivalDate
+        earliestCarrier { ${ATTRIBUTION_INLINE} }
+        latestCarrier { ${ATTRIBUTION_INLINE} }
     }
 `
 

--- a/ui/src/utils/changelogSchemaDrift.spec.ts
+++ b/ui/src/utils/changelogSchemaDrift.spec.ts
@@ -49,14 +49,13 @@ describe('changelog stripped selections vs the CE mirror schema (in-repo, always
         })
     }
 
-    // Once the CE mirror catches up (full documents validate clean there), the
-    // tagged lines should be untagged and the fallback retired for these
-    // fields -- this test surfacing as a failure is that reminder.
-    it('at least one full document is INVALID against the CE mirror (fallback is load-bearing)', () => {
-        if (!ceSchema) return
-        const anyRejected = queryEntries.some(([, text]) => validate(ceSchema, parse(text)).length > 0)
-        expect(anyRejected).toBe(true)
-    })
+    // NOTE: this suite used to also assert that at least one FULL document was
+    // INVALID against the CE mirror ("fallback is load-bearing") as a reminder
+    // to untag fields once the mirror caught up. It caught up with the re-scan
+    // visibility fields (2026-08 Pro sync), the lines were untagged, and the
+    // reminder test retired with them. The stripped-vs-CE invariant above stays:
+    // it is what guarantees the runtime fallback document remains valid if
+    // future Pro-first fields get tagged again.
 })
 
 describe('changelog full selections vs the Pro schema (skipped if rearm-core absent)', () => {

--- a/ui/src/utils/notificationInboxSchemaDrift.spec.ts
+++ b/ui/src/utils/notificationInboxSchemaDrift.spec.ts
@@ -33,16 +33,13 @@ describe('inbox core selection vs the CE mirror schema (in-repo, always runs)', 
         expect(validate(ceSchema, INBOX_QUERY_CORE).map(e => e.message)).toEqual([])
     })
 
-    // Proves the core/enrichment split is actually doing something: at least
-    // one enrichment field is genuinely absent from the CE mirror, so FULL is
-    // rejected there. If FULL ever validates clean against CE, the split has
-    // silently become meaningless (enrichment caught up, or a field was
-    // miscategorised) -- surface that so the partition gets revisited.
-    it('the FULL inbox selection is INVALID against the CE mirror (split is load-bearing)', () => {
-        if (!ceSchema) return
-        expect(INBOX_ENRICHMENT_ITEM_FIELDS.length).toBeGreaterThan(0)
-        expect(validate(ceSchema, INBOX_QUERY_FULL).length).toBeGreaterThan(0)
-    })
+    // NOTE: this suite used to also assert that the FULL selection was INVALID
+    // against the CE mirror ("split is load-bearing"). The mirror caught up with
+    // the enrichment fields (Pro sync), so that canary fired and was retired --
+    // the FULL/CORE split is now dormant at runtime (FULL succeeds everywhere).
+    // The split machinery stays: move future Pro-first fields into
+    // INBOX_ENRICHMENT_ITEM_FIELDS to re-arm it; the CORE-vs-CE invariant above
+    // keeps the fallback document valid either way.
 })
 
 describe('inbox full selection vs the Pro schema (skipped if rearm-core absent)', () => {

--- a/ui/src/utils/routeInputSchemaDrift.spec.ts
+++ b/ui/src/utils/routeInputSchemaDrift.spec.ts
@@ -62,14 +62,16 @@ describe('buildNotificationRouteInput vs the CE mirror schema (in-repo, always r
         expect(ceSchema).not.toBeNull()
     })
 
-    it('CE really does lack `teams` -- the premise of the omission', () => {
+    // The old premise test here asserted CE really DID lack `teams`, as the
+    // reminder to simplify the omission once CE caught up. The 2026-08 Pro sync
+    // brought `teams` into the CE mirror, so the premise flipped: assert the
+    // caught-up reality instead. The omit-when-empty behavior itself stays --
+    // it is harmless on both editions (absent and empty lists are equivalent)
+    // and still protects any deployed CE backend that predates the sync.
+    it('CE now models `teams` -- a route WITH teams coerces cleanly on CE too', () => {
         if (!ceSchema) return
-        // Guards against "fixed" meaning "CE caught up and we forgot". If CE
-        // gains `teams`, this fails and the omission can be simplified away.
-        const errs = coerceErrors(ceSchema, 'NotificationRouteInput', {
-            channels: ['ch-1'], teams: ['team-1'],
-        })
-        expect(errs.join(' ')).toMatch(/teams/)
+        expect(coerceErrors(ceSchema, 'NotificationRouteInput',
+            buildNotificationRouteInput(ROUTE_WITH_TEAMS))).toEqual([])
     })
 
     it('a route with NO teams coerces cleanly on CE', () => {


### PR DESCRIPTION
Routine backend sync-up with ReARM Pro via `backend/copy-src.sh` (shared `src/` tree mirrored; `oss/`, `saas/` and the per-repo excluded tests untouched).

**What this brings to CE:**
- **Changelog re-scan visibility**: late-advisory findings (a CVE matched by a later re-scan against already-shipped releases) get an arrival date + earliest/latest carrier attribution (`scanArrivalDate`, `earliestCarrier`, `latestCarrier`), the date-window NONE changelog shows every in-window release, and a component's first-ever release renders as a labeled baseline (`baselineRelease`) instead of being suppressed.
- **Duplicate component registration repair**: unified VCS-URI canonicalization, tri-state component resolution (no create on ambiguity), feature-gated repair sweep + `repairDuplicateComponents` org-admin mutation + startup duplicate census.
- **Auto-integrate queue hardening**: a re-trigger arriving while a worker holds the lease is no longer lost (claim timestamp + conditional clear), and the auto-integrate test suite is deterministic.
- **Teams**: `TeamRole`, org-wide team-assignment rules (`setGlobalTeamAssignmentRules`), team notification-channel routing (T3), with tests.
- **KEV series** support in the findings-over-time analytics.

**OSS reconciliation check:** none needed — CE `oss/` classes compile untouched (full `test-compile` clean) and the backend suite runs at parity. The only local test errors are environment artifacts: the two `UserTest` fixed-email collisions against a persistent dev database (green on a fresh DB), and one non-reproducing Mockito ordering flake in `FindingChangeEventEmitIntegrationTest` (passes 4/4 in isolation and on full-suite re-run).

**UI (small, folded in):** the CE schema catching up fires three schema-drift retirement canaries that were designed for exactly this moment — retired so vitest is green post-merge: changelog additive-field fallback untagged (machinery kept dormant for future Pro-first fields), notification-inbox FULL/CORE canary retired (split kept dormant), and the notification-route `teams` premise test flipped to assert `teams` now coerces cleanly on CE (omit-when-empty behavior kept — it still protects deployed CE backends that predate this sync). `validate:graphql`: 0 failures, 0 drift warnings (was 4). Vitest 112/112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)