### PR TITLE
fix(test): stub the emit spy through the unwrapped target, not the tx proxy

### DIFF
--- a/backend/src/test/java/io/reliza/service/FindingChangeEventEmitIntegrationTest.java
+++ b/backend/src/test/java/io/reliza/service/FindingChangeEventEmitIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.util.AopTestUtils;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -208,8 +209,17 @@ public class FindingChangeEventEmitIntegrationTest {
 		saveMetrics(releaseUuid, metricsWith());
 
 		// Force the REQUIRES_NEW emit to blow up on the next save (which WOULD emit APPEARED).
+		// Stub the UNWRAPPED spy, not the injected bean: emit() is
+		// @Transactional(REQUIRES_NEW), so the injected bean is a CGLIB
+		// transaction proxy around the Mockito spy, and depending on the
+		// wrapping order Spring picked for this context, when(proxy).emit(...)
+		// can fall THROUGH the proxy into the real emit() mid-stubbing --
+		// observed in CE container builds as UnfinishedStubbingException with
+		// the real emit() frames inside the when() call. Unwrapping targets
+		// the spy directly, immune to proxy pass-through.
+		FindingChangeEventEmitter emitterSpy = AopTestUtils.getUltimateTargetObject(findingChangeEventEmitter);
 		doThrow(new RuntimeException("simulated diff-emit failure"))
-				.when(findingChangeEventEmitter).emit(any(), any(), any(), any(), anyInt());
+				.when(emitterSpy).emit(any(), any(), any(), any(), anyInt());
 
 		ReleaseMetricsDto newMetrics = metricsWith(vuln(VulnerabilitySeverity.HIGH, false));
 		// Must NOT propagate -- the failure is swallowed (logged at ERROR).


### PR DESCRIPTION
CE port of relizaio/rearm-saas#387 — same commit, applied clean. This is the fix for the two red backend container builds on main (runs 30729073654 / 30729289600).

**Cause:** `emit()` is `@Transactional(REQUIRES_NEW)`; the injected `@MockitoSpyBean` is a CGLIB tx proxy; `when(proxy).emit(...)` intermittently falls through into the real method mid-stubbing → `UnfinishedStubbingException` (CI stack shows real `emit` frames inside the `when()` call; wrapping order is suite-composition dependent, hence CE-only).

**What CI showed instead:** the cascade — failed docker build → empty `image_digest` → `sbom-sign-scan` "invalid reference format". Cause is the test, not the SBOM phase.

**Fix:** stub via `AopTestUtils.getUltimateTargetObject(...)`. Test-only; class passes 4/4 in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)