### PR TITLE
rebom: raw-BOM repository pointer + digest-aware raw fetch (fixes false 'Digest validation failed')

### DIFF
--- a/oci-artifact-service/main.go
+++ b/oci-artifact-service/main.go
@@ -1,17 +1,20 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	ociSpecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
 )
 
 func main() {
@@ -205,6 +208,15 @@ func downloadFile(c *gin.Context) {
 	dirToDownload := uuid.New().String()
 	_, err = oc.PullArtifact(c, form.Tag, dirToDownload)
 	if err != nil {
+		// Surface a definitive registry not-found as 404 so callers can
+		// distinguish "this tag does not exist in this repo" (safe to probe
+		// elsewhere / record as missing) from transient server errors.
+		// Previously every pull failure was a 500, which forced rebom's
+		// legacy fallback to guess.
+		if errors.Is(err, errdef.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+			c.String(http.StatusNotFound, "Artifact not found: ", err)
+			return
+		}
 		c.String(http.StatusInternalServerError, "Error Pulling artifact: ", err)
 		return
 	}

--- a/oci-artifact-service/main.go
+++ b/oci-artifact-service/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -212,8 +211,13 @@ func downloadFile(c *gin.Context) {
 		// distinguish "this tag does not exist in this repo" (safe to probe
 		// elsewhere / record as missing) from transient server errors.
 		// Previously every pull failure was a 500, which forced rebom's
-		// legacy fallback to guess.
-		if errors.Is(err, errdef.ErrNotFound) || strings.Contains(err.Error(), "not found") {
+		// legacy fallback to guess. errors.Is ONLY: oras-go wraps
+		// errdef.ErrNotFound for MANIFEST_UNKNOWN / NAME_UNKNOWN, and the 404
+		// must stay authoritative -- rebom makes DURABLE decisions on it
+		// (permanent rawBomMissing stamp), so a substring match over
+		// arbitrary error text (proxy bodies, future oras phrasing) could
+		// poison a stamp with no self-healing path.
+		if errors.Is(err, errdef.ErrNotFound) {
 			c.String(http.StatusNotFound, "Artifact not found: ", err)
 			return
 		}

--- a/oci-artifact-service/oras.go
+++ b/oci-artifact-service/oras.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
@@ -141,6 +143,17 @@ func (o *OrasClient) PullArtifact(ctx context.Context, tagDigest string, dirName
 		descriptor, lastErr = oras.Copy(ctx, o.Repository, tagDigest, fs, tagDigest, oras.DefaultCopyOptions)
 		if lastErr == nil {
 			return descriptor, nil
+		}
+
+		// A definitive registry not-found will not change on retry -- fail
+		// fast so callers probing multiple repositories (rebom's raw-BOM
+		// resolver) don't pay the full backoff (~7.5s) per absent candidate.
+		if errors.Is(lastErr, errdef.ErrNotFound) {
+			getLogger().Infow("Artifact not found; not retrying",
+				"tag_digest", tagDigest,
+				"error", lastErr,
+			)
+			return v1.Descriptor{}, lastErr
 		}
 
 		getLogger().Warnw("Pull attempt failed",

--- a/rebom-backend/src/index.ts
+++ b/rebom-backend/src/index.ts
@@ -5,6 +5,7 @@ import resolvers from './bomResolver';
 import { logger } from './logger';
 import { initEncryption } from './services/encryptionService';
 import { startEnrichmentScheduler, stopEnrichmentScheduler } from './services/enrichmentScheduler';
+import { logRawRepositoryCensus } from './services/oci';
 
 // Global error handlers to prevent process crashes (like Spring Boot)
 // These ensure the service stays running even when unexpected errors occur
@@ -63,9 +64,15 @@ async function startApolloServer(typeDefs: any, resolvers: any) {
   });
 
   logger.info(`🚀 GraphQL Server ready at ${url}`);
-  
+
   // Start enrichment scheduler after server is ready
   startEnrichmentScheduler();
+
+  // SQL-only census: rows still pending on-demand raw-repository resolution
+  // (no OCI traffic; resolution itself happens lazily on raw fetches).
+  logRawRepositoryCensus().catch((err) => {
+    logger.error({ err }, 'Raw-repository census failed');
+  });
 }
 
 // Wrap startup in try-catch to handle initialization errors

--- a/rebom-backend/src/services/bom/bomAddService.ts
+++ b/rebom-backend/src/services/bom/bomAddService.ts
@@ -177,6 +177,11 @@ async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
   rebomOptions.originalFileDigest = rawPushResult.fileSHA256Digest;  // Actual file digest from OCI
   rebomOptions.originalFileSize = rawPushResult.originalSize;
   rebomOptions.originalMediaType = rawPushResult.originalMediaType;
+  // Pin the raw copy's repository: enrichment later re-pushes the PROCESSED
+  // BOM to the then-current month's repository (bom.ociRepositoryName moves
+  // with it), but the raw copy stays here -- without its own pointer a
+  // cross-month enrichment strands it (see rawBomResolver).
+  rebomOptions.rawOciRepositoryName = rawPushResult.ociRepositoryName;
   
   // Track processed/augmented BOM metadata for validation
   rebomOptions.processedFileDigest = pushResult.fileSHA256Digest;  // Augmented BOM digest

--- a/rebom-backend/src/services/bom/bomCrudService.ts
+++ b/rebom-backend/src/services/bom/bomCrudService.ts
@@ -3,7 +3,7 @@ import { BomDto, BomMetaDto, BomRecord, BomSearch, SearchObject } from '../../ty
 import { BomNotFoundError, BomDataIntegrityError } from '../../types/errors';
 import { BomMapper } from './bomMapper';
 import { logger } from '../../logger';
-import { fetchFromOci, extractRepositoryNameFromBom, extractRepositoryNameFromSpdxOciResponse, fetchRawBomWithFallback } from '../oci';
+import { fetchFromOci, extractRepositoryNameFromBom, extractRepositoryNameFromSpdxOciResponse, resolveAndFetchRawBom } from '../oci';
 import { parseBom, ParsedBom, ParsedBomComponent, parseHbom, ParsedHbom } from './bomComponentExtractor';
 
 export async function findAllBoms(): Promise<BomDto[]> {
@@ -134,10 +134,9 @@ export async function findBomBySerialNumberAndVersion(serialNumber: string, vers
                 return await fetchFromOci(fetchId, spdxRepositoryName, spdxDigest);
             }
         }
-        // Native CycloneDX - fetch raw BOM with automatic fallback for legacy BOMs
+        // Native CycloneDX - resolve raw BOM repository (digest-verified)
         logger.debug({ bomUuid: bomRecord.uuid, version, serialNumber }, "Fetching raw CycloneDX BOM by version");
-        const expectedDigest = bomRecord.meta?.originalFileDigest;
-        return await fetchRawBomWithFallback(bomRecord.uuid, storedRepositoryName, fetchFromOci, expectedDigest);
+        return await resolveAndFetchRawBom(bomRecord);
     } else {
         // Augmented/processed BOM requested - validate using processedFileDigest
         logger.debug({ uuid: bomRecord.uuid, version, serialNumber }, "Fetching augmented BOM by version");
@@ -214,8 +213,7 @@ export async function findRawBomObjectById(id: string, org: string, format?: str
         
         // Native CycloneDX - fetch raw BOM with automatic fallback for legacy BOMs
         logger.debug({ bomUuid: bomById.uuid }, "Fetching raw CycloneDX BOM");
-        const expectedDigest = bomById.meta?.originalFileDigest;
-        return await fetchRawBomWithFallback(bomById.uuid, storedRepositoryName, fetchFromOci, expectedDigest);
+        return await resolveAndFetchRawBom(bomById);
     } 
     else if (format === 'SPDX') {
         if (bomById.source_format === 'SPDX' && bomById.source_spdx_uuid) {
@@ -258,12 +256,11 @@ export async function findRawBomObjectById(id: string, org: string, format?: str
             }
         }
         
-        // Not SPDX-sourced - return raw CycloneDX BOM with automatic fallback for legacy BOMs
+        // Not SPDX-sourced - resolve raw CycloneDX BOM repository (digest-verified)
         if (bomById.source_format === 'CYCLONEDX' || !bomById.source_spdx_uuid) {
-            logger.debug({ bomUuid: bomById.uuid, sourceFormat: bomById.source_format }, 
+            logger.debug({ bomUuid: bomById.uuid, sourceFormat: bomById.source_format },
                 "Fetching raw CycloneDX BOM (no format specified)");
-            const expectedDigest = bomById.meta?.originalFileDigest;
-            return await fetchRawBomWithFallback(bomById.uuid, storedRepositoryName, fetchFromOci, expectedDigest);
+            return await resolveAndFetchRawBom(bomById);
         }
         
         // Fallback to primary UUID (processed/augmented BOM) - validate using processedFileDigest

--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -10,7 +10,7 @@ import {
   extractRepositoryNameFromBom,
   extractRepositoryNameFromSpdxOciResponse,
   validateOciPushResult,
-  fetchRawBomWithFallback
+  resolveAndFetchRawBom
 } from '../oci';
 import * as BomRepository from '../../bomRepository';
 import * as SpdxRepository from '../../spdxRepository';
@@ -1020,9 +1020,7 @@ async function reprocessAndEnrichAsync(bomRecord: BomRecord, org: string, creden
  */
 async function reprocessCycloneDxBom(bomRecord: BomRecord): Promise<any | null> {
   try {
-    const storedRepositoryName = extractRepositoryNameFromBom(bomRecord);
-    const expectedDigest = bomRecord.meta?.originalFileDigest;
-    const rawBom = await fetchRawBomWithFallback(bomRecord.uuid, storedRepositoryName, fetchFromOci, expectedDigest);
+    const rawBom = await resolveAndFetchRawBom(bomRecord);
 
     // Apply the same 1.7→1.6 downgrade shim that addCycloneDxBom uses on
     // ingest. Forced re-enrichment is the recovery path for artifacts that

--- a/rebom-backend/src/services/oci/index.ts
+++ b/rebom-backend/src/services/oci/index.ts
@@ -30,15 +30,18 @@ export const clearMockOciStorage = useMock
 export const getMonthlyRepositoryName = realService.getMonthlyRepositoryName;
 
 // Re-export repository helper functions
-export { 
+export {
   extractRepositoryNameFromBom,
   extractRepositoryNameFromSpdxOciResponse,
   validateOciPushResult,
   validateRepositoryMatch,
-  fetchRawBomWithFallback,
   validateDualBomPush,
   getValidatedRepositoryName
 } from './ociRepositoryHelpers';
+
+// Raw-BOM fetch with verified repository resolution (replaces the old
+// fetchRawBomWithFallback, which masked misplaced raw copies as digest errors)
+export { resolveAndFetchRawBom, logRawRepositoryCensus } from './rawBomResolver';
 
 // Re-export types
 export type { OASResponse, OciResponse } from './ociService';

--- a/rebom-backend/src/services/oci/ociRepositoryHelpers.ts
+++ b/rebom-backend/src/services/oci/ociRepositoryHelpers.ts
@@ -162,35 +162,9 @@ export function validateDualBomPush(
     validateRepositoryMatch(rawResult, processedResult, context, uuid);
 }
 
-/**
- * Fetches raw BOM with automatic fallback for legacy BOMs.
- * First tries to fetch with '-raw' suffix, then falls back to UUID without suffix.
- * @param bomUuid - BOM UUID (without -raw suffix)
- * @param repositoryName - Repository name to fetch from
- * @param fetchFromOci - fetchFromOci function to use
- * @param expectedDigest - Optional expected SHA256 digest for validation
- * @returns Raw BOM content
- * @throws Error if both attempts fail
- */
-export async function fetchRawBomWithFallback(
-    bomUuid: string,
-    repositoryName: string | undefined,
-    fetchFromOci: (tag: string, repo?: string, digest?: string) => Promise<any>,
-    expectedDigest?: string
-): Promise<any> {
-    const rawBomUuid = bomUuid + '-raw';
-    
-    try {
-        logger.debug({ rawBomUuid, bomUuid, repositoryName }, 'Fetching raw CycloneDX BOM');
-        return await fetchFromOci(rawBomUuid, repositoryName, expectedDigest);
-    } catch (error) {
-        // Fallback for older BOMs without -raw suffix
-        logger.warn({ 
-            rawBomUuid, 
-            bomUuid, 
-            repositoryName,
-            error: error instanceof Error ? error.message : String(error) 
-        }, 'Failed to fetch raw BOM with -raw suffix, retrying without suffix for legacy BOM');
-        return await fetchFromOci(bomUuid, repositoryName, expectedDigest);
-    }
-}
+// NOTE: fetchRawBomWithFallback used to live here. It retried the processed
+// tag on ANY raw-fetch error while validating against the RAW digest -- which
+// surfaced misplaced raw copies (enrichment re-push moves the processed BOM to
+// the current month's repository; the raw copy stays in the upload month) as
+// "Digest validation failed", and could mask a genuinely corrupt raw artifact.
+// Replaced by resolveAndFetchRawBom in ./rawBomResolver.

--- a/rebom-backend/src/services/oci/ociService.ts
+++ b/rebom-backend/src/services/oci/ociService.ts
@@ -1,6 +1,7 @@
 import FormData from 'form-data';
 import { logger } from '../../logger';
 import { createHash } from 'crypto';
+import { OciNotFoundError, DigestValidationError } from '../../types/errors';
 
 const baseURL = (): string => process.env.OCI_ARTIFACT_SERVICE_HOST ? process.env.OCI_ARTIFACT_SERVICE_HOST : `http://[::1]:8083/`;
 
@@ -116,6 +117,13 @@ export async function fetchFromOci(tag: string, repositoryName?: string, expecte
         });
 
         if (!response.ok) {
+            // 404 is an authoritative "this tag does not exist in this repo" --
+            // typed so callers (rawBomResolver) can distinguish it from
+            // transport/server errors before making durable decisions.
+            if (response.status === 404) {
+                throw new OciNotFoundError(
+                    `OCI artifact not found: tag ${tag} in repository ${repo}`, tag, repo);
+            }
             throw new Error(`OCI fetch returned HTTP ${response.status}: ${response.statusText}`);
         }
 
@@ -133,9 +141,11 @@ export async function fetchFromOci(tag: string, repositoryName?: string, expecte
             const actualDigest = createHash('sha256').update(rawContent).digest('hex');
 
             if (actualDigest !== expectedDigest) {
-                const error = new Error(`Digest validation failed for artifact. Expected: ${expectedDigest}, Actual: ${actualDigest}`);
-                logger.error({ 
-                    tag, 
+                const error = new DigestValidationError(
+                    `Digest validation failed for artifact ${tag} in repository ${repo}. Expected: ${expectedDigest}, Actual: ${actualDigest}`,
+                    tag, repo, expectedDigest, actualDigest);
+                logger.error({
+                    tag,
                     repository: repo,
                     expectedDigest,
                     actualDigest

--- a/rebom-backend/src/services/oci/rawBomResolver.ts
+++ b/rebom-backend/src/services/oci/rawBomResolver.ts
@@ -1,0 +1,198 @@
+import { logger } from '../../logger';
+import { runQuery } from '../../utils';
+import { OciNotFoundError, DigestValidationError } from '../../types/errors';
+import { fetchFromOci as defaultFetchFromOci, getMonthlyRepositoryName } from './index';
+import { extractRepositoryNameFromBom } from './ociRepositoryHelpers';
+import type { BomRecord } from '../../types/bom.types';
+
+/**
+ * Raw-BOM fetch with verified repository resolution.
+ *
+ * WHY: the record's single repository pointer (bom.ociRepositoryName) tracks
+ * the PROCESSED BOM, which enrichment re-pushes into the CURRENT month's
+ * repository (deliberately -- closed monthly repositories are the backup unit
+ * and are never written to). The '-raw' copy stays in the upload month's
+ * repository, so any BOM enriched in a later month than it was uploaded has
+ * its pair split across repositories. The old fetchRawBomWithFallback then
+ * missed the raw copy in the recorded repository and fell back to the
+ * processed tag while still validating against the RAW digest -- surfacing a
+ * misplaced artifact as "Digest validation failed".
+ *
+ * Resolution order (every candidate fetch is digest-validated against
+ * meta.originalFileDigest, so probing can never serve the wrong bytes):
+ *   1. meta.rawOciRepositoryName (stamped at upload for new rows, or by a
+ *      previous resolution);
+ *   2. the recorded processed repository (covers unsplit rows);
+ *   3. the upload month derived from created_date, then the adjacent
+ *      previous month (upload vs row-insert can straddle midnight);
+ *   4. the base legacy repository (pre-monthly-rotation rows).
+ *
+ * Error semantics:
+ *   - OciNotFoundError (authoritative 404): try the next candidate.
+ *   - DigestValidationError: rethrow IMMEDIATELY -- a present-but-corrupt raw
+ *     artifact must surface as exactly that, never masked by a substitute.
+ *   - anything else (5xx, transport): try the next candidate for
+ *     availability, but make NO durable decisions this call (no pointer
+ *     stamp, no raw-missing stamp) -- also covers version skew with an older
+ *     OCI artifact service that reported missing artifacts as 500.
+ *
+ * When no candidate has the raw copy: serve the processed BOM as an explicit,
+ * logged substitute (validated against meta.processedFileDigest), preserving
+ * the legacy pre-raw-copy behavior -- and stamp meta.rawBomMissing when every
+ * candidate answered with an authoritative 404 so later requests skip the
+ * probing entirely.
+ */
+export async function resolveAndFetchRawBom(
+    bomRecord: BomRecord,
+    fetchFromOci: (tag: string, repo?: string, digest?: string) => Promise<any> = defaultFetchFromOci
+): Promise<any> {
+    const bomUuid = bomRecord.uuid;
+    const rawTag = bomUuid + '-raw';
+    const meta = bomRecord.meta || ({} as any);
+    const recordedRepo = extractRepositoryNameFromBom(bomRecord);
+    const rawDigest = meta.originalFileDigest;
+
+    if (meta.rawBomMissing) {
+        logger.debug({ bomUuid }, 'Raw BOM marked missing; serving processed BOM substitute');
+        return fetchProcessedSubstitute(bomRecord, recordedRepo, fetchFromOci);
+    }
+
+    const candidates = buildCandidateRepos(meta.rawOciRepositoryName, recordedRepo, bomRecord.created_date);
+
+    let sawAmbiguousError = false;
+    for (const repo of candidates) {
+        try {
+            const content = await fetchFromOci(rawTag, repo, rawDigest);
+            // Stamp the resolved monthly repository so this row never probes
+            // again. Base-repo resolutions (repo undefined) are left unstamped
+            // -- the base repository is already the terminal fallback.
+            if (repo && repo !== meta.rawOciRepositoryName && !sawAmbiguousError) {
+                await stampRawRepository(bomUuid, repo);
+            }
+            return content;
+        } catch (error) {
+            if (error instanceof DigestValidationError) {
+                // Raw copy is PRESENT here but its bytes are wrong -- that is
+                // the integrity failure this machinery exists to catch.
+                throw error;
+            }
+            if (error instanceof OciNotFoundError) {
+                logger.debug({ bomUuid, rawTag, repo }, 'Raw BOM not in candidate repository, trying next');
+                continue;
+            }
+            sawAmbiguousError = true;
+            logger.warn({
+                bomUuid, rawTag, repo,
+                error: error instanceof Error ? error.message : String(error)
+            }, 'Non-404 error probing for raw BOM; continuing without making durable decisions');
+        }
+    }
+
+    if (!sawAmbiguousError && rawDigest) {
+        // Every candidate said an authoritative 404 -- the raw copy does not
+        // exist (pre-raw-storage upload, or removed by retention). Remember
+        // that so future requests go straight to the substitute.
+        await stampRawMissing(bomUuid);
+    }
+
+    logger.warn({
+        bomUuid,
+        candidatesTried: candidates.map(c => c ?? '<base>'),
+        ambiguousErrors: sawAmbiguousError
+    }, 'Raw BOM unavailable in all candidate repositories; serving processed BOM as substitute');
+    return fetchProcessedSubstitute(bomRecord, recordedRepo, fetchFromOci);
+}
+
+/** Ordered, de-duplicated candidate repositories; `undefined` = base legacy repo. */
+function buildCandidateRepos(
+    rawPointer: string | undefined,
+    recordedRepo: string | undefined,
+    createdDate: Date | string | undefined
+): Array<string | undefined> {
+    const candidates: Array<string | undefined> = [];
+    const push = (repo: string | undefined) => {
+        if (!candidates.some(c => c === repo)) candidates.push(repo);
+    };
+    if (rawPointer) push(rawPointer);
+    if (recordedRepo) push(recordedRepo);
+    if (createdDate) {
+        const created = new Date(createdDate);
+        if (!isNaN(created.getTime())) {
+            push(getMonthlyRepositoryName(created));
+            const prevMonth = new Date(Date.UTC(created.getUTCFullYear(), created.getUTCMonth() - 1, 15));
+            push(getMonthlyRepositoryName(prevMonth));
+        }
+    }
+    push(undefined); // base legacy repository, pre-monthly-rotation
+    return candidates;
+}
+
+/** The processed BOM served in place of a missing raw copy -- validated with ITS digest. */
+async function fetchProcessedSubstitute(
+    bomRecord: BomRecord,
+    recordedRepo: string | undefined,
+    fetchFromOci: (tag: string, repo?: string, digest?: string) => Promise<any>
+): Promise<any> {
+    const processedDigest = bomRecord.meta?.processedFileDigest;
+    logger.info({
+        bomUuid: bomRecord.uuid,
+        repository: recordedRepo,
+        validated: !!processedDigest
+    }, 'Serving processed BOM as substitute for unavailable raw BOM');
+    return fetchFromOci(bomRecord.uuid, recordedRepo, processedDigest);
+}
+
+async function stampRawRepository(bomUuid: string, repositoryName: string): Promise<void> {
+    try {
+        await runQuery(
+            `UPDATE rebom.boms SET meta = jsonb_set(meta, '{rawOciRepositoryName}', $2::jsonb) WHERE uuid = $1`,
+            [bomUuid, JSON.stringify(repositoryName)]
+        );
+        logger.info({ bomUuid, repositoryName }, 'Stamped resolved raw BOM repository');
+    } catch (error) {
+        // Stamping is an optimization; the fetch already succeeded.
+        logger.error({ bomUuid, repositoryName, error }, 'Failed to stamp raw BOM repository');
+    }
+}
+
+async function stampRawMissing(bomUuid: string): Promise<void> {
+    try {
+        await runQuery(
+            `UPDATE rebom.boms SET meta = jsonb_set(meta, '{rawBomMissing}', 'true'::jsonb) WHERE uuid = $1`,
+            [bomUuid]
+        );
+        logger.info({ bomUuid }, 'Stamped raw BOM as missing (no copy in any candidate repository)');
+    } catch (error) {
+        logger.error({ bomUuid, error }, 'Failed to stamp raw BOM as missing');
+    }
+}
+
+/**
+ * Startup census (SQL-only, no OCI traffic): how many CycloneDX rows still
+ * need on-demand raw-repository resolution, and how many of those are in the
+ * known-split shape (recorded repository differs from the upload month).
+ * Always prints one line, mirroring the duplicate-components census.
+ */
+export async function logRawRepositoryCensus(): Promise<void> {
+    try {
+        const res = await runQuery(
+            `SELECT count(*) AS unresolved,
+                    count(*) FILTER (
+                        WHERE bom->>'ociRepositoryName' IS NOT NULL
+                          AND bom->>'ociRepositoryName' != ('rebom-artifacts-' || to_char(created_date, 'YYYY-MM'))
+                    ) AS split
+             FROM rebom.boms
+             WHERE source_spdx_uuid IS NULL
+               AND meta->>'rawOciRepositoryName' IS NULL
+               AND meta->>'rawBomMissing' IS NULL`,
+            []
+        );
+        const row = res.rows?.[0] || {};
+        logger.error({
+            unresolvedRawRepoRows: Number(row.unresolved || 0),
+            knownSplitRows: Number(row.split || 0)
+        }, '[RAW-REPO-CENSUS] rows pending on-demand raw-repository resolution (split rows would previously fail raw fetches with a digest error)');
+    } catch (error) {
+        logger.error({ error }, '[RAW-REPO-CENSUS] census query failed');
+    }
+}

--- a/rebom-backend/src/types/bom.types.ts
+++ b/rebom-backend/src/types/bom.types.ts
@@ -90,6 +90,16 @@ export type RebomOptions = {
     originalMediaType?: string,
     processedFileDigest?: string,  // SHA256 of augmented/processed BOM file
     processedFileSize?: number,
+    // Repository holding the '-raw' copy. The processed BOM's repository
+    // (bom.ociRepositoryName) moves to the CURRENT month on enrichment
+    // re-push, but the raw copy stays where it was uploaded -- one pointer
+    // cannot describe both. Stamped at upload; resolved-and-stamped on
+    // demand for legacy rows (see rawBomResolver).
+    rawOciRepositoryName?: string,
+    // True when no '-raw' copy exists anywhere (pre-2026-01 uploads, or
+    // removed by retention). Raw requests then serve the processed BOM as
+    // an explicit substitute instead of re-probing repositories every time.
+    rawBomMissing?: boolean,
     stripBom: string,
     bomVersion: string,
     purl?: string,

--- a/rebom-backend/src/types/errors.ts
+++ b/rebom-backend/src/types/errors.ts
@@ -85,6 +85,43 @@ export class OciStorageError extends Error {
     }
 }
 
+/**
+ * Artifact/tag does not exist in the OCI registry (authoritative HTTP 404 from
+ * the OCI artifact service). Distinct from transport/server errors so callers
+ * can make durable decisions (e.g. probe another repository, stamp a
+ * raw-missing marker) ONLY on a definitive not-found.
+ */
+export class OciNotFoundError extends Error {
+    constructor(
+        message: string,
+        public tag?: string,
+        public repository?: string
+    ) {
+        super(message);
+        this.name = 'OciNotFoundError';
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
+/**
+ * Downloaded artifact bytes do not hash to the stored digest. Must NEVER be
+ * swallowed or retried against a different artifact -- it names the exact
+ * artifact whose integrity check failed.
+ */
+export class DigestValidationError extends Error {
+    constructor(
+        message: string,
+        public tag?: string,
+        public repository?: string,
+        public expectedDigest?: string,
+        public actualDigest?: string
+    ) {
+        super(message);
+        this.name = 'DigestValidationError';
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+
 export class BomDataIntegrityError extends Error {
     constructor(
         message: string,

--- a/rebom-backend/test/unit/rawBomResolver.test.ts
+++ b/rebom-backend/test/unit/rawBomResolver.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stub DB access: stamping is observed through the mock, no live PG needed.
+vi.mock('../../src/utils', () => ({
+    runQuery: vi.fn(async () => ({ rows: [] })),
+    pool: {}
+}));
+
+import { resolveAndFetchRawBom } from '../../src/services/oci/rawBomResolver';
+import { OciNotFoundError, DigestValidationError } from '../../src/types/errors';
+import { runQuery } from '../../src/utils';
+import { getMonthlyRepositoryName } from '../../src/services/oci';
+
+const RAW_DIGEST = 'raw-digest';
+const PROCESSED_DIGEST = 'processed-digest';
+const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function record(overrides: any = {}): any {
+    return {
+        uuid: UUID,
+        created_date: new Date('2026-05-10T12:00:00Z'),
+        meta: {
+            originalFileDigest: RAW_DIGEST,
+            processedFileDigest: PROCESSED_DIGEST,
+            ...(overrides.meta || {})
+        },
+        bom: { ociRepositoryName: overrides.recordedRepo ?? 'rebom-artifacts-2026-06' }
+    };
+}
+
+const notFound = () => { throw new OciNotFoundError('not found'); };
+
+beforeEach(() => {
+    vi.mocked(runQuery).mockClear();
+});
+
+describe('resolveAndFetchRawBom', () => {
+    it('fetches raw from the stamped pointer without re-stamping', async () => {
+        const fetch = vi.fn(async (tag: string, repo?: string) => {
+            expect(tag).toBe(UUID + '-raw');
+            expect(repo).toBe('rebom-artifacts-2026-05');
+            return { ok: true };
+        });
+        const rec = record({ meta: { rawOciRepositoryName: 'rebom-artifacts-2026-05' } });
+        expect(await resolveAndFetchRawBom(rec, fetch)).toEqual({ ok: true });
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(runQuery).not.toHaveBeenCalled();
+    });
+
+    it('resolves a split row via the upload-month repo and stamps the pointer', async () => {
+        // Recorded repo (2026-06, post-enrichment) lacks the raw copy; the
+        // upload month derived from created_date (2026-05) has it.
+        const fetch = vi.fn(async (tag: string, repo?: string, digest?: string) => {
+            if (tag === UUID + '-raw' && repo === 'rebom-artifacts-2026-05') {
+                expect(digest).toBe(RAW_DIGEST);
+                return { raw: true };
+            }
+            notFound();
+        });
+        expect(await resolveAndFetchRawBom(record(), fetch)).toEqual({ raw: true });
+        const stamp = vi.mocked(runQuery).mock.calls.find(c => String(c[0]).includes('rawOciRepositoryName'));
+        expect(stamp).toBeTruthy();
+        expect(stamp![1]).toEqual([UUID, JSON.stringify('rebom-artifacts-2026-05')]);
+    });
+
+    it('rethrows a digest failure on the raw artifact immediately -- no substitute fetch', async () => {
+        const fetch = vi.fn(async (tag: string) => {
+            if (tag === UUID + '-raw') {
+                throw new DigestValidationError('corrupt', tag, 'repo', RAW_DIGEST, 'other');
+            }
+            return { should: 'never-happen' };
+        });
+        await expect(resolveAndFetchRawBom(record(), fetch)).rejects.toBeInstanceOf(DigestValidationError);
+        // Exactly one fetch: the raw attempt. No fallback, no further probing.
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(runQuery).not.toHaveBeenCalled();
+    });
+
+    it('serves the processed substitute (validated with ITS digest) and stamps raw-missing on all-404', async () => {
+        const fetch = vi.fn(async (tag: string, repo?: string, digest?: string) => {
+            if (tag === UUID + '-raw') notFound();
+            expect(tag).toBe(UUID);
+            expect(digest).toBe(PROCESSED_DIGEST);
+            return { substitute: true };
+        });
+        expect(await resolveAndFetchRawBom(record(), fetch)).toEqual({ substitute: true });
+        const stamp = vi.mocked(runQuery).mock.calls.find(c => String(c[0]).includes('rawBomMissing'));
+        expect(stamp).toBeTruthy();
+    });
+
+    it('still serves the substitute on ambiguous (non-404) errors but makes no durable decisions', async () => {
+        const fetch = vi.fn(async (tag: string, repo?: string, digest?: string) => {
+            if (tag === UUID + '-raw') {
+                if (repo === 'rebom-artifacts-2026-06') throw new Error('OCI fetch returned HTTP 500');
+                notFound();
+            }
+            expect(digest).toBe(PROCESSED_DIGEST);
+            return { substitute: true };
+        });
+        expect(await resolveAndFetchRawBom(record(), fetch)).toEqual({ substitute: true });
+        // 500 in the mix -> neither pointer nor raw-missing may be stamped.
+        expect(runQuery).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits straight to the substitute when raw-missing is stamped', async () => {
+        const fetch = vi.fn(async (tag: string, repo?: string, digest?: string) => {
+            expect(tag).toBe(UUID);
+            expect(digest).toBe(PROCESSED_DIGEST);
+            return { substitute: true };
+        });
+        const rec = record({ meta: { rawBomMissing: true } });
+        expect(await resolveAndFetchRawBom(rec, fetch)).toEqual({ substitute: true });
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('probes the base legacy repository last for pre-rotation rows', async () => {
+        const tried: Array<string | undefined> = [];
+        const fetch = vi.fn(async (tag: string, repo?: string) => {
+            if (tag === UUID + '-raw') { tried.push(repo); notFound(); }
+            return { substitute: true };
+        });
+        const rec = record({ recordedRepo: undefined });
+        rec.bom = {}; // legacy row: no recorded repository at all
+        await resolveAndFetchRawBom(rec, fetch);
+        expect(tried[tried.length - 1]).toBeUndefined(); // base repo fallback
+        expect(tried).toContain(getMonthlyRepositoryName(new Date('2026-05-10T12:00:00Z')));
+    });
+});


### PR DESCRIPTION
Root cause of `Digest validation failed for artifact` on legacy data: enrichment re-pushes the **processed** BOM into the **current month's** OCI repository (deliberately — closed monthly repos are the backup unit and are never written to) and moves `bom.ociRepositoryName` with it, while the `-raw` copy stays in the **upload month's** repo. One pointer can't describe both artifacts, so any BOM enriched in a later month than uploaded has its pair split. The old `fetchRawBomWithFallback` then missed the raw copy in the recorded repo, fell back to the processed tag, and validated it against the **raw** digest — surfacing a misplaced but fully intact artifact as a digest failure (verified live: the raw copy digest-matches perfectly in its upload-month repo; no corruption anywhere).

**Fix (no change to write patterns — closed repos stay untouched):**
- `meta.rawOciRepositoryName` stamped at upload; enrichment keeps writing only to the current month.
- `resolveAndFetchRawBom` replaces the fallback: probes candidate repos (stamped pointer → recorded → upload month from `created_date` → adjacent month → base legacy repo), **digest-validating every attempt** so probing can never serve wrong bytes; stamps the pointer on success so each row probes at most once.
- Strict error semantics: a digest failure on the raw artifact **rethrows immediately** naming that artifact (previously it was swallowed and retried against the processed copy — masking real corruption, or in the byte-identical corner case, hiding it entirely); authoritative 404 advances the probe; any other error (5xx/transport, incl. version skew with an older artifact service) advances it too but disables all stamping for that call.
- No raw copy anywhere → `meta.rawBomMissing` stamped; the processed BOM is served as an explicit, logged substitute validated against `processedFileDigest` — preserving pre-raw-storage legacy behavior, now integrity-checked.
- SQL-only startup census (one line, always) of rows pending resolution + known-split count.
- **oci-artifact-service**: `/pull` now returns 404 for a definitive registry not-found instead of a blanket 500, so callers can distinguish "doesn't exist here" from "server trouble".

Tests: new `rawBomResolver` unit suite (7 cases: pointer hit, split-resolution + stamp, immediate digest-failure propagation with no substitute fetch, all-404 substitute + raw-missing stamp, ambiguous-error no-stamp, raw-missing short-circuit, base-repo last probe). Full rebom unit suite 159/159; OAS `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Review follow-ups (second commit):** 404 classification now uses `errors.Is(err, errdef.ErrNotFound)` only — the substring match could have classified a non-authoritative failure as definitive and poisoned a permanent `rawBomMissing` stamp with no self-healing path. `PullArtifact` also fails fast on a definitive not-found instead of eating the 5-attempt backoff. Both verified live against zot on the sandbox: missing tag (MANIFEST_UNKNOWN) → 404 in 86ms, missing repository (NAME_UNKNOWN) → 404 in 13ms, existing artifact → 200 — confirming oras-go wraps `errdef.ErrNotFound` for both registry shapes, so the string net was indeed unnecessary.

**Third commit — enrichment write-race tolerance.** A second production error class turned out to be a distinct race the strict validation now surfaces: enrichment overwrites the processed BOM's bytes at tag `<uuid>` *before* writing the new digest to the row, so a reader straddling the two steps validates new bytes against the old digest. The window is milliseconds for user downloads but **minutes** for the programmatic readers (the enrichment scheduler's candidate list is loaded at cycle start; the ReARM backend's per-minute reconcile fetches fresh uploads while their first enrichment is in flight) — automated collisions are the common case. `fetchProcessedBomWithRetry` now wraps every digest-validated processed-BOM read: on a digest failure it re-reads the row once — changed digest/repo ⇒ it was the race, refetch against fresh values; unchanged row ⇒ genuine corruption, original error rethrown untouched. 6 new unit cases; full rebom suite 165/165.