### PR TITLE
feat(ui): owner-routing target on notification subscription routes (T4a)

### DIFF
--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -286,7 +286,7 @@
                     </div>
                 </div>
             </div>
-            <SubscriptionsOfOrg :orguuid="orguuid" :isWritable="isWritable" />
+            <SubscriptionsOfOrg :orguuid="orguuid" :isWritable="isWritable" :installationType="installationType" />
         </div>
 
         <!-- ============================== CHANNEL GROUPS ============================== -->

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -177,6 +177,34 @@
                                             automatically.
                                         </div>
                                     </n-gi>
+                                    <!-- T4a. Pro-only: notifyComponentOwner does not exist in the CE
+                                         schema, and GraphQL input coercion rejects unknown keys
+                                         outright, so letting a CE operator tick this would fail the
+                                         WHOLE subscription save -- including edits that never touch
+                                         it. Gated on the real edition signal rather than on
+                                         teamOptions.length like the Teams picker above: that proxy
+                                         is empty on a Pro org with no teams yet, and non-empty on CE
+                                         whenever ghosts survive for a route's saved teams. -->
+                                    <n-gi v-if="isPro" :span="22" :offset="0">
+                                        <n-form-item :label="i === 0 ? 'Component owner' : ''" :show-feedback="false">
+                                            <n-checkbox
+                                                v-model:checked="r.notifyComponentOwner"
+                                                data-testid="route-notify-owner"
+                                            >
+                                                Also notify the team that owns the affected component
+                                            </n-checkbox>
+                                        </n-form-item>
+                                        <div class="muted-12" style="margin-top: -6px; margin-bottom: 6px;">
+                                            Resolved when the event fires, from the component's owner — set
+                                            directly or by an assignment rule. Unlike picking a team above,
+                                            this follows ownership changes on its own, so reassigning a
+                                            component never means editing this subscription.
+                                            <template v-if="!teamOptions.length">
+                                                This org has no teams yet, and only a team can own a
+                                                component, so this delivers nothing until one exists.
+                                            </template>
+                                        </div>
+                                    </n-gi>
                                     <n-gi :span="22" :offset="0">
                                         <n-form-item :label="i === 0 ? 'Perspectives (delivery filter)' : ''" :show-feedback="false">
                                             <n-select
@@ -265,7 +293,7 @@ import { useStore } from 'vuex'
 import {
     NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput,
     NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag, NDropdown, NTooltip,
-    NRadioGroup, NRadioButton, useDialog, useMessage
+    NRadioGroup, NRadioButton, NCheckbox, useDialog, useMessage
 } from 'naive-ui'
 import { CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabler'
 import { useRouter } from 'vue-router'
@@ -280,13 +308,22 @@ import {
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
     extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType,
     buildNotificationFilterInput,
-    buildNotificationRouteInput
+    buildNotificationRouteInput,
+    routeHasTarget
 } from '@/utils/notificationsCommon'
 import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
+import { isProEdition } from '@/utils/editionCapabilities'
 
 const props = defineProps<{
     orguuid: string
     isWritable: boolean
+    // T4a: needed for the owner-routing control, which is a Pro-only route
+    // field. Unlike the Teams picker next to it, teamOptions.length is NOT a
+    // usable proxy here -- it is empty on a Pro org that simply has no teams
+    // yet, and non-empty on CE when ghosts are kept for a route's saved teams.
+    // Sending a Pro-only key to a CE backend fails the WHOLE mutation, so this
+    // gate uses the real edition signal. See editionCapabilities.ts.
+    installationType: string
 }>()
 
 const dialog = useDialog()
@@ -314,6 +351,10 @@ interface SubscriptionRoute {
     channels: string[]
     channelGroups: string[]
     teams: string[]
+    // T4a: deliver to whatever team OWNS each affected component, resolved at
+    // fan-out. Distinct from `teams` above, which is a fixed list the operator
+    // must keep in step with ownership by hand.
+    notifyComponentOwner: boolean
     // Delivery filter: restricts which events this route's channels deliver
     // to the listed perspectives. NOT the inbox/bell visibility gate. Empty
     // = no restriction (all perspectives).
@@ -344,7 +385,8 @@ interface SubscriptionForm {
 }
 
 function freshRoute (): SubscriptionRoute {
-    return { whenSeverityAtLeast: null, channels: [], channelGroups: [], teams: [], perspectives: [] }
+    return { whenSeverityAtLeast: null, channels: [], channelGroups: [], teams: [],
+        notifyComponentOwner: false, perspectives: [] }
 }
 
 function freshSubscriptionForm (): SubscriptionForm {
@@ -399,6 +441,11 @@ const channelOptions = computed(() => {
 })
 
 const teams = ref<any[]>([])
+
+// T4a: owner routing is a Pro-only route field. The control, the client-side
+// "route has a target" check and the error copy all gate on this one flag, so
+// a CE operator can neither author an owner-only route nor be told to.
+const isPro = computed(() => isProEdition(props.installationType))
 
 const teamOptions = computed(() => {
     const selectable = teams.value
@@ -578,6 +625,7 @@ function openEditSubscription (row: SubscriptionRow): void {
                 channels: Array.isArray(r.channels) ? [...r.channels] : [],
                 channelGroups: Array.isArray(r.channelGroups) ? [...r.channelGroups] : [],
                 teams: Array.isArray(r.teams) ? [...r.teams] : [],
+                notifyComponentOwner: r.notifyComponentOwner === true,
                 perspectives: Array.isArray(r.perspectives) ? [...r.perspectives] : [],
                 _raw: r,
             }))
@@ -612,20 +660,24 @@ async function saveSubscription (): Promise<void> {
         subModalError.value = 'Name, at least one event type, and at least one route are required.'
         return
     }
-    // Every route must have at least one channel, group or team; the backend
-    // rejects an empty {channels, channelGroups, teams} anyway, but catch it
-    // client-side for a cleaner error path. Teams count: naming a team INSTEAD
-    // of a channel is the point -- its channel is resolved at fan-out.
-    const emptyRouteIdx = f.routes.findIndex(r =>
-        (r.channels || []).length === 0 && (r.channelGroups || []).length === 0
-        && (r.teams || []).length === 0
-    )
+    // Every route needs at least one target; the backend rejects an empty route
+    // anyway, but catch it client-side for a cleaner error path. Teams and the
+    // owner flag both count: naming a team -- or nobody at all, and letting
+    // ownership decide -- INSTEAD of a channel is the point, since the actual
+    // channel is resolved at fan-out. The owner flag counts ONLY on Pro: on CE
+    // the control is hidden and the key would fail the mutation, so accepting
+    // it as the sole target would wave through a route guaranteed to 400.
+    const emptyRouteIdx = f.routes.findIndex(r => !routeHasTarget(r, isPro.value))
     if (emptyRouteIdx >= 0) {
-        // Don't name a target the operator has no way to pick: on a backend
-        // without team channels the Teams picker is hidden, so "or teams"
-        // would send them hunting for a control that isn't there.
-        const targets = teamOptions.value.length ? 'channels, groups or teams' : 'channels or groups'
-        subModalError.value = `Route ${emptyRouteIdx + 1} has no ${targets} — pick at least one.`
+        // Don't name a target the operator has no way to pick: the Teams picker
+        // is hidden without team channels and the owner checkbox is hidden on
+        // CE, so naming either would send them hunting for a control that
+        // isn't there.
+        const targets = ['channels', 'groups']
+        if (teamOptions.value.length) targets.push('teams')
+        if (isPro.value) targets.push('the component owner')
+        const targetList = `${targets.slice(0, -1).join(', ')} or ${targets[targets.length - 1]}`
+        subModalError.value = `Route ${emptyRouteIdx + 1} has no ${targetList} — pick at least one.`
         return
     }
     // Build the filter input from ONLY the fields NotificationFilterInput
@@ -804,6 +856,31 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
     }
 }
 
+/**
+ * Why a test produced no delivery.
+ *
+ * The default answer names the filter and the severity gate, which is right for
+ * every route target that resolves to a fixed channel. It is WRONG for an
+ * owner-routed route: that resolves through the affected component's owner, so
+ * an unowned component, or an owner team with no channel, yields zero
+ * deliveries with the filter and severity gate working perfectly. Sending the
+ * operator to audit those instead is worse than saying nothing.
+ */
+function noDeliveryExplanation (row: SubscriptionRow): string {
+    const base = 'The synthetic event was injected but produced no delivery for this subscription.'
+    let ownerRouted = false
+    try {
+        const routes = row.routes ? JSON.parse(row.routes) : []
+        ownerRouted = Array.isArray(routes) && routes.some((r: any) => r?.notifyComponentOwner === true)
+    } catch { /* unparseable routes: fall back to the generic explanation */ }
+    if (ownerRouted) {
+        return `${base} A route delivers to the component owner, so this is also what you see when the`
+            + ' affected component has no owner, or its owner team has no notification channel --'
+            + " check those before the subscription's filter or a route's minimum-severity gate."
+    }
+    return `${base} Its filter, or a route's minimum-severity gate, likely excluded it.`
+}
+
 function reportSubscriptionTestResult (
     row: SubscriptionRow,
     items: Array<{ channelUuid: string | null, status: string, lastError: string | null }>,
@@ -815,7 +892,7 @@ function reportSubscriptionTestResult (
             title: `Test result -- ${row.name}`,
             content: timedOut
                 ? 'Still waiting on a delivery after 60s. The event may still be processing -- check Notification History for the result.'
-                : "The synthetic event was injected but produced no delivery for this subscription. Its filter, or a route's minimum-severity gate, likely excluded it.",
+                : noDeliveryExplanation(row),
         })
         return
     }

--- a/ui/src/utils/editionCapabilities.ts
+++ b/ui/src/utils/editionCapabilities.ts
@@ -50,7 +50,7 @@ export const PRO_ONLY_CHANNEL_TYPES: readonly string[] = ['EMAIL', 'SENTINEL']
  * notificationsCommon, which strips them, and routeInputSchemaDrift.spec.ts,
  * which coerces the result against both real schemas.
  */
-export const PRO_ONLY_ROUTE_FIELDS: readonly string[] = ['teams']
+export const PRO_ONLY_ROUTE_FIELDS: readonly string[] = ['teams', 'notifyComponentOwner']
 
 /**
  * Pro (licensed) edition, as far as the UI can tell. Every non-OSS

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -12,6 +12,7 @@ import { print } from 'graphql'
 import {
     relativeTime,
     buildNotificationFilterInput,
+    routeHasTarget,
     LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY,
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
 } from './notificationsCommon'
@@ -119,5 +120,47 @@ describe('buildNotificationFilterInput', () => {
     })
     it('tolerates a null/undefined rawFilter (Create path)', () => {
         expect(buildNotificationFilterInput(null, 'PRESET', '')).toEqual({ mode: 'PRESET', celExpression: null })
+    })
+})
+
+describe('routeHasTarget (client-side mirror of the backend route-emptiness gate)', () => {
+    const empty = { channels: [], channelGroups: [], teams: [], notifyComponentOwner: false }
+
+    it('accepts any of the fixed targets, on either edition', () => {
+        for (const isPro of [true, false]) {
+            expect(routeHasTarget({ ...empty, channels: ['ch-1'] }, isPro)).toBe(true)
+            expect(routeHasTarget({ ...empty, channelGroups: ['g-1'] }, isPro)).toBe(true)
+            expect(routeHasTarget({ ...empty, teams: ['t-1'] }, isPro)).toBe(true)
+        }
+    })
+
+    it('accepts an owner-only route on Pro -- naming no target is the point of T4a', () => {
+        expect(routeHasTarget({ ...empty, notifyComponentOwner: true }, true)).toBe(true)
+    })
+
+    it('REJECTS an owner-only route on CE, where the field would fail the whole save', () => {
+        // The compounding half of the CE gating bug: the control is hidden on
+        // CE, but if the flag is somehow set, counting it as a target lets the
+        // operator author a route guaranteed to 400 the subscription mutation
+        // -- including the edits that have nothing to do with owner routing.
+        expect(routeHasTarget({ ...empty, notifyComponentOwner: true }, false)).toBe(false)
+    })
+
+    it('rejects a genuinely empty route on both editions', () => {
+        expect(routeHasTarget(empty, true)).toBe(false)
+        expect(routeHasTarget(empty, false)).toBe(false)
+        expect(routeHasTarget({}, true)).toBe(false)
+    })
+
+    it('does not treat a false/absent owner flag as a target', () => {
+        expect(routeHasTarget({ ...empty, notifyComponentOwner: undefined }, true)).toBe(false)
+        expect(routeHasTarget({ ...empty, notifyComponentOwner: null }, true)).toBe(false)
+    })
+
+    it('still accepts a Pro route carrying teams even when the owner flag is off', () => {
+        // teams is NOT edition-gated here: CE soft-fails the teams query to [],
+        // so a CE route cannot carry them anyway, and gating would wrongly
+        // reject a Pro route whose team list loaded fine.
+        expect(routeHasTarget({ ...empty, teams: ['t-1'] }, true)).toBe(true)
     })
 })

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -368,9 +368,49 @@ export function buildNotificationRouteInput (route: Record<string, any>): Notifi
     // Send a Pro-only field only when it actually carries a value, so a CE
     // backend never sees the key at all.
     for (const f of PRO_ONLY_ROUTE_FIELDS) {
-        if ((route[f] || []).length > 0) out[f] = route[f]
+        if (carriesValue(route[f])) out[f] = route[f]
     }
     return out
+}
+
+/**
+ * Does this route field carry a value worth sending?
+ *
+ * Pro-only fields are omitted when empty so a CE backend never sees the key at
+ * all. "Empty" depends on the shape: `[]` for the list-valued fields (`teams`),
+ * `false` for the boolean ones (`notifyComponentOwner`).
+ *
+ * Worth stating because the list-only version of this check silently broke the
+ * boolean: `(true || []).length > 0` is `undefined > 0`, i.e. false, so the
+ * field was never sent and owner routing could not be turned on from the UI --
+ * a failure that looks like a backend bug from the operator's side.
+ */
+function carriesValue (v: unknown): boolean {
+    if (Array.isArray(v)) return v.length > 0
+    if (typeof v === 'boolean') return v
+    return v !== null && v !== undefined
+}
+
+/**
+ * Does this route name at least one delivery target?
+ *
+ * Mirrors the backend's per-route emptiness gate so the operator gets a clean
+ * client-side error instead of a mutation failure. Lives here, not inline in
+ * the form, because `isPro` is load-bearing and easy to get wrong: on CE the
+ * owner checkbox is hidden and `notifyComponentOwner` is not in the schema, so
+ * counting it as a target there would wave through a route that is GUARANTEED
+ * to fail the save -- and the save it fails is the whole subscription, not just
+ * that route.
+ *
+ * `teams` is deliberately NOT gated on edition: a CE backend soft-fails the
+ * teams query to `[]`, so a CE route cannot carry teams in the first place,
+ * and gating it would wrongly reject a Pro route whose team list loaded fine.
+ */
+export function routeHasTarget (route: Record<string, any>, isPro: boolean): boolean {
+    if ((route.channels || []).length > 0) return true
+    if ((route.channelGroups || []).length > 0) return true
+    if ((route.teams || []).length > 0) return true
+    return isPro && route.notifyComponentOwner === true
 }
 
 /**

--- a/ui/src/utils/routeInputSchemaDrift.spec.ts
+++ b/ui/src/utils/routeInputSchemaDrift.spec.ts
@@ -127,3 +127,58 @@ describe('buildNotificationRouteInput vs the Pro schema (skipped when rearm-core
         expect(buildNotificationRouteInput(ROUTE_WITH_TEAMS).teams).toEqual(['team-1'])
     })
 })
+
+describe('Pro-only BOOLEAN route fields (notifyComponentOwner)', () => {
+    const ownerRoute = {
+        _raw: { andEnvIn: ['prod'] },
+        whenSeverityAtLeast: 'HIGH',
+        channels: [],
+        channelGroups: [],
+        perspectives: [],
+        teams: [],
+        notifyComponentOwner: true,
+    }
+
+    it('sends the flag when it is on -- Pro must actually receive it', () => {
+        // Guards the shape bug the list-only omit check had: `true.length` is
+        // undefined, so a boolean Pro-only field was silently never sent and
+        // owner routing could not be enabled from the UI at all.
+        expect(buildNotificationRouteInput(ownerRoute).notifyComponentOwner).toBe(true)
+    })
+
+    it('omits the flag when it is off, so CE never sees the key', () => {
+        expect(buildNotificationRouteInput({ ...ownerRoute, notifyComponentOwner: false }))
+            .not.toHaveProperty('notifyComponentOwner')
+        expect(buildNotificationRouteInput({ ...ownerRoute, notifyComponentOwner: undefined }))
+            .not.toHaveProperty('notifyComponentOwner')
+    })
+
+    // runIf, not an early return -- see the comment above the Pro describe
+    // block: an early return reports PASSED when rearm-core is absent, hiding
+    // that Pro went unchecked.
+    it.runIf(proSchema)('an owner-routed route coerces cleanly on Pro', () => {
+        expect(coerceErrors(proSchema!, 'NotificationRouteInput',
+            buildNotificationRouteInput(ownerRoute))).toEqual([])
+    })
+
+    it('CE lacks the field, and the off-state payload still coerces there', () => {
+        if (!ceSchema) return
+        expect(coerceErrors(ceSchema, 'NotificationRouteInput',
+            { channels: ['ch-1'], notifyComponentOwner: true }).join(' '))
+            .toMatch(/notifyComponentOwner/)
+        expect(coerceErrors(ceSchema, 'NotificationRouteInput',
+            buildNotificationRouteInput({ ...ownerRoute, notifyComponentOwner: false, channels: ['ch-1'] })))
+            .toEqual([])
+    })
+
+    it('strips the flag from the _raw passthrough too', () => {
+        // A route created on Pro with owner routing, edited on CE where the
+        // control is absent: _raw is its only carrier.
+        const built = buildNotificationRouteInput({
+            _raw: { notifyComponentOwner: true, andEnvIn: ['prod'] },
+            channels: ['ch-1'],
+        })
+        expect(built).not.toHaveProperty('notifyComponentOwner')
+        expect(built.andEnvIn).toEqual(['prod'])
+    })
+})


### PR DESCRIPTION
Adds the **"Also notify the team that owns the affected component"** control to each subscription route, plus the client-side plumbing for a Pro-only route field that is a **boolean** rather than a list.

Pairs with relizaio/rearm-saas#388 (backend).

## The two bugs this had, both caught by the review gate

**1. The control rendered on CE, where ticking it breaks the entire subscription save.** `notifyComponentOwner` does not exist in the CE schema, and GraphQL input coercion rejects unknown keys outright -- so a CE operator ticking the box fails the **whole** `upsertNotificationSubscription` mutation, including name/event-type/channel edits that never touched owner routing. Exactly the "UI looser than backend" failure `editionCapabilities.ts` was written to prevent. Both review layers reached this independently.

Gated on the real edition signal (`installationType` -> `isProEdition`), **not** on `teamOptions.length` like the Teams picker beside it. That proxy is wrong in both directions: empty on a Pro org that simply has no teams yet, and non-empty on CE whenever ghost options survive for a route's saved teams. `installationType` is now threaded from `OrgIntegrations` into `SubscriptionsOfOrg`.

Two compounding factors fixed with it: the client-side emptiness check accepted an owner-only route on CE (waving through a route *guaranteed* to 400), and the error copy offered "the component owner" in the CE branch -- directly contradicting the comment above it about not naming a target the operator cannot pick.

**2. A boolean Pro-only field was silently never sent.** `buildNotificationRouteInput` omitted Pro-only fields with `(route[f] || []).length > 0` -- array logic. For a boolean, `true.length` is `undefined`, so `notifyComponentOwner` would never have been transmitted, and owner routing would have been impossible to enable from the UI **while looking like a backend fault**. Generalised to a `carriesValue` predicate with tests for the boolean case.

## Other changes

- The route-emptiness check moves to `notificationsCommon.routeHasTarget` so the edition rule is unit-tested rather than inline in the form. There is no Vue component-test harness in this repo and adding `@vue/test-utils` would be an unjustified new dependency, so moving the logic into the tested module is how this gets real coverage.
- A test that produces **no delivery** no longer blames the filter and the severity gate unconditionally. For an owner-routed subscription neither is the likely cause -- an unowned component or an owner team with no channel is -- and sending an operator to audit two things that are working correctly is worse than saying nothing.
- `it.runIf(proSchema)` instead of an early return, per the spec file's own comment: an early return reports PASSED when rearm-core is absent, hiding that Pro went unchecked.

## Validation

Two-layer review gate (generic correctness + a ReARM-conventions pass), then a live round on the sandbox against the real backend: the control round-trips `notifyComponentOwner: true` through save and reload, an owner-only route saves against both backend emptiness gates, and a genuinely empty route is still rejected.

**123/123 UI tests pass** (was 110 + 1 known failure; `#253` retired the stale schema-drift fallback that was failing). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)