### PR TITLE
fix(search): resolve a pasted purl in org-wide SBOM component search (CE mirror of rearm-saas#381)

### DIFF
--- a/backend/src/main/java/io/reliza/common/Utils.java
+++ b/backend/src/main/java/io/reliza/common/Utils.java
@@ -1180,4 +1180,79 @@ public class Utils {
 			return null;
 		}
 	}
+
+	/** Scheme prefix every purl carries, per the purl spec. */
+	public static final String PURL_SCHEME_PREFIX = "pkg:";
+
+	/**
+	 * Whether a string is shaped like a purl, i.e. carries the purl scheme.
+	 * A cheap prefix test, not a parse -- {@link #canonicalizePurl} still
+	 * returns null for a well-prefixed but malformed purl.
+	 */
+	public static boolean isPurl(String value) {
+		return value != null && value.startsWith(PURL_SCHEME_PREFIX);
+	}
+
+	/**
+	 * Escapes SQL LIKE wildcards ({@code %}, {@code _}) and the escape
+	 * character itself so the input matches literally under {@code ESCAPE '\'}.
+	 * Backslash is escaped first, or it would double-escape the escapes the
+	 * later replacements add.
+	 */
+	public static String escapeSqlLikeLiteral(String value) {
+		if (value == null) return "";
+		return value.replace("\\", "\\\\")
+				.replace("%", "\\%")
+				.replace("_", "\\_");
+	}
+
+	/**
+	 * The bare type/namespace/name coordinate of a purl, with version,
+	 * qualifiers and subpath all dropped -- {@code pkg:npm/lodash@4.17.21?foo=bar}
+	 * becomes {@code pkg:npm/lodash}.
+	 *
+	 * <p>This is the anchor for a version-agnostic search: canonical purls are
+	 * stored as {@code <coordinate>@<version>[?qualifiers]}, so the coordinate
+	 * plus an {@code '@'} is a safe prefix for "every version of this package".
+	 * Qualifiers are deliberately dropped rather than preserved (unlike
+	 * {@link #canonicalizePurl}) because they sort *after* the version in a
+	 * purl, so keeping them would break the prefix.
+	 *
+	 * @return the coordinate, or null if {@code purl} is not a parseable purl
+	 */
+	public static String purlCoordinateBase(String purl) {
+		if (!isPurl(purl)) {
+			return null;
+		}
+		try {
+			PackageURL packageUrl = new PackageURL(purl);
+			return PackageURLBuilder.aPackageURL()
+					.withType(packageUrl.getType())
+					.withNamespace(packageUrl.getNamespace())
+					.withName(packageUrl.getName())
+					.build().toString();
+		} catch (MalformedPackageURLException e) {
+			log.warn("Failed to parse PURL for coordinate base: {}", purl, e);
+			return null;
+		}
+	}
+
+	/**
+	 * The version component of a purl, or null when the purl carries none
+	 * (or does not parse). Lets callers distinguish "this purl pins a version"
+	 * from "this purl names a package" without re-implementing purl parsing.
+	 *
+	 * @return the version, or null if absent or {@code purl} does not parse
+	 */
+	public static String purlVersion(String purl) {
+		if (!isPurl(purl)) {
+			return null;
+		}
+		try {
+			return new PackageURL(purl).getVersion();
+		} catch (MalformedPackageURLException e) {
+			log.warn("Failed to parse PURL for version extraction: {}", purl, e);
+			return null;
+		}
+	}
 }

--- a/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
@@ -71,6 +71,44 @@ public interface SbomComponentRepository extends CrudRepository<SbomComponent, U
 			@Param("version") String version);
 
 	/**
+	 * Version-agnostic purl search: every canonical component sharing one
+	 * type/namespace/name coordinate, whatever its version. Backs a pasted
+	 * versionless purl ({@code pkg:npm/lodash}), which is the shape advisories
+	 * quote.
+	 *
+	 * <p>The {@code '@'} anchor on the LIKE is load-bearing -- without it
+	 * {@code pkg:npm/lodash} would also match {@code pkg:npm/lodash-es@1.0.0}.
+	 * The equality arm catches a stored component that genuinely has no version.
+	 *
+	 * <p>Two forms of the same coordinate are passed deliberately:
+	 * {@code basePurl} raw for the equality arm, {@code basePurlLike}
+	 * LIKE-escaped for the pattern arm. Purls routinely contain {@code _},
+	 * which is a single-character LIKE wildcard, so the pattern arm would
+	 * otherwise over-match.
+	 *
+	 * <p>Bounded by LIMIT: a prefix LIKE cannot use the
+	 * {@code (org, canonical_purl)} unique btree under a non-C collation, so
+	 * this is a scan of the org's components. The cap keeps a pathological
+	 * coordinate (thousands of versions) from returning an unbounded payload
+	 * to a search box.
+	 */
+	@Query(
+		value = """
+			SELECT *
+			FROM rearm.sbom_components
+			WHERE org = CAST(:orgUuidAsString AS uuid)
+			AND (canonical_purl = :basePurl
+			     OR canonical_purl LIKE :basePurlLike || '@%' ESCAPE '\\')
+			ORDER BY canonical_purl ASC
+			LIMIT 500
+		""",
+		nativeQuery = true)
+	List<SbomComponent> searchByOrgAndCanonicalPurlCoordinate(
+			@Param("orgUuidAsString") String orgUuidAsString,
+			@Param("basePurl") String basePurl,
+			@Param("basePurlLike") String basePurlLike);
+
+	/**
 	 * The matchable population for an org's synthetic Dependency-Track buckets:
 	 * canonical components keyed on a purl or cpe (the only schemes DTrack can
 	 * match advisories against). Ordered by canonical_purl so bucket membership

--- a/backend/src/main/java/io/reliza/service/SbomComponentService.java
+++ b/backend/src/main/java/io/reliza/service/SbomComponentService.java
@@ -1843,6 +1843,36 @@ private static int currentReconcileFailureCount(Release r) {
 
 	public record ComponentPurlToSbom(String purl, List<UUID> sbomComponents) {}
 
+	/**
+	 * Org-wide search backing the "which releases ship this?" lookup. Each
+	 * query term is resolved one of two ways:
+	 *
+	 * <ul>
+	 * <li><b>Purl term</b> (starts with {@code pkg:}) -- resolved against
+	 *     {@code canonical_purl}. A purl that pins a version resolves to that
+	 *     one canonical row; a versionless purl resolves to every version of
+	 *     the coordinate.</li>
+	 * <li><b>Anything else</b> -- exact match on the component name, with the
+	 *     optional version filter, as before.</li>
+	 * </ul>
+	 *
+	 * <p>The purl arm exists because the search box has always advertised
+	 * "Name or Purl" while only the name path was wired up: pasting
+	 * {@code pkg:npm/lodash@4.17.21} matched nothing, since a purl is never
+	 * equal to a bare {@code record_data->>'name'}.
+	 *
+	 * <p>A purl term is self-contained, so the separate {@code version}
+	 * argument is ignored for it -- splicing a version into a purl that may
+	 * already carry qualifiers produces malformed input more often than it
+	 * helps. Pin the version inside the purl instead.
+	 *
+	 * <p><b>Purl is the only identifier scheme routed here.</b>
+	 * {@code canonical_purl} also stores {@code cpe:} (and, via
+	 * {@link #schemeOf}, other CDX identity schemes), but those are
+	 * deliberately out of scope: a pasted CPE falls through to the name path
+	 * and finds nothing. Adding one is a new arm on the scheme test plus its
+	 * own canonicalization -- not a behaviour change to the purl arm.
+	 */
 	public List<ComponentPurlToSbom> searchSbomComponentsBatch(
 			List<SbomComponentSearchQuery> queries, UUID orgUuid) {
 		if (queries == null || queries.isEmpty() || orgUuid == null) return List.of();
@@ -1850,8 +1880,11 @@ private static int currentReconcileFailureCount(Release r) {
 		Map<String, Set<UUID>> byCanonical = new LinkedHashMap<>();
 		for (SbomComponentSearchQuery q : queries) {
 			if (q == null || q.name() == null || q.name().isBlank()) continue;
-			List<SbomComponent> matches = sbomComponentRepository
-					.searchByOrgAndNameAndOptionalVersion(orgUuidStr, q.name(), q.version());
+			String term = q.name().strip();
+			List<SbomComponent> matches = Utils.isPurl(term)
+					? searchByPurlTerm(term, orgUuid, orgUuidStr)
+					: sbomComponentRepository
+							.searchByOrgAndNameAndOptionalVersion(orgUuidStr, term, q.version());
 			for (SbomComponent sc : matches) {
 				byCanonical.computeIfAbsent(sc.getCanonicalPurl(), k -> new LinkedHashSet<>())
 						.add(sc.getUuid());
@@ -1864,9 +1897,46 @@ private static int currentReconcileFailureCount(Release r) {
 		return out;
 	}
 
+	/**
+	 * Resolves a purl search term. Version-pinned purls take the unique-index
+	 * lookup; versionless ones fan out over the coordinate. An unparseable
+	 * purl yields no matches rather than falling back to a name lookup -- a
+	 * string starting with {@code pkg:} is never a package name, so a name
+	 * match would only ever produce confusing noise.
+	 */
+	private List<SbomComponent> searchByPurlTerm(String term, UUID orgUuid, String orgUuidStr) {
+		String base = Utils.purlCoordinateBase(term);
+		if (base == null) return List.of();
+		String pinnedVersion = Utils.purlVersion(term);
+		if (pinnedVersion == null || pinnedVersion.isEmpty()) {
+			return searchCoordinate(orgUuidStr, base);
+		}
+		String canonical = Utils.canonicalizePurl(term);
+		if (canonical != null) {
+			Optional<SbomComponent> exact = sbomComponentRepository
+					.findByOrgAndCanonicalPurl(orgUuid, canonical);
+			if (exact.isPresent()) return List.of(exact.get());
+		}
+		// The exact arm only hits when the pasted purl carries the same identity
+		// qualifiers the stored canonical does. Advisories quote the bare
+		// coordinate -- 'pkg:deb/debian/attr@1:2.5.2-3' against a stored
+		// '...@1:2.5.2-3?distro=debian-13' -- so fall back to the coordinate and
+		// match the version semantically. Comparing parsed versions rather than
+		// raw strings also absorbs encoding drift between eras of writer (a
+		// Debian epoch colon persists as both ':' and '%3A').
+		return searchCoordinate(orgUuidStr, base).stream()
+				.filter(sc -> pinnedVersion.equals(Utils.purlVersion(sc.getCanonicalPurl())))
+				.toList();
+	}
+
+	private List<SbomComponent> searchCoordinate(String orgUuidStr, String base) {
+		return sbomComponentRepository.searchByOrgAndCanonicalPurlCoordinate(
+				orgUuidStr, base, Utils.escapeSqlLikeLiteral(base));
+	}
+
 	public UUID searchSbomComponentByPurl(String purl, UUID orgUuid) {
 		if (orgUuid == null) return null;
-		String canonical = io.reliza.common.Utils.canonicalizePurl(purl);
+		String canonical = Utils.canonicalizePurl(purl);
 		if (canonical == null) return null;
 		return sbomComponentRepository.findByOrgAndCanonicalPurl(orgUuid, canonical)
 				.map(SbomComponent::getUuid)

--- a/backend/src/main/java/io/reliza/service/VersionAssignmentService.java
+++ b/backend/src/main/java/io/reliza/service/VersionAssignmentService.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.reliza.common.CommonVariables.BranchSuffixMode;
+import io.reliza.common.Utils;
 import io.reliza.exceptions.RelizaException;
 import io.reliza.model.BranchData;
 import io.reliza.model.BranchData.BranchType;
@@ -348,7 +349,7 @@ public class VersionAssignmentService {
 		// ("1.2.3-0", "1.2.3-1", ...). Up to 5 attempts after the scanned maximum.
 		if (getVersionAssignment(pd.getUuid(), versionString, versionType).isPresent()) {
 			final String baseVersion = versionString;
-			String likePattern = escapeForLike(baseVersion) + "-%";
+			String likePattern = Utils.escapeSqlLikeLiteral(baseVersion) + "-%";
 			List<VersionAssignment> existingVas = repository.findVersionAssignmentsByComponentAndVersionLike(
 					pd.getUuid(), versionType.name(), likePattern);
 			int maxSuffix = -1;
@@ -693,16 +694,6 @@ public class VersionAssignmentService {
 
 	public void saveAll(List<VersionAssignment> versionAssignments){
 		repository.saveAll(versionAssignments);
-	}
-
-	/**
-	 * Escapes SQL LIKE wildcard characters ('%', '_') and the escape character ('\')
-	 * so that the input string can be used as a literal prefix in a LIKE pattern
-	 * with {@code ESCAPE '\'}.
-	 */
-	private static String escapeForLike(String s) {
-		if (s == null) return "";
-		return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
 	}
 
 	public record GetNewVersionDto(

--- a/backend/src/test/java/io/reliza/common/UtilsPurlCoordinateTest.java
+++ b/backend/src/test/java/io/reliza/common/UtilsPurlCoordinateTest.java
@@ -1,0 +1,77 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link Utils#purlCoordinateBase} and {@link Utils#purlVersion}, the two
+ * helpers backing version-agnostic purl search.
+ *
+ * <p>The behaviour that matters downstream: the coordinate base is used as a
+ * LIKE prefix against {@code canonical_purl}, so it must drop everything that
+ * sorts after the version (qualifiers, subpath) or the prefix stops matching.
+ */
+public class UtilsPurlCoordinateTest {
+
+	@Test
+	public void stripsVersionFromCoordinate() {
+		assertEquals("pkg:npm/lodash", Utils.purlCoordinateBase("pkg:npm/lodash@4.17.21"));
+	}
+
+	@Test
+	public void keepsNamespaceInCoordinate() {
+		assertEquals("pkg:maven/org.apache.logging.log4j/log4j-core",
+				Utils.purlCoordinateBase("pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"));
+	}
+
+	@Test
+	public void versionlessPurlIsAlreadyItsOwnCoordinate() {
+		assertEquals("pkg:npm/lodash", Utils.purlCoordinateBase("pkg:npm/lodash"));
+	}
+
+	/**
+	 * Qualifiers sort AFTER the version in a purl, so a coordinate that kept
+	 * them could never prefix-match a stored {@code coordinate@version?quals}.
+	 * This is the one place the coordinate base deliberately diverges from
+	 * {@link Utils#canonicalizePurl}, which preserves identity qualifiers.
+	 */
+	@Test
+	public void dropsQualifiersAndSubpathSoThePrefixStillMatches() {
+		assertEquals("pkg:deb/debian/attr",
+				Utils.purlCoordinateBase("pkg:deb/debian/attr@1:2.5.2-3?distro=debian-13"));
+		assertEquals("pkg:golang/github.com/foo/bar",
+				Utils.purlCoordinateBase("pkg:golang/github.com/foo/bar@v1.2.3#sub/dir"));
+	}
+
+	@Test
+	public void rejectsNonPurlInput() {
+		assertNull(Utils.purlCoordinateBase("lodash"));
+		assertNull(Utils.purlCoordinateBase(""));
+		assertNull(Utils.purlCoordinateBase(null));
+		assertNull(Utils.purlCoordinateBase("pkg:"));
+	}
+
+	@Test
+	public void extractsPinnedVersion() {
+		assertEquals("4.17.21", Utils.purlVersion("pkg:npm/lodash@4.17.21"));
+		assertEquals("1:2.5.2-3", Utils.purlVersion("pkg:deb/debian/attr@1:2.5.2-3?distro=debian-13"));
+	}
+
+	@Test
+	public void reportsNullVersionForVersionlessPurl() {
+		assertNull(Utils.purlVersion("pkg:npm/lodash"));
+		assertNull(Utils.purlVersion("pkg:npm/lodash?arch=amd64"));
+	}
+
+	@Test
+	public void reportsNullVersionForNonPurl() {
+		assertNull(Utils.purlVersion("lodash"));
+		assertNull(Utils.purlVersion(null));
+	}
+}

--- a/backend/src/test/java/io/reliza/service/SbomComponentPurlSearchTest.java
+++ b/backend/src/test/java/io/reliza/service/SbomComponentPurlSearchTest.java
@@ -1,0 +1,216 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.reliza.model.SbomComponent;
+import io.reliza.repositories.ArtifactCanonicalMapRepository;
+import io.reliza.repositories.ArtifactSbomComponentRepository;
+import io.reliza.repositories.ReleaseArtifactIndexRepository;
+import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.service.SbomComponentService.ComponentPurlToSbom;
+import io.reliza.service.SbomComponentService.SbomComponentSearchQuery;
+
+/**
+ * Covers the search-term routing in
+ * {@link SbomComponentService#searchSbomComponentsBatch}.
+ *
+ * <p>The regression these guard: the org-wide search box has always been
+ * labelled "Name or Purl", but every term went to an exact-equality match on
+ * {@code record_data->>'name'}. A pasted purl is never equal to a bare name, so
+ * it silently returned nothing.
+ */
+@ExtendWith(MockitoExtension.class)
+class SbomComponentPurlSearchTest {
+
+	@Mock private SbomComponentRepository sbomComponentRepository;
+	@Mock private ArtifactSbomComponentRepository artifactSbomComponentRepository;
+	@Mock private ReleaseArtifactIndexRepository releaseArtifactIndexRepository;
+	@Mock private ArtifactCanonicalMapRepository artifactCanonicalMapRepository;
+
+	private SbomComponentService service;
+
+	private final UUID ORG = UUID.randomUUID();
+
+	@BeforeEach
+	void setUp() {
+		service = new SbomComponentService(
+				sbomComponentRepository, artifactSbomComponentRepository,
+				releaseArtifactIndexRepository, artifactCanonicalMapRepository);
+	}
+
+	private SbomComponent comp(String canonicalPurl) {
+		SbomComponent sc = new SbomComponent();
+		sc.setUuid(UUID.randomUUID());
+		sc.setOrg(ORG);
+		sc.setCanonicalPurl(canonicalPurl);
+		return sc;
+	}
+
+	private List<ComponentPurlToSbom> search(String term, String version) {
+		return service.searchSbomComponentsBatch(
+				List.of(new SbomComponentSearchQuery(term, version)), ORG);
+	}
+
+	@Test
+	void versionPinnedPurlResolvesViaCanonicalPurlNotName() {
+		SbomComponent sc = comp("pkg:npm/lodash@4.17.21");
+		when(sbomComponentRepository.findByOrgAndCanonicalPurl(ORG, "pkg:npm/lodash@4.17.21"))
+				.thenReturn(Optional.of(sc));
+
+		List<ComponentPurlToSbom> out = search("pkg:npm/lodash@4.17.21", null);
+
+		assertEquals(1, out.size(), "a pasted purl must resolve -- this returning 0 is the original bug");
+		assertEquals("pkg:npm/lodash@4.17.21", out.get(0).purl());
+		assertEquals(List.of(sc.getUuid()), out.get(0).sbomComponents());
+		verify(sbomComponentRepository, never())
+				.searchByOrgAndNameAndOptionalVersion(anyString(), anyString(), any());
+	}
+
+	@Test
+	void versionlessPurlFansOutOverEveryVersionOfTheCoordinate() {
+		SbomComponent v20 = comp("pkg:npm/lodash@4.17.20");
+		SbomComponent v21 = comp("pkg:npm/lodash@4.17.21");
+		when(sbomComponentRepository.searchByOrgAndCanonicalPurlCoordinate(
+				ORG.toString(), "pkg:npm/lodash", "pkg:npm/lodash"))
+				.thenReturn(List.of(v20, v21));
+
+		List<ComponentPurlToSbom> out = search("pkg:npm/lodash", null);
+
+		assertEquals(2, out.size(), "a versionless purl must fan out -- advisories quote the bare coordinate");
+		assertEquals(List.of("pkg:npm/lodash@4.17.20", "pkg:npm/lodash@4.17.21"),
+				out.stream().map(ComponentPurlToSbom::purl).toList());
+	}
+
+	/**
+	 * {@code _} is a single-character LIKE wildcard and survives into plenty of
+	 * canonical purls, so the pattern arm must receive an escaped copy while
+	 * the equality arm receives the raw coordinate.
+	 *
+	 * <p>Uses a gem purl deliberately: the purl spec's pypi rule folds {@code _}
+	 * to {@code -}, so a pypi coordinate can never exercise this. Types that
+	 * preserve the underscore are the ones that need the escape.
+	 */
+	@Test
+	void underscoreInCoordinateIsLikeEscapedForThePatternArmOnly() {
+		when(sbomComponentRepository.searchByOrgAndCanonicalPurlCoordinate(
+				anyString(), anyString(), anyString())).thenReturn(List.of());
+
+		search("pkg:gem/my_pkg", null);
+
+		ArgumentCaptor<String> raw = ArgumentCaptor.forClass(String.class);
+		ArgumentCaptor<String> escaped = ArgumentCaptor.forClass(String.class);
+		verify(sbomComponentRepository).searchByOrgAndCanonicalPurlCoordinate(
+				anyString(), raw.capture(), escaped.capture());
+		assertEquals("pkg:gem/my_pkg", raw.getValue());
+		assertEquals("pkg:gem/my\\_pkg", escaped.getValue());
+	}
+
+	/**
+	 * The regression that motivated the fallback arm: identity qualifiers are
+	 * preserved in a stored canonical (deb/apk/rpm keep {@code distro}), but an
+	 * advisory quotes the bare coordinate. The exact lookup misses, so the
+	 * coordinate scan has to pick it up and match on version.
+	 *
+	 * <p>The exact arm is stubbed loosely on purpose: canonicalization also
+	 * percent-encodes a Debian epoch colon ({@code 1:2.5.2-3} becomes
+	 * {@code 1%3A2.5.2-3}), which is a second, independent reason the exact
+	 * lookup misses here. Pinning that byte form belongs in
+	 * {@code UtilsCanonicalizePurlEncodingTest}, not in this routing test. The
+	 * version match below survives it because both sides are parsed, not
+	 * string-compared.
+	 */
+	@Test
+	void versionPinnedPurlLackingIdentityQualifiersFallsBackToCoordinate() {
+		SbomComponent stored = comp("pkg:deb/debian/attr@1:2.5.2-3?distro=debian-13");
+		when(sbomComponentRepository.findByOrgAndCanonicalPurl(any(), anyString()))
+				.thenReturn(Optional.empty());
+		when(sbomComponentRepository.searchByOrgAndCanonicalPurlCoordinate(
+				ORG.toString(), "pkg:deb/debian/attr", "pkg:deb/debian/attr"))
+				.thenReturn(List.of(stored, comp("pkg:deb/debian/attr@9.9.9?distro=debian-13")));
+
+		List<ComponentPurlToSbom> out = search("pkg:deb/debian/attr@1:2.5.2-3", null);
+
+		assertEquals(1, out.size(), "only the pinned version may survive the fallback");
+		assertEquals("pkg:deb/debian/attr@1:2.5.2-3?distro=debian-13", out.get(0).purl());
+	}
+
+	/** The exact arm must short-circuit -- no coordinate scan when it hits. */
+	@Test
+	void exactCanonicalHitSkipsTheCoordinateScan() {
+		when(sbomComponentRepository.findByOrgAndCanonicalPurl(ORG, "pkg:npm/lodash@4.17.21"))
+				.thenReturn(Optional.of(comp("pkg:npm/lodash@4.17.21")));
+
+		search("pkg:npm/lodash@4.17.21", null);
+
+		verify(sbomComponentRepository, never())
+				.searchByOrgAndCanonicalPurlCoordinate(anyString(), anyString(), anyString());
+	}
+
+	@Test
+	void plainNameStillTakesTheNamePathWithItsVersionFilter() {
+		SbomComponent sc = comp("pkg:npm/lodash@4.17.21");
+		when(sbomComponentRepository.searchByOrgAndNameAndOptionalVersion(
+				ORG.toString(), "lodash", "4.17.21")).thenReturn(List.of(sc));
+
+		List<ComponentPurlToSbom> out = search("lodash", "4.17.21");
+
+		assertEquals(1, out.size());
+		verify(sbomComponentRepository, never()).findByOrgAndCanonicalPurl(any(), anyString());
+	}
+
+	/**
+	 * A purl is self-contained; splicing the separate version box into one that
+	 * may already carry qualifiers produces malformed input more often than it
+	 * helps, so the version argument is ignored for purl terms.
+	 */
+	@Test
+	void separateVersionArgumentIsIgnoredForPurlTerms() {
+		when(sbomComponentRepository.findByOrgAndCanonicalPurl(ORG, "pkg:npm/lodash@4.17.21"))
+				.thenReturn(Optional.empty());
+
+		search("pkg:npm/lodash@4.17.21", "1.0.0");
+
+		verify(sbomComponentRepository).findByOrgAndCanonicalPurl(ORG, "pkg:npm/lodash@4.17.21");
+		verify(sbomComponentRepository, never())
+				.searchByOrgAndNameAndOptionalVersion(anyString(), anyString(), any());
+	}
+
+	@Test
+	void unparseablePurlYieldsNoMatchesRatherThanFallingBackToName() {
+		List<ComponentPurlToSbom> out = search("pkg:", null);
+
+		assertTrue(out.isEmpty());
+		verify(sbomComponentRepository, never())
+				.searchByOrgAndNameAndOptionalVersion(anyString(), anyString(), any());
+	}
+
+	@Test
+	void whitespacePaddedPurlIsStillTreatedAsAPurl() {
+		when(sbomComponentRepository.findByOrgAndCanonicalPurl(ORG, "pkg:npm/lodash@4.17.21"))
+				.thenReturn(Optional.of(comp("pkg:npm/lodash@4.17.21")));
+
+		List<ComponentPurlToSbom> out = search("  pkg:npm/lodash@4.17.21  ", null);
+
+		assertEquals(1, out.size());
+	}
+}


### PR DESCRIPTION
CE mirror of **relizaio/rearm-saas#381** (merged as `9d065192`).

## Problem

The dashboard's **Search Releases -> By SBOM Components** box is labelled *"SBOM Component Name, Group or Purl"*, but only the name path was ever wired up: every term went to an exact-equality match on `record_data->>'name'`. A purl is never equal to a bare component name, so pasting `pkg:npm/lodash@4.17.21` silently returned nothing -- the one input a responder actually has to hand when an advisory drops.

## Change

Terms carrying the `pkg:` scheme now resolve against `canonical_purl`:

| Input | Resolution |
|---|---|
| `pkg:npm/lodash@4.17.21` | `(org, canonical_purl)` unique-index lookup |
| ...that misses | coordinate scan filtered by **parsed** version |
| `pkg:npm/lodash` | every version of the type/namespace/name coordinate |
| `lodash` | unchanged -- name path, with its optional version filter |

The fallback arm exists because an exact lookup alone misses for two independent reasons, both hitting deb/apk/rpm hardest: stored canonicals preserve identity qualifiers that advisories do not quote (`...@1:2.5.2-3?distro=debian-13` vs `...@1:2.5.2-3`), and canonicalization percent-encodes a Debian epoch colon. Comparing parsed versions absorbs both.

Also promotes `VersionAssignmentService`'s private `escapeForLike` to `Utils.escapeSqlLikeLiteral`, shared with the new coordinate query.

Purl is the only scheme routed; `canonical_purl` also stores `cpe:`, which stays out of scope and is documented as such. No UI change -- this makes the existing on-screen copy true.

## Mirror provenance

Produced with `backend/copy-src.sh` from a **detached worktree at `rearm-core` `origin/main`** (mirroring from a feature branch would let `--delete` remove CE code the branch lacks). All six files verified **byte-identical** to the Pro tree.

**Scoped deliberately.** The same mirror also carries the notifications **T4a `notifyComponentOwner`** backend (~1000 lines, from rearm-saas#388). That is left out of this PR so it can land as its own mirror alongside its UI half, #258 -- shipping them together would mix two unrelated features and pre-empt that work.

## Verification

- **93 tests green on CE**, including the 17 new purl tests.
- Notably **CE's own `VersionAssignmentTest`** (13 tests) passes against the promoted escaper. `copy-src.sh` excludes that file, so CE maintains a separate copy from Pro's -- it was the one real mirror risk here and it is clean.
- The Pro original was additionally sandbox-validated before merge: API before/after, a Playwright UI run driving the real search box through to expanded release rows, and a 68k-component stress pass (coordinate scan 14ms, version-pinned lookup 0.039ms).

## Known follow-up (not a blocker, carried from #381)

The coordinate query is `LIMIT`-bounded, and a coordinate with more versions than the cap is truncated **silently** -- no on-screen indication more exist. Low real-world impact (the version-pinned path is unaffected, and the prior behaviour was returning nothing at all), but worth either raising the cap or surfacing a "showing first N" note.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
