### PR TITLE
fix(ui): stop CISA KEV modal labels wrapping mid-label (BUG 12)

### DIFF
--- a/ui/src/components/KevDetailsModal.vue
+++ b/ui/src/components/KevDetailsModal.vue
@@ -13,7 +13,29 @@
         </template>
         <n-spin :show="loading">
             <div v-if="record && primary">
-                <n-descriptions label-placement="left" :column="1" bordered size="small">
+                <!-- Without this the table layout squeezes the label cell to fit
+                     the value and the longer labels below wrap mid-label. 200px
+                     because the widest of them, "Ransomware campaign use",
+                     shrink-to-fits at 199px -- the 160px used by
+                     MitigationAttestationReview / VexProposalReview still wraps
+                     it.
+
+                     A width, NOT white-space: nowrap. nowrap makes 199px a hard
+                     floor, and naive-ui's bordered wrapper is overflow: hidden
+                     (descriptions/src/styles/index.cssr.mjs), so once the dialog
+                     is narrower than the table it clips values with no scrollbar
+                     -- measured 41px cut off every value cell at a 320px
+                     viewport, where nothing was clipped before. A specified
+                     width is honoured when there is room and collapses when
+                     there is not, so narrow viewports degrade to the old
+                     cosmetic wrap instead of losing content. -->
+                <n-descriptions
+                    label-placement="left"
+                    :column="1"
+                    bordered
+                    size="small"
+                    :label-style="{ width: '200px' }"
+                >
                     <n-descriptions-item v-if="primary.vulnerabilityName" label="Name">
                         {{ primary.vulnerabilityName }}
                     </n-descriptions-item>


### PR DESCRIPTION
Fixes board `t20260723-142442-15768` ("BUG 12"), from the notifications walkthrough ledger.

The `n-descriptions` label column in `KevDetailsModal` had no width, so the table layout squeezed it to fit the value and the longer labels wrapped mid-label -- "Ransomware campaign use" and "Remediation due (FCEB)" broke across lines. Cosmetic only: the modal's content was always correct and fully populated.

## The fix

An explicit `200px` label column. The number is measured, not guessed: rendered against the live CISA feed, the widest label shrink-to-fits at **199px**, so the `160px` the sibling review modals use still wraps it -- and so would the `150px` this bug originally suggested.

## Why a width and not `white-space: nowrap`

`nowrap` was the obvious fix, and it is wrong. It turns 199px into a hard min-content floor, and naive-ui's bordered wrapper is `overflow: hidden` rather than `auto` -- so as soon as the dialog is narrower than the table it **clips values with no scrollbar and no way to reach them**.

| viewport | `nowrap` | `width: 200px` |
|---|---|---|
| 1440 / 768 / 414 | 0 clipped | 0 clipped |
| 360 | 1px clipped | 0 clipped |
| **320** | **41px cut off every value cell** | **0 clipped** |

Nothing was clipped before this change at any width, so `nowrap` would have introduced content loss to fix a wrap. A specified width is honoured when there is room and collapses when there is not, so narrow viewports degrade to the old cosmetic wrap instead.

## Verification

Rendered the real component in a vite + naive-ui 2.44.1 harness against the **live CISA catalog** (1656 entries) at 1440/768/414/375/360/320px:

- labels wrapping **2 -> 0** at the real 640px dialog
- **zero clipping at every viewport**, down to 320px
- the table is *shorter* than before: 1172px vs 1462px
- value column settles at 383px, which holds the feed's worst cases -- 821-char `shortDescription`, 520-char `requiredAction`, a 3-item CWE list, and a 250-char unbreakable URL in one `notes` field (wraps cleanly, `scrollWidth == clientWidth`)

123 UI tests pass and the build is clean, though neither can see layout -- which is why this was verified by rendering rather than by reasoning.

## Review

Two-layer gate run on the settled diff. Layer 2 (conventions) cleared it, including the question of whether a third `label-style` shape is justified: the repo's two existing shapes disagree with each other (`{width, minWidth}` at 160px vs a `metaLabelStyle` const at 180px), and neither would fix the bug.

Layer 1 (correctness) is what produced the final shape -- it caught that my first attempt's `nowrap` introduced the clipping regression above, and that its stated rationale ("a fixed number re-breaks when CISA wording changes") was simply false: all 11 labels are hardcoded string literals in this template. CISA supplies values, not labels.

Not done deliberately: the bug also offered widening the modal to ~700px. Unnecessary -- values still get 383px and long prose wrapping is normal, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)