### PR TITLE
fix(tea): stop double-decoding the TEI, and stop swallowing TEA errors

### DIFF
--- a/backend/src/main/java/io/reliza/ws/tea/DiscoveryApiController.java
+++ b/backend/src/main/java/io/reliza/ws/tea/DiscoveryApiController.java
@@ -27,8 +27,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 import jakarta.validation.constraints.*;
 import jakarta.validation.Valid;
 
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -59,9 +57,16 @@ public class DiscoveryApiController implements DiscoveryApi {
     public ResponseEntity<List<TeaDiscoveryInfo>> discoveryByTei(
             @NotNull @Parameter(name = "tei", description = "Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987.", required = true, in = ParameterIn.QUERY) @Valid @RequestParam(value = "tei", required = true) String tei
         ) {
-    		String decodedTEI = URLDecoder.decode(tei, StandardCharsets.UTF_8);
-    		
-            var tdiList = teaTransformerService.performTeiDiscovery(decodedTEI);
+            // NB: do NOT decode here. Spring already percent-decodes @RequestParam,
+            // so a second URLDecoder pass ate one level of escaping: a purl whose
+            // canonical form contains a literal '%' -- every sid PURL for a component
+            // whose name has a space, e.g.
+            // pkg:sid/example.com/My%20Product@1.0.0 -- arrived at the lookup with
+            // '%20' collapsed to a space and never matched the stored identifier.
+            // Spec-correct single escaping (what `rearm tea discovery` sends via
+            // url.QueryEscape) now resolves; only a triple-escaped URL, which was
+            // the workaround for this bug, stops working.
+            var tdiList = teaTransformerService.performTeiDiscovery(tei);
             if (tdiList.isEmpty()) {
             	TeaErrorResponse errorResponse = new TeaErrorResponse(TeaUnknownErrorType.OBJECT_UNKNOWN);
             	return (ResponseEntity<List<TeaDiscoveryInfo>>) (ResponseEntity<?>) ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);

--- a/backend/src/test/java/io/reliza/service/tea/TeiPurlReconstructionTest.java
+++ b/backend/src/test/java/io/reliza/service/tea/TeiPurlReconstructionTest.java
@@ -1,0 +1,97 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service.tea;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the decode contract of the TEA {@code /discovery} endpoint against the
+ * double-decode regression.
+ *
+ * <p>The controller used to call {@code URLDecoder.decode} on the {@code tei}
+ * request parameter, which Spring had ALREADY percent-decoded. That second pass
+ * ate one level of escaping. It was invisible for purls made of unreserved
+ * characters, but every sid PURL whose component name contains a space carries a
+ * literal {@code %20} in its canonical form -- and that {@code %20} collapsed to
+ * a space, so the reconstructed purl never matched the stored identifier
+ * (observed live: only a triple-escaped URL resolved).
+ *
+ * <p>These tests model the wire -> lookup chain for the fixed single-decode
+ * behaviour, and assert the purl reconstruction in
+ * {@code TeaTransformerService.performTeiDiscovery} round-trips a
+ * {@code %}-bearing sid purl exactly.
+ */
+class TeiPurlReconstructionTest {
+
+	/** Canonical sid purl for a component whose name contains a space. */
+	private static final String SID_PURL = "pkg:sid/example.com/My%20Product@1.0.0";
+	private static final String TEI = "urn:tei:purl:example.com:" + SID_PURL;
+
+	/**
+	 * Mirror of the purl reconstruction in {@code performTeiDiscovery}: rebuild
+	 * from the {@code pkg} token onward, re-joining the ':' the split consumed.
+	 */
+	private static String reconstructPurl(String decodedTei) {
+		String[] teiEls = decodedTei.split(":");
+		StringBuilder purlBuilder = new StringBuilder();
+		boolean foundPurlStart = false;
+		for (int i = 4; i < teiEls.length; i++) {
+			if (!foundPurlStart && "pkg".equals(teiEls[i])) foundPurlStart = true;
+			if (foundPurlStart) {
+				purlBuilder.append(teiEls[i]);
+				if (i < teiEls.length - 1) purlBuilder.append(":");
+			}
+		}
+		return purlBuilder.toString();
+	}
+
+	/** What Spring hands the controller, i.e. exactly one percent-decode of the wire value. */
+	private static String afterSpringDecode(String wireValue) {
+		return URLDecoder.decode(wireValue, StandardCharsets.UTF_8);
+	}
+
+	@Test
+	void singleEscapedTeiRoundTripsSidPurlWithPercentEscape() {
+		// What `rearm tea discovery` sends: one url.QueryEscape over the raw TEI,
+		// so the purl's own '%' becomes '%25' on the wire.
+		String wire = "urn%3Atei%3Apurl%3Aexample.com%3Apkg%3Asid%2Fexample.com%2FMy%2520Product%401.0.0";
+		String decodedTei = afterSpringDecode(wire);
+		assertEquals(TEI, decodedTei, "one decode must yield the raw TEI with its literal %20 intact");
+		assertEquals(SID_PURL, reconstructPurl(decodedTei),
+				"reconstructed purl must match the stored identifier byte for byte");
+	}
+
+	@Test
+	void secondDecodeWouldDestroyThePercentEscape() {
+		// The regression: decoding again (as the controller used to) turns the
+		// purl's %20 into a space, which no stored identifier will ever match.
+		String decodedTei = afterSpringDecode(
+				"urn%3Atei%3Apurl%3Aexample.com%3Apkg%3Asid%2Fexample.com%2FMy%2520Product%401.0.0");
+		String doubleDecoded = URLDecoder.decode(decodedTei, StandardCharsets.UTF_8);
+		assertEquals("pkg:sid/example.com/My Product@1.0.0", reconstructPurl(doubleDecoded),
+				"guard: a second decode collapses %20 to a space -- this is the bug being fixed");
+	}
+
+	@Test
+	void purlsWithoutPercentEscapesAreUnaffected() {
+		// Why this hid for so long: plain purls survive any number of decodes.
+		String plain = "pkg:github/relizaio/rearm@26.07.158";
+		String wire = "urn%3Atei%3Apurl%3Ademo.example.com%3Apkg%3Agithub%2Frelizaio%2Frearm%4026.07.158";
+		assertEquals(plain, reconstructPurl(afterSpringDecode(wire)));
+	}
+
+	@Test
+	void versionBuildMetadataSurvivesSingleDecode() {
+		// '+' is form-decoded to a space by URLDecoder; QueryEscape emits %2B, so
+		// semver build metadata survives the single remaining decode.
+		String purl = "pkg:sid/example.com/thing@1.0.0+build.5";
+		String wire = "urn%3Atei%3Apurl%3Aexample.com%3Apkg%3Asid%2Fexample.com%2Fthing%401.0.0%2Bbuild.5";
+		assertEquals(purl, reconstructPurl(afterSpringDecode(wire)));
+	}
+}

--- a/ui/nginx/default.conf.template
+++ b/ui/nginx/default.conf.template
@@ -61,6 +61,12 @@ server {
 
     location /tea {
         proxy_pass http://backend;
+        # TEA is a machine API: its 404 is a structured TeaErrorResponse
+        # (OBJECT_UNKNOWN) that clients are specified to read. The server-level
+        # proxy_intercept_errors swaps upstream error bodies for the branded
+        # static pages, which turned every TEA error into 132 bytes of HTML and
+        # made backend faults indistinguishable from edge ones while debugging.
+        proxy_intercept_errors off;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host            $host;
@@ -74,6 +80,8 @@ server {
 
     location /.well-known/tea {
         proxy_pass http://backend;
+        # Same rationale as /tea above -- keep upstream JSON intact.
+        proxy_intercept_errors off;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host            $host;


### PR DESCRIPTION
Two fixes from the same debugging session, both on the TEA discovery path. Backend half is the CE port of relizaio/rearm-saas#392; the nginx half is CE-only.

## 1. TEI double-decode (backend)

`GET /tea/v0.4.0/discovery?tei=…` could not resolve any release whose PURL contains a percent-escape — **every sid PURL for a component whose name has a space**.

`DiscoveryApiController` called `URLDecoder.decode` on the `tei` parameter that Spring had **already** percent-decoded, eating one level of escaping. Invisible for purls of unreserved characters, fatal for:

```
pkg:sid/rearmce.rearmhq.com/Mafia%20Card%20Shuffle@26.07.4
```

whose `%20` collapsed to a space, so the reconstructed purl never matched the stored identifier.

Localised live on rearmce, same release: `uuid`-form TEI → **200** (org scope and storage fine), `purl`-form single- and double-escaped → 404, **triple**-escaped → **200** — the signature of two decoders in the chain.

## 2. `proxy_intercept_errors off` for TEA routes (nginx)

TEA's 404 is a structured `TeaErrorResponse` (`OBJECT_UNKNOWN`) that clients are specified to read. The server-level `proxy_intercept_errors` replaced it with the 132-byte branded static page — so a machine API returned HTML, **and** a genuine backend 404 became indistinguishable from an edge/routing 404. That ambiguity is what made bug 1 take several passes to localise (it produced two wrong diagnoses along the way: "CE lacks the route" and "CE requires auth", both false).

Now off for `/tea` and `/.well-known/tea`. Static-asset and SPA routes keep the branded pages.

## Verification

Backend fix built and hot-swapped onto the sandbox with a release carrying a `%`-bearing sid purl:

```
$ rearm tea discovery -d true --tei 'urn:tei:purl:agent-scully.rearmhq.com:pkg:sid/agent-scully.rearmhq.com/Mafia%20Card%20Shuffle@1.0.0'
11111111-2222-3333-4444-555555555555
```

Converse confirmed: single-escaped → 200, triple-escaped → 404. Sandbox data cleaned up.

`TeiPurlReconstructionTest` (4 tests) passes in this repo. nginx template validated with `nginx -t` against a fully-rendered copy.

**Caveat on the nginx half:** it was syntax-validated, not exercised against a running CE stack — the sandbox is Pro and has no such interception, so the "TEA errors come back as JSON" outcome is reasoned from the directive, not observed. Worth a glance on the first CE deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)