### PR TITLE
feat(ui): withdraw the External Members editor -- nothing ever notified them

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -620,35 +620,12 @@
                                 </div>
                             </n-space>
 
-                            <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
-                                <n-h5>
-                                    <n-text depth="1">
-                                        External Members (no ReARM account):
-                                    </n-text>
-                                </n-h5>
-                                <n-text depth="3" style="font-size: 12px;">
-                                    People reachable only by email or handle, such as a vendor contact. They can be
-                                    notified, but do not count toward the team's durability.
-                                </n-text>
-                                <n-dynamic-input
-                                    v-model:value="teamExternalMembers"
-                                    :on-create="onAddExternalMember"
-                                >
-                                    <template #default="{ value }">
-                                        <div style="display: flex; gap: 8px; width: 100%;">
-                                            <n-input v-model:value="value.name"
-                                                placeholder="Name" style="width: 200px;" />
-                                            <n-input v-model:value="value.contact"
-                                                placeholder="Email or handle" style="width: 240px;" />
-                                            <n-select v-model:value="value.role" :options="constants.TeamRoles"
-                                                placeholder="No role" clearable style="width: 200px;" />
-                                            <n-input v-if="value.role === constants.TeamRoleCustom"
-                                                v-model:value="value.customRole"
-                                                placeholder="Custom role label" style="width: 200px;" />
-                                        </div>
-                                    </template>
-                                </n-dynamic-input>
-                            </n-space>
+                            <!-- The External Members editor lived here. It promised "they can be
+                                 notified" and nothing ever delivered to an external contact: there is
+                                 no transport discriminator on the contact string, the email dispatcher
+                                 sends to a static per-channel recipient list, and Slack/Teams post to
+                                 an incoming webhook that cannot DM anyone. Stored values are kept and
+                                 are not sent by this form. -->
 
                             <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
                                 <n-h5>
@@ -1233,7 +1210,7 @@ import constants from '../utils/constants'
 import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
 import { buildChannelOptions } from '@/utils/channelOptions'
 import { TYPE_LABELS } from '@/utils/notificationsCommon'
-import { buildMemberRolesPayload, buildExternalMembersPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
+import { buildMemberRolesPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
@@ -1956,19 +1933,18 @@ const userPermissionsDirty = computed(() => {
 })
 
 // Projects the modal's editable state. NOTE the team-member keys come from
-// the module-level editor refs (teamRoles / teamExternalMembers), not from
-// `group` -- they are per-modal editor state, not part of the group record.
+// the module-level editor refs (teamRoles / teamChannels), not from `group` --
+// they are per-modal editor state, not part of the group record.
 function getUserGroupEditableState(group: any) {
     return {
         name: group?.name || '',
         description: group?.description || '',
         manualUsers: group?.manualUsers || [],
         connectedSsoGroups: group?.connectedSsoGroups || [],
-        // Compare the NORMALIZED payload, not the raw editor arrays -- otherwise
-        // an untouched blank row added by "+" (or stray whitespace) reads as
-        // dirty while producing nothing to save.
+        // Compare the NORMALIZED payload, not the raw editor map -- otherwise
+        // stray whitespace in a custom label reads as dirty while producing
+        // nothing to save.
         memberRoles: teamMemberRolesPayload(),
-        externalMembers: teamExternalMembersPayload(),
         notificationChannels: teamChannels.value
     }
 }
@@ -1985,13 +1961,12 @@ const orgChannelsFailed = ref(false)
 // removable so the operator can clear it.
 const teamChannelOptions = computed(() =>
     buildChannelOptions(orgChannels.value, teamChannels.value, TYPE_LABELS))
-const teamExternalMembers: Ref<any[]> = ref([])
 
 /**
  * True only when we have actually loaded this group's team data. Guards both
  * rendering and the save payload: hydrating an empty editor from a not-yet-
  * loaded map and then saving would send [], which the backend applies as a
- * REPLACE -- wiping the team's roles and external members.
+ * REPLACE -- wiping the team's roles.
  */
 const teamMembersKnown = computed(() =>
     teamFieldsSupported.value === true
@@ -2018,10 +1993,6 @@ function teamMemberRolesPayload() {
     return buildMemberRolesPayload(teamRoles.value, rosterMembers.value.map(m => m.uuid))
 }
 
-function teamExternalMembersPayload() {
-    return buildExternalMembersPayload(teamExternalMembers.value)
-}
-
 function setMemberRole(uuid: string, role: string | null) {
     teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), role }
 }
@@ -2030,14 +2001,10 @@ function setMemberCustomRole(uuid: string, customRole: string) {
     teamRoles.value[uuid] = { ...(teamRoles.value[uuid] || {}), customRole }
 }
 
-function onAddExternalMember() {
-    return { name: '', contact: '', role: null, customRole: '' }
-}
-
 /** Pre-submit mirror of the backend rules, so an invalid row names itself
  *  instead of failing the whole mutation with a generic server error. */
 const teamMembersError = computed(() => teamMembersKnown.value
-    ? validateTeamMembers(teamMemberRolesPayload(), teamExternalMembersPayload(), memberLabelFor)
+    ? validateTeamMembers(teamMemberRolesPayload(), memberLabelFor)
     : null)
 
 const userGroupPermissionsDirty = computed(() => {
@@ -2185,7 +2152,6 @@ async function loadTeamMemberFields() {
                     getUserGroups(org: $org) {
                         uuid
                         memberRoles { userRef role customRole }
-                        externalMembers { name contact role customRole }
                         notificationChannels
                     }
                 }`,
@@ -2196,7 +2162,6 @@ async function loadTeamMemberFields() {
         for (const g of (response.data.getUserGroups || [])) {
             map[g.uuid] = {
                 memberRoles: g.memberRoles || [],
-                externalMembers: g.externalMembers || [],
                 notificationChannels: g.notificationChannels || []
             }
         }
@@ -4279,7 +4244,9 @@ async function updateUserGroup() {
             // instead would block every unrelated team edit (rename, members).
             if (!orgChannelsFailed.value) updateInput.notificationChannels = teamChannels.value
             updateInput.memberRoles = teamMemberRolesPayload()
-            updateInput.externalMembers = teamExternalMembersPayload()
+            // externalMembers is deliberately never sent -- the editor was
+            // withdrawn, and omitting the field is what keeps a group's stored
+            // contacts intact instead of replacing them with [].
         }
         
         const response = await graphqlClient.mutate({
@@ -4314,19 +4281,13 @@ async function editUserGroup(groupUuid: string) {
     const group = userGroups.value.find(g => g.uuid === groupUuid)
     if (group) {
         selectedUserGroup.value = commonFunctions.deepCopy(group)
-        const tm = groupTeamMembers.value[groupUuid] || { memberRoles: [], externalMembers: [] }
+        const tm = groupTeamMembers.value[groupUuid] || { memberRoles: [] }
         const roleMap: Record<string, any> = {}
         for (const mr of tm.memberRoles) {
             roleMap[mr.userRef] = { role: mr.role, customRole: mr.customRole || '' }
         }
         teamRoles.value = roleMap
         teamChannels.value = [...(tm.notificationChannels || [])]
-        teamExternalMembers.value = commonFunctions.deepCopy(tm.externalMembers).map((e: any) => ({
-            name: e.name || '',
-            contact: e.contact || '',
-            role: e.role || null,
-            customRole: e.customRole || ''
-        }))
         await Promise.all([
             loadPerspectives(),
             store.dispatch('fetchComponents', orgResolved.value),

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -620,12 +620,7 @@
                                 </div>
                             </n-space>
 
-                            <!-- The External Members editor lived here. It promised "they can be
-                                 notified" and nothing ever delivered to an external contact: there is
-                                 no transport discriminator on the contact string, the email dispatcher
-                                 sends to a static per-channel recipient list, and Slack/Teams post to
-                                 an incoming webhook that cannot DM anyone. Stored values are kept and
-                                 are not sent by this form. -->
+                            <!-- The External Members editor lived here; see utils/teamMembers.ts. -->
 
                             <n-space v-if="teamMembersKnown && !restoreMode" vertical style="margin-bottom: 20px; width: 100%;">
                                 <n-h5>
@@ -1211,6 +1206,7 @@ import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
 import { buildChannelOptions } from '@/utils/channelOptions'
 import { TYPE_LABELS } from '@/utils/notificationsCommon'
 import { buildMemberRolesPayload, validateTeamMembers, type TeamRoleMap } from '../utils/teamMembers'
+import { buildUserGroupUpdateInput } from '../utils/userGroupUpdateInput'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
@@ -2108,7 +2104,7 @@ async function loadUserGroups() {
     await loadOrgChannels()
 }
 
-// Team member roles + external members (T1) are loaded by a SEPARATE query on
+// Team member roles + notification channels are loaded by a SEPARATE query on
 // purpose. Folding these fields into getUserGroups above would make the whole
 // User Groups tab fail against a backend that predates them -- the same
 // field-selection drift that has broken a tab before. Isolated here, a lagging
@@ -2116,8 +2112,8 @@ async function loadUserGroups() {
 //
 // null = not probed yet. The distinction matters: the backend treats a non-null
 // list as a REPLACE, so sending [] because we had not loaded yet would silently
-// delete every role and external member on the team. Unknown => render nothing
-// and send nothing (omitted = keep).
+// delete every role on the team. Unknown => render nothing and send nothing
+// (omitted = keep).
 const teamFieldsSupported: Ref<boolean | null> = ref(null)
 const groupTeamMembers: Ref<Record<string, any>> = ref({})
 
@@ -2170,8 +2166,8 @@ async function loadTeamMemberFields() {
     } catch (error: any) {
         // Only a schema-drift-shaped failure means "this backend is older".
         // A 401/500/network blip must NOT be mistaken for that: this flag also
-        // gates the save payload, so misclassifying would strip roles and
-        // external members from the next save with no operator-visible signal.
+        // gates the save payload, so misclassifying would strip roles from the
+        // next save with no operator-visible signal.
         if (isSchemaDriftError(error)) {
             console.warn('Team member fields unavailable on this backend', error?.message)
             teamFieldsSupported.value = false
@@ -4226,28 +4222,14 @@ async function updateUserGroup() {
             }
         }
         
-        const updateInput = {
-            groupId: selectedUserGroup.value.uuid,
-            name: selectedUserGroup.value.name,
-            description: selectedUserGroup.value.description,
-            manualUsers: selectedUserGroup.value.manualUsers || [],
-            status: selectedUserGroup.value.status,
-            connectedSsoGroups: selectedUserGroup.value.connectedSsoGroups || [],
-            permissions
-        } as any
-        // Only send the team fields when this group's data was actually loaded.
-        // Omitting them means "keep existing" on the backend; sending [] would
-        // REPLACE, i.e. delete. Never send from an unknown state.
-        if (teamMembersKnown.value) {
-            // Omit when the channel list failed to load: sending the current value
-            // would be based on an incomplete picker, and disabling the picker
-            // instead would block every unrelated team edit (rename, members).
-            if (!orgChannelsFailed.value) updateInput.notificationChannels = teamChannels.value
-            updateInput.memberRoles = teamMemberRolesPayload()
-            // externalMembers is deliberately never sent -- the editor was
-            // withdrawn, and omitting the field is what keeps a group's stored
-            // contacts intact instead of replacing them with [].
-        }
+        // Assembled in utils so its omit-or-you-delete rules are unit-tested
+        // rather than comment-protected -- see userGroupUpdateInput.ts.
+        const updateInput = buildUserGroupUpdateInput(selectedUserGroup.value, permissions, {
+            known: teamMembersKnown.value,
+            channelsLoadFailed: orgChannelsFailed.value,
+            channels: teamChannels.value,
+            memberRoles: teamMemberRolesPayload()
+        })
         
         const response = await graphqlClient.mutate({
             mutation: gql`

--- a/ui/src/utils/teamMembers.spec.ts
+++ b/ui/src/utils/teamMembers.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
     buildMemberRolesPayload,
-    buildExternalMembersPayload,
     validateTeamMembers,
 } from './teamMembers'
 
@@ -38,43 +37,17 @@ describe('buildMemberRolesPayload', () => {
     })
 })
 
-describe('buildExternalMembersPayload', () => {
-    it('drops a wholly blank scaffold row added by "+"', () => {
-        expect(buildExternalMembersPayload([{ name: '', contact: '', role: null, customRole: '' }])).toEqual([])
-    })
-
-    it('keeps a half-filled row so validation can flag it', () => {
-        expect(buildExternalMembersPayload([{ name: 'Vendor', contact: '', role: 'QA' }]))
-            .toEqual([{ name: 'Vendor', contact: '', role: 'QA', customRole: null }])
-    })
-
-    it('trims name and contact', () => {
-        expect(buildExternalMembersPayload([{ name: ' V ', contact: ' v@x.example ', role: 'QA' }]))
-            .toEqual([{ name: 'V', contact: 'v@x.example', role: 'QA', customRole: null }])
-    })
-})
-
 describe('validateTeamMembers', () => {
     it('passes a well-formed payload', () => {
-        expect(validateTeamMembers(
-            [{ userRef: A, role: 'QA', customRole: null }],
-            [{ name: 'V', contact: 'v@x.example', role: 'DEVELOPER', customRole: null }],
-            label)).toBeNull()
+        expect(validateTeamMembers([{ userRef: A, role: 'QA', customRole: null }], label)).toBeNull()
     })
 
     it('names the member whose CUSTOM role has no label', () => {
-        const err = validateTeamMembers([{ userRef: A, role: 'CUSTOM', customRole: null }], [], label)
+        const err = validateTeamMembers([{ userRef: A, role: 'CUSTOM', customRole: null }], label)
         expect(err).toContain('Alice')
     })
 
-    it('rejects an external member missing a contact', () => {
-        const err = validateTeamMembers([], [{ name: 'Vendor', contact: '', role: 'QA', customRole: null }], label)
-        expect(err).toContain('Vendor')
-    })
-
-    it('rejects an external member with a CUSTOM role and no label', () => {
-        const err = validateTeamMembers(
-            [], [{ name: 'Vendor', contact: 'v@x.example', role: 'CUSTOM', customRole: null }], label)
-        expect(err).toContain('Vendor')
+    it('passes an empty payload', () => {
+        expect(validateTeamMembers([], label)).toBeNull()
     })
 })

--- a/ui/src/utils/teamMembers.ts
+++ b/ui/src/utils/teamMembers.ts
@@ -1,19 +1,17 @@
-// Pure payload/validation helpers for the Team editor (member roles + external
-// members). Kept out of the SFC so they are unit-testable, and so the DIRTY
-// comparison and the SAVE payload can be built by the same code -- comparing a
-// raw editor array against a filtered/trimmed payload is what makes a modal
-// look dirty while having nothing to send.
+// Pure payload/validation helpers for the Team editor (member roles). Kept out
+// of the SFC so they are unit-testable, and so the DIRTY comparison and the SAVE
+// payload can be built by the same code -- comparing a raw editor array against
+// a filtered/trimmed payload is what makes a modal look dirty while having
+// nothing to send.
+//
+// External members used to be built and validated here too. That editor was
+// withdrawn because nothing ever delivered to an external contact, and the
+// version that returns will carry a TYPED contact rather than one freeform
+// string -- so the old builders would not have fitted it anyway.
 import constants from '@/utils/constants'
 
 export interface TeamMemberRolePayload {
     userRef: string
-    role: string
-    customRole: string | null
-}
-
-export interface ExternalTeamMemberPayload {
-    name: string
-    contact: string
     role: string
     customRole: string | null
 }
@@ -42,19 +40,6 @@ export function buildMemberRolesPayload (roles: TeamRoleMap, rosterUuids: string
         }))
 }
 
-/** Rows where BOTH name and contact are blank are treated as untouched scaffolding
- *  and dropped; a half-filled row is kept so validation can flag it. */
-export function buildExternalMembersPayload (rows: any[]): ExternalTeamMemberPayload[] {
-    return (rows || [])
-        .filter(r => (r.name || '').trim() || (r.contact || '').trim())
-        .map(r => ({
-            name: (r.name || '').trim(),
-            contact: (r.contact || '').trim(),
-            role: r.role,
-            customRole: customLabel(r.role, r.customRole)
-        }))
-}
-
 /**
  * Mirrors the backend's rejection rules so the operator gets a specific,
  * pre-submit message naming the offending member -- instead of a generic
@@ -63,20 +48,11 @@ export function buildExternalMembersPayload (rows: any[]): ExternalTeamMemberPay
  */
 export function validateTeamMembers (
     roles: TeamMemberRolePayload[],
-    externals: ExternalTeamMemberPayload[],
     labelFor: (uuid: string) => string,
 ): string | null {
     for (const r of roles) {
         if (r.role === constants.TeamRoleCustom && !r.customRole) {
             return `Enter a custom role label for ${labelFor(r.userRef)}, or pick a listed role.`
-        }
-    }
-    for (const e of externals) {
-        if (!e.name || !e.contact) {
-            return `External member "${e.name || e.contact}" needs both a name and a contact.`
-        }
-        if (e.role === constants.TeamRoleCustom && !e.customRole) {
-            return `Enter a custom role label for external member "${e.name}", or pick a listed role.`
         }
     }
     return null

--- a/ui/src/utils/teamMembers.ts
+++ b/ui/src/utils/teamMembers.ts
@@ -1,6 +1,6 @@
 // Pure payload/validation helpers for the Team editor (member roles). Kept out
 // of the SFC so they are unit-testable, and so the DIRTY comparison and the SAVE
-// payload can be built by the same code -- comparing a raw editor array against
+// payload can be built by the same code -- comparing the raw editor map against
 // a filtered/trimmed payload is what makes a modal look dirty while having
 // nothing to send.
 //

--- a/ui/src/utils/userGroupUpdateInput.spec.ts
+++ b/ui/src/utils/userGroupUpdateInput.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { buildUserGroupUpdateInput } from './userGroupUpdateInput'
+
+const GROUP = {
+    uuid: 'g-1',
+    name: 'Docs Team',
+    description: 'writers',
+    manualUsers: ['u-1'],
+    status: 'ACTIVE',
+    connectedSsoGroups: ['sso-docs'],
+}
+const ROLES = [{ userRef: 'u-1', role: 'QA', customRole: null }]
+const LOADED = { known: true, channelsLoadFailed: false, channels: ['c-1'], memberRoles: ROLES }
+
+describe('buildUserGroupUpdateInput', () => {
+    it('never sends externalMembers, even with team data fully loaded', () => {
+        // The editor for it was withdrawn, so the form does not know the stored
+        // value. The backend REPLACES on a non-null list -- sending [] here
+        // would delete every external contact on the team, silently, with no UI
+        // left to notice or restore it.
+        expect('externalMembers' in buildUserGroupUpdateInput(GROUP, [], LOADED)).toBe(false)
+    })
+
+    it('omits every team field until this group is loaded', () => {
+        const input = buildUserGroupUpdateInput(GROUP, [], {
+            known: false, channelsLoadFailed: false, channels: [], memberRoles: [],
+        })
+        expect('memberRoles' in input).toBe(false)
+        expect('notificationChannels' in input).toBe(false)
+    })
+
+    it('omits channels when the channel list failed to load, but still saves roles', () => {
+        // A picker built from a partial list must not be written over the real
+        // one -- while a rename or role edit in the same modal still saves.
+        const input = buildUserGroupUpdateInput(GROUP, [], { ...LOADED, channelsLoadFailed: true })
+        expect('notificationChannels' in input).toBe(false)
+        expect(input.memberRoles).toEqual(ROLES)
+    })
+
+    it('sends roles and channels once loaded', () => {
+        const input = buildUserGroupUpdateInput(GROUP, [], LOADED)
+        expect(input.memberRoles).toEqual(ROLES)
+        expect(input.notificationChannels).toEqual(['c-1'])
+    })
+
+    it('carries the core fields through, defaulting the list ones', () => {
+        const input = buildUserGroupUpdateInput({ uuid: 'g-2' }, [{ scope: 'ORGANIZATION' }], {
+            known: false, channelsLoadFailed: false, channels: [], memberRoles: [],
+        })
+        expect(input.groupId).toBe('g-2')
+        expect(input.manualUsers).toEqual([])
+        expect(input.connectedSsoGroups).toEqual([])
+        expect(input.permissions).toEqual([{ scope: 'ORGANIZATION' }])
+    })
+})

--- a/ui/src/utils/userGroupUpdateInput.ts
+++ b/ui/src/utils/userGroupUpdateInput.ts
@@ -1,0 +1,57 @@
+// Builds the `updateUserGroup` mutation input.
+//
+// Extracted from the SFC because three of its rules are OMIT-OR-YOU-DELETE
+// rules, and a comment is not a guard. The backend treats a non-null list as a
+// REPLACE, so every one of these is a silent data-loss bug if it regresses:
+//
+//   1. Team fields go out only when this group's team data was actually loaded.
+//      Sending [] from an unloaded editor wipes the roles.
+//   2. Channels go out only when the channel list loaded. A picker built from a
+//      partial list would save that partial list over the real one.
+//   3. `externalMembers` is NEVER sent. Its editor was withdrawn, so the form
+//      has no idea what the stored value is; omitting it is the only thing
+//      keeping a team's stored contacts alive.
+//
+// Rule 3 in particular has no operator-visible failure mode -- nothing in the
+// UI shows external members any more, so a regression would destroy them with
+// nobody watching. Hence a test rather than a comment.
+import type { TeamMemberRolePayload } from '@/utils/teamMembers'
+
+export interface UserGroupTeamState {
+    /** True only once this group's team data has actually been fetched. */
+    known: boolean
+    /** True when the org channel list failed to load, so the picker is partial. */
+    channelsLoadFailed: boolean
+    channels: string[]
+    memberRoles: TeamMemberRolePayload[]
+}
+
+export interface UserGroupCore {
+    uuid: string
+    name?: string
+    description?: string
+    manualUsers?: string[]
+    status?: string
+    connectedSsoGroups?: string[]
+}
+
+export function buildUserGroupUpdateInput (
+    group: UserGroupCore,
+    permissions: any[],
+    team: UserGroupTeamState,
+): Record<string, any> {
+    const input: Record<string, any> = {
+        groupId: group.uuid,
+        name: group.name,
+        description: group.description,
+        manualUsers: group.manualUsers || [],
+        status: group.status,
+        connectedSsoGroups: group.connectedSsoGroups || [],
+        permissions,
+    }
+    if (team.known) {
+        if (!team.channelsLoadFailed) input.notificationChannels = team.channels
+        input.memberRoles = team.memberRoles
+    }
+    return input
+}


### PR DESCRIPTION
The team editor told operators:

> People reachable only by email or handle, such as a vendor contact. **They can be notified**, but do not count toward the team's durability.

They cannot be notified. The field is collected, stored, rendered back — and no code path has ever sent anything to one of those contacts.

## Why hiding, and not delivering

Rhythm's call was "deliver to them, or hide until we have the mechanism". There is no mechanism, and building one is a feature with its own design decisions. Three separate things are missing:

1. **No transport discriminator.** `contact` is one freeform string. Nothing distinguishes an email address from a Slack handle, so fan-out cannot pick a dispatcher.
2. **Email cannot address a person.** `EmailChannelDispatcher` reads a *static* recipient list off the channel. There is no per-delivery override, so adding an external member to one event's send would mean editing the channel itself.
3. **Slack and Teams cannot DM at all.** Both post to an incoming-webhook URL, which delivers to one preconfigured channel. DMing a handle needs a bot token and `chat.postMessage` — a different integration with its own scopes, install flow and secret handling.

So a handle-shaped contact is undeliverable today at any price. Filed as its own task; the Team RFC deliberately does not carry `externalMembers` forward, so the delivery feature gets to choose its own shape — most likely a typed contact rather than a free string.

## Stored data is untouched

The form no longer sends `externalMembers` at all, and the backend reads an omitted field as "keep" — sending `[]` would REPLACE, i.e. delete.

**Verified rather than assumed:** a group carrying two real external members went through two *accepted* saves (the probe asserts the backend accepted them, so this can't pass because nothing was written) and kept all three of its team fields — external members 2, member roles 1, channels 2, name restored.

## Helpers removed too

`buildExternalMembersPayload` and the externals arm of `validateTeamMembers` go with the editor rather than lingering as unreachable code. The returning feature needs a typed contact, so these builders would not have fitted it.

**Unit suite goes 142 → 138** — 5 tests removed with the code they covered, 1 added for the now-empty validation case. Build and `validate-graphql` clean.

## Validation

`probe-external-members-hidden.js`, 7/7 against the sandbox. It sanity-checks that the modal actually opened before asserting the section is absent, and restores the group name it edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)