### PR TITLE
fix(ui): a double-click on Trigger Auto Integrate sent two mutations

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -181,8 +181,13 @@
                         @click="showAddComponentModal = true" title="Add Dependency" size="20" style="margin-left: 4px; vertical-align: middle;">
                         <CirclePlus />
                     </n-icon>
-                    <n-icon v-if="isWritable && branchData.autoIntegrate === 'ENABLED' && modifiedBranch.autoIntegrate === 'ENABLED'" class="clickable"
-                        @click="triggerAutoIntegrate" title="Trigger Auto Integrate" size="20" style="margin-left: 4px; vertical-align: middle;">
+                    <n-icon v-if="isWritable && branchData.autoIntegrate === 'ENABLED' && modifiedBranch.autoIntegrate === 'ENABLED'" :class="autoIntegrateInFlight ? '' : 'clickable'"
+                        @click="triggerAutoIntegrate"
+                        :title="autoIntegrateInFlight ? 'Auto Integrate in progress...' : 'Trigger Auto Integrate'"
+                        size="20"
+                        :style="{ 'margin-left': '4px', 'vertical-align': 'middle',
+                                  opacity: autoIntegrateInFlight ? 0.5 : 1,
+                                  cursor: autoIntegrateInFlight ? 'not-allowed' : undefined }">
                         <TrendingUp />
                     </n-icon>
                 </p>
@@ -449,6 +454,7 @@ const selectNewVcsRepo = ref(false)
 
 
 const compareMode = ref(false)
+const autoIntegrateInFlight = ref(false)
 const comparisonCheckboxes: Ref<any> = ref({})
 const showReleaseComparisonModal = ref(false)
 
@@ -566,24 +572,36 @@ const createFsFromRelease = async function(){
 }
 
 async function triggerAutoIntegrate () {
-    const resp = await graphqlClient.mutate({
-        mutation: gql`
-            mutation autoIntegrateFeatureSet($branchUuid: ID!) {
-                autoIntegrateFeatureSet(branchUuid: $branchUuid) {
-                    uuid
-                    version
-                }
-            }`,
-        variables: { branchUuid: branchUuid.value },
-        fetchPolicy: 'no-cache'
-    })
-    const release = (resp.data as any)?.autoIntegrateFeatureSet
-    await onCreated()
-    if (release && release.version) {
-        notify('success', 'Auto Integrate Completed', `Release ${release.version} was created via auto-integration.`)
-        showBranchSettingsModal.value = false
-    } else {
-        notify('info', 'Auto Integrate Completed', 'Auto-integrate was attempted, but no new release was created.')
+    // The mutation is not idempotent: autoIntegrateFeatureSetOnDemand gathers each dependency's
+    // latest release, checks whether a matching product release already exists, and creates one if
+    // not. That check-then-act takes no lock server-side, so two in-flight calls can both find
+    // nothing and both create a product release. The button is a plain icon with no built-in
+    // disabled state, so without this a double-click sends two mutations.
+    if (autoIntegrateInFlight.value) return
+    autoIntegrateInFlight.value = true
+    try {
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation autoIntegrateFeatureSet($branchUuid: ID!) {
+                    autoIntegrateFeatureSet(branchUuid: $branchUuid) {
+                        uuid
+                        version
+                    }
+                }`,
+            variables: { branchUuid: branchUuid.value },
+            fetchPolicy: 'no-cache'
+        })
+        const release = (resp.data as any)?.autoIntegrateFeatureSet
+        await onCreated()
+        if (release && release.version) {
+            notify('success', 'Auto Integrate Completed', `Release ${release.version} was created via auto-integration.`)
+            showBranchSettingsModal.value = false
+        } else {
+            notify('info', 'Auto Integrate Completed', 'Auto-integrate was attempted, but no new release was created.')
+        }
+    } finally {
+        // finally, not after the notify: a failed mutation must not leave the button dead.
+        autoIntegrateInFlight.value = false
     }
 }
 


### PR DESCRIPTION
## The problem

`autoIntegrateFeatureSet` is **not idempotent**. Server-side it gathers each dependency's latest release, asks whether a matching product release already exists, and creates one if not — a check-then-act that takes no lock, so two in-flight calls can both find nothing and both create a product release.

The control is a plain `n-icon` with an `@click` handler: no built-in disabled or loading state, and the handler had no re-entry guard. A double-click fired two concurrent mutations.

## The fix

Guards on an in-flight ref and reflects it in the control — reduced opacity, `not-allowed` cursor, and the tooltip switching to *"Auto Integrate in progress..."*.

Reset in a `finally`, **not** after the notify, so a failed mutation cannot leave the button permanently dead.

## Why this instead of a server-side lock

The server-side fix was implemented and measured (relizaio/rearm-saas#408, now **closed**): four concurrent calls did produce four product releases. But the evidence did not justify shipping it:

- **Zero** feature sets in sandbox data have two product releases sharing a parent set — the path being unguarded had never actually caused harm. The 4/4 number came from a synthetic four-thread harness, not a realistic scenario.
- The lock would have been held across `createProductRelease -> createRelease`, which performs **synchronous external I/O** (GitHub build trigger, email send). A stalled user request would then block the *automatic* integrator for that feature set until a 30s lock timeout — a failure mode that does not exist today.

Trading a real new failure mode for a theoretical one was the wrong direction. A double-click is the realistic trigger, and this covers it with no locking, no new coupling, and no risk to the version pipeline.

## Checks

- UI build clean.
- **No new lint violations** — the repo's error count is unchanged from main at 273 (pre-existing, repo-wide). My first attempt added 13 by wrapping the body in `try` without re-indenting; fixed.

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)