### PR TITLE
fix(ui): restore userGroupPermissionsDirty, and move assignment rules to Teams

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -611,18 +611,14 @@
                         </div>
                     </n-modal>
 
-                    <OrgTeamAssignmentRules
-                        :orgUuid="orgResolved"
-                        :isWritable="isWritable"
-                        :teams="userGroups"
-                        :components="allComponents"/>
                 </div>
             </n-tab-pane>
 
             <n-tab-pane v-if="isOrgAdmin" name="teams" tab="Teams">
                 <TeamsOfOrg
                     :orguuid="orgResolved"
-                    :isWritable="isWritable" />
+                    :isWritable="isWritable"
+                    :components="allComponents" />
             </n-tab-pane>
 
             <n-tab-pane name="programmaticAccess" tab="Programmatic Access" v-if="isOrgAdmin">
@@ -1162,7 +1158,6 @@ import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
 import OrgIntegrations from './OrgIntegrations.vue'
 import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
-import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
 import TeamsOfOrg from './TeamsOfOrg.vue'
 import AiAgentPoliciesOfOrg from './AiAgentPoliciesOfOrg.vue'
 import CommittersOfOrg from './CommittersOfOrg.vue'
@@ -1894,6 +1889,28 @@ function getUserGroupEditableState(group: any) {
 // Shared builder so a channel that was disabled or deleted after being picked
 // still renders a name here instead of a bare uuid (BUG 2) -- and stays
 // removable so the operator can clear it.
+/**
+ * Gates the modal's Save/Reset buttons and the close-confirmation prompt.
+ *
+ * <p>Deleted by accident in the Phase 2b cleanup: it sat immediately below
+ * `teamMembersError`, and the regex removing that computed ran on past its
+ * closing line and took this one too. Nothing caught it -- a template
+ * reference to a missing setup binding is a RUNTIME ReferenceError, so the
+ * build stays green, and every unit test here covers `utils/`, not components.
+ * The symptom was that the edit-group modal could not be closed.
+ */
+const userGroupPermissionsDirty = computed(() => {
+    const scopedDirty = userGroupScopedPermissionsOriginal.value
+        ? commonFunctions.stableStringify(userGroupScopedPermissions.value) !== commonFunctions.stableStringify(userGroupScopedPermissionsOriginal.value)
+        : false
+
+    const detailsDirty = selectedUserGroupOriginal.value
+        ? commonFunctions.stableStringify(getUserGroupEditableState(selectedUserGroup.value)) !== commonFunctions.stableStringify(selectedUserGroupOriginal.value)
+        : false
+
+    return scopedDirty || detailsDirty
+})
+
 const orgComponents = computed(() => store.getters.componentsOfOrg(orgResolved.value) || [])
 const orgProducts = computed(() => store.getters.productsOfOrg(orgResolved.value) || [])
 const allComponents = computed(() => [...orgComponents.value, ...orgProducts.value])

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1144,9 +1144,6 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
 import constants from '../utils/constants'
-import { isSchemaDriftError } from '../utils/graphqlDriftFallback'
-import { buildChannelOptions } from '@/utils/channelOptions'
-import { TYPE_LABELS } from '@/utils/notificationsCommon'
 import { buildUserGroupUpdateInput } from '../utils/userGroupUpdateInput'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
@@ -1869,26 +1866,17 @@ const userPermissionsDirty = computed(() => {
     return commonFunctions.stableStringify(userScopedPermissions.value) !== commonFunctions.stableStringify(userScopedPermissionsOriginal.value)
 })
 
-// Projects the modal's editable state. NOTE the team-member keys come from
-// there is no per-modal editor state left beyond the group's own fields.
+// Projects the modal's editable state. Nothing here is per-modal editor state
+// any more -- every key is a field of the group record itself.
 function getUserGroupEditableState(group: any) {
     return {
         name: group?.name || '',
         description: group?.description || '',
         manualUsers: group?.manualUsers || [],
         connectedSsoGroups: group?.connectedSsoGroups || [],
-        // Compare the NORMALIZED payload, not the raw editor map -- otherwise
-        // stray whitespace in a custom label reads as dirty while producing
-        // nothing to save.
     }
 }
 
-// Keyed by user uuid rather than held as a list: the backend rejects two roles
-// for the same member, and a per-member map makes that impossible to express.
-
-// Shared builder so a channel that was disabled or deleted after being picked
-// still renders a name here instead of a bare uuid (BUG 2) -- and stays
-// removable so the operator can clear it.
 /**
  * Gates the modal's Save/Reset buttons and the close-confirmation prompt.
  *

--- a/ui/src/components/TeamsOfOrg.vue
+++ b/ui/src/components/TeamsOfOrg.vue
@@ -37,6 +37,17 @@
             data-testid="teams-table"
         />
 
+        <!-- Assignment rules pick an owner TEAM by component-name pattern, so they
+             belong beside the teams themselves -- and this is where the real team
+             list lives. They previously sat under User Groups and were handed the
+             org's user groups, which stopped being teams in Phase 2a. -->
+        <OrgTeamAssignmentRules
+            v-if="teamsSupported"
+            :orgUuid="orgUuid"
+            :isWritable="canWrite"
+            :teams="teams"
+            :components="props.components || []" />
+
         <n-modal v-model:show="showTeamModal" preset="dialog" :show-icon="false">
             <n-card
                 style="width: 640px"
@@ -141,10 +152,13 @@ import graphqlClient from '@/utils/graphql'
 import { LIST_CHANNELS_QUERY, TYPE_LABELS, extractError } from '@/utils/notificationsCommon'
 import { isSchemaDriftError } from '@/utils/graphqlDriftFallback'
 import gql from 'graphql-tag'
+import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
 
 const props = defineProps<{
     orguuid: string
     isWritable: boolean
+    /** Passed down for the assignment rules' match preview; the parent has them loaded. */
+    components?: any[]
 }>()
 
 const store = useStore()

--- a/ui/src/components/TeamsOfOrg.vue
+++ b/ui/src/components/TeamsOfOrg.vue
@@ -46,7 +46,7 @@
             :orgUuid="orgUuid"
             :isWritable="canWrite"
             :teams="teams"
-            :components="props.components || []" />
+            :components="ruleComponents" />
 
         <n-modal v-model:show="showTeamModal" preset="dialog" :show-icon="false">
             <n-card
@@ -157,8 +157,13 @@ import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
 const props = defineProps<{
     orguuid: string
     isWritable: boolean
-    /** Passed down for the assignment rules' match preview; the parent has them loaded. */
-    components?: any[]
+    /**
+     * Components AND products, for the assignment rules' match preview.
+     * REQUIRED, not optional: an empty list makes the preview say "matches no
+     * components right now", which is indistinguishable from a genuinely bad
+     * pattern -- so a missing prop would degrade silently rather than loudly.
+     */
+    components: any[]
 }>()
 
 const store = useStore()
@@ -167,6 +172,7 @@ const message = useMessage()
 
 const orgUuid = computed<string>(() => props.orguuid)
 const canWrite = computed<boolean>(() => props.isWritable)
+const ruleComponents = computed<any[]>(() => props.components)
 
 interface TeamRow {
     uuid: string
@@ -228,8 +234,9 @@ const LIST_GROUPS_WITH_ROSTER_QUERY = gql`
 const teams = ref<TeamRow[]>([])
 const teamsLoading = ref<boolean>(false)
 // Teams is a Pro-ahead surface, so a backend that predates it must cost only
-// THIS pane rather than the whole page -- the same isolation the team-member
-// fields use in OrgSettings. Null until probed.
+// THIS pane rather than the whole page. Starts true and flips only on a
+// drift-shaped failure, so the pane renders optimistically and hides itself if
+// the backend turns out not to have Teams.
 const teamsSupported = ref<boolean>(true)
 const users = ref<any[]>([])
 const groups = ref<any[]>([])


### PR DESCRIPTION
Two findings from rhythm walking the sandbox.

## 1. The edit-group modal could not be closed

Phase 2b (#279) deleted `userGroupPermissionsDirty` along with the block above it — a regex removing `teamMembersError` ran past its closing line. The modal's close handler reads it, so closing threw `ReferenceError` and the modal became a trap.

**Nothing caught it, and that is the part worth fixing in process:**

- `npm run build` compiles the SFC, but a template/handler reference to a missing setup binding only fails at **runtime**;
- all 132 unit tests cover `utils/` — there are no component tests;
- no browser probe had ever opened this modal.

Build-green plus tests-green said nothing at all about it. This is the third time this week that combination has proved hollow for a UI surface, after `npm run dev` being dead on main and the interpolated GraphQL documents opting themselves out of validation.

## 2. Team Assignment Rules were on the wrong tab, with the wrong data

They sat under **User Groups** and were handed `:teams="userGroups"`. Since Phase 2a a rule's `ownerTeam` is a **Team** — so that prop had been wrong since the switch, and the rule editor was offering the wrong entity entirely. rhythm spotted the placement; the broken prop came out of looking at why.

Moved into `TeamsOfOrg`, which already owns the real team list, with the parent passing `components` down for the match preview.

## Guard

`probe-usergroup-modal.js` covers both, and watches the **console**, not just the DOM — a modal that closes while throwing is still broken.

It separates auth-redirect noise from app-phase errors rather than filtering errors wholesale: the login page's own Keycloak theme serves stylesheets with a bad MIME type, and folding that in would make the assertion permanently red and therefore ignored.

**9/9** against the sandbox. 132/132 unit tests, build clean.