### PR TITLE
docs: correct the CE/Pro split and document ownership-based routing

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -31,7 +31,9 @@ function sidebar() {
           {text: 'Committers & Commit Signing', link: '/workflows/committers'}
         ]},
         {text: 'Configure', link: '/configure/', items: [
-          {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'}
+          {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'},
+          {text: 'Notifications', link: '/configure/notifications'},
+          {text: 'Approval Queues', link: '/configure/approval-queues'}
         ]},
         {text: 'Transparency Exchange API', link: '/tea/' },
         {text: 'Integrations', link: '/integrations/',
@@ -64,6 +66,7 @@ function sidebar() {
             },
             {text: 'Slack', link: '/integrations/slack'},
             {text: 'Microsoft Teams', link: '/integrations/msteams'},
+            {text: 'Microsoft Sentinel', link: '/integrations/sentinel'},
             {text: 'Dependency-Track', link: '/integrations/dtrack',
               items: [
                 {text: 'Dependency-Track 5 Helm Chart', link: '/integrations/dtrackChart'}

--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -32,6 +32,7 @@ function sidebar() {
         ]},
         {text: 'Configure', link: '/configure/', items: [
           {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'},
+          {text: 'Component Ownership', link: '/configure/component-ownership'},
           {text: 'Notifications', link: '/configure/notifications'},
           {text: 'Approval Queues', link: '/configure/approval-queues'}
         ]},

--- a/documentation_site/docs/configure/approval-queues.md
+++ b/documentation_site/docs/configure/approval-queues.md
@@ -1,11 +1,10 @@
-
 ---
 sidebarDepth: 2
 ---
 
 # Approval Queues
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 :::
 
 An **approval policy** on a release can require a minimum number of approvals

--- a/documentation_site/docs/configure/approval-queues.md
+++ b/documentation_site/docs/configure/approval-queues.md
@@ -1,0 +1,66 @@
+
+---
+sidebarDepth: 2
+---
+
+# Approval Queues
+
+::: info ReARM Pro only
+:::
+
+An **approval policy** on a release can require a minimum number of approvals
+(and set a maximum number of disapprovals before the release is vetoed) from
+users holding specific **approval roles**, before the release can be
+considered fully approved. This page covers where those pending approvals
+show up and who gets notified about them -- see [Manage Users and User Group
+Permissions](./user-and-user-group-permissions) for how approval roles and
+permissions are granted in the first place.
+
+## Where to find pending approvals
+
+Open **Notification Inbox -> Needs my approval**. This tab lists every
+release that is currently waiting on *your* vote -- it's computed live from
+each release's approval policy and current votes, not a saved list, so it's
+always current.
+
+This is different from **Notification History**, which is an org-admin audit
+log of every notification ReARM has sent -- the approval-queue tab only shows
+what's still actionable for you specifically.
+
+## Casting a vote vs. being asked to vote
+
+These are two different things, and they don't always go together:
+
+- **Casting a vote (approve/disapprove) on a release:** any user holding an
+  approval role that the release's policy accepts can vote. **Organization
+  Admins can always vote, on any release, regardless of role** -- this is the
+  existing rule described in [Manage Users and User Group
+  Permissions](./user-and-user-group-permissions#3-organization-wide-approval-permissions).
+- **Showing up in "Needs my approval" / getting an `APPROVAL_REQUESTED`
+  notification:** this is driven **only** by whether you hold an explicit
+  approval role that the release's policy accepts -- the Organization Admin
+  override does **not** put releases in your queue or trigger a notification
+  to you.
+
+::: warning An Org Admin with no approval role has a quiet inbox
+Being an Organization Admin gives you the *capability* to approve anything,
+but not *visibility* into what's waiting. If you want an admin to be
+proactively notified and see items in their approval queue, grant them an
+explicit approval role in addition to Admin -- Admin alone is not enough for
+that. This is intentional (it keeps an admin's queue from filling up with
+every pending release org-wide), but it surprises people who expect "Admin"
+to imply "sees everything."
+:::
+
+## Requesting an approval
+
+Requesting an approval on a release notifies the release's eligible approvers
+(the same role-based set described above -- Organization Admins without an
+approval role are not included in the notification, for the same reason they
+don't appear in the queue). A request is advisory: it doesn't change what's
+required to approve the release, and a release can still be approved or
+disapproved without ever having a request opened on it.
+
+Approval-related notifications (`APPROVAL_REQUESTED` and `APPROVAL_RESOLVED`,
+see [Notifications](./notifications#event-types)) always deliver immediately,
+even on channels configured for digest/batched delivery elsewhere.

--- a/documentation_site/docs/configure/component-ownership.md
+++ b/documentation_site/docs/configure/component-ownership.md
@@ -1,0 +1,107 @@
+---
+sidebarDepth: 2
+---
+
+# Component Ownership
+
+Every component can have an **owner**: the team accountable for it. ReARM uses
+the owner to answer "who should hear about this?" without anyone having to
+maintain that list by hand in each place it matters --
+[notification routes](./notifications#notifying-the-component-owner) can
+address the owner directly, and the ownership report tells you which components
+have nobody durable behind them.
+
+Ownership is deliberately **separate from access**. Owning a component does not
+grant permissions on it, and holding permissions does not make you the owner.
+Access is configured under
+[Users and User Groups Permissions](./user-and-user-group-permissions).
+
+## Setting an owner
+
+Open a component, go to **Settings**, and use the **Owner** picker. You can
+name a team or an individual user.
+
+Prefer a **team**. An individual owner is valid and ReARM records it, but a
+person leaves, and only a team can be a notification target -- a user has no
+channels of their own, so a route that notifies the component owner will not
+deliver for a user-owned component.
+
+## Ownership status
+
+ReARM recomputes a component's ownership status on read; it is never stored, so
+it always reflects the current state of the owner it points at.
+
+| Status | Meaning |
+|---|---|
+| `OWNED` | A stored owner that is valid and durable. The healthy state. |
+| `NON_DURABLE` | Valid, but resting on a single point of failure: an individual owner, or a team with fewer than two direct members that is not SSO-backed. |
+| `DEGRADED` | The owner still resolves but has weakened -- typically the owner team has been archived or made inactive. |
+| `UNSET` | No owner has been chosen, but ReARM can suggest a candidate team. |
+| `ORPHANED` | No owner and nothing to suggest, or a stored owner that no longer resolves. Needs a human. |
+
+A component is **addressable for notifications** when it is owned by a team and
+its status is `OWNED` or `NON_DURABLE`. The other three states have no usable
+owner, so an owner-routed notification simply produces no delivery for that
+component.
+
+::: tip Ownership never blocks a release
+None of these states gate a release, a build, or an approval. They drive a
+non-blocking banner on the component and the at-risk report -- nothing else.
+:::
+
+### Why "durable" is its own state
+
+A one-person team is a real owner, not a mistake, so ReARM does not report it
+as an error. But it is a weak one: when that person leaves, the component
+becomes orphaned silently. `NON_DURABLE` names that risk without treating it as
+a failure, which is why those components still receive notifications while
+still showing up on the at-risk report.
+
+A team counts as durable when it has at least **two** direct members, or when
+it is backed by an SSO group.
+
+## Assignment rules
+
+Setting an owner component by component does not scale. **Team assignment
+rules** (Organization Settings -> User Groups, org admins only) assign
+ownership in bulk: each rule pairs a regular expression against the component
+**name** with an owner team, and can optionally restrict itself to components
+only or products only.
+
+For example, a rule matching `Payments.*` pointing at the Payments Platform
+team makes every current and future component whose name starts with
+`Payments` owned by that team, with nothing to set per component.
+
+Notes on how rules resolve:
+
+- The pattern must match the **entire** component name, not just part of it. So
+  the pattern `Payments` matches only a component called exactly `Payments`; to
+  catch `Payments API` as well you need `Payments.*`.
+- Rules are evaluated in the order they appear, and the **first** match wins.
+- A rule-assigned owner is a real owner and is treated exactly like a stored
+  one for notifications and durability -- a rule pointing at a one-person team
+  still reports `NON_DURABLE`.
+
+### Precedence
+
+When more than one source could decide an owner, ReARM resolves in this order:
+
+1. **A stored owner** set on the component. A rule never overrides a deliberate
+   human choice.
+2. **The first matching assignment rule.**
+3. **A suggested candidate**, if one is derivable. This is a suggestion only:
+   the component reports `UNSET` until somebody accepts it or a rule covers it.
+
+## Finding components at risk
+
+On an individual component, the **Settings** panel shows the computed status
+next to the owner picker, along with the reason behind it -- for example that
+the owner team has fewer than two members, or that it was assigned by a
+particular rule rather than chosen directly.
+
+Organization-wide, an **ownership report** returns every component that is not
+cleanly `OWNED`, together with its computed status. This is the practical
+starting point after enabling owner-routed notifications: a component missing
+from your alerts is usually a component missing an owner. The report is
+currently available through the GraphQL API (`componentOwnershipReport`,
+org-admin only) rather than as a page in the UI.

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -1,0 +1,128 @@
+
+---
+sidebarDepth: 2
+---
+
+# Notifications
+
+::: info ReARM Pro only
+Everything on this page -- channels, subscriptions, routes, and KEV alerts --
+is part of ReARM Pro's security-and-operational notification framework,
+configured under **Organization Settings -> Integrations -> Notifications**.
+This is separate from the CE-level Slack/Teams **release** notifications
+described on the [Slack](../integrations/slack) and [Microsoft
+Teams](../integrations/msteams) pages -- see the callout on the Microsoft
+Teams page if you're not sure which one you need.
+:::
+
+## How it fits together
+
+1. A **channel** is a named destination: Slack, Microsoft Teams, a generic
+   webhook, email, or [Microsoft Sentinel](../integrations/sentinel). Add one
+   from the **Notifications -> Channels** tab.
+2. A **subscription** decides which events go to which channels. Add one from
+   the **Notifications -> Subscriptions** tab: pick the event types you care
+   about, an optional filter, and one or more **routes** -- each route pairs a
+   minimum severity with a set of channels (or channel groups).
+3. A **channel group** (Notifications -> Channel Groups) is just a named,
+   reusable list of channels you can reference from a route instead of
+   repeating the same channels on every subscription.
+
+Nothing is delivered until both a channel *and* a subscription routing to it
+exist -- adding a channel alone does not send you anything.
+
+## Event types
+
+A subscription's `eventTypes` list controls what it can match:
+
+| Event | Fires when |
+|---|---|
+| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability is newly linked to one of your releases |
+| `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
+| `VEX_STATE_CHANGED` | A VEX (exploitability) status changes on a finding |
+| `RELEASE_CREATED` | A new release is created |
+| `RELEASE_LIFECYCLE_CHANGED` | A release moves lifecycle stage |
+| `RELEASE_BOM_DIFF` | A release's BOM diff is computed |
+| `APPROVAL_REQUESTED` | Someone requests approval on a release -- see [Approval queues](./approval-queues) |
+| `APPROVAL_RESOLVED` | An approval request is satisfied or disapproved |
+
+## Filters, severity, and routes
+
+- A subscription can carry an optional filter, built either with the preset
+  toggles or as an advanced expression. Advanced filters run under limits
+  (size, nesting depth, iteration count, and a short evaluation timeout) so a
+  runaway expression can't stall delivery for the rest of the org -- a filter
+  that exceeds its budget fails that one delivery rather than blocking others.
+- Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
+  `MEDIUM` / ...); only events at or above that threshold on that route are
+  sent to its channels.
+
+## Duplicate delivery protection
+
+ReARM deduplicates deliveries to the same channel from the same subscription
+within a rolling window (configurable per subscription; several hours by
+default), so a flapping upstream signal won't repeat-fire the same alert to
+the same channel over and over. Test/synthetic events (see
+[Testing](#testing-channels-and-subscriptions) below) intentionally bypass
+dedup, so a test always produces a visible delivery.
+
+::: warning Per-subscription rate limit is not enforced yet
+The subscription rate-limit fields (`maxPerWindow` / `windowMinutes`) are
+present and saved, but do not currently throttle delivery volume at
+fan-out -- setting them has no runtime effect. This is a known, deliberate
+gap, not a bug you need to work around; if you're relying on a specific
+delivery cap today, use your destination's own rate limiting (e.g. a Slack
+app's built-in limits) in the meantime.
+:::
+
+## Retention
+
+Notification history (deliveries and inbox rows) is retained for a
+configurable number of days per organization, with an enforced 14-day floor --
+an org can't set retention short enough to delete a row that might still be
+scheduled to send (e.g. one parked in an email digest).
+
+## Testing channels and subscriptions
+
+::: warning No "send test" button yet
+Sending a real test event to a channel currently has no UI -- the backend
+supports it, but you'll need a direct API call (or ask someone with API
+access) until the button ships. Documenting the current state here rather
+than the button because this comes up as soon as you add a channel and want
+to confirm it works.
+:::
+
+If you have API access, two mutations exist for confirming a channel or
+subscription actually works, without waiting for a real event: one that pings
+a single channel directly (bypassing subscription matching, filters, and
+severity gates, so it always produces a visible delivery), and one that
+injects a synthetic event of a chosen scenario (e.g. a critical vulnerability
+on a single shipped release, a newly-KEV-listed CVE) through the normal
+subscription-matching path, so you can confirm your filters and routes behave
+the way you expect. Both bypass the dedup window described above.
+
+## KEV (Known Exploited Vulnerabilities) notifications
+
+ReARM can alert you when a vulnerability affecting your releases is added to
+a Known Exploited Vulnerabilities catalog. Two sources are supported:
+
+- **CISA KEV** -- the public CISA catalog, enabled by default for every
+  organization, no credential required.
+- **VulnCheck KEV** -- opt-in, requires your own VulnCheck API token
+  (Organization Settings -> Integrations).
+
+When a CVE is newly added to an enabled KEV source **and** it affects one of
+your existing vulnerability records, ReARM emits a `VULNERABILITY_RECORD_UPDATED`
+event your subscriptions can route on.
+
+::: tip You won't get flooded with historical KEV alerts on day one
+The *first* KEV sync for a newly enabled source treats every existing catalog
+entry as a baseline rather than "newly added," so enabling CISA KEV (or
+VulnCheck KEV) doesn't fire years of historical listings at you all at once.
+Only CVEs that become KEV-listed *after* that first sync trigger a
+notification.
+:::
+
+A CVE dropping off a KEV catalog does not currently un-list it on ReARM's
+side -- KEV status is treated as sticky once observed, so a temporary upstream
+catalog issue can't make your org's KEV picture shrink unexpectedly.

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -1,11 +1,10 @@
-
 ---
 sidebarDepth: 2
 ---
 
 # Notifications
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 Everything on this page -- channels, subscriptions, routes, and KEV alerts --
 is part of ReARM Pro's security-and-operational notification framework,
 configured under **Organization Settings -> Integrations -> Notifications**.
@@ -60,7 +59,7 @@ A subscription's `eventTypes` list controls what it can match:
 ## Duplicate delivery protection
 
 ReARM deduplicates deliveries to the same channel from the same subscription
-within a rolling window (configurable per subscription; several hours by
+within a rolling window (configurable per subscription; 24 hours by
 default), so a flapping upstream signal won't repeat-fire the same alert to
 the same channel over and over. Test/synthetic events (see
 [Testing](#testing-channels-and-subscriptions) below) intentionally bypass

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -18,7 +18,8 @@ Teams page if you're not sure which one you need.
 
 1. A **channel** is a named destination: Slack, Microsoft Teams, a generic
    webhook, email, or [Microsoft Sentinel](../integrations/sentinel). Add one
-   from the **Notifications -> Channels** tab.
+   from the **Integrations -> Catalog** tab -- each channel type is a card
+   there; click **Add** on the card to configure a destination.
 2. A **subscription** decides which events go to which channels. Add one from
    the **Notifications -> Subscriptions** tab: pick the event types you care
    about, an optional filter, and one or more **routes** -- each route pairs a
@@ -38,7 +39,7 @@ A subscription's `eventTypes` list controls what it can match:
 |---|---|
 | `NEW_VULN_AFFECTS_RELEASES` | A vulnerability is newly linked to one of your releases |
 | `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
-| `VEX_STATE_CHANGED` | A VEX (exploitability) status changes on a finding |
+| `VEX_STATE_CHANGED` | Reserved for VEX (exploitability) status changes. No event source emits this yet, so a subscription on it will not fire today -- prefer `VULNERABILITY_RECORD_UPDATED` for vulnerability-state changes |
 | `RELEASE_CREATED` | A new release is created |
 | `RELEASE_LIFECYCLE_CHANGED` | A release moves lifecycle stage |
 | `RELEASE_BOM_DIFF` | A release's BOM diff is computed |
@@ -83,22 +84,25 @@ scheduled to send (e.g. one parked in an email digest).
 
 ## Testing channels and subscriptions
 
-::: warning No "send test" button yet
-Sending a real test event to a channel currently has no UI -- the backend
-supports it, but you'll need a direct API call (or ask someone with API
-access) until the button ships. Documenting the current state here rather
-than the button because this comes up as soon as you add a channel and want
-to confirm it works.
-:::
+You can confirm a channel or subscription works without waiting for a real
+event, straight from the UI:
 
-If you have API access, two mutations exist for confirming a channel or
-subscription actually works, without waiting for a real event: one that pings
-a single channel directly (bypassing subscription matching, filters, and
-severity gates, so it always produces a visible delivery), and one that
-injects a synthetic event of a chosen scenario (e.g. a critical vulnerability
-on a single shipped release, a newly-KEV-listed CVE) through the normal
-subscription-matching path, so you can confirm your filters and routes behave
-the way you expect. Both bypass the dedup window described above.
+- **Test a channel** -- on the channel's card in **Integrations -> Catalog**,
+  use the **Send test** (paper-plane) action on the configured instance. This
+  pings that one channel directly, bypassing subscription matching, filters,
+  and severity gates, so it always produces a visible delivery -- the fastest
+  way to confirm a webhook URL is reachable and authorized.
+- **Test a subscription** -- in **Integrations -> Subscriptions**, use the
+  **Test** action on a subscription row and pick a synthetic scenario (e.g. a
+  critical vulnerability on a single shipped release, a newly-KEV-listed CVE).
+  The event is injected through the normal subscription-matching path, so you
+  can confirm your filters, severity gates, and routes behave the way you
+  expect. Note this injects a real synthetic event for the whole organization,
+  so any *other* active subscription matching the same event type will also
+  fire -- the UI asks you to confirm before sending.
+
+Both bypass the dedup window described above, so a test always produces a
+delivery you can see in **Delivery History**.
 
 ## KEV (Known Exploited Vulnerabilities) notifications
 

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -4,14 +4,20 @@ sidebarDepth: 2
 
 # Notifications
 
-::: warning ReARM Pro only
-Everything on this page -- channels, subscriptions, routes, and KEV alerts --
-is part of ReARM Pro's security-and-operational notification framework,
-configured under **Organization Settings -> Integrations -> Notifications**.
-This is separate from the CE-level Slack/Teams **release** notifications
-described on the [Slack](../integrations/slack) and [Microsoft
-Teams](../integrations/msteams) pages -- see the callout on the Microsoft
-Teams page if you're not sure which one you need.
+The security-and-operational notification framework is configured under
+**Organization Settings -> Integrations**. It is separate from the Slack/Teams
+**release** notifications described on the [Slack](../integrations/slack) and
+[Microsoft Teams](../integrations/msteams) pages -- see the callout on the
+Microsoft Teams page if you're not sure which one you need.
+
+::: tip What Community Edition includes
+Subscriptions, routes, and channel groups are available on **both** editions,
+as are the **Slack**, **Microsoft Teams**, and **Webhook** channel types.
+
+Pro adds two channel types -- **Email** and
+[**Microsoft Sentinel**](../integrations/sentinel) -- and two route targets,
+**teams** and **notify the component owner**. Everything else on this page
+works the same on either edition.
 :::
 
 ## How it fits together
@@ -20,11 +26,11 @@ Teams page if you're not sure which one you need.
    webhook, email, or [Microsoft Sentinel](../integrations/sentinel). Add one
    from the **Integrations -> Catalog** tab -- each channel type is a card
    there; click **Add** on the card to configure a destination.
-2. A **subscription** decides which events go to which channels. Add one from
-   the **Notifications -> Subscriptions** tab: pick the event types you care
-   about, an optional filter, and one or more **routes** -- each route pairs a
-   minimum severity with a set of channels (or channel groups).
-3. A **channel group** (Notifications -> Channel Groups) is just a named,
+2. A **subscription** decides which events go where. Add one from the
+   **Integrations -> Subscriptions** tab: pick the event types you care about,
+   an optional filter, and one or more **routes** -- each route pairs a minimum
+   severity with one or more [targets](#route-targets).
+3. A **channel group** (Integrations -> Channel groups) is just a named,
    reusable list of channels you can reference from a route instead of
    repeating the same channels on every subscription.
 
@@ -55,7 +61,51 @@ A subscription's `eventTypes` list controls what it can match:
   that exceeds its budget fails that one delivery rather than blocking others.
 - Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
   `MEDIUM` / ...); only events at or above that threshold on that route are
-  sent to its channels.
+  sent to its targets.
+
+### Route targets
+
+A route can deliver to any combination of these. A route with no target at all
+delivers nothing, so the editor will not let you save one.
+
+| Target | Delivers to | Edition |
+|---|---|---|
+| **Channels** | The channels you name explicitly | CE and Pro |
+| **Channel groups** | Every channel in the named group | CE and Pro |
+| **Teams** | The named team's own notification channels | Pro |
+| **Notify the component owner** | The channels of whichever team owns the affected component | Pro |
+
+The last two are what let a route describe *who* should hear about something
+rather than *where* to send it. That distinction matters most for owner
+routing, described next.
+
+### Notifying the component owner
+
+Tick **notify the component owner** on a route and you do not name a
+destination at all. When an event arrives, ReARM works out which components it
+affects, resolves each one's owner, and delivers to that owner team's channels.
+
+Because this is resolved at delivery time rather than stored on the
+subscription, the route keeps working when ownership changes: reassign a
+component to a different team, or change an
+[assignment rule](./component-ownership#assignment-rules), and the next event
+goes to the new owner with no edit to the subscription.
+
+For a delivery to happen, the affected component's owner must be:
+
+- a **team** (an individual owner has no channels of its own -- see
+  [Component ownership](./component-ownership)), and
+- in the `OWNED` or `NON_DURABLE` state (a `DEGRADED`, `UNSET`, or `ORPHANED`
+  component has no usable owner), and
+- a team that has at least one notification channel configured.
+
+If none of those hold, the route contributes no delivery. It does **not** fall
+back to sending anywhere else, so an unowned component is silent rather than
+noisy -- worth remembering when a test produces nothing (see
+[Testing](#testing-channels-and-subscriptions)).
+
+One event can affect several components with different owners; each owner team
+is resolved independently and every one of them is notified.
 
 ## Duplicate delivery protection
 
@@ -78,9 +128,9 @@ app's built-in limits) in the meantime.
 ## Retention
 
 Notification history (deliveries and inbox rows) is retained for a
-configurable number of days per organization, with an enforced 14-day floor --
-an org can't set retention short enough to delete a row that might still be
-scheduled to send (e.g. one parked in an email digest).
+configurable number of days per organization -- 90 by default, with an enforced
+14-day floor. An org can't set retention short enough to delete a row that
+might still be scheduled to send (e.g. one parked in an email digest).
 
 ## Testing channels and subscriptions
 
@@ -103,6 +153,14 @@ event, straight from the UI:
 
 Both bypass the dedup window described above, so a test always produces a
 delivery you can see in **Delivery History**.
+
+::: tip A test on an owner-routed subscription can legitimately show nothing
+If the only route on the subscription
+[notifies the component owner](#notifying-the-component-owner), a test that
+reports no delivery usually means the component the test event landed on has no
+owner, or its owner team has no channel -- not that your filter or severity
+gate is wrong. Check ownership first; the result dialog says so too.
+:::
 
 ## KEV (Known Exploited Vulnerabilities) notifications
 

--- a/documentation_site/docs/configure/user-and-user-group-permissions.md
+++ b/documentation_site/docs/configure/user-and-user-group-permissions.md
@@ -90,6 +90,13 @@ All functions are always available for `Administrator` permission type.
 
 If set, allow users to set granted approvals for all objects in the organization. Organization Admins can always set granted approvals.
 
+::: tip Approving vs. being notified
+The "Admins can always approve" rule above only covers the capability to
+*cast* a vote -- it does not put releases in an admin's approval queue or
+notify them. See [Approval Queues](./approval-queues) for the distinction and
+how to give an admin visibility, not just capability.
+:::
+
 ### 4) Scoped Permissions
 
 Both users and user groups support scoped overrides for:

--- a/documentation_site/docs/integrations/index.md
+++ b/documentation_site/docs/integrations/index.md
@@ -14,6 +14,7 @@ Generic integrations with ReARM can be done using [ReARM CLI](./rearmcli).
 ## Notification Integrations
 1. [Slack](./slack)
 2. [Microsoft Teams](./msteams)
+3. [Microsoft Sentinel](./sentinel)
 
 ## Integrations with Cyber-Security Tools
 1. [Dependency-Track](./dtrack)

--- a/documentation_site/docs/integrations/sentinel.md
+++ b/documentation_site/docs/integrations/sentinel.md
@@ -1,7 +1,6 @@
-
 # Microsoft Sentinel
 
-::: info ReARM Pro only
+::: warning ReARM Pro only
 Microsoft Sentinel is a **security and operational notification channel** (routed
 through **Notifications -> Channels**), not a release-notification integration.
 It streams the same event feed described in [Notifications](../configure/notifications)
@@ -46,10 +45,12 @@ the DCE/DCR/service-principal trio if you don't have them yet.
 4. Click **Save**.
 
 ::: tip Editing later
-On edit, the tenant ID / client ID / client secret fields show as
-`(unchanged)` -- leave them blank to keep the existing credentials, or fill in
-all three together to rotate them. The DCR endpoint / immutable ID / stream
-name always show their current values and can be changed independently.
+On edit, all six fields show blank with an `(unchanged)` placeholder --
+credentials and DCR routing are stored and replaced together as one unit.
+Leave all six blank to keep everything as-is, or fill in all six together to
+replace the whole configuration (e.g. to point at a different DCR, you must
+re-enter the tenant ID / client ID / client secret too, even if those
+haven't changed).
 :::
 
 ## Route events to the channel

--- a/documentation_site/docs/integrations/sentinel.md
+++ b/documentation_site/docs/integrations/sentinel.md
@@ -1,0 +1,72 @@
+
+# Microsoft Sentinel
+
+::: info ReARM Pro only
+Microsoft Sentinel is a **security and operational notification channel** (routed
+through **Notifications -> Channels**), not a release-notification integration.
+It streams the same event feed described in [Notifications](../configure/notifications)
+into Microsoft Sentinel (Azure Log Analytics) via the [Logs Ingestion
+API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview).
+:::
+
+## Prerequisites
+
+Before adding a Sentinel channel in ReARM, you need, in the Azure portal:
+
+1. **A Data Collection Endpoint (DCE)** and its ingestion URL, e.g.
+   `https://<dce-name>.<region>.ingest.monitor.azure.com`.
+2. **A Data Collection Rule (DCR)** that targets your Sentinel/Log Analytics table,
+   its **immutable ID** (`dcr-...`), and the **stream name** it exposes
+   (typically `Custom-<TableName>_CL`).
+3. **An Azure AD app registration (service principal)** with the **Monitoring
+   Metrics Publisher** role assigned on the DCR, giving you a **tenant ID**,
+   **client ID**, and **client secret**.
+
+Microsoft's own [Sentinel data connector
+docs](https://learn.microsoft.com/en-us/azure/sentinel/) walk through creating
+the DCE/DCR/service-principal trio if you don't have them yet.
+
+## Add the Sentinel channel in ReARM
+
+1. Open **Organization Settings -> Integrations**, then the **Notifications ->
+   Channels** tab.
+2. Click the **Microsoft Sentinel** card in the catalog to open **Add Microsoft
+   Sentinel channel**.
+3. Fill in all six fields -- ReARM requires all of them together when you first
+   create the channel:
+   - **Name** -- a label for this channel, e.g. `SOC workspace`.
+   - **Tenant ID** -- your Azure AD tenant ID.
+   - **Client ID** -- the app registration's client ID.
+   - **Client secret** -- the app registration's client secret.
+   - **DCR endpoint** -- the DCE ingestion URL, e.g.
+     `https://<dce-name>.<region>.ingest.monitor.azure.com`. Must be HTTPS at an
+     `azure.com` host, or the save is rejected.
+   - **DCR immutable ID** -- e.g. `dcr-...`.
+   - **Stream name** -- e.g. `Custom-<TableName>_CL`.
+4. Click **Save**.
+
+::: tip Editing later
+On edit, the tenant ID / client ID / client secret fields show as
+`(unchanged)` -- leave them blank to keep the existing credentials, or fill in
+all three together to rotate them. The DCR endpoint / immutable ID / stream
+name always show their current values and can be changed independently.
+:::
+
+## Route events to the channel
+
+Adding the channel doesn't send anything by itself -- you also need a
+**subscription** with a route pointing at it. See
+[Notifications](../configure/notifications) for event types, severity gates,
+and how routes work. ReARM doesn't currently offer a UI button to send a test
+event to a Sentinel channel; the only way to confirm delivery today is to
+route a real (or synthetic, via the API) event to it and check your Log
+Analytics table for the resulting rows.
+
+## What gets sent
+
+Each delivery is an array of flattened log records, one per matched event,
+posted to your DCE's Logs Ingestion API endpoint for the configured stream.
+Authentication is a short-lived Azure AD OAuth token acquired with your
+service-principal credentials (cached for the token's lifetime and refreshed
+automatically) -- ReARM never stores a long-lived Sentinel-side secret beyond
+the client secret you provided.


### PR DESCRIPTION
Supersedes #164 (open since 2026-07-02, idle since 07-07, 135 commits behind
main). Its three commits are replayed here on current main, then corrected and
extended. Close #164 in favour of this one.

## Why

The notifications page is **absent from `main`** today, so none of this is
live. #164 would have shipped it, but it now describes a July world and one of
its claims is actively wrong.

### 1. The Pro-only banner was wrong, in the way a customer complained about

The page opened with a blanket warning that channels, subscriptions, routes and
KEV alerts are all "ReARM Pro only". The real licence gate is two channel types
(EMAIL, SENTINEL) plus two route fields. CE ships working Slack, Teams and
Webhook dispatchers, and subscriptions, routes and channel groups are available
on both editions.

That is the same claim the recent edition-parity work was done to fix. Merging
#164 unchanged would have re-asserted it in writing, on the docs site, after
the code was corrected. Replaced with a tip stating what each edition has.

### 2. Routes gained targets the page never mentioned

A route was described as "a minimum severity with a set of channels (or channel
groups)". It can now also address a **team**, or the **owner of whichever
component the event affects**. Added a route-target table and a section on
owner routing: that it resolves at delivery time (so it survives reassignment),
the three conditions a component must meet, and that it fails closed rather
than falling back to another destination -- which is why a test on an
owner-routed subscription can legitimately report no delivery.

### 3. Ownership was undocumented entirely

The word "owner" did not appear in any documentation source file. New
**Component Ownership** page: the owner picker, why a team beats an individual
(a user has no channels, so owner routing cannot deliver), the five computed
states and which two are addressable, the durability rule, and assignment rules
with their precedence against a stored owner.

Also fixed: subscriptions and channel groups live under **Integrations**, not
Notifications; retention's 90-day default noted alongside the existing 14-day
floor.

## Verification

Every factual claim was checked against source rather than carried over from
the previous draft. Two errors were caught that way and fixed before commit:

- an earlier draft implied the org-wide ownership report has a UI page. It does
  not -- it is an org-admin GraphQL query (`componentOwnershipReport`), and the
  page now says so. The per-component status badge, which does exist in
  Component Settings, is documented separately.
- the regex-anchoring example compared two different patterns and read
  ambiguously; rewritten to state that a pattern must match the entire name.

Claims verified against code include the channel/route edition gates, the four
route targets and the no-empty-route rule, the owner-routing preconditions, the
five ownership states, the two-member durability bar, rule precedence
(stored > rule > suggestion), and the retention floor and default.

The owner-routing behaviour described here was also exercised end to end on a
sandbox: an owner-routed route with no channels named delivered to exactly the
owner team's channels, an unowned component produced no delivery and no
fallback, and one event affecting two components with different owners resolved
each independently.

`npm run docs:build` passes (dead-link checking included). Changed files are
plain ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)