### PR TITLE
feat(ui): point the team pickers at Team, not UserGroup (Phase 2a)

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -424,7 +424,7 @@
                                                         filterable
                                                         v-model:value="ownerDraftRef"
                                                         :options="ownerDraftType === 'TEAM' ? userGroups : users"
-                                                        :placeholder="ownerDraftType === 'TEAM' ? 'Pick a team (user group)' : 'Pick a user'" />
+                                                        :placeholder="ownerDraftType === 'TEAM' ? 'Pick a team' : 'Pick a user'" />
                                                     <n-button type="primary" size="small" :loading="savingOwner" :disabled="!ownerDraftRef" @click="saveOwner">
                                                         Set owner
                                                     </n-button>
@@ -3375,8 +3375,10 @@ const COMPONENT_OWNERSHIP_QUERY = gql`
             ownership { ownerType ownerRef status durable derived reason }
         }
     }`
-const GET_USER_GROUPS_QUERY = gql`
-    query getUserGroups($org: ID!) { getUserGroups(org: $org) { uuid name } }`
+// Owner points at a Team, not a permission group -- a team is who is
+// accountable, a group is who has access, and they are separate entities now.
+const GET_TEAMS_QUERY = gql`
+    query getTeamsForOwner($org: ID!) { getTeams(org: $org) { uuid name status } }`
 const SET_COMPONENT_OWNER_MUTATION = gql`
     mutation setComponentOwner($component: UpdateComponentInput!) {
         updateComponent(component: $component) { uuid }
@@ -3442,12 +3444,15 @@ async function loadOwnership() {
 async function loadUserGroups() {
     try {
         const res = await graphqlClient.query({
-            query: GET_USER_GROUPS_QUERY,
+            query: GET_TEAMS_QUERY,
             variables: { org: orguuid.value },
             fetchPolicy: 'network-only',
         })
-        userGroups.value = (res.data?.getUserGroups || [])
-            .filter((g: any) => g)
+        // Archived teams are dropped: notification routing ignores them, so
+        // offering one here would let an operator pick an owner that is
+        // immediately reported DEGRADED.
+        userGroups.value = (res.data?.getTeams || [])
+            .filter((g: any) => g && g.status !== 'INACTIVE')
             .map((g: any) => ({ label: g.name, value: g.uuid }))
     } catch {
         userGroups.value = []

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -561,13 +561,13 @@ async function loadTeams (): Promise<void> {
     try {
         const res = await graphqlClient.query({
             query: gql`
-                query getUserGroupsForRoutes($org: ID!) {
-                    getUserGroups(org: $org) { uuid name status notificationChannels }
+                query getTeamsForRoutes($org: ID!) {
+                    getTeams(org: $org) { uuid name status notificationChannels }
                 }`,
             variables: { org: orgUuid.value },
             fetchPolicy: 'network-only',
         })
-        teams.value = res.data?.getUserGroups || []
+        teams.value = res.data?.getTeams || []
     } catch (e: any) {
         // Only schema drift means "this backend is older". A 401/5xx must not
         // blank the list: saved team targets have no ghost source then, and the


### PR DESCRIPTION
**Stacked on #276**, and needs rearm-saas#410.

Two pickers still chose permission groups where the backend now expects a Team:

- the **subscription route's** team targets (`SubscriptionsOfOrg`)
- a component's **Owner** (`ComponentView`)

## Degradation, because both surfaces exist on CE

Team is Pro-only, so `validate-graphql` now reports **5 CE-mirror warnings** (up from 3) — the correct category: *valid on Pro, must degrade gracefully at runtime*. Both do:

- the subscription list treats a schema-drift error as "this backend has no teams" and empties the list rather than blanking the pane — a 401/5xx still surfaces as a real error, because silently emptying on a network blip would render saved targets as bare uuids;
- the owner picker sits behind `ownershipSupported`, which already fails closed on a CE backend, and falls back to an empty list.

## One behaviour change worth naming

The owner picker now **drops archived teams**. Routing ignores them, so offering one would let an operator pick an owner that is reported `DEGRADED` the instant it is saved.

## Expected on the sandbox

Subscriptions whose saved `routes[].teams` hold **UserGroup** uuids will render bare ids and stop resolving to channels. That is the clean switch working as designed — routing was confirmed not in production — but it is visible on the sandbox, and I will check it degrades without breaking the pane rather than assuming it.

143/143 unit tests, build clean.