### PR TITLE
KEV-only filter in the findings modal (all views), pre-enabled from the KEV chart series

### DIFF
--- a/ui/src/components/FindingsOverTimeChart.vue
+++ b/ui/src/components/FindingsOverTimeChart.vue
@@ -81,6 +81,7 @@
             :component-type="props.componentType"
             :initial-severity-filter="directFindingsDate ? directFindingsSeverity : findingsPerDaySeverity"
             :initial-type-filter="directFindingsDate ? directFindingsType : findingsPerDayType"
+            :initial-kev-only="directFindingsDate ? directFindingsKev : findingsPerDayKev"
             :show-refresh-action="hasNoExtraContext && isGlobalAdmin"
             :on-refresh-action="refreshAnalyticsForCurrentDate"
             @update:show="(val: boolean) => { if (!val) closeFindingsPerDayModal() }"
@@ -221,12 +222,14 @@ const showOrgChangelogModal: Ref<boolean> = ref(false)
 const directFindingsDate: Ref<string> = ref('')
 const directFindingsSeverity: Ref<string> = ref('')
 const directFindingsType: Ref<string> = ref('')
+const directFindingsKev: Ref<boolean> = ref(false)
 
 // Route-based query params for findings per day display
 const showFindingsPerDay = computed(() => route.query.display === 'findingsPerDay' && route.query.date)
 const findingsPerDayDate = computed(() => route.query.date as string || '')
 const findingsPerDaySeverity = computed(() => route.query.severity as string || '')
 const findingsPerDayType = computed(() => route.query.type as string || '')
+const findingsPerDayKev = computed(() => route.query.kev === 'true')
 
 const findingsPerDayModalTitle = computed(() => {
     const date = directFindingsDate.value || findingsPerDayDate.value
@@ -459,18 +462,20 @@ const fullPageViewUrl = computed(() => {
     return `/findingsOverTime/${orgUuid.value}${params.toString() ? '?' + params.toString() : ''}`
 })
 
-async function openFindingsModal(date: string, severity: string = '', typeParam: string = '') {
+async function openFindingsModal(date: string, severity: string = '', typeParam: string = '', kevOnly: boolean = false) {
     directFindingsDate.value = date
     directFindingsSeverity.value = severity
     directFindingsType.value = typeParam
+    directFindingsKev.value = kevOnly
     showFindingsPerDayModal.value = true
-    
+
     // Update URL without triggering watchers so page reload works
     const params = new URLSearchParams()
     params.set('display', 'findingsPerDay')
     params.set('date', date)
     if (severity) params.set('severity', severity)
     if (typeParam) params.set('type', typeParam)
+    if (kevOnly) params.set('kev', 'true')
     window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`)
     
     await fetchFindingsPerDay(date)
@@ -737,11 +742,16 @@ function renderChart() {
                 const datum = item.datum
                 let severity = ''
                 let typeParam = ''
+                let kevOnly = false
                 if (datum.type === 'KEV Vulnerabilities') {
                     // KEV is not a severity, so a severity filter of 'KEV' would
-                    // match nothing in the per-day table. Open the day unfiltered;
-                    // the table flags known-exploited findings individually.
+                    // match nothing in the per-day table. Open with the modal's
+                    // KEV-only switch pre-enabled instead: the day view then
+                    // shows exactly the rows this series point counted (a
+                    // known-exploited MEDIUM otherwise hides below the
+                    // CRITICALs/HIGHs in the severity-sorted table).
                     typeParam = 'Vulnerability'
+                    kevOnly = true
                 } else if (datum.type && datum.type.indexOf('Vulnerabilities') >= 0) {
                     severity = datum.type.split(' ')[0].toUpperCase()
                     typeParam = 'Vulnerability'
@@ -751,7 +761,7 @@ function renderChart() {
                 const dateObj = new Date(datum.createdDate)
                 const date = dateObj.toISOString().split('T')[0]
                 if (date) {
-                    openFindingsModal(date, severity, typeParam)
+                    openFindingsModal(date, severity, typeParam, kevOnly)
                 }
             }
         })

--- a/ui/src/components/VulnerabilityModal.vue
+++ b/ui/src/components/VulnerabilityModal.vue
@@ -22,6 +22,12 @@
                     <n-text depth="3" style="font-size: 12px;">
                         ({{ unsuppressedCount }} unsuppressed)
                     </n-text>
+                    <n-divider vertical />
+                    <span>KEV Only:</span>
+                    <n-switch v-model:value="kevOnly" />
+                    <n-text depth="3" style="font-size: 12px;">
+                        ({{ kevCount }} known-exploited)
+                    </n-text>
                 </n-space>
                 <n-button @click="exportToPdf" type="primary" size="small">
                     <template #icon>
@@ -156,7 +162,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { computed, ComputedRef, h, ref } from 'vue'
+import { computed, ComputedRef, h, ref, watch } from 'vue'
 import { useStore } from 'vuex'
 import { NModal, NSpin, NDataTable, NTag, NTooltip, NIcon, NSwitch, NSpace, NText, NButton, NCheckboxGroup, NCheckbox, NFormItem, NDivider, NRadio, NRadioGroup, DataTableColumns, useNotification } from 'naive-ui'
 import { RouterLink, useRouter } from 'vue-router'
@@ -190,6 +196,9 @@ interface Props {
     rowKey?: (row: any) => string
     initialSeverityFilter?: string
     initialTypeFilter?: string | string[]
+    // Open with the KEV-only filter pre-enabled (e.g. arriving from a click on
+    // the "KEV Vulnerabilities" chart series). The switch stays user-togglable.
+    initialKevOnly?: boolean
     showRefreshAction?: boolean
     onRefreshAction?: () => void
 }
@@ -211,6 +220,7 @@ const props = withDefaults(defineProps<Props>(), {
     rowKey: (row: any) => row.type + '-' + row.id + '-' + row.purl,
     initialSeverityFilter: '',
     initialTypeFilter: '',
+    initialKevOnly: false,
     showRefreshAction: false,
     onRefreshAction: undefined
 })
@@ -324,20 +334,40 @@ function handlePurlClick (purl: string) {
 
 const isSuppressed = (row: any): boolean => isSuppressedAnalysisState(row.analysisState)
 
+// KEV-only filter. Findings-modal lists sort by severity, so a known-exploited
+// MEDIUM can sit dozens of rows below the CRITICALs and read as "not there" --
+// this narrows the table to exactly the rows the KEV chart series counted.
+// Re-seeded from initialKevOnly on every open so a modal reused across
+// entry points (chart series click vs plain open) starts in the right state.
+const kevOnly = ref(props.initialKevOnly)
+watch(() => props.show, (open) => {
+    if (open) kevOnly.value = props.initialKevOnly
+})
+
 const filteredData = computed(() => {
     let data = props.data
-    
+
     // Apply suppressed filter
     if (!showSuppressed.value) {
         data = data.filter(row => !isSuppressed(row))
     }
-    
+
     // Apply unsuppressed filter
     if (!showUnsuppressed.value) {
         data = data.filter(row => isSuppressed(row))
     }
-    
+
+    // Apply KEV-only filter (knownExploited is only ever set on vulnerability
+    // rows, so this also hides violations/weaknesses -- KEV is a vuln property)
+    if (kevOnly.value) {
+        data = data.filter(row => !!row.knownExploited)
+    }
+
     return data
+})
+
+const kevCount = computed(() => {
+    return props.data.filter(row => !!row.knownExploited).length
 })
 
 const suppressedCount = computed(() => {


### PR DESCRIPTION
Follow-up to a live investigation where an org's "KEV Vulnerabilities" chart series read 3 while a top-down scan of the day view found only 2 KEV chips: the third finding (genuinely CISA-KEV) was a MEDIUM buried mid-table below 12 criticals and 84 highs in the severity-sorted list. The count was right; the row was just undiscoverable.

- **"KEV Only" switch** in the shared findings modal (`VulnerabilityModal`), next to the suppression toggles, with a known-exploited count. Filters to `knownExploited` rows (which also hides violations/weaknesses — KEV is a vulnerability property). Since the modal is shared, the filter is available in every view that uses it: findings-over-time day views at org/component/branch/perspective scope, release findings, home widgets.
- **Clicking the KEV chart series** now opens the day view with the switch pre-enabled (`initialKevOnly`, re-seeded on each open so reused modals start in the right state) — the modal then shows exactly the rows the clicked series point counted. The deep-link URL carries `kev=true` so reloads restore the filter. Other entry points open with the switch off, as before.

Build green, vitest 112/112, eslint clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)