### PR TITLE
feat(vex): show linkified component / branch / release on VEX proposals

### DIFF
--- a/backend/src/main/java/io/reliza/model/dto/VexStatementProposalWebDto.java
+++ b/backend/src/main/java/io/reliza/model/dto/VexStatementProposalWebDto.java
@@ -59,6 +59,19 @@ public class VexStatementProposalWebDto {
 	private IssuerClass userIssuerClassOverride;
 	private String demotionReason;
 
+	// --- resolved scope display (see VexProposalScopeResolver) ---
+	// scopeUuid alone is unreadable in the UI, and the client cannot resolve it
+	// without one query per proposal on an org-wide list. These are filled in
+	// batch by the datafetcher and are all nullable: a RELEASE-scoped proposal
+	// fills all three levels, BRANCH fills branch + component, COMPONENT fills
+	// only the component, and ORG / RESOURCE_GROUP fill none.
+	private UUID scopeComponentUuid;
+	private String scopeComponentName;
+	private UUID scopeBranchUuid;
+	private String scopeBranchName;
+	private UUID scopeReleaseUuid;
+	private String scopeReleaseVersion;
+
 	public static VexStatementProposalWebDto fromData(VexStatementProposalData d) {
 		VexStatementProposalWebDto w = new VexStatementProposalWebDto();
 		w.uuid = d.getUuid();

--- a/backend/src/main/java/io/reliza/service/VexProposalScopeResolver.java
+++ b/backend/src/main/java/io/reliza/service/VexProposalScopeResolver.java
@@ -38,13 +38,18 @@ import io.reliza.model.dto.VexStatementProposalWebDto;
  *       branches, so nothing is fetched twice.</li>
  * </ol>
  *
- * <p>Branches have no batch reader, so they are fetched individually behind a
- * per-call cache -- bounded by the number of DISTINCT branch-bearing scopes on
- * the page, not by the proposal count.
+ * <p>Branches are batched the same way, via
+ * {@link BranchService#getBranchDataList(Iterable)}.
  *
- * <p>Resolution is best-effort display data: a scope pointing at a deleted or
- * inaccessible object simply leaves the fields null and the UI falls back to
- * the raw uuid. It never fails the query.
+ * <p>Every resolved object is checked to belong to the proposal's own org
+ * before its name is used. Scope targets are set server-side today and cannot
+ * point across orgs, so this is defence-in-depth for future write paths: a
+ * cross-org mismatch is treated as unresolvable rather than leaking another
+ * org's component / branch / release names to this org's viewers.
+ *
+ * <p>Resolution is best-effort display data: a scope pointing at a deleted,
+ * inaccessible or cross-org object simply leaves the fields null and the UI
+ * falls back to the raw uuid. It never fails the query.
  */
 @Service
 public class VexProposalScopeResolver {
@@ -88,14 +93,19 @@ public class VexProposalScopeResolver {
 
 		// Branches: the scope-level ones, plus every branch a resolved release
 		// points at (so a RELEASE-scoped proposal can show its branch too).
+		// RELEASE is the dominant scope kind and distinct releases mean distinct
+		// branches, so this MUST be batched -- resolving one at a time here would
+		// reinstate the per-proposal lookup this class exists to avoid.
 		Map<UUID, BranchData> branches = new HashMap<>();
 		Set<UUID> branchesToLoad = new LinkedHashSet<>(branchUuids);
 		releases.values().stream()
 				.map(ReleaseData::getBranch)
 				.filter(java.util.Objects::nonNull)
 				.forEach(branchesToLoad::add);
-		for (UUID branchUuid : branchesToLoad) {
-			branchService.getBranchData(branchUuid).ifPresent(bd -> branches.put(branchUuid, bd));
+		if (!branchesToLoad.isEmpty()) {
+			for (BranchData bd : branchService.getBranchDataList(branchesToLoad)) {
+				branches.put(bd.getUuid(), bd);
+			}
 		}
 
 		// Components: the scope-level ones, plus the parents of everything above.
@@ -129,7 +139,9 @@ public class VexProposalScopeResolver {
 
 		if (scope == AnalysisScope.RELEASE) {
 			ReleaseData rd = releases.get(scopeUuid);
-			if (rd == null) return; // deleted / not visible -- leave nulls, UI shows the uuid
+			// null => deleted / not visible; org mismatch => never surface another
+			// org's names here. Both leave nulls and the UI shows the raw uuid.
+			if (rd == null || !sameOrg(dto, rd.getOrg())) return;
 			dto.setScopeReleaseUuid(rd.getUuid());
 			dto.setScopeReleaseVersion(rd.getVersion());
 			branchUuid = rd.getBranch();
@@ -144,7 +156,7 @@ public class VexProposalScopeResolver {
 
 		if (branchUuid != null) {
 			BranchData bd = branches.get(branchUuid);
-			if (bd != null) {
+			if (bd != null && sameOrg(dto, bd.getOrg())) {
 				dto.setScopeBranchUuid(branchUuid);
 				dto.setScopeBranchName(bd.getName());
 				// A release's component is denormalized onto the release, but a
@@ -154,10 +166,20 @@ public class VexProposalScopeResolver {
 		}
 		if (componentUuid != null) {
 			Optional<ComponentData> ocd = Optional.ofNullable(components.get(componentUuid));
-			if (ocd.isPresent()) {
+			if (ocd.isPresent() && sameOrg(dto, ocd.get().getOrg())) {
 				dto.setScopeComponentUuid(componentUuid);
 				dto.setScopeComponentName(ocd.get().getName());
 			}
 		}
+	}
+
+	/**
+	 * Guards every resolved level against cross-org leakage. Scope targets are
+	 * assigned server-side from the org's own objects today, so a mismatch is
+	 * not currently reachable -- this keeps it unreachable if a future write
+	 * path ever accepts a caller-supplied scopeUuid.
+	 */
+	private static boolean sameOrg(VexStatementProposalWebDto dto, UUID resolvedOrg) {
+		return dto.getOrg() != null && dto.getOrg().equals(resolvedOrg);
 	}
 }

--- a/backend/src/main/java/io/reliza/service/VexProposalScopeResolver.java
+++ b/backend/src/main/java/io/reliza/service/VexProposalScopeResolver.java
@@ -1,0 +1,163 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import io.reliza.model.AnalysisScope;
+import io.reliza.model.BranchData;
+import io.reliza.model.ComponentData;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.dto.VexStatementProposalWebDto;
+
+/**
+ * Fills the human-readable scope fields on {@link VexStatementProposalWebDto}.
+ *
+ * <p>A proposal stores only {@code scope} + {@code scopeUuid}, which renders in
+ * the UI as a bare UUID. Resolving it client-side would cost one to three
+ * queries PER proposal, and the VEX inbox is an org-wide list -- so resolution
+ * happens here, batched across the whole page:
+ *
+ * <ol>
+ *   <li>partition the distinct scope uuids by scope kind;</li>
+ *   <li>one batch read for releases (light: no metrics jsonb) and one for
+ *       components;</li>
+ *   <li>a second component batch for the parents discovered via releases and
+ *       branches, so nothing is fetched twice.</li>
+ * </ol>
+ *
+ * <p>Branches have no batch reader, so they are fetched individually behind a
+ * per-call cache -- bounded by the number of DISTINCT branch-bearing scopes on
+ * the page, not by the proposal count.
+ *
+ * <p>Resolution is best-effort display data: a scope pointing at a deleted or
+ * inaccessible object simply leaves the fields null and the UI falls back to
+ * the raw uuid. It never fails the query.
+ */
+@Service
+public class VexProposalScopeResolver {
+
+	@Autowired private SharedReleaseService sharedReleaseService;
+	@Autowired private GetComponentService getComponentService;
+	@Autowired private BranchService branchService;
+
+	/** Convenience for the single-proposal read paths. */
+	public void resolveScopeNames(VexStatementProposalWebDto dto) {
+		if (dto != null) resolveScopeNames(List.of(dto));
+	}
+
+	/**
+	 * Fills scope display fields on every dto in the list, in batch.
+	 * Safe on an empty or null list.
+	 */
+	public void resolveScopeNames(Collection<VexStatementProposalWebDto> dtos) {
+		if (dtos == null || dtos.isEmpty()) return;
+
+		Set<UUID> releaseUuids = new LinkedHashSet<>();
+		Set<UUID> branchUuids = new LinkedHashSet<>();
+		Set<UUID> componentUuids = new LinkedHashSet<>();
+		for (VexStatementProposalWebDto dto : dtos) {
+			UUID scopeUuid = dto.getScopeUuid();
+			if (scopeUuid == null || dto.getScope() == null) continue;
+			switch (dto.getScope()) {
+				case RELEASE -> releaseUuids.add(scopeUuid);
+				case BRANCH -> branchUuids.add(scopeUuid);
+				case COMPONENT -> componentUuids.add(scopeUuid);
+				// ORG / RESOURCE_GROUP have no component-level identity to show.
+				default -> { }
+			}
+		}
+		if (releaseUuids.isEmpty() && branchUuids.isEmpty() && componentUuids.isEmpty()) return;
+
+		Map<UUID, ReleaseData> releases = new HashMap<>();
+		for (ReleaseData rd : sharedReleaseService.getReleaseDataListLight(releaseUuids)) {
+			releases.put(rd.getUuid(), rd);
+		}
+
+		// Branches: the scope-level ones, plus every branch a resolved release
+		// points at (so a RELEASE-scoped proposal can show its branch too).
+		Map<UUID, BranchData> branches = new HashMap<>();
+		Set<UUID> branchesToLoad = new LinkedHashSet<>(branchUuids);
+		releases.values().stream()
+				.map(ReleaseData::getBranch)
+				.filter(java.util.Objects::nonNull)
+				.forEach(branchesToLoad::add);
+		for (UUID branchUuid : branchesToLoad) {
+			branchService.getBranchData(branchUuid).ifPresent(bd -> branches.put(branchUuid, bd));
+		}
+
+		// Components: the scope-level ones, plus the parents of everything above.
+		Set<UUID> componentsToLoad = new LinkedHashSet<>(componentUuids);
+		releases.values().stream()
+				.map(ReleaseData::getComponent)
+				.filter(java.util.Objects::nonNull)
+				.forEach(componentsToLoad::add);
+		branches.values().stream()
+				.map(BranchData::getComponent)
+				.filter(java.util.Objects::nonNull)
+				.forEach(componentsToLoad::add);
+		Map<UUID, ComponentData> components = new HashMap<>();
+		for (ComponentData cd : getComponentService.getListOfComponentData(componentsToLoad)) {
+			components.put(cd.getUuid(), cd);
+		}
+
+		for (VexStatementProposalWebDto dto : dtos) {
+			applyResolution(dto, releases, branches, components);
+		}
+	}
+
+	private void applyResolution(VexStatementProposalWebDto dto, Map<UUID, ReleaseData> releases,
+			Map<UUID, BranchData> branches, Map<UUID, ComponentData> components) {
+		UUID scopeUuid = dto.getScopeUuid();
+		AnalysisScope scope = dto.getScope();
+		if (scopeUuid == null || scope == null) return;
+
+		UUID branchUuid = null;
+		UUID componentUuid = null;
+
+		if (scope == AnalysisScope.RELEASE) {
+			ReleaseData rd = releases.get(scopeUuid);
+			if (rd == null) return; // deleted / not visible -- leave nulls, UI shows the uuid
+			dto.setScopeReleaseUuid(rd.getUuid());
+			dto.setScopeReleaseVersion(rd.getVersion());
+			branchUuid = rd.getBranch();
+			componentUuid = rd.getComponent();
+		} else if (scope == AnalysisScope.BRANCH) {
+			branchUuid = scopeUuid;
+		} else if (scope == AnalysisScope.COMPONENT) {
+			componentUuid = scopeUuid;
+		} else {
+			return;
+		}
+
+		if (branchUuid != null) {
+			BranchData bd = branches.get(branchUuid);
+			if (bd != null) {
+				dto.setScopeBranchUuid(branchUuid);
+				dto.setScopeBranchName(bd.getName());
+				// A release's component is denormalized onto the release, but a
+				// BRANCH-scoped proposal only learns its component here.
+				if (componentUuid == null) componentUuid = bd.getComponent();
+			}
+		}
+		if (componentUuid != null) {
+			Optional<ComponentData> ocd = Optional.ofNullable(components.get(componentUuid));
+			if (ocd.isPresent()) {
+				dto.setScopeComponentUuid(componentUuid);
+				dto.setScopeComponentName(ocd.get().getName());
+			}
+		}
+	}
+}

--- a/backend/src/main/java/io/reliza/ws/VexStatementProposalDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/VexStatementProposalDataFetcher.java
@@ -35,6 +35,7 @@ import io.reliza.model.VexStatementProposalData;
 import io.reliza.model.WhoUpdated;
 import io.reliza.model.dto.VexStatementProposalWebDto;
 import io.reliza.service.ArtifactService;
+import io.reliza.service.VexProposalScopeResolver;
 import io.reliza.service.AuthorizationService;
 import io.reliza.service.GetOrganizationService;
 import io.reliza.service.SharedReleaseService;
@@ -64,6 +65,9 @@ public class VexStatementProposalDataFetcher {
 	@Autowired
 	private ArtifactService artifactService;
 
+	@Autowired
+	private VexProposalScopeResolver vexProposalScopeResolver;
+
 	@PreAuthorize("isAuthenticated()")
 	@DgsData(parentType = "Query", field = "getVexStatementProposals")
 	public List<VexStatementProposalWebDto> getVexStatementProposals(
@@ -75,7 +79,7 @@ public class VexStatementProposalDataFetcher {
 		List<VexStatementProposalData> data = (status == null)
 			? proposalService.listForOrg(org)
 			: proposalService.listForOrgAndStatus(org, status);
-		return data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList());
+		return resolved(data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList()));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -85,7 +89,7 @@ public class VexStatementProposalDataFetcher {
 		Optional<VexStatementProposalData> opt = proposalService.getProposal(uuid);
 		if (opt.isEmpty()) throw new AccessDeniedException("Proposal not found: " + uuid);
 		gateProposal(oud, opt.get(), PermissionFunction.FINDING_ANALYSIS_READ, CallType.READ);
-		return VexStatementProposalWebDto.fromData(opt.get());
+		return resolved(VexStatementProposalWebDto.fromData(opt.get()));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -101,10 +105,10 @@ public class VexStatementProposalDataFetcher {
 		if (oad.isEmpty()) {
 			// Proposals exist but artifact is gone — fall back to org gate on first proposal's org.
 			gateOrg(oud, data.get(0).getOrg(), PermissionFunction.FINDING_ANALYSIS_READ, CallType.READ);
-			return data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList());
+			return resolved(data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList()));
 		}
 		gateArtifact(oud, oad.get(), PermissionFunction.FINDING_ANALYSIS_READ, CallType.READ);
-		return data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList());
+		return resolved(data.stream().map(VexStatementProposalWebDto::fromData).collect(Collectors.toList()));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -114,8 +118,8 @@ public class VexStatementProposalDataFetcher {
 			@InputArgument("release") UUID release) throws RelizaException {
 		UserData oud = currentUser();
 		gateRelease(oud, org, release, PermissionFunction.FINDING_ANALYSIS_READ, CallType.READ);
-		return proposalService.listForRelease(org, release).stream()
-			.map(VexStatementProposalWebDto::fromData).collect(Collectors.toList());
+		return resolved(proposalService.listForRelease(org, release).stream()
+			.map(VexStatementProposalWebDto::fromData).collect(Collectors.toList()));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -128,7 +132,7 @@ public class VexStatementProposalDataFetcher {
 		if (opt.isEmpty()) throw new AccessDeniedException("Proposal not found: " + uuid);
 		gateProposal(oud, opt.get(), PermissionFunction.FINDING_ANALYSIS_WRITE, CallType.WRITE);
 		WhoUpdated wu = WhoUpdated.getWhoUpdated(oud);
-		return VexStatementProposalWebDto.fromData(proposalService.accept(uuid, comment, wu));
+		return resolved(VexStatementProposalWebDto.fromData(proposalService.accept(uuid, comment, wu)));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -141,7 +145,7 @@ public class VexStatementProposalDataFetcher {
 		if (opt.isEmpty()) throw new AccessDeniedException("Proposal not found: " + uuid);
 		gateProposal(oud, opt.get(), PermissionFunction.FINDING_ANALYSIS_WRITE, CallType.WRITE);
 		WhoUpdated wu = WhoUpdated.getWhoUpdated(oud);
-		return VexStatementProposalWebDto.fromData(proposalService.reject(uuid, wu, reason));
+		return resolved(VexStatementProposalWebDto.fromData(proposalService.reject(uuid, wu, reason)));
 	}
 
 	@PreAuthorize("isAuthenticated()")
@@ -154,7 +158,7 @@ public class VexStatementProposalDataFetcher {
 		if (opt.isEmpty()) throw new AccessDeniedException("Proposal not found: " + uuid);
 		gateProposal(oud, opt.get(), PermissionFunction.FINDING_ANALYSIS_WRITE, CallType.WRITE);
 		WhoUpdated wu = WhoUpdated.getWhoUpdated(oud);
-		return VexStatementProposalWebDto.fromData(proposalService.updateProposal(uuid, updates, wu));
+		return resolved(VexStatementProposalWebDto.fromData(proposalService.updateProposal(uuid, updates, wu)));
 	}
 
 	private UserData currentUser() {
@@ -211,5 +215,20 @@ public class VexStatementProposalDataFetcher {
 		// surfaces its component/release linkage for the authorizer.
 		authorizationService.isUserAuthorizedForObjectGraphQL(oud, perm,
 			PermissionScope.ORGANIZATION, ad.getOrg(), List.of((RelizaObject) ad), callType);
+	}
+
+	/**
+	 * Fill the human-readable scope fields before handing dtos to the client.
+	 * Batched across the list -- see {@link VexProposalScopeResolver} for why
+	 * this cannot sensibly be done client-side.
+	 */
+	private List<VexStatementProposalWebDto> resolved(List<VexStatementProposalWebDto> dtos) {
+		vexProposalScopeResolver.resolveScopeNames(dtos);
+		return dtos;
+	}
+
+	private VexStatementProposalWebDto resolved(VexStatementProposalWebDto dto) {
+		vexProposalScopeResolver.resolveScopeNames(dto);
+		return dto;
 	}
 }

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -6133,19 +6133,23 @@ type VexStatementProposalWebDto {
 	userImportMode: VexImportMode
 	userIssuerClassOverride: IssuerClass
 	demotionReason: String
-	"""
-	Human-readable resolution of scope + scopeUuid, filled server-side (batched)
-	because the client would otherwise need one to three lookups per proposal on
-	an org-wide list. All nullable: a RELEASE-scoped proposal fills all three
-	levels, BRANCH fills branch + component, COMPONENT fills only the component,
-	and ORG / RESOURCE_GROUP fill none. Null also when the scoped object no
-	longer resolves -- render the raw scopeUuid in that case.
-	"""
+	# Human-readable resolution of scope + scopeUuid, filled server-side and
+	# batched across the page (the client would otherwise need one to three
+	# lookups per proposal on an org-wide list). A RELEASE-scoped proposal fills
+	# all three levels, BRANCH fills branch + component, COMPONENT fills only the
+	# component, ORG / RESOURCE_GROUP fill none. Every field below is also null
+	# when the scoped object no longer resolves -- render the raw scopeUuid then.
+	"""Component owning this proposal's scope; null for ORG / RESOURCE_GROUP scope or when unresolvable."""
 	scopeComponentUuid: ID
+	"""Display name of scopeComponentUuid; null whenever that is null."""
 	scopeComponentName: String
+	"""Branch of this proposal's scope; null for COMPONENT / ORG / RESOURCE_GROUP scope or when unresolvable."""
 	scopeBranchUuid: ID
+	"""Display name of scopeBranchUuid; null whenever that is null."""
 	scopeBranchName: String
+	"""Release of this proposal's scope; set only for RELEASE scope, and null when unresolvable."""
 	scopeReleaseUuid: ID
+	"""Version string of scopeReleaseUuid; null whenever that is null."""
 	scopeReleaseVersion: String
 }
 

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -6133,6 +6133,20 @@ type VexStatementProposalWebDto {
 	userImportMode: VexImportMode
 	userIssuerClassOverride: IssuerClass
 	demotionReason: String
+	"""
+	Human-readable resolution of scope + scopeUuid, filled server-side (batched)
+	because the client would otherwise need one to three lookups per proposal on
+	an org-wide list. All nullable: a RELEASE-scoped proposal fills all three
+	levels, BRANCH fills branch + component, COMPONENT fills only the component,
+	and ORG / RESOURCE_GROUP fill none. Null also when the scoped object no
+	longer resolves -- render the raw scopeUuid in that case.
+	"""
+	scopeComponentUuid: ID
+	scopeComponentName: String
+	scopeBranchUuid: ID
+	scopeBranchName: String
+	scopeReleaseUuid: ID
+	scopeReleaseVersion: String
 }
 
 enum ProposalStatus {

--- a/backend/src/test/java/io/reliza/service/VexProposalScopeResolverTest.java
+++ b/backend/src/test/java/io/reliza/service/VexProposalScopeResolverTest.java
@@ -1,0 +1,167 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.AnalysisScope;
+import io.reliza.model.Branch;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.WhoUpdated;
+import io.reliza.model.dto.CreateComponentDto;
+import io.reliza.model.dto.ReleaseDto;
+import io.reliza.model.dto.VexStatementProposalWebDto;
+import io.reliza.service.oss.OssReleaseService;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Pins the scope resolution that makes VEX proposals readable in the UI: a
+ * proposal stores only {@code scope} + {@code scopeUuid}, so without this the
+ * inbox and the review page can only show a bare UUID.
+ *
+ * <p>Covers the fill rules per scope kind, the "most specific name" the UI uses
+ * as link text, and the degradation contract -- a scope pointing at something
+ * that no longer resolves must leave the fields null rather than fail the query.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class VexProposalScopeResolverTest {
+
+	@Autowired private VexProposalScopeResolver resolver;
+	@Autowired private ComponentService componentService;
+	@Autowired private BranchService branchService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final WhoUpdated WU = WhoUpdated.getTestWhoUpdated();
+
+	private record Fx(UUID org, UUID component, String componentName, UUID branch, UUID release, String version) {}
+
+	private Fx fixture() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		String name = "vex-scope-" + UUID.randomUUID().toString().substring(0, 8);
+		UUID componentUuid = componentService.createComponent(CreateComponentDto.builder()
+				.organization(org.getUuid())
+				.name(name)
+				.type(ComponentType.COMPONENT)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build(), WU).getUuid();
+		Branch branch = branchService.findBranchByName(componentUuid, "main", true, WU).get();
+		UUID releaseUuid = ossReleaseService.createRelease(ReleaseDto.builder()
+				.component(componentUuid)
+				.branch(branch.getUuid())
+				.org(org.getUuid())
+				.status(ReleaseData.ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseData.ReleaseLifecycle.ASSEMBLED)
+				.version("1.4.2")
+				.build(), WU).getUuid();
+		return new Fx(org.getUuid(), componentUuid, name, branch.getUuid(), releaseUuid, "1.4.2");
+	}
+
+	private static VexStatementProposalWebDto proposal(UUID org, AnalysisScope scope, UUID scopeUuid) {
+		VexStatementProposalWebDto dto = new VexStatementProposalWebDto();
+		dto.setUuid(UUID.randomUUID());
+		dto.setOrg(org);
+		dto.setScope(scope);
+		dto.setScopeUuid(scopeUuid);
+		return dto;
+	}
+
+	@Test
+	public void releaseScopeFillsAllThreeLevels() throws RelizaException {
+		Fx fx = fixture();
+		var dto = proposal(fx.org(), AnalysisScope.RELEASE, fx.release());
+		resolver.resolveScopeNames(dto);
+
+		assertEquals(fx.release(), dto.getScopeReleaseUuid());
+		assertEquals(fx.version(), dto.getScopeReleaseVersion(),
+				"release version is the most specific name -- the UI's link text");
+		assertEquals(fx.branch(), dto.getScopeBranchUuid());
+		assertEquals("main", dto.getScopeBranchName());
+		assertEquals(fx.component(), dto.getScopeComponentUuid());
+		assertEquals(fx.componentName(), dto.getScopeComponentName());
+	}
+
+	@Test
+	public void branchScopeFillsBranchAndItsComponentButNoRelease() throws RelizaException {
+		Fx fx = fixture();
+		var dto = proposal(fx.org(), AnalysisScope.BRANCH, fx.branch());
+		resolver.resolveScopeNames(dto);
+
+		assertNull(dto.getScopeReleaseUuid(), "a BRANCH scope names no release");
+		assertEquals("main", dto.getScopeBranchName());
+		assertEquals(fx.component(), dto.getScopeComponentUuid(),
+				"the component is reachable only via the branch on this path");
+		assertEquals(fx.componentName(), dto.getScopeComponentName());
+	}
+
+	@Test
+	public void componentScopeFillsComponentOnly() throws RelizaException {
+		Fx fx = fixture();
+		var dto = proposal(fx.org(), AnalysisScope.COMPONENT, fx.component());
+		resolver.resolveScopeNames(dto);
+
+		assertEquals(fx.componentName(), dto.getScopeComponentName());
+		assertNull(dto.getScopeBranchName());
+		assertNull(dto.getScopeReleaseVersion());
+	}
+
+	@Test
+	public void orgScopeFillsNothing() throws RelizaException {
+		Fx fx = fixture();
+		var dto = proposal(fx.org(), AnalysisScope.ORG, fx.org());
+		resolver.resolveScopeNames(dto);
+
+		assertNull(dto.getScopeComponentName());
+		assertNull(dto.getScopeBranchName());
+		assertNull(dto.getScopeReleaseVersion());
+	}
+
+	@Test
+	public void unresolvableScopeLeavesNullsAndDoesNotThrow() throws RelizaException {
+		Fx fx = fixture();
+		// Deleted / invisible release: display degrades to the raw uuid in the UI.
+		var dto = proposal(fx.org(), AnalysisScope.RELEASE, UUID.randomUUID());
+		resolver.resolveScopeNames(dto);
+
+		assertNull(dto.getScopeReleaseVersion());
+		assertNull(dto.getScopeComponentName());
+	}
+
+	@Test
+	public void mixedBatchResolvesEveryScopeKindInOnePass() throws RelizaException {
+		Fx a = fixture();
+		Fx b = fixture();
+		List<VexStatementProposalWebDto> batch = List.of(
+				proposal(a.org(), AnalysisScope.RELEASE, a.release()),
+				proposal(a.org(), AnalysisScope.BRANCH, a.branch()),
+				proposal(b.org(), AnalysisScope.COMPONENT, b.component()),
+				proposal(b.org(), AnalysisScope.ORG, b.org()),
+				proposal(b.org(), AnalysisScope.RELEASE, UUID.randomUUID()));
+		resolver.resolveScopeNames(batch);
+
+		assertEquals(a.version(), batch.get(0).getScopeReleaseVersion());
+		assertEquals(a.componentName(), batch.get(0).getScopeComponentName());
+		assertEquals("main", batch.get(1).getScopeBranchName());
+		assertEquals(b.componentName(), batch.get(2).getScopeComponentName());
+		assertNull(batch.get(3).getScopeComponentName());
+		assertNull(batch.get(4).getScopeReleaseVersion());
+	}
+}

--- a/backend/src/test/java/io/reliza/service/VexProposalScopeResolverTest.java
+++ b/backend/src/test/java/io/reliza/service/VexProposalScopeResolverTest.java
@@ -164,4 +164,39 @@ public class VexProposalScopeResolverTest {
 		assertNull(batch.get(3).getScopeComponentName());
 		assertNull(batch.get(4).getScopeReleaseVersion());
 	}
+
+	/**
+	 * Defence-in-depth: a proposal must never surface names from another org's
+	 * objects. Not reachable through today's write paths (scope targets are
+	 * assigned server-side from the org's own objects), so this pins the guard
+	 * for any future path that accepts a caller-supplied scopeUuid. Fails
+	 * without the sameOrg() checks in the resolver.
+	 */
+	@Test
+	public void crossOrgScopeResolvesToNothing() throws RelizaException {
+		Fx owner = fixture();
+		Fx foreign = fixture();
+		// Proposal belongs to `owner`'s org but points at `foreign`'s release.
+		var dto = proposal(owner.org(), AnalysisScope.RELEASE, foreign.release());
+		resolver.resolveScopeNames(dto);
+
+		assertNull(dto.getScopeReleaseVersion(), "must not leak another org's release version");
+		assertNull(dto.getScopeBranchName(), "must not leak another org's branch name");
+		assertNull(dto.getScopeComponentName(), "must not leak another org's component name");
+	}
+
+	/**
+	 * The component behind a cross-org BRANCH scope must stay hidden too -- the
+	 * component is reached indirectly there, so it needs its own guard.
+	 */
+	@Test
+	public void crossOrgBranchScopeHidesComponentToo() throws RelizaException {
+		Fx owner = fixture();
+		Fx foreign = fixture();
+		var dto = proposal(owner.org(), AnalysisScope.BRANCH, foreign.branch());
+		resolver.resolveScopeNames(dto);
+
+		assertNull(dto.getScopeBranchName());
+		assertNull(dto.getScopeComponentName());
+	}
 }

--- a/backend/src/test/java/io/reliza/ws/VexStatementProposalDataFetcherAuthzNullSafetyTest.java
+++ b/backend/src/test/java/io/reliza/ws/VexStatementProposalDataFetcherAuthzNullSafetyTest.java
@@ -33,6 +33,7 @@ import io.reliza.model.RelizaObject;
 import io.reliza.model.UserData;
 import io.reliza.model.VexStatementProposalData;
 import io.reliza.service.ArtifactService;
+import io.reliza.service.VexProposalScopeResolver;
 import io.reliza.service.AuthorizationService;
 import io.reliza.service.GetOrganizationService;
 import io.reliza.service.SharedReleaseService;
@@ -68,6 +69,7 @@ class VexStatementProposalDataFetcherAuthzNullSafetyTest {
 	private GetOrganizationService getOrganizationService;
 	private SharedReleaseService sharedReleaseService;
 	private ArtifactService artifactService;
+	private VexProposalScopeResolver vexProposalScopeResolver;
 	private VexStatementProposalDataFetcher fetcher;
 
 	@BeforeEach
@@ -78,6 +80,9 @@ class VexStatementProposalDataFetcherAuthzNullSafetyTest {
 		getOrganizationService = mock(GetOrganizationService.class);
 		sharedReleaseService = mock(SharedReleaseService.class);
 		artifactService = mock(ArtifactService.class);
+		// Scope resolution is display-only enrichment; the mock keeps this
+		// authz-focused test from depending on resolver behaviour.
+		vexProposalScopeResolver = mock(VexProposalScopeResolver.class);
 
 		when(userService.getUserDataByAuth(any(JwtAuthenticationToken.class)))
 				.thenReturn(Optional.of(mock(UserData.class)));
@@ -93,6 +98,7 @@ class VexStatementProposalDataFetcherAuthzNullSafetyTest {
 		inject("getOrganizationService", getOrganizationService);
 		inject("sharedReleaseService", sharedReleaseService);
 		inject("artifactService", artifactService);
+		inject("vexProposalScopeResolver", vexProposalScopeResolver);
 
 		SecurityContext ctx = mock(SecurityContext.class);
 		when(ctx.getAuthentication()).thenReturn(mock(JwtAuthenticationToken.class));

--- a/ui/src/components/VexProposalReview.vue
+++ b/ui/src/components/VexProposalReview.vue
@@ -35,7 +35,16 @@
                     <!-- Read-only view -->
                     <n-descriptions v-if="!editing" :column="1" bordered label-placement="left" :label-style="{ width: '160px', minWidth: '160px' }">
                         <n-descriptions-item label="Vulnerability">{{ proposal.findingId }}</n-descriptions-item>
-                        <n-descriptions-item label="Component">{{ proposal.rawLocation }}</n-descriptions-item>
+                        <n-descriptions-item label="Location">{{ proposal.rawLocation }}</n-descriptions-item>
+                        <n-descriptions-item label="Scope">
+                            <n-tag size="small" round style="margin-right: 6px;">{{ proposal.scope }}</n-tag>
+                            <router-link v-if="scopeLink" :to="scopeLink.to" target="_blank">{{ scopeLink.text }}</router-link>
+                            <span v-else-if="proposal.scope !== 'ORG' && proposal.scope !== 'RESOURCE_GROUP'"
+                                class="text-muted">{{ proposal.scopeUuid }}</span>
+                            <span v-if="scopePath && scopePath !== scopeLink?.text" class="text-muted" style="margin-left: 8px;">
+                                ({{ scopePath }})
+                            </span>
+                        </n-descriptions-item>
                         <n-descriptions-item label="State">{{ proposal.analysisState }}</n-descriptions-item>
                         <n-descriptions-item label="Justification">{{ proposal.analysisJustification ?? '—' }}</n-descriptions-item>
                         <n-descriptions-item label="Responses">{{ (proposal.responses?.length ? proposal.responses.join(', ') : '—') }}</n-descriptions-item>
@@ -189,7 +198,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import {
     NAlert, NButton, NCard, NCode, NDataTable, NDescriptions, NDescriptionsItem, NDivider,
-    NForm, NFormItem, NGi, NGrid, NH4, NInput, NList, NListItem, NSelect, NSpace, NSpin, NText, useMessage
+    NForm, NFormItem, NGi, NGrid, NH4, NInput, NList, NListItem, NSelect, NSpace, NSpin, NTag, NText, useMessage
 } from 'naive-ui'
 import graphqlClient from '@/utils/graphql'
 import { useOrgUsersIndex } from '@/utils/userLookup'
@@ -281,6 +290,34 @@ function hasDemotion (reason: string): boolean {
     if (!raw) return false
     return raw.split(';').map((s: string) => s.trim()).includes(reason)
 }
+
+// Scope display: the backend resolves scope+scopeUuid into component / branch /
+// release names. Link text is the MOST SPECIFIC name; the fuller path is shown
+// beside it. Falls back to the raw uuid when the scoped object no longer
+// resolves, and to the bare enum for ORG scope.
+const scopePath = computed(() => {
+    const p: any = proposal.value
+    if (!p) return ''
+    return [p.scopeComponentName, p.scopeBranchName, p.scopeReleaseVersion].filter(Boolean).join(' / ')
+})
+
+const scopeLink = computed(() => {
+    const p: any = proposal.value
+    if (!p) return null
+    if (p.scope === 'RELEASE' && p.scopeReleaseUuid) {
+        return { text: p.scopeReleaseVersion || p.scopeReleaseUuid, to: `/release/show/${p.scopeReleaseUuid}` }
+    }
+    if (p.scope === 'BRANCH' && p.scopeBranchUuid && p.scopeComponentUuid) {
+        return {
+            text: p.scopeBranchName || p.scopeBranchUuid,
+            to: `/componentsOfOrg/${p.org}/${p.scopeComponentUuid}/${p.scopeBranchUuid}`
+        }
+    }
+    if (p.scope === 'COMPONENT' && p.scopeComponentUuid) {
+        return { text: p.scopeComponentName || p.scopeComponentUuid, to: `/componentsOfOrg/${p.org}/${p.scopeComponentUuid}` }
+    }
+    return null
+})
 
 const otherAnalyses = computed(() => {
     if (!proposal.value) return []

--- a/ui/src/components/VexProposalsInbox.vue
+++ b/ui/src/components/VexProposalsInbox.vue
@@ -24,8 +24,8 @@ export default {
 </script>
 <script lang="ts" setup>
 import { computed, h, onMounted, ref, watch } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
-import { NButton, NCard, NDataTable, NIcon, NTabs, NTabPane, NTag } from 'naive-ui'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+import { NButton, NCard, NDataTable, NIcon, NTabs, NTabPane, NTag, NTooltip } from 'naive-ui'
 import { Eye } from '@vicons/tabler'
 import graphqlClient from '@/utils/graphql'
 import { useOrgUsersIndex } from '@/utils/userLookup'
@@ -56,13 +56,64 @@ async function fetchProposals () {
 onMounted(fetchProposals)
 watch([statusFilter, orgUuid], fetchProposals)
 
+// Scope display: the backend resolves scope+scopeUuid into component / branch /
+// release names (batched -- see VexProposalScopeResolver). Show the MOST
+// SPECIFIC name as the link text, with the fuller path in a tooltip, so the
+// column stays narrow in an already-wide table. Falls back to the raw uuid when
+// the scoped object no longer resolves, and to the bare enum for ORG scope.
+function scopePath (r: any): string {
+    return [r.scopeComponentName, r.scopeBranchName, r.scopeReleaseVersion]
+        .filter(Boolean).join(' / ')
+}
+
+function scopeLink (r: any): { text: string, to: string } | null {
+    if (r.scope === 'RELEASE' && r.scopeReleaseUuid) {
+        return { text: r.scopeReleaseVersion || r.scopeReleaseUuid, to: `/release/show/${r.scopeReleaseUuid}` }
+    }
+    if (r.scope === 'BRANCH' && r.scopeBranchUuid && r.scopeComponentUuid) {
+        return {
+            text: r.scopeBranchName || r.scopeBranchUuid,
+            to: `/componentsOfOrg/${r.org}/${r.scopeComponentUuid}/${r.scopeBranchUuid}`
+        }
+    }
+    if (r.scope === 'COMPONENT' && r.scopeComponentUuid) {
+        return { text: r.scopeComponentName || r.scopeComponentUuid, to: `/componentsOfOrg/${r.org}/${r.scopeComponentUuid}` }
+    }
+    return null
+}
+
+function renderScope (r: any) {
+    const tag = h(NTag, { size: 'small', round: true, style: 'margin-right: 6px;' }, () => r.scope)
+    const link = scopeLink(r)
+    if (!link) {
+        // ORG / RESOURCE_GROUP have no narrower object; anything else that failed
+        // to resolve shows its raw uuid so the row is still actionable.
+        const unresolved = (r.scope !== 'ORG' && r.scope !== 'RESOURCE_GROUP' && r.scopeUuid)
+            ? h('span', { class: 'text-muted' }, r.scopeUuid)
+            : null
+        return h('span', {}, unresolved ? [tag, unresolved] : [tag])
+    }
+    const anchorEl = h(RouterLink, { to: link.to, target: '_blank' }, () => link.text)
+    const path = scopePath(r)
+    return h('span', {}, [
+        tag,
+        path && path !== link.text
+            ? h(NTooltip, { trigger: 'hover' }, { trigger: () => anchorEl, default: () => path })
+            : anchorEl
+    ])
+}
+
 const columns = computed(() => {
     const cols: any[] = [
         { title: 'CVE', key: 'findingId' },
-        { title: 'Component', key: 'location' },
+        { title: 'Location', key: 'location' },
         { title: 'State', key: 'analysisState' },
         { title: 'Justification', key: 'analysisJustification', render: (r: any) => r.analysisJustification ?? '—' },
-        { title: 'Scope', key: 'scope' },
+        {
+            title: 'Scope',
+            key: 'scope',
+            render: (r: any) => renderScope(r)
+        },
         {
             title: 'Status',
             key: 'status',

--- a/ui/src/graphql/vexImport.ts
+++ b/ui/src/graphql/vexImport.ts
@@ -11,6 +11,7 @@ export const GET_VEX_PROPOSALS = gql`
             actedAt actedBy
             translationNotes
             issuerClass userImportMode userIssuerClassOverride demotionReason
+            scopeComponentUuid scopeComponentName scopeBranchUuid scopeBranchName scopeReleaseUuid scopeReleaseVersion
         }
     }
 `
@@ -23,6 +24,7 @@ export const GET_VEX_PROPOSALS_BY_RELEASE = gql`
             analysisState analysisJustification
             status actedAt
             issuerClass demotionReason
+            scopeComponentUuid scopeComponentName scopeBranchUuid scopeBranchName scopeReleaseUuid scopeReleaseVersion
         }
     }
 `
@@ -38,6 +40,7 @@ export const GET_VEX_PROPOSAL = gql`
             actedAt actedBy
             translationNotes
             issuerClass userImportMode userIssuerClassOverride demotionReason
+            scopeComponentUuid scopeComponentName scopeBranchUuid scopeBranchName scopeReleaseUuid scopeReleaseVersion
         }
     }
 `


### PR DESCRIPTION
Makes VEX proposals readable: both surfaces showed the scope as a bare UUID (the review page literally had a `Scope UUID` row, and the inbox had no scope detail at all).

Backend half is the port of relizaio/rearm-saas#393; the UI is CE-only, so it rides here.

## Backend

`VexStatementProposalWebDto` gains six nullable display fields (`scopeComponentUuid/Name`, `scopeBranchUuid/Name`, `scopeReleaseUuid/Version`), filled by `VexProposalScopeResolver` on every read path. Resolution is **batched** across the page — releases, components and branches each in one read — because the inbox is org-wide and per-proposal resolution would be 1–3 queries each. `RELEASE` fills all three levels, `BRANCH` fills branch + its component, `COMPONENT` fills only the component, `ORG` / `RESOURCE_GROUP` fill none.

Every resolved object is also checked to belong to the proposal's own org (defence-in-depth; not reachable today since scope targets are server-assigned and immutable after create). Anything unresolvable — deleted, invisible, or cross-org — leaves nulls rather than failing the query.

## UI

Both surfaces show the **most specific name** as link text — release version, else branch name, else component name:

| scope | link text | links to |
|---|---|---|
| RELEASE | version (`1.4.2`) | `/release/show/<uuid>` |
| BRANCH | branch name (`main`) | `/componentsOfOrg/<org>/<component>/<branch>` |
| COMPONENT | component name | `/componentsOfOrg/<org>/<component>` |
| ORG / RESOURCE_GROUP | — (enum badge only) | — |

The fuller `component / branch / version` path is in a **tooltip** in the inbox (that table already has 8 columns, so the cell stays narrow) and shown inline on the review page. The scope enum badge stays in both. If the scope no longer resolves, the raw uuid is rendered so the row is still actionable. Links open in a new tab, matching the existing "Review proposal" action.

## Also: "Component" → "Location"

The existing column/label holds `location` / `rawLocation` — the affected **package** purl — which read confusingly next to a real ReARM component name. Renamed on both surfaces, per maintainer decision.

## Verification

- `VexProposalScopeResolverTest` 8/8 green in this repo, including two cross-org cases that are mutation-verified (disabling the org check leaks the foreign org's version and both fail).
- `npm run build` clean; `npm run validate:graphql` — 305 documents, 0 Pro failures, 0 CE drift.
- Cross-checked every `scope*` field used in the UI against the schema type: no mismatches.

**Not verified:** the rendered result in a browser — no screenshot/interaction pass was run, so link targets and tooltip are code-reviewed rather than clicked. Route shapes were taken from `router.ts` (`/release/show/:uuid`, `/componentsOfOrg/:orguuid/:compuuid?/:branchuuid?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)