### PR TITLE
fix(ui): delivery-status filters didn't match what the backend writes, in both directions

### DIFF
--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -8,13 +8,14 @@ vi.mock('@/utils/commonFunctions', () => ({
     default: { dateDisplay: (s: string) => `ABS:${s}` },
 }))
 
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, readdirSync } from 'fs'
 import { fileURLToPath } from 'url'
+import { join } from 'path'
 
 import { print } from 'graphql'
 import {
     relativeTime,
-    subscriptionStatusOptions, eventTypeOptions,
+    subscriptionStatusOptions, eventTypeOptions, deliveryStatusOptions,
     buildNotificationFilterInput,
     routeHasTarget,
     classifySubscriptionTest,
@@ -80,6 +81,97 @@ describe('unselectable options without a backend implementation', () => {
 
     it('keeps VEX_STATE_CHANGED unselectable while it has no event producer', () => {
         expect(option(eventTypeOptions, 'VEX_STATE_CHANGED')?.disabled).toBe(true)
+    })
+
+})
+
+const CE_BACKEND_SRC_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/java/io/reliza', import.meta.url))
+const PRO_BACKEND_SRC_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/java/io/reliza', import.meta.url))
+
+// Comments are stripped before scanning: javadoc in this codebase quotes call
+// forms (NotificationCelEvaluatorImpl's class doc names
+// NotificationDeliveryStatus.EVAL_TIMEOUT while explaining that nothing writes
+// it), and reading prose as code would demand we enable a filter for a status
+// that has no writer.
+function stripComments (src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+// Every delivery status the backend can WRITE. Two idioms exist and both are
+// scanned -- an earlier cut only saw the first, which left the native-SQL
+// writer in NotificationDeliveryRepository invisible and the guard's coverage
+// incomplete by coincidence rather than design:
+//   1. setStatus(NotificationDeliveryStatus.X)          -- service code
+//   2. SET status = '" + NotificationDeliveryStatus.X_VALUE   -- native @Query
+// Form 2 is matched only in the assigning position, so the WHERE-clause
+// _VALUE references on the very next line are correctly ignored.
+const WRITER_PATTERNS = [
+    /setStatus\(\s*NotificationDeliveryStatus\.([A-Z_]+)\s*\)/g,
+    /SET status = '"\s*\+\s*NotificationDeliveryStatus\.([A-Z_]+)_VALUE/g,
+]
+
+function assignedDeliveryStatuses (root: string): { statuses: Set<string>, filesScanned: number } {
+    const statuses = new Set<string>()
+    let filesScanned = 0
+    const walk = (dir: string) => {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+            const full = join(dir, entry.name)
+            if (entry.isDirectory()) walk(full)
+            else if (entry.name.endsWith('.java')) {
+                filesScanned++
+                const src = stripComments(readFileSync(full, 'utf8'))
+                for (const re of WRITER_PATTERNS) {
+                    for (const m of src.matchAll(re)) statuses.add(m[1])
+                }
+            }
+        }
+    }
+    walk(root)
+    return { statuses, filesScanned }
+}
+
+const offeredStatuses = () => new Set(deliveryStatusOptions.map(o => o.value))
+const enabledStatuses = () => new Set(deliveryStatusOptions.filter(o => !o.disabled).map(o => o.value))
+
+// Deliberately NOT the same assertion against both trees. CE is a subset
+// mirror of Pro -- core carries service/saas classes CE lacks, which is
+// exactly where a new writer is most likely to land. Demanding
+// "enabled == produced" of BOTH would become UNSATISFIABLE the moment a
+// Pro-only writer appears: Pro would require the option enabled and CE would
+// require it disabled, and the only way out is deleting a test. So Pro (the
+// source of truth) gets the exact both-ways assertion, and CE gets
+// containment only. Same shape as notificationInboxSchemaDrift.spec.ts, which
+// asserts different propositions per tree for the same reason.
+describe('delivery status filters vs the CE backend (in-repo, always runs)', () => {
+    it('has the CE backend source available', () => {
+        expect(existsSync(CE_BACKEND_SRC_PATH),
+            `CE mirror not found at ${CE_BACKEND_SRC_PATH}`).toBe(true)
+    })
+
+    it('every status the CE backend writes is offered and selectable', () => {
+        if (!existsSync(CE_BACKEND_SRC_PATH)) return
+        const { statuses, filesScanned } = assignedDeliveryStatuses(CE_BACKEND_SRC_PATH)
+        expect(filesScanned).toBeGreaterThan(0)  // a scan that saw no java is broken
+        expect(statuses.size).toBeGreaterThan(0)
+        for (const produced of statuses) {
+            expect(offeredStatuses(), `${produced} is written but has no filter option`)
+                .toContain(produced)
+            expect(enabledStatuses(), `${produced} is written but its filter is disabled`)
+                .toContain(produced)
+        }
+    })
+})
+
+describe('delivery status filters vs the Pro backend (skipped if rearm-core absent)', () => {
+    it.runIf(existsSync(PRO_BACKEND_SRC_PATH))('selectable set equals what Pro writes', () => {
+        const { statuses, filesScanned } = assignedDeliveryStatuses(PRO_BACKEND_SRC_PATH)
+        expect(filesScanned).toBeGreaterThan(0)
+        expect(statuses.size).toBeGreaterThan(0)
+        // Both directions, against the source of truth: nothing selectable
+        // without a writer, and nothing written without a selectable option.
+        expect([...enabledStatuses()].sort()).toEqual([...statuses].sort())
     })
 })
 

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -196,15 +196,43 @@ export const severityOptions = [
     { label: 'INFO', value: 'INFO' },
 ]
 
-export const deliveryStatusOptions = [
+// Which of these the backend can actually WRITE, checked rather than assumed
+// (an earlier cut of this list exempted ACKED on a guess and was wrong).
+// Sweeping every write path across the backend -- setStatus() call sites, the
+// JPA field default, native UPDATE statements, migrations -- the produced set
+// is PENDING, SENT, FAILED and BATCHED. Nothing else has a writer:
+//   ACKED         setAckedAt() has ZERO callers; read state is a LEFT JOIN on
+//                 notification_reads, not a status, so nothing ever flips a row
+//                 to ACKED no matter how much you mark read.
+//   RATE_LIMITED  the per-subscription rate limit is stored but not enforced.
+//   EVAL_TIMEOUT  a failed CEL filter is skipped and logged; no row is written.
+//   TEST          superseded -- channel tests are recorded on the ORIGIN
+//                 dimension (NotificationDeliveryOrigin.SYNTHETIC) instead.
+//   PREVIEW       the PREVIEW subscription mode was never implemented (#197).
+//
+// Filtering by an unwritable status is a silent trap: the operator filters by
+// ACKED to see what has been acknowledged, gets zero rows, and reads that as a
+// fact about their data rather than about the schema. On a diagnostic surface
+// a false negative is worse than a missing control. Left visible-but-disabled
+// rather than deleted so the reason is on screen -- same treatment as the
+// PREVIEW subscription status and VEX_STATE_CHANGED.
+//
+// Re-enable each ONE alongside the backend change that starts producing it.
+// The spec pins both directions against the backend source, so adding a writer
+// without re-enabling the filter -- or adding a filter with no writer -- fails.
+// Produced statuses first, then the unavailable ones grouped at the end. #197
+// keeps its single disabled entry in situ, which reads fine for one of three;
+// with five of nine disabled, grouping keeps the usable options scannable.
+export const deliveryStatusOptions: Array<{ label: string, value: string, disabled?: boolean }> = [
     { label: 'PENDING', value: 'PENDING' },
     { label: 'SENT', value: 'SENT' },
-    { label: 'ACKED', value: 'ACKED' },
     { label: 'FAILED', value: 'FAILED' },
-    { label: 'RATE_LIMITED', value: 'RATE_LIMITED' },
-    { label: 'EVAL_TIMEOUT', value: 'EVAL_TIMEOUT' },
-    { label: 'TEST', value: 'TEST' },
-    { label: 'PREVIEW', value: 'PREVIEW' },
+    { label: 'BATCHED', value: 'BATCHED' },
+    { label: 'ACKED (not yet available)', value: 'ACKED', disabled: true },
+    { label: 'RATE_LIMITED (not yet available)', value: 'RATE_LIMITED', disabled: true },
+    { label: 'EVAL_TIMEOUT (not yet available)', value: 'EVAL_TIMEOUT', disabled: true },
+    { label: 'TEST (not yet available)', value: 'TEST', disabled: true },
+    { label: 'PREVIEW (not yet available)', value: 'PREVIEW', disabled: true },
 ]
 
 export const deliveryOriginOptions = [
@@ -217,7 +245,9 @@ export const deliveryOriginOptions = [
 export function deliveryStatusTagType (status: string): NaiveTagType {
     if (status === 'SENT' || status === 'ACKED') return 'success'
     if (status === 'FAILED' || status === 'EVAL_TIMEOUT' || status === 'RATE_LIMITED') return 'error'
-    if (status === 'PREVIEW' || status === 'TEST') return 'info'
+    // BATCHED is produced (held in an email digest window, not yet sent), so it
+    // must not read as success -- info, alongside the not-yet-produced pair.
+    if (status === 'BATCHED' || status === 'PREVIEW' || status === 'TEST') return 'info'
     return 'default'
 }
 


### PR DESCRIPTION
Swept every write path for `notification_deliveries.status` — `setStatus()` call sites, the JPA field default, native `UPDATE`s, migrations. **The backend produces exactly `PENDING`, `SENT`, `FAILED`, `BATCHED`.**

The filter offered nine options and got it wrong in both directions:

| Status | Written? | Was | Now |
|---|---|---|---|
| PENDING / SENT / FAILED | yes | selectable | selectable |
| **BATCHED** | **yes** | **missing entirely** | **added, selectable** |
| **ACKED** | **no** | selectable | disabled |
| RATE_LIMITED | no | selectable | disabled |
| EVAL_TIMEOUT | no | selectable | disabled |
| TEST | no | selectable | disabled |
| PREVIEW | no | selectable | disabled |

## Why the dead ones matter

Same silent trap #197 just closed for the PREVIEW *subscription* status: filtering by one returns zero rows forever, which reads as a fact about your data rather than about the schema.

**`ACKED` is the one that bites.** An operator marks 40 inbox items read, filters Delivery History by `ACKED` to see what was acknowledged, and gets nothing — because `setAckedAt()` has **zero callers** and read state is a `LEFT JOIN` on `notification_reads`, not a status. The others: `RATE_LIMITED` (limit stored, not enforced), `EVAL_TIMEOUT` (failed filters are skipped and logged, no row written), `TEST` (superseded by the ORIGIN dimension), `PREVIEW` (mode never implemented).

## Why BATCHED matters

Produced since the email-digest work, present in the GraphQL filter enum, and absent from the UI — so **email-digest deliveries could not be filtered for at all**. We watched `BATCHED` rows land during the notifications walkthrough; there was no way to query them.

## Treatment

Dead statuses are **visible-but-disabled**, labelled `(not yet available)`, matching #197 and `VEX_STATE_CHANGED` so the reason is on screen rather than the option quietly vanishing. **Backend enums untouched** — they're the design intent, and removing them would break the GraphQL API for any client that sends one.

## The guard

The spec pins **both directions** against the backend source: it scrapes `setStatus()` call sites and asserts `disabled ⟺ no writer`, plus that every produced status has an option.

It scans the **CE mirror always and Pro via `it.runIf`**, because the mirror lacks the `service/saas` classes where a new writer is most likely to land — scanning only CE would leave the guard unable to fire for the case it advertises (a Pro-only `EVAL_TIMEOUT` writer).

**Mutation-verified three ways:** enabling a writerless status, disabling a written one, and removing a written one entirely each fail it.

## One correction worth recording

An earlier cut of this exempted `ACKED` via a hardcoded whitelist, on the assumption it was written by the read-tracking path. It isn't — and that whitelist was exactly what kept the test green over a fifth dead status. Caught in review. The produced set is now **derived from the source**, never asserted by hand.

Browser-verified against the sandbox: all five dead statuses render disabled, all four live ones selectable.

138 tests pass, lint clean, build clean.

Part of `t20260807-151031-14455`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)