### PR TITLE
fix(containers): exec the real process so it becomes PID 1 and can be signalled

### DIFF
--- a/backend/start-core.sh
+++ b/backend/start-core.sh
@@ -49,7 +49,23 @@
 # an hs_err_pid log to /app before exit for forensics. K8s then
 # restarts the pod within ~10–15s.
 cd /app
-java -Djava.security.egd=file:/dev/./urandom \
+# Keep in sync with rearm-core/backend/start-core.sh (hand-synced: copy-src.sh
+# mirrors backend/src only).
+# exec, so the JVM REPLACES this shell as PID 1 and receives SIGTERM directly.
+# Without it the shell stays PID 1 and java runs as its child, and the signal is not
+# merely un-forwarded -- it is never delivered at all: the kernel gives PID 1 in a
+# namespace SIGNAL_UNKILLABLE and DISCARDS any signal whose disposition is SIG_DFL, which
+# a plain sh running a script has. So neither the shell nor the JVM ever sees SIGTERM,
+# Spring's shutdown hook never fires (no graceful drain, no afterCommit completion,
+# nothing logged), the pod sits out the whole terminationGracePeriodSeconds, and the
+# kubelet then SIGKILLs it -- which cannot be caught. That makes
+# `server.shutdown: graceful`, spring.lifecycle.timeout-per-shutdown-phase and the
+# chart's grace period dead configuration.
+# Verified on the sandbox: PID 1 was `/bin/sh /app/start-core.sh` with java at PID 7,
+# and a terminating pod emitted no shutdown lines at all. With exec, the same SIGTERM
+# produces the full shutdown sequence in ~30s, so termination gets FASTER (a 45s wait
+# for SIGKILL becomes a 40s drain including the chart's 10s preStop).
+exec java -Djava.security.egd=file:/dev/./urandom \
      -Dlog4j2.formatMsgNoLookups=true \
      -XX:+ShowCodeDetailsInExceptionMessages \
      -XX:+ExitOnOutOfMemoryError \

--- a/deploy/helm/rearm-helm/templates/ui-deployment.yaml
+++ b/deploy/helm/rearm-helm/templates/ui-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         servicehook: {{ .Release.Name }}-ui
         name: rearm-ui-pod
     spec:
+      terminationGracePeriodSeconds: {{ .Values.uiService.terminationGracePeriodSeconds | default 30 }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -53,11 +54,29 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          lifecycle:
+            preStop:
+              # Sleep after the pod is removed from Service endpoints so in-flight and
+              # just-routed requests still land here. Needed now that nginx actually
+              # RECEIVES SIGTERM: for nginx SIGTERM means FAST shutdown (SIGQUIT is the
+              # graceful one), so without this window it exits in milliseconds while
+              # endpoint removal is still propagating, and the ingress serves 502s
+              # mid-rollout -- costly for an SPA pulling many chunked assets.
+              exec:
+                command: ["sh", "-c", "sleep {{ .Values.uiService.preStopSleepSeconds | default 10 }}"]
           livenessProbe:
             httpGet:
               path: /error_pages/generic.html
               port: http
             failureThreshold: 1
             periodSeconds: 10
+          readinessProbe:
+            # Absent before: with only a livenessProbe the pod counted as Ready the
+            # instant it started, so a rollout could route traffic at an nginx that was
+            # not yet serving.
+            httpGet:
+              path: /error_pages/generic.html
+              port: http
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.uiService.resources | nindent 12 }}

--- a/deploy/helm/rearm-helm/values.yaml
+++ b/deploy/helm/rearm-helm/values.yaml
@@ -95,6 +95,8 @@ backendService:
       cpu: "4000m"
 
 uiService:
+  preStopSleepSeconds: 10            # drain window after endpoint removal, before SIGTERM
+  terminationGracePeriodSeconds: 30  # >= preStopSleep + nginx exit
   type: ClusterIP
   port: 80
   targetPort: 80

--- a/ui/nginx/nginx_start.sh
+++ b/ui/nginx/nginx_start.sh
@@ -10,5 +10,17 @@ then
     find /usr/share/nginx/html/assets/ -type f -exec sed -i "s|54ab89bb-f1f1-459c-afbf-e4d78655b298|$REARM_PRODUCT_VERSION|" {} \;
 fi
 
-# run regular entrypoint
-/docker-entrypoint.sh nginx -g "daemon off;"
+# run regular entrypoint -- exec, so nginx becomes PID 1 and can be signalled at all.
+# Without it this script stays PID 1: the kernel gives PID 1 in a namespace
+# SIGNAL_UNKILLABLE and DISCARDS any signal left at SIG_DFL, which a plain sh has, so
+# nothing was ever delivered. (docker-entrypoint.sh does exec nginx, but only replaces
+# THAT shell, a child of this one.)
+#
+# What each caller then gets, and they differ:
+#   docker/compose -- the base image sets STOPSIGNAL SIGQUIT, which we inherit, so
+#     `docker stop` now performs a genuine GRACEFUL drain instead of timing out.
+#   kubernetes     -- the kubelet sends SIGTERM regardless, and for nginx SIGTERM means
+#     FAST shutdown (SIGQUIT is the graceful one). nginx therefore exits in
+#     milliseconds, so the deployment carries a preStop sleep to cover Service-endpoint
+#     propagation; without it a rollout would 502 while endpoints still point here.
+exec /docker-entrypoint.sh nginx -g "daemon off;"


### PR DESCRIPTION
## The bug

Two entrypoints ran their real process **without `exec`**, so the container's PID 1 stayed `/bin/sh` with the real process as a child.

The signal wasn't merely un-forwarded — it was **never delivered**. The kernel gives PID 1 in a namespace `SIGNAL_UNKILLABLE` and **discards** any signal left at `SIG_DFL`, which a plain `sh` running a script has. So nothing shut down: the pod sat out its entire grace period and the kubelet SIGKILLed it.

Measured, grace 30s:

| PID 1 | stop | exit |
|---|---|---|
| `/bin/sh script.sh` | 30.1s | 137 (SIGKILL) |
| shell with `trap … TERM` | 0.1s | 0 |

## `backend/start-core.sh`

Mirrors the identical fix in Pro (relizaio/rearm-saas#398). CE keeps its own copy because `copy-src.sh` mirrors `backend/src` only.

A *"keep in sync"* marker is added rather than extending the mirror: the backend root also holds files that legitimately diverge (`pom.xml`, `application.yaml`, `docs/`), and `rsync --delete` over it would be risky for a file that changes about twice a year.

## `ui/nginx/nginx_start.sh` — and why `exec` alone wasn't enough

**Verified on the sandbox.** Before: PID 1 = `/bin/sh /nginx_start.sh`, nginx master at PID 75. After deploying the fixed image: PID 1 = `nginx: master process`. The UI served HTTP 200 throughout, and the sandbox was restored afterwards.

Independently visible in nginx's own error line, which prints its pid — the same config error reports `[emerg] 7#7:` on the old image and `[emerg] 1#1:` on the fixed one.

**The two callers then diverge, and this is the part worth reading:**

| caller | behaviour after the fix |
|---|---|
| docker / compose | the base image sets `STOPSIGNAL SIGQUIT`, which we inherit, so `docker stop` now performs a **genuine graceful drain** instead of timing out |
| kubernetes | the kubelet sends **SIGTERM** regardless — and for nginx SIGTERM means **fast** shutdown, SIGQUIT is the graceful one. nginx exits in milliseconds |

On its own that trades a 30s hang for an immediate cut. The hang was an *accidental* drain window that happened to cover Service-endpoint propagation — and `ui-deployment.yaml` had **no preStop, no terminationGracePeriodSeconds and no readinessProbe**. A rollout would have started serving 502s, which is worse on an SPA fetching many chunked assets.

So the UI deployment now mirrors the backend's:

- `preStop: sleep 10` — drain window after endpoint removal
- `terminationGracePeriodSeconds: 30`
- a **readinessProbe** — with only a livenessProbe the pod counted Ready the instant it started, so a rollout could route traffic at an nginx not yet serving

`helm template` and `helm lint` verified.

## The rest of CE is clean

Checked, and these two are the complete set:

- **keycloak** — looks like the same pattern (`sh -c` chains) but is safe: `sh -c` implicitly execs the last simple command, and `kc.sh` execs java
- **rebom-backend** — safe *only because* `src/index.ts` registers SIGTERM/SIGINT handlers; without them, node as PID 1 hits the same trap
- **oci-artifact-service** — safe because the Go runtime installs its own SIGTERM handler, so the disposition is never `SIG_DFL`. It does no graceful HTTP drain, but that's a separate matter

## Risk

`exec` on two entrypoints plus a preStop/readiness addition to one deployment. The UI change was validated by a real sandbox deploy; the backend change is byte-identical to the Pro one already validated in #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
