### PR TITLE
feat(ui): drop the owner suggestion and the Component Leads editor

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -405,12 +405,10 @@
                                                         {{ componentOwnership.ownership.status }}
                                                     </n-tag>
                                                     <span v-if="ownerLabel" style="margin-left: 8px;">{{ ownerLabel }}</span>
-                                                    <!-- UNSET's reason is the backend's candidate-team SUGGESTION
-                                                         ("suggest team 'X'", "N candidate teams", "create one").
-                                                         Suppressed: nobody asked for a suggestion here, and offering
-                                                         one beside a picker invites reading it as a decision that has
-                                                         already been made. The UNSET tag alone says what is true. -->
-                                                    <span v-if="componentOwnership.ownership.reason && componentOwnership.ownership.status !== 'UNSET'"
+                                                    <!-- A suggestion's reason line is suppressed: offering a candidate
+                                                         team directly above the owner picker invites reading it as a
+                                                         decision already made. Every other status explains itself. -->
+                                                    <span v-if="componentOwnership.ownership.reason && !ownershipIsSuggestion"
                                                         class="text-muted" style="display: block; margin-top: 4px;">
                                                         {{ componentOwnership.ownership.reason }}
                                                     </span>
@@ -442,11 +440,8 @@
                                                 </span>
                                             </div>
                                         </div>
-                                        <!-- Leads were the pre-ownership way of naming who is accountable for a
-                                             component; Owner above supersedes them. Two overlapping answers to one
-                                             question is worse than one, so the editor is gone. The field itself is
-                                             untouched on the backend and any stored value survives: this form no
-                                             longer sends it, and an absent value reads as "leave unchanged". -->
+                                        <!-- The Leads editor lived here; Owner above replaces it. Stored values are
+                                             preserved and still readable over the API, but no longer shown. -->
                                         <div class="versionSchemaBlock" v-if="updatedComponent && componentData">
                                             <label>Stakeholder Contacts</label>
                                             <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
@@ -3399,18 +3394,25 @@ const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default
             : s === 'UNSET' ? 'default'  // no owner yet -> neutral, not alarming
                 : 'error'                // ORPHANED (or unknown) -> needs attention
 
+// UNSET is the one ownership status that is a SUGGESTION rather than a fact:
+// the backend fills ownerRef with a candidate team it picked and puts its pitch
+// in `reason`. Every other status describes a real (or absent) owner. Both the
+// owner label and the reason line have to special-case it, and they have to
+// agree -- so the rule lives here once instead of as a string literal in each.
+const ownershipIsSuggestion = computed<boolean>(
+    () => componentOwnership.value?.ownership?.status === 'UNSET')
+
 const ownerLabel = computed<string | null>(() => {
     // Fall back to the RESOLVED ownership when there is no per-component stored
     // owner: an org team-assignment rule can own a component without anything
     // being stored on it. Reading only `owner` showed a green OWNED badge with
     // no name next to it -- "owned by whom?".
-    // UNSET means "no owner, here is a suggestion" -- ownership.ownerRef is
-    // populated for it, so falling back blindly would print the suggested team
-    // beside an UNSET tag as though it owned the component.
+    // A suggestion is not an owner, so do NOT fall back to it: that would print
+    // the suggested team beside an UNSET tag as though it owned the component.
     const resolved = componentOwnership.value?.ownership
     const o = componentOwnership.value?.owner?.ownerRef
         ? componentOwnership.value.owner
-        : (resolved && resolved.status !== 'UNSET' ? resolved : null)
+        : (resolved && !ownershipIsSuggestion.value ? resolved : null)
     if (!o || !o.ownerRef) return null
     const list = o.ownerType === 'TEAM' ? userGroups.value : users.value
     const hit = list.find((x: any) => x.value === o.ownerRef)

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -405,7 +405,13 @@
                                                         {{ componentOwnership.ownership.status }}
                                                     </n-tag>
                                                     <span v-if="ownerLabel" style="margin-left: 8px;">{{ ownerLabel }}</span>
-                                                    <span v-if="componentOwnership.ownership.reason" class="text-muted" style="display: block; margin-top: 4px;">
+                                                    <!-- UNSET's reason is the backend's candidate-team SUGGESTION
+                                                         ("suggest team 'X'", "N candidate teams", "create one").
+                                                         Suppressed: nobody asked for a suggestion here, and offering
+                                                         one beside a picker invites reading it as a decision that has
+                                                         already been made. The UNSET tag alone says what is true. -->
+                                                    <span v-if="componentOwnership.ownership.reason && componentOwnership.ownership.status !== 'UNSET'"
+                                                        class="text-muted" style="display: block; margin-top: 4px;">
                                                         {{ componentOwnership.ownership.reason }}
                                                     </span>
                                                 </div>
@@ -436,25 +442,11 @@
                                                 </span>
                                             </div>
                                         </div>
-                                        <div class="versionSchemaBlock" v-if="updatedComponent && componentData">
-                                            <label>{{ words.componentFirstUpper }} Leads</label>
-                                            <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
-                                                <n-select
-                                                    v-if="isWritable"
-                                                    v-model:value="updatedComponent.leads"
-                                                    multiple
-                                                    filterable
-                                                    clearable
-                                                    placeholder="Assign lead users"
-                                                    :options="users" />
-                                                <span v-else>
-                                                    {{ (updatedComponent.leadDetails || []).map((u) => u.name || u.email).join(', ') || 'None' }}
-                                                </span>
-                                                <span class="text-muted" style="margin-top: 4px;">
-                                                    Manually-designated leads for this {{ words.component }}.
-                                                </span>
-                                            </div>
-                                        </div>
+                                        <!-- Leads were the pre-ownership way of naming who is accountable for a
+                                             component; Owner above supersedes them. Two overlapping answers to one
+                                             question is worse than one, so the editor is gone. The field itself is
+                                             untouched on the backend and any stored value survives: this form no
+                                             longer sends it, and an absent value reads as "leave unchanged". -->
                                         <div class="versionSchemaBlock" v-if="updatedComponent && componentData">
                                             <label>Stakeholder Contacts</label>
                                             <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
@@ -2395,7 +2387,6 @@ const hasCoreSettingsChanges: ComputedRef<boolean> = computed((): boolean => {
         (updatedComponent.value.sidPurlOverride || null) !== (componentData.value.sidPurlOverride || null) ||
         commonFunctions.stableStringify(updatedComponent.value.sidAuthoritySegments || []) !== commonFunctions.stableStringify(componentData.value.sidAuthoritySegments || []) ||
         ((updatedComponent.value.isInternal || 'INTERNAL') !== (componentData.value.isInternal || 'INTERNAL')) ||
-        commonFunctions.stableStringify(updatedComponent.value.leads || []) !== commonFunctions.stableStringify(componentData.value.leads || []) ||
         commonFunctions.stableStringify(updatedComponent.value.contacts || []) !== commonFunctions.stableStringify(componentData.value.contacts || [])
 })
 
@@ -2416,7 +2407,6 @@ function resetCoreSettings() {
     updatedComponent.value.sidPurlOverride = componentData.value.sidPurlOverride
     updatedComponent.value.sidAuthoritySegments = commonFunctions.deepCopy(componentData.value.sidAuthoritySegments) || []
     updatedComponent.value.isInternal = componentData.value.isInternal
-    updatedComponent.value.leads = commonFunctions.deepCopy(componentData.value.leads) || []
     updatedComponent.value.contacts = commonFunctions.deepCopy(componentData.value.contacts) || []
     
     // Reset marketing version enabled state

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -976,9 +976,10 @@ const storeObject : any = {
                 sidPurlOverride: component.sidPurlOverride || 'INHERIT',
                 sidAuthoritySegments: trimmedSegments,
                 isInternal: component.isInternal || null,
-                // team/approvers are read-only derived; contacts ({name, contact})
-                // is the only writeable one left. Strip Apollo's __typename off
-                // contacts so the ComponentContactInput type matches.
+                // Of the PEOPLE fields on a component, team/approvers are
+                // read-only derived and contacts ({name, contact}) is the only
+                // writeable one left. Strip Apollo's __typename off contacts so
+                // the ComponentContactInput type matches.
                 // Fall back to undefined (not []) when the field is absent: the
                 // server reads null as "leave unchanged", so a partially-loaded
                 // component can't accidentally clear contacts the operator never

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -976,14 +976,16 @@ const storeObject : any = {
                 sidPurlOverride: component.sidPurlOverride || 'INHERIT',
                 sidAuthoritySegments: trimmedSegments,
                 isInternal: component.isInternal || null,
-                // leadDetails/team/approvers are read-only derived; only leads (IDs)
-                // and contacts ({name, contact}) are writeable. Strip Apollo's
-                // __typename off contacts so the ComponentContactInput type matches.
+                // team/approvers are read-only derived; contacts ({name, contact})
+                // is the only writeable one left. Strip Apollo's __typename off
+                // contacts so the ComponentContactInput type matches.
                 // Fall back to undefined (not []) when the field is absent: the
                 // server reads null as "leave unchanged", so a partially-loaded
-                // component can't accidentally clear leads/contacts the operator
-                // never touched. A real clear arrives as an actual empty array.
-                leads: Array.isArray(component.leads) ? component.leads : undefined,
+                // component can't accidentally clear contacts the operator never
+                // touched. A real clear arrives as an actual empty array.
+                // `leads` is deliberately never sent -- the editor for it was
+                // removed in favour of Owner, and omitting it leaves any stored
+                // value intact rather than silently clearing it.
                 contacts: Array.isArray(component.contacts)
                     ? component.contacts.map(({ name, contact }: any) => ({ name, contact }))
                     : undefined

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -931,12 +931,6 @@ const COMPONENT_FULL_DATA = `
     sidPurlOverride
     sidAuthoritySegments
     isInternal
-    leads
-    leadDetails {
-        uuid
-        name
-        email
-    }
     contacts {
         name
         contact


### PR DESCRIPTION
Two removals from the component settings form, both from rhythm's manual UI surface review.

## 1. The owner candidate suggestion

The Owner block printed the backend's candidate-team suggestion as the reason line under an `UNSET` status:

> **UNSET** — No owner set; suggest team 'Platform Team'

Sitting directly above the owner picker, a suggestion reads like a decision that has already been made. The `UNSET` tag on its own says what is true.

**Only the `UNSET` reason is suppressed.** `DEGRADED` ("owner team is archived"), `ORPHANED` and `NON_DURABLE` still explain themselves — those are statements about a real owner, not a guess at one.

| before | after |
|---|---|
| `UNSET` + "No owner set; suggest team 'Platform Team'" | `UNSET` |

## 2. Component Leads

Leads were the pre-ownership way of naming who is accountable for a component, and Owner supersedes them — the field's own backend javadoc already claims leads are "retired into" owner (they were not; this finishes the UI half). Two overlapping answers to one question are worse than one.

The backend keeps the field and any stored value survives. This form no longer sends `leads` at all, and an omitted value reads as "leave unchanged". Same shape as #197.

## Validation

Hot-swapped onto the sandbox and probed in a real browser (`probe-owner-suggestion-and-leads.js`, `probe-leads-not-clobbered.js`).

**The suggestion check would have passed vacuously**, because no Demo org group held a component permission and so no component produced a suggestion at all. Setup granted one first, and the probe was run against the pre-change build to confirm it *fails* there — baseline shows "suggest team 'Platform Team'" and the Leads editor; after, both gone, `UNSET` and Stakeholder Contacts intact. 6/6 checks.

**The no-clobber check nearly went vacuous too.** The first target component (Automation Tutorial Vue) rejects every save on a dangling `vcs` reference in the demo data, so "stored leads survived" was true because nothing was written. The probe now asserts the backend *accepted* the save. On a component that saves cleanly: lead seeded, two accepted saves (revision 0 → 2), value unchanged, and the captured mutation payload carries no `leads` key.

`npm run test` 138/138, `npm run build` clean, `validate-graphql.mjs` 306 documents / 0 failures. Lint is 273 errors on this branch and 273 on `main` — pre-existing, unchanged.

Sandbox data restored (probe permission revoked, seeded leads removed, `kubectl-set` field manager stripped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)