### PR TITLE
fix(analytics): persist kevCount through the production seed/refresh writer

### DIFF
--- a/backend/src/main/java/io/reliza/service/AnalyticsMetricsService.java
+++ b/backend/src/main/java/io/reliza/service/AnalyticsMetricsService.java
@@ -93,6 +93,30 @@ public class AnalyticsMetricsService {
 		return rows.stream().flatMap(r -> mapChartDaoToChartDtos(r, zone).stream()).toList();
 	}
 	
+	/**
+	 * The numeric-metrics fields persisted onto analytics_metrics rows and read
+	 * back by the findings-over-time chart SQL. SHARED between this service's
+	 * save() and OssAnalyticsMetricsService.save() -- the production seed and
+	 * today-refresh write through the latter, and a field present in only one
+	 * copy silently never reaches the chart (which is exactly how the KEV
+	 * series shipped without kevCount ever being persisted by the real write
+	 * path).
+	 */
+	static final List<String> NUMERIC_METRIC_FIELDS = List.of(
+			"critical", "high", "medium", "low", "unassigned", "kevCount",
+			"policyViolationsLicenseTotal", "policyViolationsOperationalTotal",
+			"policyViolationsSecurityTotal");
+
+	/** Copy the whitelisted numeric fields out of a serialized metrics map. */
+	public static Map<String, Object> extractNumericMetrics(Map<String, Object> metricsMap) {
+		Map<String, Object> nm = new java.util.LinkedHashMap<>();
+		for (String field : NUMERIC_METRIC_FIELDS) {
+			Object v = metricsMap.get(field);
+			if (v != null) nm.put(field, v);
+		}
+		return nm;
+	}
+
 	private List<VulnViolationsChartDto> mapChartDaoToChartDtos(VulnViolationsChartDao row, java.time.ZoneId zone) {
 		LocalDate localDate = LocalDate.parse(row.getDateKey());
 		ZonedDateTime date = localDate.atStartOfDay(zone);
@@ -778,14 +802,7 @@ public class AnalyticsMetricsService {
 		@SuppressWarnings("unchecked")
 		Map<String, Object> metricsMap = (Map<String, Object>) recordData.get("metrics");
 		if (metricsMap != null) {
-			Map<String, Object> nm = new java.util.LinkedHashMap<>();
-			for (String field : List.of("critical", "high", "medium", "low", "unassigned", "kevCount",
-					"policyViolationsLicenseTotal", "policyViolationsOperationalTotal",
-					"policyViolationsSecurityTotal")) {
-				Object v = metricsMap.get(field);
-				if (v != null) nm.put(field, v);
-			}
-			am.setNumericMetrics(nm);
+			am.setNumericMetrics(extractNumericMetrics(metricsMap));
 		}
 		// entity field initializer only stamps construction time; on re-save
 		// (the today-row upsert path) it must be bumped explicitly, matching

--- a/backend/src/main/java/io/reliza/service/oss/OssAnalyticsMetricsService.java
+++ b/backend/src/main/java/io/reliza/service/oss/OssAnalyticsMetricsService.java
@@ -189,14 +189,11 @@ public class OssAnalyticsMetricsService {
 		@SuppressWarnings("unchecked")
 		Map<String, Object> metricsMap = (Map<String, Object>) recordData.get("metrics");
 		if (metricsMap != null) {
-			Map<String, Object> nm = new java.util.LinkedHashMap<>();
-			for (String field : List.of("critical", "high", "medium", "low", "unassigned",
-					"policyViolationsLicenseTotal", "policyViolationsOperationalTotal",
-					"policyViolationsSecurityTotal")) {
-				Object v = metricsMap.get(field);
-				if (v != null) nm.put(field, v);
-			}
-			am.setNumericMetrics(nm);
+			// Shared field list -- this save() is the one the midnight seed and
+			// the change-driven today-refresh actually write through; a field
+			// added only to AnalyticsMetricsService.save() never reaches the
+			// chart (the KEV series shipped that way).
+			am.setNumericMetrics(AnalyticsMetricsService.extractNumericMetrics(metricsMap));
 		}
 		// entity field initializer only stamps construction time; on re-save
 		// (the today-row upsert path) it must be bumped explicitly, matching

--- a/backend/src/test/java/io/reliza/service/KevSeriesChartTest.java
+++ b/backend/src/test/java/io/reliza/service/KevSeriesChartTest.java
@@ -32,6 +32,7 @@ import io.reliza.model.dto.CreateComponentDto;
 import io.reliza.model.dto.ReleaseDto;
 import io.reliza.model.dto.ReleaseMetricsDto;
 import io.reliza.repositories.AnalyticsMetricsRepository;
+import io.reliza.service.oss.OssAnalyticsMetricsService;
 import io.reliza.service.oss.OssReleaseService;
 import io.reliza.ws.App;
 import io.reliza.ws.oss.TestInitializer;
@@ -61,6 +62,7 @@ public class KevSeriesChartTest {
 	@Autowired private ComponentService componentService;
 	@Autowired private BranchService branchService;
 	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private OssAnalyticsMetricsService ossAnalyticsMetricsService;
 	@Autowired private SharedReleaseService sharedReleaseService;
 	@Autowired private TestInitializer testInitializer;
 
@@ -156,5 +158,67 @@ public class KevSeriesChartTest {
 		assertTrue(kev.isPresent(), "branch chart must emit the KEV series");
 		assertEquals(1, kev.get().num());
 		assertEquals(9, dtos.size(), "compute path emits all nine series");
+	}
+
+	/**
+	 * Goes through the PRODUCTION org-row writer -- the OssAnalyticsMetricsService
+	 * save() that the midnight seed and the change-driven today-refresh use --
+	 * rather than writing rows via the repository. The KEV series originally
+	 * shipped with kevCount added only to AnalyticsMetricsService.save(), a
+	 * duplicated whitelist the production path never calls, so the field was
+	 * never persisted by a real compute; a repository-written fixture cannot
+	 * catch that class of bug.
+	 */
+	@Test
+	public void productionOrgComputePersistsKevCount() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		String slug = "it-kevprod-" + UUID.randomUUID().toString().substring(0, 8);
+		UUID componentUuid = componentService.createComponent(CreateComponentDto.builder()
+				.organization(org.getUuid())
+				.name(slug)
+				.type(ComponentType.COMPONENT)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build(), WU).getUuid();
+		Branch branch = branchService.findBranchByName(componentUuid, "main", true, WU).get();
+		UUID releaseUuid = ossReleaseService.createRelease(ReleaseDto.builder()
+				.component(componentUuid)
+				.branch(branch.getUuid())
+				.org(org.getUuid())
+				.status(ReleaseData.ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseData.ReleaseLifecycle.ASSEMBLED)
+				.version("1.0.0")
+				.build(), WU).getUuid();
+
+		Release r = sharedReleaseService.getRelease(releaseUuid).orElseThrow();
+		ReleaseMetricsDto rmd = new ReleaseMetricsDto();
+		rmd.setVulnerabilityDetails(List.of(
+				new ReleaseMetricsDto.VulnerabilityDto(
+						"pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1", "CVE-2021-44228",
+						ReleaseMetricsDto.VulnerabilitySeverity.CRITICAL,
+						null, null, null, null, null, null, null, null, null, null, null,
+						Boolean.TRUE),
+				new ReleaseMetricsDto.VulnerabilityDto(
+						"pkg:maven/org.springframework/spring-beans@5.3.17", "CVE-2022-22965",
+						ReleaseMetricsDto.VulnerabilitySeverity.HIGH,
+						null, null, null, null, null, null, null, null, null, null, null,
+						Boolean.FALSE)));
+		rmd.computeMetricsFromFacts();
+		sharedReleaseService.saveReleaseMetrics(r, rmd);
+
+		ZonedDateTime now = ZonedDateTime.now();
+		String todayKey = now.toLocalDate().toString();
+		ossAnalyticsMetricsService.computeAndRecordAnalyticsMetricsForOrgAndDate(org.getUuid(), todayKey, WU);
+
+		List<VulnViolationsChartDto> dtos = analyticsMetricsService.listChartDataByOrgDates(
+				org.getUuid(), now.minusDays(1), now.plusDays(1));
+		Optional<VulnViolationsChartDto> kev = kevPointOn(dtos, todayKey);
+		assertTrue(kev.isPresent(),
+				"the production seed/refresh writer must persist kevCount so the chart emits the KEV point");
+		assertEquals(1, kev.get().num());
+		// and the rest of the row is intact
+		assertTrue(dtos.stream().anyMatch(d -> "Critical Vulnerabilities".equals(d.type())
+				&& d.createdDate().toLocalDate().toString().equals(todayKey) && d.num() == 1),
+				"critical count must persist alongside kevCount");
 	}
 }


### PR DESCRIPTION
CE port of relizaio/rearm-saas#385 — the Pro patch applied clean; opened separately at the maintainer's request since this is the edition the bug was reported from.

**Bug:** the numeric-metrics whitelist existed in two identical copies; the midnight seed and change-driven today-refresh write through `OssAnalyticsMetricsService.save()`, which never got `kevCount` — so the KEV series on the findings-over-time chart was never fed by any real compute. An org with live known-exploited findings showed no KEV line at all.

**Fix:** one shared field list (`AnalyticsMetricsService.NUMERIC_METRIC_FIELDS`) consumed by both writers via `extractNumericMetrics()`.

**Test:** `productionOrgComputePersistsKevCount` drives the real seed/refresh writer with a release whose stamped metrics carry a KEV finding and asserts the chart emits the point; verified red against the unfixed writer (on the Pro side), green here — all 3 `KevSeriesChartTest` tests pass in this repo.

**Note for affected instances:** after this fix, the series starts with the next seed/refresh write. Orgs whose releases haven't been rescanned since KEV support landed may chart `kevCount=0` until their next scan — the bootstrap catalog sync deliberately skips re-stamping stored release metrics; tracked as a separate follow-up on the Pro side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)