### PR TITLE
rebom: tolerate the enrichment write race in digest-validated BOM fetches

### DIFF
--- a/rebom-backend/src/services/bom/bomCrudService.ts
+++ b/rebom-backend/src/services/bom/bomCrudService.ts
@@ -3,7 +3,7 @@ import { BomDto, BomMetaDto, BomRecord, BomSearch, SearchObject } from '../../ty
 import { BomNotFoundError, BomDataIntegrityError } from '../../types/errors';
 import { BomMapper } from './bomMapper';
 import { logger } from '../../logger';
-import { fetchFromOci, extractRepositoryNameFromBom, extractRepositoryNameFromSpdxOciResponse, resolveAndFetchRawBom } from '../oci';
+import { fetchFromOci, extractRepositoryNameFromBom, extractRepositoryNameFromSpdxOciResponse, resolveAndFetchRawBom, fetchProcessedBomWithRetry } from '../oci';
 import { parseBom, ParsedBom, ParsedBomComponent, parseHbom, ParsedHbom } from './bomComponentExtractor';
 
 export async function findAllBoms(): Promise<BomDto[]> {
@@ -48,11 +48,11 @@ export async function findBomObjectById(id: string, org: string): Promise<Object
     // Extract repository name from bom field (OASResponse)
     const storedRepositoryName = extractRepositoryNameFromBom(bomRecord);
     
-    // Fetch the actual BOM content from OCI storage using the BOM's UUID
-    // Use stored repository name, or fall back to default 'rebom-artifacts' for legacy records
-    // Validate using processedFileDigest (augmented BOM digest)
-    const expectedDigest = bomRecord.meta?.processedFileDigest;
-    const bomContent = await fetchFromOci(bomRecord.uuid, storedRepositoryName, expectedDigest);
+    // Fetch the actual BOM content from OCI storage using the BOM's UUID.
+    // Digest-validated with a one-shot retry against a fresh row read, so a
+    // concurrent enrichment push (bytes overwritten before the row's digest
+    // update lands) does not surface as a spurious validation failure.
+    const bomContent = await fetchProcessedBomWithRetry(bomRecord);
     return bomContent;
 }
 
@@ -138,10 +138,9 @@ export async function findBomBySerialNumberAndVersion(serialNumber: string, vers
         logger.debug({ bomUuid: bomRecord.uuid, version, serialNumber }, "Fetching raw CycloneDX BOM by version");
         return await resolveAndFetchRawBom(bomRecord);
     } else {
-        // Augmented/processed BOM requested - validate using processedFileDigest
+        // Augmented/processed BOM requested - digest-validated, race-tolerant
         logger.debug({ uuid: bomRecord.uuid, version, serialNumber }, "Fetching augmented BOM by version");
-        const expectedDigest = bomRecord.meta?.processedFileDigest;
-        return await fetchFromOci(bomRecord.uuid, storedRepositoryName, expectedDigest);
+        return await fetchProcessedBomWithRetry(bomRecord);
     }
 }
 
@@ -206,9 +205,8 @@ export async function findRawBomObjectById(id: string, org: string, format?: str
                 bomUuid: bomById.uuid, 
                 sourceSpdxUuid: bomById.source_spdx_uuid 
             }, "Fetching converted CycloneDX from SPDX source");
-            // Converted BOMs are processed versions - validate using processedFileDigest
-            const expectedDigest = bomById.meta?.processedFileDigest;
-            return await fetchFromOci(bomById.uuid, storedRepositoryName, expectedDigest);
+            // Converted BOMs are processed versions - digest-validated, race-tolerant
+            return await fetchProcessedBomWithRetry(bomById);
         }
         
         // Native CycloneDX - fetch raw BOM with automatic fallback for legacy BOMs
@@ -263,9 +261,8 @@ export async function findRawBomObjectById(id: string, org: string, format?: str
             return await resolveAndFetchRawBom(bomById);
         }
         
-        // Fallback to primary UUID (processed/augmented BOM) - validate using processedFileDigest
+        // Fallback to primary UUID (processed/augmented BOM) - digest-validated, race-tolerant
         logger.debug({ uuid: bomById.uuid }, "Falling back to primary BOM UUID");
-        const expectedDigest = bomById.meta?.processedFileDigest;
-        return await fetchFromOci(bomById.uuid, storedRepositoryName, expectedDigest);
+        return await fetchProcessedBomWithRetry(bomById);
     }
 }

--- a/rebom-backend/src/services/bom/bomMapper.ts
+++ b/rebom-backend/src/services/bom/bomMapper.ts
@@ -1,5 +1,5 @@
 import { BomDto, BomMetaDto, BomRecord } from '../../types';
-import { fetchFromOci, extractRepositoryNameFromBom } from '../oci';
+import { fetchProcessedBomWithRetry } from '../oci';
 
 export class BomMapper {
     /**
@@ -32,10 +32,8 @@ export class BomMapper {
      */
     static async toDtoWithContent(record: BomRecord): Promise<BomDto> {
         const dto = this.toDto(record);
-        const storedRepositoryName = extractRepositoryNameFromBom(record);
-        // Validate augmented/processed BOM using processedFileDigest
-        const expectedDigest = record.meta?.processedFileDigest;
-        dto.bom = await fetchFromOci(record.uuid, storedRepositoryName, expectedDigest);
+        // Digest-validated, race-tolerant (see fetchProcessedBomWithRetry)
+        dto.bom = await fetchProcessedBomWithRetry(record);
         return dto;
     }
 

--- a/rebom-backend/src/services/bom/bomProcessingService.ts
+++ b/rebom-backend/src/services/bom/bomProcessingService.ts
@@ -10,7 +10,8 @@ import {
   extractRepositoryNameFromBom,
   extractRepositoryNameFromSpdxOciResponse,
   validateOciPushResult,
-  resolveAndFetchRawBom
+  resolveAndFetchRawBom,
+  fetchProcessedBomWithRetry
 } from '../oci';
 import * as BomRepository from '../../bomRepository';
 import * as SpdxRepository from '../../spdxRepository';
@@ -938,10 +939,10 @@ export async function triggerEnrichment(id: string, org: string, force: boolean 
       logger.error({ err, bomUuid: bomRecord.uuid }, 'Forced re-enrichment failed');
     });
   } else {
-    // Normal enrichment - fetch current augmented BOM (validate with processedFileDigest)
-    const storedRepositoryName = extractRepositoryNameFromBom(bomRecord);
-    const expectedDigest = bomRecord.meta?.processedFileDigest;
-    const bomContent = await fetchFromOci(bomRecord.uuid, storedRepositoryName, expectedDigest);
+    // Normal enrichment - fetch current augmented BOM. Race-tolerant: a manual
+    // trigger's most likely collision is ANOTHER enrichment finishing its push
+    // just before its row update lands.
+    const bomContent = await fetchProcessedBomWithRetry(bomRecord);
     enrichBomAsync(bomRecord.uuid, bomContent, org).catch(err => {
       logger.error({ err, bomUuid: bomRecord.uuid }, 'Async enrichment trigger failed');
     });

--- a/rebom-backend/src/services/bom/bomSearchService.ts
+++ b/rebom-backend/src/services/bom/bomSearchService.ts
@@ -1,7 +1,7 @@
 import { logger } from '../../logger';
 import { BomSearch, BomDto, BomMetaDto, RebomOptions, SearchObject, BomRecord } from '../../types';
 import { BomNotFoundError } from '../../types/errors';
-import { fetchFromOci, extractRepositoryNameFromBom } from '../oci';
+import { fetchProcessedBomWithRetry } from '../oci';
 import { augmentBomWithComponentContext, attachRebomToolToBom } from './bomProcessingService';
 import { runQuery } from '../../utils';
 import { BomMapper } from './bomMapper';
@@ -90,10 +90,8 @@ async function bomRecordToDto(bomRecord: BomRecord, rootOverride: boolean = true
   let name = ''
   let bomVersion = ''
   
-  // Fetch BOM content from OCI storage (augmented BOM - validate with processedFileDigest)
-  const storedRepositoryName = extractRepositoryNameFromBom(bomRecord);
-  const expectedDigest = bomRecord.meta?.processedFileDigest;
-  bomRecord.bom = await fetchFromOci(bomRecord.uuid, storedRepositoryName, expectedDigest)
+  // Fetch BOM content from OCI storage (augmented BOM - digest-validated, race-tolerant)
+  bomRecord.bom = await fetchProcessedBomWithRetry(bomRecord)
   
   if (rootOverride)
     bomRecord.bom = rootComponentOverride(bomRecord)

--- a/rebom-backend/src/services/enrichmentScheduler.ts
+++ b/rebom-backend/src/services/enrichmentScheduler.ts
@@ -1,7 +1,7 @@
 import { logger } from '../logger';
 import { EnrichmentStatus, IntegrationType } from '../types';
 import * as BomRepository from '../bomRepository';
-import { fetchFromOci, extractRepositoryNameFromBom } from './oci';
+import { fetchProcessedBomWithRetry } from './oci';
 import { enrichBomAsync } from './bom/bomProcessingService';
 import { getBearCredentials } from './integrationService';
 import { runQuery } from '../utils';
@@ -136,10 +136,10 @@ async function runEnrichmentCycle(): Promise<void> {
         
         logger.info({ bomUuid: bom.uuid, serialNumber: bom.serialNumber }, 'Enrichment scheduler: Triggering enrichment');
         
-        // Fetch BOM content from OCI (augmented BOM - validate with processedFileDigest)
-        const storedRepositoryName = extractRepositoryNameFromBom(bom);
-        const expectedDigest = bom.meta?.processedFileDigest;
-        const bomContent = await fetchFromOci(bom.uuid, storedRepositoryName, expectedDigest);
+        // Fetch BOM content from OCI (augmented BOM). The candidate list was
+        // loaded at cycle start, so this row's digest can be minutes stale --
+        // the race-tolerant fetch re-reads the row once on a digest mismatch.
+        const bomContent = await fetchProcessedBomWithRetry(bom);
         
         await enrichBomAsync(bom.uuid, bomContent, bom.organization, credentialsByOrg.get(bom.organization)).catch(err => {
           logger.error({ err, bomUuid: bom.uuid }, 'Enrichment scheduler: Async enrichment failed');

--- a/rebom-backend/src/services/oci/index.ts
+++ b/rebom-backend/src/services/oci/index.ts
@@ -43,5 +43,10 @@ export {
 // fetchRawBomWithFallback, which masked misplaced raw copies as digest errors)
 export { resolveAndFetchRawBom, logRawRepositoryCensus } from './rawBomResolver';
 
+// Processed-BOM fetch tolerant of the enrichment two-step write (bytes
+// overwritten before the row's digest update lands): one retry against a
+// fresh row read; unchanged row => genuine corruption, original error rethrown.
+export { fetchProcessedBomWithRetry } from './processedBomFetcher';
+
 // Re-export types
 export type { OASResponse, OciResponse } from './ociService';

--- a/rebom-backend/src/services/oci/processedBomFetcher.ts
+++ b/rebom-backend/src/services/oci/processedBomFetcher.ts
@@ -1,0 +1,70 @@
+import { logger } from '../../logger';
+import { DigestValidationError } from '../../types/errors';
+import { fetchFromOci as defaultFetchFromOci } from './index';
+import { extractRepositoryNameFromBom } from './ociRepositoryHelpers';
+import type { BomRecord } from '../../types/bom.types';
+
+/**
+ * Processed-BOM fetch tolerant of the enrichment write race.
+ *
+ * Enrichment updates the processed BOM in TWO steps: it overwrites the bytes
+ * at tag {@code <uuid>} in the registry, THEN writes the new
+ * processedFileDigest (+ repository pointer) to the row. A reader whose row
+ * snapshot predates step two but whose download lands after step one computes
+ * the NEW bytes against the OLD digest and fails validation -- even though
+ * nothing is corrupt. The window is milliseconds for request-scoped readers
+ * but minutes for the enrichment scheduler (it loads its candidate rows up
+ * front) and the per-minute reconcile in the ReARM backend, so purely
+ * programmatic collisions are the common case.
+ *
+ * Recovery discipline: on a digest failure, RE-READ the row once. If the
+ * stored digest (or repository pointer) changed while we were looking, it was
+ * the race -- refetch against the fresh values. If the row still describes
+ * exactly what we validated against, the mismatch is real corruption and the
+ * ORIGINAL error is rethrown untouched. One retry only: a second mismatch
+ * against fresh row state is not a race artifact.
+ */
+/** Structural minimum: callers like the enrichment scheduler carry partial rows. */
+type ProcessedBomSource = Pick<BomRecord, 'uuid' | 'meta' | 'bom'>;
+
+export async function fetchProcessedBomWithRetry(
+    bomRecord: ProcessedBomSource,
+    fetchFromOci: (tag: string, repo?: string, digest?: string) => Promise<any> = defaultFetchFromOci,
+    reReadRow: (uuid: string) => Promise<BomRecord[]> = defaultReReadRow
+): Promise<any> {
+    const bomUuid = bomRecord.uuid;
+    const repo = extractRepositoryNameFromBom(bomRecord);
+    const digest = bomRecord.meta?.processedFileDigest;
+
+    try {
+        return await fetchFromOci(bomUuid, repo, digest);
+    } catch (error) {
+        if (!(error instanceof DigestValidationError)) throw error;
+
+        const freshRows = await reReadRow(bomUuid).catch(() => []);
+        const fresh = freshRows[0];
+        const freshDigest = fresh?.meta?.processedFileDigest;
+        const freshRepo = fresh ? extractRepositoryNameFromBom(fresh) : undefined;
+
+        if (!fresh || (freshDigest === digest && freshRepo === repo)) {
+            // Row unchanged: the bytes genuinely do not match their stored
+            // digest. Surface the original failure.
+            throw error;
+        }
+
+        logger.warn({
+            bomUuid,
+            staleDigest: digest,
+            freshDigest,
+            staleRepo: repo,
+            freshRepo
+        }, 'Digest mismatch was a concurrent enrichment write (row changed under the reader); retrying with fresh digest');
+        return fetchFromOci(bomUuid, freshRepo, freshDigest);
+    }
+}
+
+async function defaultReReadRow(uuid: string): Promise<BomRecord[]> {
+    // Lazy require: bomRepository sits above this module in the import graph.
+    const BomRepository = require('../../bomRepository');
+    return BomRepository.bomById(uuid);
+}

--- a/rebom-backend/src/services/oci/rawBomResolver.ts
+++ b/rebom-backend/src/services/oci/rawBomResolver.ts
@@ -3,6 +3,7 @@ import { runQuery } from '../../utils';
 import { OciNotFoundError, DigestValidationError } from '../../types/errors';
 import { fetchFromOci as defaultFetchFromOci, getMonthlyRepositoryName } from './index';
 import { extractRepositoryNameFromBom } from './ociRepositoryHelpers';
+import { fetchProcessedBomWithRetry } from './processedBomFetcher';
 import type { BomRecord } from '../../types/bom.types';
 
 /**
@@ -127,19 +128,20 @@ function buildCandidateRepos(
     return candidates;
 }
 
-/** The processed BOM served in place of a missing raw copy -- validated with ITS digest. */
+/** The processed BOM served in place of a missing raw copy -- validated with ITS
+ * digest, via the race-tolerant fetch (a concurrent enrichment push must not
+ * turn the substitute into a spurious digest failure either). */
 async function fetchProcessedSubstitute(
     bomRecord: BomRecord,
     recordedRepo: string | undefined,
     fetchFromOci: (tag: string, repo?: string, digest?: string) => Promise<any>
 ): Promise<any> {
-    const processedDigest = bomRecord.meta?.processedFileDigest;
     logger.info({
         bomUuid: bomRecord.uuid,
         repository: recordedRepo,
-        validated: !!processedDigest
+        validated: !!bomRecord.meta?.processedFileDigest
     }, 'Serving processed BOM as substitute for unavailable raw BOM');
-    return fetchFromOci(bomRecord.uuid, recordedRepo, processedDigest);
+    return fetchProcessedBomWithRetry(bomRecord, fetchFromOci);
 }
 
 async function stampRawRepository(bomUuid: string, repositoryName: string): Promise<void> {

--- a/rebom-backend/test/unit/processedBomFetcher.test.ts
+++ b/rebom-backend/test/unit/processedBomFetcher.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/utils', () => ({
+    runQuery: vi.fn(async () => ({ rows: [] })),
+    pool: {}
+}));
+
+import { fetchProcessedBomWithRetry } from '../../src/services/oci/processedBomFetcher';
+import { DigestValidationError, OciNotFoundError } from '../../src/types/errors';
+
+const UUID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const OLD_DIGEST = 'digest-before-enrichment';
+const NEW_DIGEST = 'digest-after-enrichment';
+
+function row(digest: string, repo: string = 'rebom-artifacts-2026-08'): any {
+    return { uuid: UUID, meta: { processedFileDigest: digest }, bom: { ociRepositoryName: repo } };
+}
+
+const digestFailure = () => {
+    throw new DigestValidationError('mismatch', UUID, 'repo', OLD_DIGEST, NEW_DIGEST);
+};
+
+describe('fetchProcessedBomWithRetry', () => {
+    it('returns first-try content when digests agree (no row re-read)', async () => {
+        const fetch = vi.fn(async () => ({ ok: true }));
+        const reRead = vi.fn();
+        expect(await fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead)).toEqual({ ok: true });
+        expect(reRead).not.toHaveBeenCalled();
+    });
+
+    it('enrichment race: row digest changed under the reader -> one retry with fresh digest+repo succeeds', async () => {
+        // Reader holds the pre-enrichment row (OLD_DIGEST, old repo); the
+        // registry already serves post-enrichment bytes. The fresh row read
+        // reveals the completed update (NEW_DIGEST, possibly a new repo).
+        const calls: Array<[string | undefined, string | undefined]> = [];
+        const fetch = vi.fn(async (tag: string, repo?: string, digest?: string) => {
+            calls.push([repo, digest]);
+            if (digest === OLD_DIGEST) digestFailure();
+            return { enriched: true };
+        });
+        const reRead = vi.fn(async () => [row(NEW_DIGEST, 'rebom-artifacts-2026-09')]);
+
+        expect(await fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead)).toEqual({ enriched: true });
+        expect(calls).toEqual([
+            ['rebom-artifacts-2026-08', OLD_DIGEST],
+            ['rebom-artifacts-2026-09', NEW_DIGEST]
+        ]);
+    });
+
+    it('row unchanged -> genuine corruption, ORIGINAL digest error rethrown, no second fetch', async () => {
+        const fetch = vi.fn(async () => digestFailure());
+        const reRead = vi.fn(async () => [row(OLD_DIGEST)]);
+        await expect(fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead))
+            .rejects.toBeInstanceOf(DigestValidationError);
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('row deleted between fetch and re-read -> original error rethrown', async () => {
+        const fetch = vi.fn(async () => digestFailure());
+        const reRead = vi.fn(async () => []);
+        await expect(fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead))
+            .rejects.toBeInstanceOf(DigestValidationError);
+        expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retry is one-shot: a second mismatch against the fresh row propagates', async () => {
+        const fetch = vi.fn(async () => digestFailure());
+        const reRead = vi.fn(async () => [row(NEW_DIGEST)]);
+        await expect(fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead))
+            .rejects.toBeInstanceOf(DigestValidationError);
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(reRead).toHaveBeenCalledTimes(1);
+    });
+
+    it('non-digest errors pass through untouched (no re-read, no retry)', async () => {
+        const fetch = vi.fn(async () => { throw new OciNotFoundError('gone'); });
+        const reRead = vi.fn();
+        await expect(fetchProcessedBomWithRetry(row(OLD_DIGEST), fetch, reRead))
+            .rejects.toBeInstanceOf(OciNotFoundError);
+        expect(reRead).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Re-lands the third commit that reached the #263 branch after its merge — same change, verified on the sandbox with the built image (boot clean, raw + processed smoke fetches green), rebom unit suite 165/165.

**The race**: enrichment updates the processed BOM in two steps — overwrite the bytes at tag `<uuid>` in the current-month repository, *then* write the new `processedFileDigest` (+ repo pointer) to the row. A reader whose row snapshot predates step two but whose download lands after step one validates new bytes against the old digest → spurious `Digest validation failed` (observed in production in the current-month repo; nothing corrupt).

**Who hits it — programmatic paths are the primary victims, not user downloads**:
- the **enrichment scheduler** itself: candidate rows are loaded at cycle start, so its expected digest can be *minutes* stale by the time a given BOM is fetched — any concurrent re-push (forced re-enrichment, accept flow, slow prior cycle) trips it;
- the **per-minute SBOM-components reconcile** in the ReARM backend (`parseBomById` → digest-validated fetch): fires for every fresh upload while that upload's first enrichment is still in flight — every new upload races its own enrichment;
- DTrack synthetic-bucket building / enriched-BOM probes on their schedules.
User-initiated downloads/exports read row-and-fetch back-to-back (milliseconds window) — possible colliders, but the least likely ones.

**Fix**: `fetchProcessedBomWithRetry` wraps every digest-validated processed-BOM read (the `findBomObjectById` family, version/format paths, the scheduler fetch, the raw-resolver substitute). On a `DigestValidationError` it re-reads the row **once**: digest/repo changed under the reader ⇒ it was the race, refetch against fresh values; row unchanged ⇒ genuine corruption, the *original* error rethrows untouched. Non-digest errors pass through; the happy path adds nothing.

Tests: 6 unit cases (race retry with fresh digest+repo, unchanged-row corruption rethrow, deleted-row rethrow, one-shot limit, non-digest passthrough, clean-path no-re-read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)