### PR TITLE
fix(ui): a subscription test that legitimately delivers nothing said "still processing" for 60s

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -309,7 +309,11 @@ import {
     extractError, isConflictError, templatesForEventTypes, buildNameMap, deliveryStatusTagType,
     buildNotificationFilterInput,
     buildNotificationRouteInput,
-    routeHasTarget
+    routeHasTarget,
+    classifySubscriptionTest,
+    isOwnerRouted,
+    ownerRoutedSuccessCaveat,
+    type SubscriptionTestOutcome
 } from '@/utils/notificationsCommon'
 import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
 import { isProEdition } from '@/utils/editionCapabilities'
@@ -504,6 +508,18 @@ const DELETE_SUBSCRIPTION_MUTATION = gql`
 const INJECT_SYNTHETIC_EVENT_MUTATION = gql`
     mutation injectSyntheticEvent($orgUuid: ID!, $template: SyntheticEventTemplateEnum!) {
         injectSyntheticEvent(orgUuid: $orgUuid, template: $template) {
+            uuid status
+        }
+    }
+`
+
+// Fan-out status for the injected event. Polled alongside the deliveries so a
+// test that produces NO delivery can be reported the moment fan-out finishes,
+// instead of waiting out the full poll budget and calling a settled event
+// "still processing".
+const OUTBOX_EVENT_STATUS_QUERY = gql`
+    query notificationOutboxEventForSubscriptionTest($uuid: ID!) {
+        notificationOutboxEvent(uuid: $uuid) {
             uuid status
         }
     }
@@ -829,10 +845,26 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
             return
         }
         const channelNameById = buildNameMap(channels.value)
+        // Last non-empty delivery set seen, so a timeout can report what it
+        // actually observed rather than an empty list.
+        let lastSeenItems: Array<any> = []
         const maxAttempts = 40
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
             await new Promise(resolve => setTimeout(resolve, 1500))
             if (isUnmounted || orgUuid.value !== testOrgUuid) return
+            // ORDER MATTERS -- event status FIRST. Fan-out writes the delivery
+            // rows and flips the event terminal in ONE transaction. Reading
+            // deliveries first leaves a one-round-trip window in which that
+            // commit lands between the two queries, so we would see an empty
+            // set alongside a terminal status and confidently report "produced
+            // nothing" for a subscription that had just delivered. Reading the
+            // status first makes terminal imply the rows are already visible.
+            const evtRes = await graphqlClient.query({
+                query: OUTBOX_EVENT_STATUS_QUERY,
+                variables: { uuid: eventUuid },
+                fetchPolicy: 'no-cache',
+            })
+            const eventStatus = evtRes.data?.notificationOutboxEvent?.status ?? null
             const pollRes = await graphqlClient.query({
                 query: DELIVERIES_FOR_EVENT_QUERY,
                 variables: { orgUuid: testOrgUuid, eventUuid },
@@ -840,13 +872,20 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
             })
             const items = (pollRes.data?.notificationDeliveries?.items || [])
                 .filter((d: any) => d.subscriptionUuid === row.uuid)
-            if (items.length > 0 && items.every((d: any) => d.status !== 'PENDING')) {
-                if (!isUnmounted) reportSubscriptionTestResult(row, items, channelNameById)
+            if (items.length > 0) lastSeenItems = items
+            const outcome = classifySubscriptionTest(eventStatus, items)
+            if (outcome !== 'IN_FLIGHT') {
+                if (!isUnmounted && orgUuid.value === testOrgUuid) {
+                    reportSubscriptionTestResult(row, items, channelNameById, false, outcome)
+                }
                 return
             }
         }
         if (!isUnmounted && orgUuid.value === testOrgUuid) {
-            reportSubscriptionTestResult(row, [], channelNameById, true)
+            // Hand over whatever we last saw. A timeout with rows already
+            // present is the "fan-out done, dispatch still queued" case, and
+            // showing those rows is the single most useful thing we know.
+            reportSubscriptionTestResult(row, lastSeenItems, channelNameById, true)
         }
     } catch (err: any) {
         if (!isUnmounted) message.error(`Test failed: ${extractError(err)}`)
@@ -868,12 +907,7 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
  */
 function noDeliveryExplanation (row: SubscriptionRow): string {
     const base = 'The synthetic event was injected but produced no delivery for this subscription.'
-    let ownerRouted = false
-    try {
-        const routes = row.routes ? JSON.parse(row.routes) : []
-        ownerRouted = Array.isArray(routes) && routes.some((r: any) => r?.notifyComponentOwner === true)
-    } catch { /* unparseable routes: fall back to the generic explanation */ }
-    if (ownerRouted) {
+    if (isOwnerRouted(row.routes)) {
         return `${base} A route delivers to the component owner, so this is also what you see when the`
             + ' affected component has no owner, or its owner team has no notification channel --'
             + " check those before the subscription's filter or a route's minimum-severity gate."
@@ -886,13 +920,35 @@ function reportSubscriptionTestResult (
     items: Array<{ channelUuid: string | null, status: string, lastError: string | null }>,
     channelNameById: Record<string, string>,
     timedOut = false,
+    outcome: SubscriptionTestOutcome | null = null,
 ): void {
+    if (timedOut && items.length > 0) {
+        // Fan-out finished and produced rows; the channel worker just has not
+        // dispatched them yet (webhook backoff, a slow endpoint). Saying "the
+        // event had not finished fanning out" here would be false, and the
+        // pending rows are the most useful thing we know.
+        dialog.info({
+            title: `Test result -- ${row.name}`,
+            content: `Still waiting on delivery after 60s. ${items.length} row(s) were created and are`
+                + ' queued for dispatch -- check Notification History for the eventual status.',
+        })
+        return
+    }
     if (items.length === 0) {
         dialog.info({
             title: `Test result -- ${row.name}`,
-            content: timedOut
-                ? 'Still waiting on a delivery after 60s. The event may still be processing -- check Notification History for the result.'
-                : noDeliveryExplanation(row),
+            // Three distinct endings, deliberately not collapsed: fan-out
+            // errored, fan-out finished and chose to send nothing, or we gave
+            // up while it was still running. The old code said "may still be
+            // processing" for all of them.
+            content: outcome === 'FANOUT_FAILED'
+                ? 'Fan-out FAILED for this test event, so nothing was delivered. This is a backend'
+                    + " error, not a problem with the subscription's filter or routes -- check"
+                    + ' Notification History and the server logs before changing this subscription.'
+                : timedOut
+                    ? 'Gave up waiting after 60s -- the event had not finished fanning out.'
+                        + ' Check Notification History for the eventual result.'
+                    : noDeliveryExplanation(row),
         })
         return
     }
@@ -907,9 +963,16 @@ function reportSubscriptionTestResult (
     // otherwise fall through a FAILED-only check and render green.
     const tagTypes = items.map(d => deliveryStatusTagType(d.status))
     const dialogType = tagTypes.includes('error') ? 'warning' : (tagTypes.every(t => t === 'success') ? 'success' : 'info')
+    // A green owner-routed test proves less than it looks: injection picks a
+    // component that HAS an owner on purpose. Say so here rather than let the
+    // result imply production routing is covered.
+    const caveat = ownerRoutedSuccessCaveat(row.routes)
     dialog[dialogType]({
         title: `Test result -- ${row.name}`,
-        content: () => h('div', lines.map((l, i) => h('div', { key: i }, l))),
+        content: () => h('div', [
+            ...lines.map((l, i) => h('div', { key: i }, l)),
+            ...(caveat ? [h('div', { style: 'margin-top: 10px; font-size: 12px; color: var(--n-text-color-3, #888);' }, caveat)] : []),
+        ]),
     })
 }
 

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -8,11 +8,18 @@ vi.mock('@/utils/commonFunctions', () => ({
     default: { dateDisplay: (s: string) => `ABS:${s}` },
 }))
 
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+
 import { print } from 'graphql'
 import {
     relativeTime,
     buildNotificationFilterInput,
     routeHasTarget,
+    classifySubscriptionTest,
+    TERMINAL_OUTBOX_STATUSES,
+    isOwnerRouted,
+    ownerRoutedSuccessCaveat,
     LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY,
     LIST_SUBSCRIPTIONS_QUERY, LIST_SUBSCRIPTIONS_CORE_QUERY,
 } from './notificationsCommon'
@@ -162,5 +169,99 @@ describe('routeHasTarget (client-side mirror of the backend route-emptiness gate
         // so a CE route cannot carry them anyway, and gating would wrongly
         // reject a Pro route whose team list loaded fine.
         expect(routeHasTarget({ ...empty, teams: ['t-1'] }, true)).toBe(true)
+    })
+})
+
+describe('subscription test classification', () => {
+    const done = [{ status: 'SENT' }]
+    const mixed = [{ status: 'SENT' }, { status: 'PENDING' }]
+
+    it('reports DELIVERED once rows exist and none is still PENDING', () => {
+        expect(classifySubscriptionTest('FANNED_OUT', done)).toBe('DELIVERED')
+        // Fan-out status is irrelevant once settled rows exist.
+        expect(classifySubscriptionTest('PENDING', done)).toBe('DELIVERED')
+    })
+
+    it('keeps polling while a row is still PENDING, even after fan-out finished', () => {
+        // The channel worker dispatches AFTER fan-out, so terminal + pending row
+        // is normal and must not be reported as a final result.
+        expect(classifySubscriptionTest('FANNED_OUT', mixed)).toBe('IN_FLIGHT')
+    })
+
+    it('calls an empty set final ONLY once fan-out is terminal', () => {
+        expect(classifySubscriptionTest('PENDING', [])).toBe('IN_FLIGHT')
+        expect(classifySubscriptionTest(null, [])).toBe('IN_FLIGHT')
+        expect(classifySubscriptionTest(undefined, [])).toBe('IN_FLIGHT')
+        for (const s of ['FANNED_OUT', 'SUPPRESSED']) {
+            expect(classifySubscriptionTest(s, [])).toBe('NO_DELIVERY')
+        }
+        // FAILED is terminal too, but gets its own outcome -- see below.
+        expect(classifySubscriptionTest('FAILED', [])).toBe('FANOUT_FAILED')
+    })
+
+    it('an unknown outbox status is not treated as terminal', () => {
+        // Fail safe: a status this UI has not heard of keeps us polling rather
+        // than declaring a premature "produced nothing".
+        expect(classifySubscriptionTest('SOME_NEW_STATUS', [])).toBe('IN_FLIGHT')
+    })
+
+    it('separates a fan-out FAILURE from a deliberate no-delivery', () => {
+        // Both end with zero rows, but the no-delivery copy blames the
+        // subscription's filter / severity gate. Saying that after a backend
+        // fan-out error sends the operator to audit a filter that is fine.
+        expect(classifySubscriptionTest('FAILED', [])).toBe('FANOUT_FAILED')
+        expect(classifySubscriptionTest('FANNED_OUT', [])).toBe('NO_DELIVERY')
+        expect(classifySubscriptionTest('SUPPRESSED', [])).toBe('NO_DELIVERY')
+        // A failure that still produced rows is reported from the rows.
+        expect(classifySubscriptionTest('FAILED', done)).toBe('DELIVERED')
+    })
+})
+
+// Drift pin against the mirrored backend enum, so the UI's notion of "fan-out
+// is finished" cannot drift silently -- an unrecognised status degrades the
+// test dialog back to a 60s timeout with nothing to point at.
+//
+// SUPERSET, not equality, and deliberately so: this UI is shared between CE
+// and Pro, and the enum mirrored into this repo is the CE one, which currently
+// trails Pro (Pro has SUPPRESSED, added with the vuln-withholding work; CE does
+// not). The UI must handle every status the backend it is talking to can emit,
+// so covering MORE than CE declares is correct and covering less is the bug.
+const OUTBOX_STATUS_SRC_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/java/io/reliza/model/NotificationOutboxStatus.java',
+    import.meta.url))
+
+describe('TERMINAL_OUTBOX_STATUSES tracks the backend enum', () => {
+    it('has the backend source available', () => {
+        expect(existsSync(OUTBOX_STATUS_SRC_PATH)).toBe(true)
+    })
+
+    it('covers at least every mirrored NotificationOutboxStatus except PENDING', () => {
+        if (!existsSync(OUTBOX_STATUS_SRC_PATH)) return
+        const src = readFileSync(OUTBOX_STATUS_SRC_PATH, 'utf8')
+        const body = src.slice(src.indexOf('public enum NotificationOutboxStatus'))
+        const declared = [...body.matchAll(/^\t([A-Z_]+)[,;]/gm)].map(m => m[1])
+        expect(declared.length).toBeGreaterThan(1)
+        expect(declared).toContain('PENDING')
+        for (const terminal of declared.filter(v => v !== 'PENDING')) {
+            expect(TERMINAL_OUTBOX_STATUSES).toContain(terminal)
+        }
+        expect(TERMINAL_OUTBOX_STATUSES).not.toContain('PENDING')
+    })
+})
+
+describe('owner-routed test caveat', () => {
+    const ownerRoute = JSON.stringify([{ channels: [], notifyComponentOwner: true }])
+    const plainRoute = JSON.stringify([{ channels: ['abc'], notifyComponentOwner: null }])
+
+    it('detects an owner-routed subscription', () => {
+        expect(isOwnerRouted(ownerRoute)).toBe(true)
+        expect(isOwnerRouted(plainRoute)).toBe(false)
+        expect(isOwnerRouted(null)).toBe(false)
+        expect(isOwnerRouted('not json')).toBe(false)
+    })
+
+    it('warns only for owner-routed subscriptions', () => {
+        expect(ownerRoutedSuccessCaveat(ownerRoute)).toContain('deliberately stamped')
+        expect(ownerRoutedSuccessCaveat(plainRoute)).toBeNull()
     })
 })

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -441,3 +441,90 @@ export function buildNotificationFilterInput (
     }
     return out
 }
+
+// ---------------------------------------------------------------------------
+// Subscription-test result classification.
+//
+// Split out of SubscriptionsOfOrg.vue so it can be unit-tested: the polling
+// loop there previously exited early ONLY when a delivery row existed, so a
+// test that legitimately produced NO delivery -- an unowned component, a filter
+// that excluded it, a severity gate -- could never take the "finished" branch.
+// It burned all 40 polls and then reported a timeout, which reads as "still
+// working on it" for an event that finished seconds earlier. Worse, the
+// accurate no-delivery explanation was written for exactly that case and was
+// unreachable.
+// ---------------------------------------------------------------------------
+
+/**
+ * Outbox statuses meaning fan-out is DONE for this event, so the set of
+ * delivery rows it produced is final and will not grow. Mirrors
+ * NotificationOutboxStatus: PENDING is the only non-terminal value.
+ */
+export const TERMINAL_OUTBOX_STATUSES: readonly string[] = ['FANNED_OUT', 'SUPPRESSED', 'FAILED']
+
+export type SubscriptionTestOutcome = 'DELIVERED' | 'NO_DELIVERY' | 'FANOUT_FAILED' | 'IN_FLIGHT'
+
+/**
+ * What a poll tick learned.
+ *
+ * - `DELIVERED`     rows exist and none is still PENDING -- render them.
+ * - `NO_DELIVERY`   fan-out finished and produced nothing for this
+ *                   subscription. A real, final answer, NOT a timeout.
+ * - `FANOUT_FAILED` fan-out itself errored. Kept separate from NO_DELIVERY
+ *                   because the no-delivery copy blames the subscription's
+ *                   filter or severity gate, and sending an operator to audit
+ *                   a perfectly good filter while a backend failure goes
+ *                   unmentioned is worse than saying nothing.
+ * - `IN_FLIGHT`     keep polling.
+ *
+ * Ordering is deliberate. Non-empty rows win over the event status: rows that
+ * exist but are still PENDING stay IN_FLIGHT even once fan-out is terminal,
+ * because the channel worker dispatches AFTER fan-out commits. Only an EMPTY
+ * set is final at that point.
+ *
+ * CALLER CONTRACT: read the event status BEFORE the deliveries. Fan-out writes
+ * the delivery rows and flips the event terminal in one transaction, so a
+ * status read first that comes back terminal guarantees a deliveries read
+ * issued after it sees those rows. Reading deliveries first opens a
+ * one-round-trip window where the commit lands between the two queries, and
+ * this function would then be handed an empty set with a terminal status and
+ * confidently report NO_DELIVERY for a subscription that did deliver.
+ */
+export function classifySubscriptionTest (
+    eventStatus: string | null | undefined,
+    items: Array<{ status: string }>,
+): SubscriptionTestOutcome {
+    if (items.length > 0) {
+        return items.every(d => d.status !== 'PENDING') ? 'DELIVERED' : 'IN_FLIGHT'
+    }
+    if (eventStatus === 'FAILED') return 'FANOUT_FAILED'
+    const fanOutFinished = !!eventStatus && TERMINAL_OUTBOX_STATUSES.includes(eventStatus)
+    return fanOutFinished ? 'NO_DELIVERY' : 'IN_FLIGHT'
+}
+
+/** True when any route on the subscription delivers to the component owner. */
+export function isOwnerRouted (routesJson: string | null | undefined): boolean {
+    try {
+        const routes = routesJson ? JSON.parse(routesJson) : []
+        return Array.isArray(routes) && routes.some((r: any) => r?.notifyComponentOwner === true)
+    } catch {
+        return false  // unparseable routes: fall back to the generic wording
+    }
+}
+
+/**
+ * Caveat shown on a SUCCESSFUL owner-routed test.
+ *
+ * Injection deliberately stamps the event onto a component that HAS a routable
+ * owner, so an owner-routed subscription passes its test almost regardless of
+ * how much of the inventory is actually owned. A real event lands on whichever
+ * component carries the finding. Without this note a green test reads as proof
+ * that production routing works, which it is not.
+ */
+export function ownerRoutedSuccessCaveat (routesJson: string | null | undefined): string | null {
+    if (!isOwnerRouted(routesJson)) return null
+    return 'Note: test events are deliberately stamped onto a component that has an owner,'
+        + ' so an owner-routed subscription will usually pass this test. A real event lands on'
+        + ' whichever component actually carries the finding, which may be unowned -- check the'
+        + ' ownership report for coverage rather than relying on this result.'
+}


### PR DESCRIPTION
## The bug

The poll loop exited early **only** when a delivery row existed:

```js
if (items.length > 0 && items.every(d => d.status !== 'PENDING'))
```

So a test that produced **no** delivery — an unowned component on an owner-routed route, a filter that excluded the event, a severity gate — could never take the finished branch. It burned all 40 polls and reported a timeout: *"The event may still be processing."* The event had reached `FANNED_OUT` seconds earlier and had deliberately produced nothing.

Worse: `noDeliveryExplanation()` was written for exactly this case, names the owner-routing possibility specifically, and was **unreachable** — the only caller passing `timedOut=false` required `items.length > 0`.

## The fix

Poll the outbox event's own status alongside the deliveries. Once fan-out is terminal, an empty delivery set is a final answer, so the real explanation is reachable and arrives in seconds.

**Order matters, and my first cut had it backwards.** Fan-out writes the delivery rows and flips the event terminal in **one** transaction (`fanOutOneEvent`, `REQUIRES_NEW`). Reading deliveries first left a one-round-trip window where that commit landed *between* the two queries — the UI would then see an empty set beside a terminal status and confidently report "produced nothing" for a subscription that had just delivered, with no self-correction since the loop returns. Reading the status first makes terminal imply the rows are already visible. Caught in review; the contract is documented on `classifySubscriptionTest` so a future edit can't quietly re-swap them.

## Three endings, no longer collapsed

| Situation | Now says |
|---|---|
| Fan-out **FAILED** | it's a backend error, explicitly **not** your filter or routes |
| Fan-out finished, nothing to send | the real explanation (owner-routing aware) |
| Still fanning out when we gave up | a timeout that says so |
| Timeout **with rows present** | reports those rows — "dispatch queued", not "fan-out unfinished" |

The `FAILED` case previously got the no-delivery copy, sending an operator to audit a filter that was fine while a backend failure went unmentioned.

## Plus the caveat this surface was missing

Injection deliberately stamps the event onto a component that **has** a routable owner (`SyntheticEventService.pickComponentForTest`), so an owner-routed subscription passes its test almost regardless of how much of the inventory is owned. A green result was reading as proof that production routing works. It now says what it actually proves.

## Verification

Decision logic lives in `utils/notificationsCommon.ts` so it's unit-testable, matching the other notification helpers. **Mutations verified:** dropping the terminal-status check, treating a `PENDING` row as settled, and dropping the `FAILED` branch each turn tests red.

Added a drift pin against the mirrored backend enum — and **it found real drift on its first run**: the CE mirror lacks `SUPPRESSED`, which Pro gained with the vuln-withholding work. The assertion is therefore a **superset** check: this UI is shared, so covering more than CE declares is correct and covering less is the bug.

**Driven in a real browser against the sandbox, before and after:**

```
before   A  61.7s  "may still be processing"      B  no caveat   4/4 checks FAIL
after    A   3.7s  owner-routed explanation       B  caveat      4/4 checks PASS
```

One probe assertion was itself buggy on the first pass — it looked for `"still processing"` where the old dialog says `"may still be processing"`, so it passed against both builds. Corrected before drawing that comparison.

Full UI suite: 132 tests, 0 failures. Build clean, eslint clean on the touched files.

Closes board tasks `t20260807-131521-14126` and `t20260807-153603-282`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)