### PR TITLE
docs: correct three notification claims that don't match behaviour

### DIFF
--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -62,6 +62,11 @@ A subscription's `eventTypes` list controls what it can match:
 - Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
   `MEDIUM` / ...); only events at or above that threshold on that route are
   sent to its targets.
+- A route can also carry a **perspectives** list. Left empty it means "any
+  perspective". Set, it gates delivery: the event only goes out on that route
+  when an affected release's component belongs to one of the named
+  perspectives. This gates **delivery only** -- it does not change what appears
+  in the in-app inbox or the bell.
 
 ::: warning Filters are not applied on Community Edition
 Filter evaluation is a Pro capability. On CE the evaluator is absent, and

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -56,9 +56,16 @@ A subscription's `eventTypes` list controls what it can match:
 
 - A subscription can carry an optional filter, built either with the preset
   toggles or as an advanced expression. Filters run under limits (size, nesting
-  depth, iteration count, and a short evaluation timeout) so a runaway
-  expression can't stall delivery for the rest of the org -- a filter that
-  exceeds its budget fails that one delivery rather than blocking others.
+  depth, iteration count, and a 50 ms evaluation budget) so a runaway
+  expression can't stall delivery for the rest of the org. A filter that
+  exceeds its budget -- or fails to evaluate for any other reason -- causes
+  that subscription to be **skipped for that event**; other subscriptions on
+  the same event are unaffected.
+
+  Note that a skip is silent: no delivery row is written, so a filter that
+  never evaluates shows up in [Delivery History](#delivery-history) as
+  *nothing at all*, not as a failure. If a subscription you expect to fire
+  produces no rows whatsoever, an unevaluatable filter is a candidate cause.
 - Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
   `MEDIUM` / ...); only events at or above that threshold on that route are
   sent to its targets.
@@ -140,6 +147,88 @@ gap, not a bug you need to work around; if you're relying on a specific
 delivery cap today, use your destination's own rate limiting (e.g. a Slack
 app's built-in limits) in the meantime.
 :::
+
+## Email digest batching
+
+Email channels do not send one message per event by default. They apply a
+**rolling cap**: the first non-actionable event after a quiet period sends
+immediately and anchors a window; anything arriving within the configured
+interval of that send is held and flushed as a **single digest email** when
+the window expires.
+
+Configure it on the Email channel itself (**Integrations -> Catalog ->
+Email**):
+
+- **Digest** (the default) -- batch routine notifications into at most one
+  email per interval. The interval ranges from **every 5 minutes** to
+  **weekly**; the accepted bounds are 5 minutes to 7 days.
+- **Immediate** -- disable batching; every event sends its own email.
+
+The channel card shows the current setting as a chip, so you can see at a
+glance which mode a channel is in.
+
+Two things always bypass the digest and send immediately regardless of mode:
+
+- **Approval events** (`APPROVAL_REQUESTED`, `APPROVAL_RESOLVED`). These ask a
+  specific person to act now, so holding them for a digest window would defeat
+  the point.
+- **Test and synthetic events** -- see the caveat below.
+
+Only EMAIL channels batch. Slack, Microsoft Teams, webhook, and Sentinel
+channels always dispatch as soon as the worker picks the delivery up.
+
+::: warning The default is a 24-hour digest
+An email channel created without touching these settings is in **rolling
+digest mode with a 24-hour interval**. That means the first event of a window
+arrives immediately and everything after it can be held for up to a day.
+
+This surprises people who expect an alerting channel to be chatty by default.
+If you want per-event email, set the channel to **Immediate** explicitly, or
+shorten the interval.
+:::
+
+::: warning A channel test will not show you digest behaviour
+Test and synthetic events skip the digest unconditionally, so **Send test**
+always produces an immediate email. A channel can therefore pass its test
+perfectly while real traffic is being held for up to 24 hours.
+
+To see batching, cause two real events in quick succession and watch the
+second land in [Delivery History](#delivery-history) as `BATCHED`.
+:::
+
+## Delivery History
+
+**Organization Settings -> Audit -> Delivery History** lists every delivery
+ReARM has attempted, with the channel, the subscription that caused it, the
+attempt count, and any error.
+
+One event produces **one row per (subscription, channel) pair**. That is worth
+internalising, because it explains the most common "why did I get this twice?"
+question: two subscriptions that both route to the same channel produce two
+rows and two messages. [Duplicate protection](#duplicate-delivery-protection)
+is scoped per subscription, so it does not collapse them. This is easy to hit
+without noticing when one subscription names a channel directly and another
+reaches the same channel indirectly through a team or the
+[component owner](#notifying-the-component-owner).
+
+The **Origin** column separates `REAL` traffic from `SYNTHETIC` rows produced
+by the test actions, so a history full of test runs stays legible.
+
+Statuses you will see:
+
+| Status | Meaning |
+|---|---|
+| `PENDING` | Queued; the channel worker has not attempted it yet |
+| `SENT` | The channel transport accepted it |
+| `BATCHED` | Held in an email channel's [digest window](#email-digest-batching); flushed with the next digest. All rows in one digest flip to `SENT` together, sharing a timestamp |
+| `FAILED` | Retries exhausted, or a non-retriable error. Terminal |
+| `ACKED` | Acknowledged by a user in the in-app inbox |
+
+An event that produced **no rows at all** is a different situation from a
+failed row, and the outbox event's own status tells you which: `FANNED_OUT`
+with no deliveries means "offered, and no subscription wanted it", while
+`SUPPRESSED` means ReARM withheld it deliberately -- today that means a
+[vulnerability event naming no release](#vulnerability-events-that-affect-nothing).
 
 ## Vulnerability events that affect nothing
 

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -240,10 +240,34 @@ yet.
 
 ReARM therefore resolves the affected releases at **delivery** time. If the set
 comes back empty, the event is not delivered immediately and not discarded --
-it is deferred and retried (roughly 30s, then 60s, then every 2 minutes). Only
-if the set is still empty after those attempts is the event **withheld**, on
-the grounds that a vulnerability notification naming no release is not
-actionable.
+it is deferred and retried (roughly 30s, then 60s, then every 2 minutes).
+
+What happens after those retries depends on whether the empty answer can be
+**trusted**, because "this affects nothing" and "we could not work out what
+this affects" are different claims:
+
+- **The empty result is trustworthy.** ReARM checks whether the pipeline that
+  writes the CVE-to-release link has actually run for your organization since
+  the event was emitted. If it has, then "we found nothing" really does mean
+  "there is nothing", and the event is **withheld** after about 3 attempts --
+  a vulnerability notification naming no release is not actionable.
+- **The empty result cannot be proven.** If those artifact metrics have *not*
+  been refreshed since the event, elapsed time proves nothing: the scan may
+  simply be lagging. ReARM keeps retrying for roughly 15 minutes and then
+  **delivers the notification anyway**, naming no releases, rather than
+  dropping it. Silently discarding a real vulnerability alert is the worse
+  failure.
+
+::: tip "Affects 0 releases" means your scan pipeline is behind
+Receiving a vulnerability notification that names no release is the second
+case above, and it is a signal worth acting on: it means the vulnerability
+scan / SBOM fan-out had not run for your organization in the ~15 minutes
+after the CVE was recorded. ReARM logs this at ERROR with the event id and
+the time it gave up, so it is greppable in the backend logs.
+
+The notification itself is not wrong -- the CVE really is new to your
+organization. It just could not be attributed to releases yet.
+:::
 
 Withheld events are recorded as `SUPPRESSED` rather than failed. That is
 deliberately distinct from an event that fanned out and simply matched no
@@ -302,6 +326,22 @@ If the only route on the subscription
 reports no delivery usually means the component the test event landed on has no
 owner, or its owner team has no channel -- not that your filter or severity
 gate is wrong. Check ownership first; the result dialog says so too.
+:::
+
+::: warning A passing owner-routing test does not mean production will deliver
+The reverse case is the one that bites. When a test event is injected, ReARM
+deliberately stamps it onto a component that **has a routable owner**, so that
+the test exercises owner routing rather than reporting a confusing nothing.
+
+A real event has no such courtesy: it lands on whatever component actually
+carries the vulnerability. If that component has no owner -- no stored owner,
+and no matching [assignment rule](./component-ownership#assignment-rules) --
+the route contributes nothing and the event is silent.
+
+So an owner-routed subscription can pass its test every single time and still
+never fire in production. The test proves the *route* is wired correctly; it
+does not prove your *components are owned*. Use the ownership report to check
+coverage across the inventory, not the Test button.
 :::
 
 ## KEV (Known Exploited Vulnerabilities) notifications

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -15,9 +15,9 @@ Subscriptions, routes, and channel groups are available on **both** editions,
 as are the **Slack**, **Microsoft Teams**, and **Webhook** channel types.
 
 Pro adds two channel types -- **Email** and
-[**Microsoft Sentinel**](../integrations/sentinel) -- and two route targets,
-**teams** and **notify the component owner**. Everything else on this page
-works the same on either edition.
+[**Microsoft Sentinel**](../integrations/sentinel) -- two route targets,
+**teams** and **notify the component owner**, and
+[subscription filtering](#filters-severity-and-routes).
 :::
 
 ## How it fits together
@@ -43,11 +43,11 @@ A subscription's `eventTypes` list controls what it can match:
 
 | Event | Fires when |
 |---|---|
-| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability is newly linked to one of your releases |
+| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability record is created for your organization. The releases it affects are resolved when the event is delivered, and that list can legitimately be empty -- the event still fires, so treat "affects releases" as the intent rather than a guarantee |
 | `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
 | `VEX_STATE_CHANGED` | Reserved for VEX (exploitability) status changes. No event source emits this yet, so a subscription on it will not fire today -- prefer `VULNERABILITY_RECORD_UPDATED` for vulnerability-state changes |
 | `RELEASE_CREATED` | A new release is created |
-| `RELEASE_LIFECYCLE_CHANGED` | A release moves lifecycle stage |
+| `RELEASE_LIFECYCLE_CHANGED` | A release enters `DRAFT`, `ASSEMBLED`, `CANCELLED` or `REJECTED`. **Only those four**, matching what the older Slack/Teams release notifications sent -- later stages such as `READY_TO_SHIP`, `GENERAL_AVAILABILITY` and the end-of-life stages emit nothing |
 | `RELEASE_BOM_DIFF` | A release's BOM diff is computed |
 | `APPROVAL_REQUESTED` | Someone requests approval on a release -- see [Approval queues](./approval-queues) |
 | `APPROVAL_RESOLVED` | An approval request is satisfied or disapproved |
@@ -55,13 +55,24 @@ A subscription's `eventTypes` list controls what it can match:
 ## Filters, severity, and routes
 
 - A subscription can carry an optional filter, built either with the preset
-  toggles or as an advanced expression. Advanced filters run under limits
-  (size, nesting depth, iteration count, and a short evaluation timeout) so a
-  runaway expression can't stall delivery for the rest of the org -- a filter
-  that exceeds its budget fails that one delivery rather than blocking others.
+  toggles or as an advanced expression. Filters run under limits (size, nesting
+  depth, iteration count, and a short evaluation timeout) so a runaway
+  expression can't stall delivery for the rest of the org -- a filter that
+  exceeds its budget fails that one delivery rather than blocking others.
 - Each route on a subscription sets a minimum severity (`CRITICAL` / `HIGH` /
   `MEDIUM` / ...); only events at or above that threshold on that route are
   sent to its targets.
+
+::: warning Filters are not applied on Community Edition
+Filter evaluation is a Pro capability. On CE the evaluator is absent, and
+rather than dropping subscriptions it cannot evaluate, ReARM delivers them
+**unfiltered** -- a filter you save is accepted and then ignored, so the
+subscription fires on every event of its type.
+
+This applies to the preset toggles as well as advanced expressions, since the
+toggles compile down to the same expression. Minimum severity, event types and
+route targets are all still enforced on CE; only the filter is not.
+:::
 
 ### Route targets
 

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -195,6 +195,18 @@ event, straight from the UI:
 Both bypass the dedup window described above, so a test always produces a
 delivery you can see in **Delivery History**.
 
+::: warning Not every event type can be tested
+Synthetic scenarios exist only for `NEW_VULN_AFFECTS_RELEASES`,
+`VULNERABILITY_RECORD_UPDATED` and `VEX_STATE_CHANGED`. A subscription on any
+of the release or approval event types has no scenario to inject, so its
+**Test** control is disabled and hovering it explains why.
+
+That is deliberate -- injecting would fire a real org-wide event that could
+never match the subscription you are testing -- but it does mean a
+release-lifecycle or approval subscription can only be verified by causing the
+real event: transition a release, or open an actual approval request.
+:::
+
 ::: tip A test on an owner-routed subscription can legitimately show nothing
 If the only route on the subscription
 [notifies the component owner](#notifying-the-component-owner), a test that

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -43,7 +43,7 @@ A subscription's `eventTypes` list controls what it can match:
 
 | Event | Fires when |
 |---|---|
-| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability record is created for your organization. The releases it affects are resolved when the event is delivered, and that list can legitimately be empty -- the event still fires, so treat "affects releases" as the intent rather than a guarantee |
+| `NEW_VULN_AFFECTS_RELEASES` | A vulnerability record is created for your organization **and** at least one of your releases carries it. The affected releases are resolved at delivery time, not when the record is written, so an event whose set is still empty is retried for a short while and then withheld rather than delivered (see [below](#vulnerability-events-that-affect-nothing)) |
 | `VULNERABILITY_RECORD_UPDATED` | An existing vulnerability record changes -- including a CVE newly appearing on the KEV catalog (see [KEV notifications](#kev-known-exploited-vulnerabilities-notifications) below) |
 | `VEX_STATE_CHANGED` | Reserved for VEX (exploitability) status changes. No event source emits this yet, so a subscription on it will not fire today -- prefer `VULNERABILITY_RECORD_UPDATED` for vulnerability-state changes |
 | `RELEASE_CREATED` | A new release is created |
@@ -135,6 +135,26 @@ gap, not a bug you need to work around; if you're relying on a specific
 delivery cap today, use your destination's own rate limiting (e.g. a Slack
 app's built-in limits) in the meantime.
 :::
+
+## Vulnerability events that affect nothing
+
+A vulnerability record is written the moment ReARM learns the CVE is new to
+your organization, but the link from that CVE to your releases lives in
+artifact metrics, which are written slightly later. So at the instant the
+event is produced, "which releases does this affect?" genuinely has no answer
+yet.
+
+ReARM therefore resolves the affected releases at **delivery** time. If the set
+comes back empty, the event is not delivered immediately and not discarded --
+it is deferred and retried (roughly 30s, then 60s, then every 2 minutes). Only
+if the set is still empty after those attempts is the event **withheld**, on
+the grounds that a vulnerability notification naming no release is not
+actionable.
+
+Withheld events are recorded as `SUPPRESSED` rather than failed. That is
+deliberately distinct from an event that fanned out and simply matched no
+subscription: the first means "we chose not to send this", the second means
+"nobody asked for it".
 
 ## Retention
 

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -139,9 +139,14 @@ app's built-in limits) in the meantime.
 ## Retention
 
 Notification history (deliveries and inbox rows) is retained for a
-configurable number of days per organization -- 90 by default, with an enforced
-14-day floor. An org can't set retention short enough to delete a row that
-might still be scheduled to send (e.g. one parked in an email digest).
+configurable number of days per organization -- **90 by default**, and settable
+anywhere from **14 to 730**. The floor exists so an org can't set retention
+short enough to delete a row that might still be scheduled to send (e.g. one
+parked in an email digest).
+
+There is no screen for this yet: retention is set through the
+`updateOrganizationSettings` GraphQL mutation (`notificationRetentionDays`),
+not from Organization Settings.
 
 ## Testing channels and subscriptions
 

--- a/documentation_site/docs/integrations/sentinel.md
+++ b/documentation_site/docs/integrations/sentinel.md
@@ -17,6 +17,14 @@ Before adding a Sentinel channel in ReARM, you need, in the Azure portal:
 2. **A Data Collection Rule (DCR)** that targets your Sentinel/Log Analytics table,
    its **immutable ID** (`dcr-...`), and the **stream name** it exposes
    (typically `Custom-<TableName>_CL`).
+
+   You do **not** need a new table if you already have a DCE and DCR -- ReARM
+   needs three values, not three new resources. But the stream's declared
+   columns decide what survives: Azure silently drops any property the stream
+   does not declare, so a DCR built for a different purpose (or a built-in
+   table such as `CommonSecurityLog`, whose schema is fixed) will accept the
+   batch and quietly discard most of it. `PayloadJson` carries the full event
+   regardless, so declaring at least that column means nothing is ever lost.
 3. **An Azure AD app registration (service principal)** with the **Monitoring
    Metrics Publisher** role assigned on the DCR, giving you a **tenant ID**,
    **client ID**, and **client secret**.
@@ -58,10 +66,25 @@ haven't changed).
 Adding the channel doesn't send anything by itself -- you also need a
 **subscription** with a route pointing at it. See
 [Notifications](../configure/notifications) for event types, severity gates,
-and how routes work. ReARM doesn't currently offer a UI button to send a test
-event to a Sentinel channel; the only way to confirm delivery today is to
-route a real (or synthetic, via the API) event to it and check your Log
-Analytics table for the resulting rows.
+and how routes work.
+
+To confirm the six values are right before wiring any of that up, use the
+**Send test notification** (paper-plane) action on the channel instance in the
+catalog. It posts straight to your DCE, so a `SENT` delivery proves the whole
+chain -- service principal, DCE, DCR immutable ID and stream name. Worth doing
+first: a Sentinel channel saves successfully even when every credential is
+wrong, because ReARM cannot verify them against Azure at save time.
+
+`SENT` means Azure accepted the batch, not that the row is queryable yet --
+ingestion is asynchronous and the first write to a table can lag a few
+minutes. Confirm with a query against your table:
+
+```kusto
+ReARMNotifications_CL
+| where TimeGenerated > ago(30m)
+| project TimeGenerated, EventType, Severity, Origin, PayloadJson
+| order by TimeGenerated desc
+```
 
 ## What gets sent
 

--- a/documentation_site/docs/integrations/slack.md
+++ b/documentation_site/docs/integrations/slack.md
@@ -1,25 +1,64 @@
 
 ## Slack
 
-### 1. Add App To Slack
+Slack is a **notification channel**: you create one destination and then route
+events to it from a subscription. See
+[Notifications](../configure/notifications) for what you can route and how.
 
-1. Go to Slack api page at https://api.slack.com/apps and click on "Create New App"
-2. Name your app "ReARM Integration" and select your Slack workspace in the "Development Slack Workspace"
-3. Click on "Create App"
-4. Click on "Incoming Webhooks"
-5. Click on the toggle "Activate Incoming Webhooks" to change it to "On"
-6. Scroll down to the bottom of the page
-7. Click on "Add New Webhook to Workspace"
-8. On the next screen, select desired Slack channel for integration
-9. Scroll down to the bottom of the page
+::: warning Paste the WHOLE URL
+Earlier versions of ReARM stored only the path fragment
+(`T0XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXX`) and prepended the rest. That is no
+longer the case -- the channel form validates what you paste and rejects
+anything that is not an `https://` URL on `hooks.slack.com`, so a bare
+fragment fails to save with:
+
+```
+Slack webhook URL must be an https:// URL on host hooks.slack.com
+```
+
+Copy the full URL Slack gives you, starting with `https://`.
+:::
+
+### 1. Create the incoming webhook in Slack
+
+1. Go to the Slack API page at https://api.slack.com/apps and click "Create New App"
+2. Choose "From scratch", name your app "ReARM Integration" and select your Slack workspace
+3. Click "Create App"
+4. Click "Incoming Webhooks"
+5. Click the toggle "Activate Incoming Webhooks" to change it to "On"
+6. Scroll to the bottom of the page
+7. Click "Add New Webhook to Workspace"
+8. On the next screen, select the Slack channel that should receive notifications
+9. Scroll to the bottom of the page
 10. Click "Copy" where it says "Webhook URL"
-11. You would get a URL like https://hooks.slack.com/services/T0XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXX
-12. Copy everything after https://hooks.slack.com/services/, in the case above this would be T0XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXX (note that this is your Slack webhook secret so treat it accordingly)
+11. You now have a URL like `https://hooks.slack.com/services/T0XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXX`
 
-### 2. Register Slack App With ReARM
+Treat that URL as a secret: anyone holding it can post to your channel.
 
-1. In ReARM, open Organization Settings from the menu on the left
-2. In the Integrations section, click on "Add Slack Integration" button
-3. In the secret field paste the webhook secret you obtained when adding App to slack above - in this tutorial T0XXXXXXXX/XXXXXXXXX/XXXXXXXXXXXX
-4. Click "Submit"
-5. Your Slack Integration is now set up!
+### 2. Add the channel in ReARM
+
+1. In ReARM, open **Organization Settings** from the menu on the left
+2. Go to the **Integrations** tab, then the **Catalog** sub-tab
+3. Find the **Slack** card and click **Add**
+4. **Name** it for the destination it posts to, e.g. `#security-alerts` -- this
+   is the label you will pick from when building a subscription route
+5. Paste the full URL from step 1 into **Incoming-webhook URL**
+6. Save
+
+The channel now appears on the Slack card. Use the paper-plane **Send test**
+action on it to confirm delivery: a channel test posts directly and does not
+need a subscription to exist yet.
+
+### 3. Route something to it
+
+A channel on its own delivers nothing. Add a subscription under
+**Integrations -> Subscriptions** with the event types you care about and a
+route pointing at this channel. See
+[Notifications](../configure/notifications) for event types, filters, and the
+other route targets (channel groups, teams, and the affected component's
+owner).
+
+::: tip Editing later
+Leave **Incoming-webhook URL** blank when editing an existing channel to keep
+the stored URL; fill it in only to replace it.
+:::


### PR DESCRIPTION
Follow-up to #264. All three of these are corrections to text that PR
introduced, found by walking the page against a running instance instead
of against the source -- which is how they got past review the first time.

## 1. Filters do not work on Community Edition

The page claimed that outside the two Pro channel types and two Pro route
targets, "everything else on this page works the same on either edition."

It does not. `NotificationCelEvaluator` has only a saas-side
implementation. On CE the seam autowires null and the fan-out treats any
non-blank filter as **match-all**:

```java
if (celEvaluator == null) {
    log.debug("No CEL evaluator on this edition; treating non-blank filter "
            + "as match-all for subscription {} on event {}", ...);
    return true;
}
```

That is a deliberate choice -- a subscription that cannot be evaluated
delivers rather than going silent -- but nothing told the operator. A CE
user saves `event.kevListed == true`, sees it accepted, and receives every
event of that type.

Preset toggles are affected too: they compile down to the same expression,
and the gate is whether `celExpression` is blank, not which mode produced
it.

Filtering is now listed as a Pro capability, with a warning spelling out
the CE behaviour and confirming that severity, event types and route
targets *are* still enforced there.

## 2. RELEASE_LIFECYCLE_CHANGED covers 4 of 11 lifecycles

Documented as "a release moves lifecycle stage". Only `DRAFT`,
`ASSEMBLED`, `CANCELLED` and `REJECTED` reach the producer -- an explicit
else-if chain preserving what the older Slack/Teams path notified on.
Subscribing to hear about `READY_TO_SHIP`, `GENERAL_AVAILABILITY` or any
end-of-life stage yields silence, which is the worst way to discover a
gap. The table now names the four and the notable omissions.

## 3. NEW_VULN_AFFECTS_RELEASES can affect nothing

Documented as a vulnerability "newly linked to one of your releases". It
fires for any new vulnerability record in the org; `affectedReleases` is
null at emit and resolved at delivery, and may be empty with no guard.

Verified on a live instance by injecting `CVE-1999-00000`, which no
artifact carries: it enriched to `affectedReleases: 0` and
`affectedComponent: null`, and still fanned out and delivered.

## Checked and left alone

The same pass validated, and found accurate: retention (90 default / 14
floor), dedup (24h default), all eight event types against the enum, the
four route targets, the owner-routing preconditions and fail-closed
behaviour, the CEL limits, both KEV claims (first-sync baseline,
sticky-once-observed), CISA default-on, and the tab locations.

`npm run docs:build` passes with dead-link checking on. Plain ASCII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)