### PR TITLE
feat(ui): release findings recompute button + select/deselect-all on chart filter

### DIFF
--- a/ui/src/components/FindingsOverTimeChart.vue
+++ b/ui/src/components/FindingsOverTimeChart.vue
@@ -27,6 +27,10 @@
                     </n-icon>
                 </template>
                 <div class="series-filter-list">
+                    <div class="series-filter-actions">
+                        <a class="clickable" @click="setAllSeries(true)">Select all</a>
+                        <a class="clickable" @click="setAllSeries(false)">Deselect all</a>
+                    </div>
                     <n-checkbox
                         v-for="s in seriesOptions"
                         :key="s.name"
@@ -47,6 +51,10 @@
                     </n-icon>
                 </template>
                 <div class="series-filter-list">
+                    <div class="series-filter-actions">
+                        <a class="clickable" @click="setAllSeries(true)">Select all</a>
+                        <a class="clickable" @click="setAllSeries(false)">Deselect all</a>
+                    </div>
                     <n-checkbox
                         v-for="s in seriesOptions"
                         :key="s.name"
@@ -186,6 +194,12 @@ function syncSeriesSelection() {
 function applySeriesFilter() {
     analyticsMetrics.value.data.values = rawChartValues.value.filter(
         (v: any) => selectedSeries.value.includes(v.type))
+}
+
+function setAllSeries(checked: boolean) {
+    selectedSeries.value = checked ? seriesOptions.value.map(s => s.name) : []
+    applySeriesFilter()
+    renderChart()
 }
 
 function toggleSeries(name: string, checked: boolean) {
@@ -785,6 +799,14 @@ watch(showFindingsPerDay, (newVal) => {
     display: flex;
     flex-direction: column;
     gap: 4px;
+}
+
+.series-filter-actions {
+    display: flex;
+    gap: 12px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid #eee;
+    font-size: 0.85em;
 }
 
 .series-color-dot {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -658,6 +658,15 @@
                             <span title="Licensing Policy Violations" class="circle" :style="{background: constants.ViolationColors.LICENSE, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, '', 'Violation')">{{ updatedRelease.metrics.policyViolationsLicenseTotal }}</span>
                             <span title="Security Policy Violations" class="circle" :style="{background: constants.ViolationColors.SECURITY, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, '', 'Violation')">{{ updatedRelease.metrics.policyViolationsSecurityTotal }}</span>
                             <span title="Operational Policy Violations" class="circle" :style="{background: constants.ViolationColors.OPERATIONAL, cursor: 'pointer'}" @click="viewDetailedVulnerabilitiesForRelease(releaseUuid, '', 'Violation')">{{ updatedRelease.metrics.policyViolationsOperationalTotal }}</span>
+                            <Icon
+                                v-if="isWritable"
+                                class="clickable"
+                                size="18"
+                                title="Recompute findings from current scan and KEV state (no re-scan)"
+                                :style="{ opacity: recomputeFindingsPending ? 0.5 : 1, marginLeft: '10px' }"
+                                @click="recomputeFindings">
+                                <Refresh/>
+                            </Icon>
                         </n-space>
                     </n-gi>
                     <n-gi span="1">
@@ -2692,6 +2701,31 @@ async function saveApprovedEnvOverride () {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     } finally {
         approvedEnvOverridePending.value = false
+    }
+}
+
+// Findings recompute: refreshes this release's metrics from CURRENT scan +
+// KEV state (no Dependency-Track re-scan) -- the per-release remedy for
+// stored metrics gone stale, e.g. KEV membership that arrived after the
+// release was last scanned.
+const recomputeFindingsPending: Ref<boolean> = ref(false)
+async function recomputeFindings () {
+    if (recomputeFindingsPending.value) return
+    recomputeFindingsPending.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation recomputeReleaseFindings($releaseUuid: ID!) {
+                    recomputeReleaseFindings(releaseUuid: $releaseUuid)
+                }`,
+            variables: { releaseUuid: updatedRelease.value.uuid }
+        })
+        notify('success', 'Recomputed', 'Findings recomputed from current scan and KEV state.')
+        await fetchRelease()
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        recomputeFindingsPending.value = false
     }
 }
 


### PR DESCRIPTION
Two additions, per maintainer request:

## Release view: findings recompute button

A refresh icon next to the severity/violation circles (shown for `isWritable` users, matching the mutation's component-WRITE auth) calls **`recomputeReleaseFindings`** (relizaio/rearm-saas#386 / relizaio/rearm#255) — refreshes the release's metrics from current scan + KEV state, no Dependency-Track re-scan. Pending state dims the icon; success re-fetches the release so the circles update in place.

**Merge order:** needs rearm#255 (backend mutation) deployed first — the button errors against an older backend.

## Findings-over-time filter: Select all / Deselect all

Two links at the top of the series-filter popover, present in both the widget and full-page header variants. `Select all` re-checks every series present in the data; `Deselect all` clears them (still rendering an empty chart rather than the no-data state — that judgement intentionally stays on the raw fetch result).

## Verification

- `npm run build` clean; deployed as a dev image to the agent-scully sandbox — mutation call, tooltip and both filter links confirmed present in the served bundle.
- Backend side: the sandbox runs a dev image of the #386 branch; the deployed schema carries `recomputeReleaseFindings`, and the mutation's semantics (KEV re-stamp on recompute) are pinned by `RecomputeReleaseFindingsTest`, green in both repos.
- Honest limit: the click path itself was **not** exercised end-to-end — the mutation requires a browser session (user JWT), and no browser automation was run. The wiring mirrors the adjacent `reconcileReleaseSbomComponents` call verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
