### PR TITLE
feat(ui): hide durability, and tidy the subscription editor

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1105,6 +1105,9 @@ import graphqlClient from '../utils/graphql'
 import constants from '@/utils/constants'
 import { InputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
+// Shared "keep a dangling reference visible and removable" builder, so the owner
+// picker behaves like the notification channel and team pickers.
+import { withGhosts } from '@/utils/channelOptions'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
 import graphqlQueries from '../utils/graphqlQueries'
 
@@ -1501,10 +1504,15 @@ const openComponentSettings = async function() {
     // Durable ownership (Phase 4 UI): load the owner picker's team list + the
     // computed ownership status when the settings panel opens.
     //
-    // AWAIT the team list FIRST. loadOwnership pre-selects the stored owner only
-    // if it resolves to an option, so racing these would leave a perfectly valid
-    // owner unselected whenever the ownership query happened to win.
-    await loadUserGroups()
+    // AWAIT both option lists FIRST. loadOwnership pre-selects the stored owner
+    // only if it resolves to an option, so racing these would leave a perfectly
+    // valid owner unselected whenever the ownership query happened to win. Users
+    // are in here too: they are otherwise loaded fire-and-forget from initLoad,
+    // which is the same race one field over for a USER-typed owner.
+    // loadUserGroups swallows its own errors; loadUsers does not, and a rejection
+    // here would abort openComponentSettings before it ever shows the modal. A
+    // failed lookup must cost one empty picker, not the whole settings panel.
+    await Promise.all([loadUserGroups(), loadUsers().catch(() => {})])
     await loadOwnership()
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
     showComponentSettingsModal.value = true
@@ -3386,26 +3394,55 @@ const SET_COMPONENT_OWNER_MUTATION = gql`
 
 const componentOwnership = ref<any>(null)
 const ownershipSupported = ref<boolean>(true)
-const userGroups = ref<{ label: string, value: string }[]>([])
+// Every team the org has, INCLUDING archived ones. The picker's options are
+// derived below rather than filtered here, because an archived team can still
+// be the stored owner and has to stay visible.
+const orgTeams = ref<any[]>([])
 const ownerDraftType = ref<'TEAM' | 'USER'>('TEAM')
 const ownerDraftRef = ref<string | null>(null)
 const savingOwner = ref<boolean>(false)
 
 // UNSET is the one ownership status that is a SUGGESTION rather than a fact:
 // the backend fills ownerRef with a candidate team it picked and puts its pitch
-// in `reason`. Every other status describes a real (or absent) owner. Both the
-// owner label and the reason line have to special-case it, and they have to
-// agree -- so the rule lives here once instead of as a string literal in each.
+// in `reason`. Every other status describes a real (or absent) owner. The owner
+// label special-cases it so a suggested team is never printed as the owner.
 const ownershipIsSuggestion = computed<boolean>(
     () => componentOwnership.value?.ownership?.status === 'UNSET')
+
+/** The team reference this component is stored against, if any. */
+const ownerTeamRef = computed<string | null>(() => {
+    const o = componentOwnership.value?.owner
+    return o?.ownerType === 'TEAM' && o?.ownerRef ? o.ownerRef : null
+})
+
+/**
+ * Selectable teams, plus a labelled ghost for a stored owner that is no longer
+ * selectable.
+ *
+ * Archived teams are not offered as NEW owners -- notification routing ignores
+ * them, so picking one buys an owner that is immediately reported DEGRADED. But
+ * dropping them outright is what made an archived owner render as no owner at
+ * all: the label found nothing, the picker pre-select found nothing, and with
+ * the status chip gone the block went silent about a component that IS owned.
+ * withGhosts is the same shared helper the subscription editor's team picker
+ * uses for the identical case, so the two cannot drift.
+ */
+const userGroups = computed<{ label: string, value: string }[]>(() => {
+    const selectable = (orgTeams.value || [])
+        .filter((t: any) => t && t.status !== 'INACTIVE')
+        .map((t: any) => ({ label: t.name, value: t.uuid }))
+    const referenced = ownerTeamRef.value ? [ownerTeamRef.value] : []
+    return withGhosts(selectable, orgTeams.value || [], referenced,
+        (t: any, uuid: string) => t ? `${t.name} (archived)` : `(deleted team) ${String(uuid).slice(0, 8)}`)
+})
 
 const ownerLabel = computed<string | null>(() => {
     // Fall back to the RESOLVED ownership when there is no per-component stored
     // owner: an org team-assignment rule can own a component without anything
-    // being stored on it. Reading only `owner` showed a green OWNED badge with
-    // no name next to it -- "owned by whom?".
+    // being stored on it. Reading only `owner` left the block naming nobody for
+    // a component that is genuinely owned -- "owned by whom?".
     // A suggestion is not an owner, so do NOT fall back to it: that would print
-    // the suggested team beside an UNSET tag as though it owned the component.
+    // a team the backend merely proposed as though it already owned this.
     const resolved = componentOwnership.value?.ownership
     const o = componentOwnership.value?.owner?.ownerRef
         ? componentOwnership.value.owner
@@ -3413,10 +3450,11 @@ const ownerLabel = computed<string | null>(() => {
     if (!o || !o.ownerRef) return null
     const list = o.ownerType === 'TEAM' ? userGroups.value : users.value
     const hit = list.find((x: any) => x.value === o.ownerRef)
-    // A ref that resolves to nothing -- an archived or deleted owner -- used to
-    // fall back to the raw uuid. With the status chip and reason line gone that
-    // uuid would be the only thing on screen and would explain nothing, so an
-    // unresolvable owner reads as no owner and the picker below is the fix.
+    // A stored TEAM ref always resolves now -- userGroups keeps a ghost for it --
+    // so this is the genuinely unknown case: a user ref with no matching user, or
+    // a team ref on a component whose team list failed to load. Printing the raw
+    // uuid was the old behaviour; with the status chip and reason line gone it
+    // would be the only thing on the block and would explain nothing.
     if (!hit) return null
     return `${hit.label} (${o.ownerType === 'TEAM' ? 'team' : 'user'})`
 })
@@ -3458,14 +3496,12 @@ async function loadUserGroups() {
             variables: { org: orguuid.value },
             fetchPolicy: 'network-only',
         })
-        // Archived teams are dropped: notification routing ignores them, so
-        // offering one here would let an operator pick an owner that is
-        // immediately reported DEGRADED.
-        userGroups.value = (res.data?.getTeams || [])
-            .filter((g: any) => g && g.status !== 'INACTIVE')
-            .map((g: any) => ({ label: g.name, value: g.uuid }))
+        // Stored whole, archived teams included. The `userGroups` computed
+        // decides what is SELECTABLE; an archived team still has to be
+        // renderable when a component is already owned by it.
+        orgTeams.value = (res.data?.getTeams || []).filter((g: any) => !!g)
     } catch {
-        userGroups.value = []
+        orgTeams.value = []
     }
 }
 

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -401,14 +401,22 @@
                                             <label>Owner</label>
                                             <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
                                                 <div v-if="componentOwnership && componentOwnership.ownership">
+                                                    <!-- OWNED and NON_DURABLE differ only in DURABILITY -- whether the
+                                                         owner survives someone leaving. That is a governance signal, not
+                                                         something an operator setting an owner needs to act on, and
+                                                         showing it here reads as a complaint about a perfectly valid
+                                                         choice. Both render as "Owned". DEGRADED and ORPHANED still show
+                                                         through: those say the owner is archived or gone, which IS
+                                                         actionable. The backend still computes durability for the
+                                                         ownership report. -->
                                                     <n-tag :type="ownershipTagType(componentOwnership.ownership.status)" size="small">
-                                                        {{ componentOwnership.ownership.status }}
+                                                        {{ ownershipLabel }}
                                                     </n-tag>
                                                     <span v-if="ownerLabel" style="margin-left: 8px;">{{ ownerLabel }}</span>
                                                     <!-- A suggestion's reason line is suppressed: offering a candidate
                                                          team directly above the owner picker invites reading it as a
                                                          decision already made. Every other status explains itself. -->
-                                                    <span v-if="componentOwnership.ownership.reason && !ownershipIsSuggestion"
+                                                    <span v-if="componentOwnership.ownership.reason && !ownershipIsSuggestion && !ownershipIsDurabilityOnly"
                                                         class="text-muted" style="display: block; margin-top: 4px;">
                                                         {{ componentOwnership.ownership.reason }}
                                                     </span>
@@ -436,7 +444,7 @@
                                                     </n-button>
                                                 </div>
                                                 <span class="text-muted" style="margin-top: 4px;">
-                                                    The durable owner accountable for this {{ words.component }}. A team is durable (survives members leaving); a single user is flagged non-durable.
+                                                    Who is accountable for this {{ words.component }}.
                                                 </span>
                                             </div>
                                         </div>
@@ -3393,7 +3401,8 @@ const savingOwner = ref<boolean>(false)
 
 const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default' =>
     s === 'OWNED' ? 'success'
-        : (s === 'NON_DURABLE' || s === 'DEGRADED') ? 'warning'
+        : s === 'NON_DURABLE' ? 'success'   // shown as "Owned": colour must not leak the distinction
+            : s === 'DEGRADED' ? 'warning'
             : s === 'UNSET' ? 'default'  // no owner yet -> neutral, not alarming
                 : 'error'                // ORPHANED (or unknown) -> needs attention
 
@@ -3404,6 +3413,20 @@ const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default
 // agree -- so the rule lives here once instead of as a string literal in each.
 const ownershipIsSuggestion = computed<boolean>(
     () => componentOwnership.value?.ownership?.status === 'UNSET')
+
+/**
+ * OWNED and NON_DURABLE both mean "this thing has an owner"; they differ only on
+ * whether that owner survives a departure. Rendered identically so the picker
+ * does not editorialise about a valid choice -- see the template comment.
+ */
+const ownershipIsDurabilityOnly = computed<boolean>(
+    () => componentOwnership.value?.ownership?.status === 'NON_DURABLE')
+
+const ownershipLabel = computed<string>(() => {
+    const st = componentOwnership.value?.ownership?.status
+    if (st === 'OWNED' || st === 'NON_DURABLE') return 'Owned'
+    return st || ''
+})
 
 const ownerLabel = computed<string | null>(() => {
     // Fall back to the RESOLVED ownership when there is no per-component stored

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1500,8 +1500,12 @@ const openComponentSettings = async function() {
     await fetchEffectiveApprovalPolicy()
     // Durable ownership (Phase 4 UI): load the owner picker's team list + the
     // computed ownership status when the settings panel opens.
-    loadUserGroups()
-    loadOwnership()
+    //
+    // AWAIT the team list FIRST. loadOwnership pre-selects the stored owner only
+    // if it resolves to an option, so racing these would leave a perfectly valid
+    // owner unselected whenever the ownership query happened to win.
+    await loadUserGroups()
+    await loadOwnership()
     originalComponent.value = commonFunctions.deepCopy(updatedComponent.value)
     showComponentSettingsModal.value = true
     
@@ -3428,8 +3432,19 @@ async function loadOwnership() {
         })
         componentOwnership.value = res.data?.component || null
         ownershipSupported.value = true
+        // Pre-select the stored owner in the picker -- but ONLY if it resolves to
+        // an option. An archived or deleted owner does not, and naive-ui then
+        // renders the raw uuid as the selected value: with the status chip gone
+        // that uuid is the only thing on the block, sitting in an editable
+        // control where it reads as a valid choice rather than a dangling
+        // reference. Leaving the picker empty says the same thing honestly, and
+        // Clear owner is still offered because a stored ref does exist.
         const o = componentOwnership.value?.owner
-        if (o && o.ownerType && o.ownerRef) { ownerDraftType.value = o.ownerType; ownerDraftRef.value = o.ownerRef }
+        if (o && o.ownerType && o.ownerRef) {
+            ownerDraftType.value = o.ownerType
+            const opts = o.ownerType === 'TEAM' ? userGroups.value : users.value
+            ownerDraftRef.value = opts.some((x: any) => x.value === o.ownerRef) ? o.ownerRef : null
+        }
     } catch {
         // Backend without the ownership fields (older / CE mirror) -> hide the section.
         ownershipSupported.value = false

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -400,27 +400,15 @@
                                         <div class="versionSchemaBlock" v-if="updatedComponent && componentData && ownershipSupported">
                                             <label>Owner</label>
                                             <div style="display: flex; flex-direction: column; flex: 1; min-width: 0;">
-                                                <div v-if="componentOwnership && componentOwnership.ownership">
-                                                    <!-- OWNED and NON_DURABLE differ only in DURABILITY -- whether the
-                                                         owner survives someone leaving. That is a governance signal, not
-                                                         something an operator setting an owner needs to act on, and
-                                                         showing it here reads as a complaint about a perfectly valid
-                                                         choice. Both render as "Owned". DEGRADED and ORPHANED still show
-                                                         through: those say the owner is archived or gone, which IS
-                                                         actionable. The backend still computes durability for the
-                                                         ownership report. -->
-                                                    <n-tag :type="ownershipTagType(componentOwnership.ownership.status)" size="small">
-                                                        {{ ownershipLabel }}
-                                                    </n-tag>
-                                                    <span v-if="ownerLabel" style="margin-left: 8px;">{{ ownerLabel }}</span>
-                                                    <!-- A suggestion's reason line is suppressed: offering a candidate
-                                                         team directly above the owner picker invites reading it as a
-                                                         decision already made. Every other status explains itself. -->
-                                                    <span v-if="componentOwnership.ownership.reason && !ownershipIsSuggestion && !ownershipIsDurabilityOnly"
-                                                        class="text-muted" style="display: block; margin-top: 4px;">
-                                                        {{ componentOwnership.ownership.reason }}
-                                                    </span>
-                                                </div>
+                                                <!-- No status chip and no reason line, in ANY state. The chip
+                                                     used to report OWNED / NON_DURABLE / DEGRADED / ORPHANED; the
+                                                     first two differ only on durability, which is a governance
+                                                     signal rather than something an operator picking an owner acts
+                                                     on, and rhythm asked for the whole label gone rather than just
+                                                     the distinction. This block now answers one question: who owns
+                                                     it. The backend still computes every status for the ownership
+                                                     report, which is where coverage belongs. -->
+                                                <div v-if="ownerLabel">{{ ownerLabel }}</div>
                                                 <div v-if="isWritable" style="display: flex; gap: 8px; margin-top: 8px; align-items: center;">
                                                     <n-select
                                                         style="width: 110px;"
@@ -3399,13 +3387,6 @@ const ownerDraftType = ref<'TEAM' | 'USER'>('TEAM')
 const ownerDraftRef = ref<string | null>(null)
 const savingOwner = ref<boolean>(false)
 
-const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default' =>
-    s === 'OWNED' ? 'success'
-        : s === 'NON_DURABLE' ? 'success'   // shown as "Owned": colour must not leak the distinction
-            : s === 'DEGRADED' ? 'warning'
-            : s === 'UNSET' ? 'default'  // no owner yet -> neutral, not alarming
-                : 'error'                // ORPHANED (or unknown) -> needs attention
-
 // UNSET is the one ownership status that is a SUGGESTION rather than a fact:
 // the backend fills ownerRef with a candidate team it picked and puts its pitch
 // in `reason`. Every other status describes a real (or absent) owner. Both the
@@ -3413,20 +3394,6 @@ const ownershipTagType = (s: string): 'success' | 'warning' | 'error' | 'default
 // agree -- so the rule lives here once instead of as a string literal in each.
 const ownershipIsSuggestion = computed<boolean>(
     () => componentOwnership.value?.ownership?.status === 'UNSET')
-
-/**
- * OWNED and NON_DURABLE both mean "this thing has an owner"; they differ only on
- * whether that owner survives a departure. Rendered identically so the picker
- * does not editorialise about a valid choice -- see the template comment.
- */
-const ownershipIsDurabilityOnly = computed<boolean>(
-    () => componentOwnership.value?.ownership?.status === 'NON_DURABLE')
-
-const ownershipLabel = computed<string>(() => {
-    const st = componentOwnership.value?.ownership?.status
-    if (st === 'OWNED' || st === 'NON_DURABLE') return 'Owned'
-    return st || ''
-})
 
 const ownerLabel = computed<string | null>(() => {
     // Fall back to the RESOLVED ownership when there is no per-component stored
@@ -3442,7 +3409,12 @@ const ownerLabel = computed<string | null>(() => {
     if (!o || !o.ownerRef) return null
     const list = o.ownerType === 'TEAM' ? userGroups.value : users.value
     const hit = list.find((x: any) => x.value === o.ownerRef)
-    return `${hit?.label || o.ownerRef} (${o.ownerType === 'TEAM' ? 'team' : 'user'})`
+    // A ref that resolves to nothing -- an archived or deleted owner -- used to
+    // fall back to the raw uuid. With the status chip and reason line gone that
+    // uuid would be the only thing on screen and would explain nothing, so an
+    // unresolvable owner reads as no owner and the picker below is the fix.
+    if (!hit) return null
+    return `${hit.label} (${o.ownerType === 'TEAM' ? 'team' : 'user'})`
 })
 
 async function loadOwnership() {

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -56,7 +56,6 @@
                                 <n-form-item label="Status">
                                     <n-select v-model:value="subForm.status" :options="subscriptionStatusOptions" />
                                 </n-form-item>
-                                <div class="field-hint">"Preview" is reserved and not available yet, so it isn't selectable -- a preview subscription would never deliver anything, exactly like Disabled. (An existing Preview subscription can still be switched to Active or Disabled.)</div>
                             </n-gi>
                         </n-grid>
 
@@ -100,7 +99,7 @@
                              filters here and written back onto the single
                              route on save. -->
                         <n-grid :cols="2" :x-gap="12">
-                            <n-gi>
+                            <n-gi v-if="severityApplies">
                                 <n-form-item label="Minimum severity">
                                     <n-select
                                         v-model:value="subForm.routes[0].whenSeverityAtLeast"
@@ -165,7 +164,22 @@
                                      than no picker. teamOptions still keeps ghosts for teams
                                      already saved on the route, so those stay removable. -->
                                 <template v-if="teamOptions.length">
-                                    <n-form-item label="Teams (optional)" :show-feedback="false">
+                                    <n-form-item :show-feedback="false">
+                                        <template #label>
+                                            <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                                Teams (optional)
+                                                <n-tooltip trigger="hover">
+                                                    <template #trigger>
+                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                    </template>
+                                                    <span style="max-width: 320px; display: inline-block;">
+                                                        Delivers to each team's own notification channels, resolved
+                                                        when the event fires -- so if a team changes its channel,
+                                                        this follows automatically.
+                                                    </span>
+                                                </n-tooltip>
+                                            </span>
+                                        </template>
                                         <n-select
                                             v-model:value="subForm.routes[0].teams"
                                             :options="teamOptions"
@@ -175,11 +189,6 @@
                                             data-testid="route-teams"
                                         />
                                     </n-form-item>
-                                    <div class="muted-12" style="margin-top: -6px; margin-bottom: 6px;">
-                                        Delivers to each team's own notification channels, resolved when the
-                                        event fires — so if a team changes its channel, this follows
-                                        automatically.
-                                    </div>
                                 </template>
                                 <!-- T4a. Pro-only: notifyComponentOwner does not exist in the CE
                                      schema, and GraphQL input coercion rejects unknown keys
@@ -190,7 +199,24 @@
                                      is empty on a Pro org with no teams yet, and non-empty on CE
                                      whenever ghosts survive for a route's saved teams. -->
                                 <template v-if="isPro">
-                                    <n-form-item label="Component owner" :show-feedback="false">
+                                    <n-form-item :show-feedback="false">
+                                        <template #label>
+                                            <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                                Notify Component Owner
+                                                <n-tooltip trigger="hover">
+                                                    <template #trigger>
+                                                        <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                                    </template>
+                                                    <span style="max-width: 340px; display: inline-block;">
+                                                        Resolved when the event fires, from the component's owner --
+                                                        set directly or by an assignment rule. Unlike picking a team
+                                                        above, this follows ownership changes on its own, so
+                                                        reassigning a component never means editing this
+                                                        subscription.
+                                                    </span>
+                                                </n-tooltip>
+                                            </span>
+                                        </template>
                                         <n-checkbox
                                             v-model:checked="subForm.routes[0].notifyComponentOwner"
                                             data-testid="route-notify-owner"
@@ -198,15 +224,15 @@
                                             Also notify the team that owns the affected component
                                         </n-checkbox>
                                     </n-form-item>
-                                    <div class="muted-12" style="margin-top: -6px; margin-bottom: 6px;">
-                                        Resolved when the event fires, from the component's owner — set
-                                        directly or by an assignment rule. Unlike picking a team above,
-                                        this follows ownership changes on its own, so reassigning a
-                                        component never means editing this subscription.
-                                        <template v-if="!teamOptions.length">
-                                            This org has no teams yet, and only a team can own a
-                                            component, so this delivers nothing until one exists.
-                                        </template>
+                                    <!-- The description moved to the label's tooltip. This warning
+                                         stays INLINE and unconditional-looking on purpose: it is not
+                                         an explanation of the feature, it is a statement that ticking
+                                         the box right now achieves nothing, and a caveat hidden
+                                         behind a hover is a caveat nobody reads. -->
+                                    <div v-if="!teamOptions.length" class="muted-12"
+                                        style="margin-top: -6px; margin-bottom: 6px;">
+                                        This org has no teams yet, and only a team can own a
+                                        component, so this delivers nothing until one exists.
                                     </div>
                                 </template>
                             </div>
@@ -225,29 +251,19 @@
                                 </n-form-item>
                                 <div class="field-hint">Suppresses repeat deliveries of the same event within the window. Leave empty for the 24h default; set 0 to deliver every matching event.</div>
                             </n-gi>
-                            <n-gi>
-                                <n-space>
-                                    <n-form-item label="Rate limit max">
-                                        <n-input-number
-                                            v-model:value="subForm.rateLimitMaxPerWindow"
-                                            :min="1"
-                                            clearable
-                                            placeholder="None"
-                                            style="width: 100px;"
-                                        />
-                                    </n-form-item>
-                                    <n-form-item label="per (min)">
-                                        <n-input-number
-                                            v-model:value="subForm.rateLimitWindowMinutes"
-                                            :min="1"
-                                            clearable
-                                            placeholder="None"
-                                            style="width: 100px;"
-                                        />
-                                    </n-form-item>
-                                </n-space>
-                                <div class="field-hint">Stored but not enforced yet -- rate limiting is planned; leave empty for now.</div>
-                            </n-gi>
+                            <!-- The rate-limit control is deliberately absent. `rateLimit` is
+                                 parsed, stored and echoed back by the API, but NOTHING reads it:
+                                 neither the fan-out nor the delivery worker consults it, so a
+                                 rate limit set here has never suppressed anything. A field that
+                                 does nothing is a trap even with a hint saying so, which is the
+                                 same reason PREVIEW came out of the status list.
+
+                                 The PLUMBING stays on purpose -- the form still loads the stored
+                                 value in openEditSubscription and still sends it back on save --
+                                 so an existing subscription's rate limit round-trips untouched
+                                 rather than being silently cleared by an unrelated edit. When
+                                 enforcement lands, the control comes back and no data was lost
+                                 in the meantime. -->
                         </n-grid>
 
                         <n-alert v-if="subModalError" type="error" :show-icon="false">
@@ -279,14 +295,14 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, h, onMounted, onUnmounted, Ref } from 'vue'
+import { ref, computed, h, onMounted, onUnmounted, watch, Ref } from 'vue'
 import { useStore } from 'vuex'
 import {
     NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput,
     NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag, NDropdown, NTooltip,
     NRadioGroup, NRadioButton, NCheckbox, useDialog, useMessage
 } from 'naive-ui'
-import { CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabler'
+import { InfoCircle, CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabler'
 import { useRouter } from 'vue-router'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
@@ -414,6 +430,28 @@ const showSubscriptionModal = ref<boolean>(false)
 const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
+
+/**
+ * Only two event types carry a severity: NEW_VULN_AFFECTS_RELEASES and
+ * VULNERABILITY_RECORD_UPDATED. Everything else -- release and approval events,
+ * and VEX -- returns null from the backend's extractEventSeverity, and
+ * severityGateMatches treats "gate set, severity null" as NO MATCH.
+ *
+ * So a minimum severity on a subscription with no vuln event type does not
+ * merely have no effect: it silently gates out EVERY event, and the operator
+ * sees a subscription that never fires with nothing on screen explaining why.
+ * The control is therefore hidden when it cannot apply -- and the stored value
+ * cleared, because hiding a set gate would leave exactly that trap in place
+ * where nobody can see or reach it.
+ */
+const SEVERITY_BEARING_EVENT_TYPES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED']
+
+const severityApplies = computed<boolean>(() =>
+    (subForm.value.eventTypes || []).some(t => SEVERITY_BEARING_EVENT_TYPES.includes(t)))
+
+watch(severityApplies, (applies) => {
+    if (!applies && subForm.value.routes[0]) subForm.value.routes[0].whenSeverityAtLeast = null
+})
 
 // Event-type options for THIS form. The shared eventTypeOptions marks
 // VEX_STATE_CHANGED disabled (no backend producer yet), which also makes

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -130,6 +130,15 @@
                             events carry: with perspectives set, release and approval events match
                             nothing. Keep those on their own subscription.
                         </div>
+                        <!-- Perspectives have the SAME shape of trap as the minimum-severity gate
+                             above -- perspectiveGateMatches returns false when the event carries no
+                             affectedReleases -- yet this one is still shown for every event type,
+                             with a hint, rather than hidden. That is a deliberate asymmetry, not an
+                             oversight: severity is hidden because it can NEVER apply to a
+                             release-only subscription, whereas which events carry affectedReleases
+                             has not been confirmed the same way, and hiding a control on an
+                             unverified premise removes a feature people may be using. Tracked on the
+                             board to be settled one way or the other. -->
 
                         <div class="routes-section">
                             <div class="routes-title">Destination</div>
@@ -166,17 +175,15 @@
                                 <template v-if="teamOptions.length">
                                     <n-form-item :show-feedback="false">
                                         <template #label>
-                                            <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
                                                 Teams (optional)
-                                                <n-tooltip trigger="hover">
+                                                <n-tooltip trigger="hover" style="max-width: 360px;">
                                                     <template #trigger>
                                                         <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
                                                     </template>
-                                                    <span style="max-width: 320px; display: inline-block;">
-                                                        Delivers to each team's own notification channels, resolved
-                                                        when the event fires -- so if a team changes its channel,
-                                                        this follows automatically.
-                                                    </span>
+                                                    Delivers to each team's own notification channels, resolved
+                                                    when the event fires -- so if a team changes its channel,
+                                                    this follows automatically.
                                                 </n-tooltip>
                                             </span>
                                         </template>
@@ -201,19 +208,17 @@
                                 <template v-if="isPro">
                                     <n-form-item :show-feedback="false">
                                         <template #label>
-                                            <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                            <span style="display: inline-flex; align-items: center; gap: 6px;">
                                                 Notify Component Owner
-                                                <n-tooltip trigger="hover">
+                                                <n-tooltip trigger="hover" style="max-width: 360px;">
                                                     <template #trigger>
                                                         <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
                                                     </template>
-                                                    <span style="max-width: 340px; display: inline-block;">
-                                                        Resolved when the event fires, from the component's owner --
-                                                        set directly or by an assignment rule. Unlike picking a team
-                                                        above, this follows ownership changes on its own, so
-                                                        reassigning a component never means editing this
-                                                        subscription.
-                                                    </span>
+                                                    Resolved when the event fires, from the component's owner --
+                                                    set directly or by an assignment rule. Unlike picking a team
+                                                    above, this follows ownership changes on its own, so
+                                                    reassigning a component never means editing this
+                                                    subscription.
                                                 </n-tooltip>
                                             </span>
                                         </template>
@@ -318,8 +323,9 @@ import {
     buildNotificationRouteInput,
     routeHasTarget,
     classifySubscriptionTest,
-    isOwnerRouted,
-    isTeamRouted,
+    severityAppliesTo,
+    clearInapplicableSeverity,
+    noDeliveryExplanation,
     ownerRoutedSuccessCaveat,
     routeCount,
     hasUneditableMultiRoute,
@@ -396,6 +402,10 @@ interface SubscriptionForm {
     // (and any other field the UI doesn't model yet) survives an
     // Edit -> Save round-trip. Empty on Create.
     _rawFilter?: Record<string, any>
+    // Same idea for the rate limit, and load-bearing now that the control is
+    // hidden: the modelled pair drops a partial limit, and nothing on screen
+    // would show the operator what was lost. Empty on Create.
+    _rawRateLimit?: Record<string, any>
 }
 
 function freshRoute (): SubscriptionRoute {
@@ -431,26 +441,20 @@ const savingSubscription = ref<boolean>(false)
 const subModalError = ref<string>('')
 const subForm = ref<SubscriptionForm>(freshSubscriptionForm())
 
-/**
- * Only two event types carry a severity: NEW_VULN_AFFECTS_RELEASES and
- * VULNERABILITY_RECORD_UPDATED. Everything else -- release and approval events,
- * and VEX -- returns null from the backend's extractEventSeverity, and
- * severityGateMatches treats "gate set, severity null" as NO MATCH.
- *
- * So a minimum severity on a subscription with no vuln event type does not
- * merely have no effect: it silently gates out EVERY event, and the operator
- * sees a subscription that never fires with nothing on screen explaining why.
- * The control is therefore hidden when it cannot apply -- and the stored value
- * cleared, because hiding a set gate would leave exactly that trap in place
- * where nobody can see or reach it.
- */
-const SEVERITY_BEARING_EVENT_TYPES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED']
+// Hide the minimum-severity control when no selected event type can carry a
+// severity. The predicate and the clearing live in notificationsCommon so the
+// spec suite can pin them -- there is no component test environment here, and
+// review found the first cut of this shipped its only behavioural rule inside
+// the .vue where nothing could reach it. See severityAppliesTo /
+// clearInapplicableSeverity for WHY a stale gate is a trap rather than a no-op.
+const severityApplies = computed<boolean>(() => severityAppliesTo(subForm.value.eventTypes))
 
-const severityApplies = computed<boolean>(() =>
-    (subForm.value.eventTypes || []).some(t => SEVERITY_BEARING_EVENT_TYPES.includes(t)))
-
-watch(severityApplies, (applies) => {
-    if (!applies && subForm.value.routes[0]) subForm.value.routes[0].whenSeverityAtLeast = null
+// Clears while the modal is OPEN, i.e. when the last vuln event type is
+// removed. The load and save paths clear too, and must: a watcher fires on
+// CHANGE, so opening a subscription that was ALREADY in the bad state never
+// runs this one.
+watch(severityApplies, () => {
+    clearInapplicableSeverity(subForm.value.routes, subForm.value.eventTypes)
 })
 
 // Event-type options for THIS form. The shared eventTypeOptions marks
@@ -684,8 +688,20 @@ function openEditSubscription (row: SubscriptionRow): void {
         if (rl) {
             f.rateLimitMaxPerWindow = rl.maxPerWindow ?? null
             f.rateLimitWindowMinutes = rl.windowMinutes ?? null
+            // Stash the blob for the same reason filter and routes stash theirs:
+            // the modelled pair cannot express a PARTIAL limit ({maxPerWindow}
+            // with no window, which the API accepts), and with the control gone
+            // there is no longer a field where an operator could even see the
+            // orphaned half before an unrelated save dropped it.
+            f._rawRateLimit = rl
         }
     } catch { /* skip */ }
+    // A gate that can never match is dropped HERE, not left to the watcher: the
+    // watcher is change-driven, and the common path -- open a subscription that
+    // was already release-only with a stored gate -- is not a change. Verified
+    // live before the fix: edit + save re-persisted whenSeverityAtLeast=HIGH on
+    // a RELEASE_CREATED subscription, with the control hidden.
+    clearInapplicableSeverity(f.routes, f.eventTypes)
     subForm.value = f
     subModalError.value = ''
     showSubscriptionModal.value = true
@@ -723,6 +739,11 @@ async function saveSubscription (): Promise<void> {
     // carries an unmodelled `presetConfig` object that must not leak into the
     // input (it 400s the mutation). See buildNotificationFilterInput.
     const filterInput = buildNotificationFilterInput(f._rawFilter, f.filterMode, f.celExpression)
+    // Belt and braces on the way out. openEditSubscription already clears an
+    // inapplicable gate, but this is the only choke point EVERY save passes
+    // through, and the failure it prevents is invisible: a gate that matches
+    // nothing, on a control that is no longer rendered.
+    clearInapplicableSeverity(f.routes, f.eventTypes)
     const input: any = {
         uuid: f.uuid || undefined,
         expectedRevision: f.expectedRevision,
@@ -741,6 +762,13 @@ async function saveSubscription (): Promise<void> {
             maxPerWindow: f.rateLimitMaxPerWindow,
             windowMinutes: f.rateLimitWindowMinutes,
         }
+    } else if (f._rawRateLimit) {
+        // A limit that the modelled pair cannot represent -- a partial one, or
+        // one carrying keys this form does not know about -- rides back
+        // verbatim. The upsert REPLACES rateLimit wholesale, so omitting it here
+        // is not "leave it alone", it is a silent delete on the next edit of any
+        // unrelated field. Same reasoning as _rawFilter and route._raw.
+        input.rateLimit = f._rawRateLimit
     }
     savingSubscription.value = true
     try {
@@ -918,43 +946,6 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
     }
 }
 
-/**
- * Why a test produced no delivery.
- *
- * The default answer names the filter and the severity gate, which is right for
- * every route target that resolves to a fixed channel. It is WRONG whenever a
- * route resolves through something else, because then the filter and the gate
- * can both be working perfectly:
- *
- * <ul>
- *   <li>OWNER-routed: an unowned affected component, or an owner team with no
- *       channel, yields nothing.</li>
- *   <li>TEAM-targeted: resolution drops a team that is archived, cross-org,
- *       unreadable, or has no channels. Observed live -- archiving a targeted
- *       team produced this message blaming the filter and the gate, both
- *       innocent.</li>
- * </ul>
- *
- * Sending the operator to audit the wrong thing is worse than saying nothing,
- * so each resolving target names its own likely causes FIRST.
- */
-function noDeliveryExplanation (row: SubscriptionRow): string {
-    const base = 'The synthetic event was injected but produced no delivery for this subscription.'
-    const causes: string[] = []
-    if (isOwnerRouted(row.routes)) {
-        causes.push('a route delivers to the component owner, so the affected component may have no'
-            + ' owner, or its owner team no notification channel')
-    }
-    if (isTeamRouted(row.routes)) {
-        causes.push('a route targets a team, which contributes nothing while it is archived or has'
-            + ' no notification channels')
-    }
-    if (causes.length) {
-        return `${base} Check these first: ${causes.join('; and ')}.`
-            + " Only then the subscription's filter or a route's minimum-severity gate."
-    }
-    return `${base} Its filter, or a route's minimum-severity gate, likely excluded it.`
-}
 
 function reportSubscriptionTestResult (
     row: SubscriptionRow,
@@ -989,7 +980,7 @@ function reportSubscriptionTestResult (
                 : timedOut
                     ? 'Gave up waiting after 60s -- the event had not finished fanning out.'
                         + ' Check Notification History for the eventual result.'
-                    : noDeliveryExplanation(row),
+                    : noDeliveryExplanation(row.routes),
         })
         return
     }

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -303,6 +303,7 @@ import {
     routeHasTarget,
     classifySubscriptionTest,
     isOwnerRouted,
+    isTeamRouted,
     ownerRoutedSuccessCaveat,
     routeCount,
     hasUneditableMultiRoute,
@@ -883,18 +884,36 @@ async function runSubscriptionTest (row: SubscriptionRow, template: string): Pro
  * Why a test produced no delivery.
  *
  * The default answer names the filter and the severity gate, which is right for
- * every route target that resolves to a fixed channel. It is WRONG for an
- * owner-routed route: that resolves through the affected component's owner, so
- * an unowned component, or an owner team with no channel, yields zero
- * deliveries with the filter and severity gate working perfectly. Sending the
- * operator to audit those instead is worse than saying nothing.
+ * every route target that resolves to a fixed channel. It is WRONG whenever a
+ * route resolves through something else, because then the filter and the gate
+ * can both be working perfectly:
+ *
+ * <ul>
+ *   <li>OWNER-routed: an unowned affected component, or an owner team with no
+ *       channel, yields nothing.</li>
+ *   <li>TEAM-targeted: resolution drops a team that is archived, cross-org,
+ *       unreadable, or has no channels. Observed live -- archiving a targeted
+ *       team produced this message blaming the filter and the gate, both
+ *       innocent.</li>
+ * </ul>
+ *
+ * Sending the operator to audit the wrong thing is worse than saying nothing,
+ * so each resolving target names its own likely causes FIRST.
  */
 function noDeliveryExplanation (row: SubscriptionRow): string {
     const base = 'The synthetic event was injected but produced no delivery for this subscription.'
+    const causes: string[] = []
     if (isOwnerRouted(row.routes)) {
-        return `${base} A route delivers to the component owner, so this is also what you see when the`
-            + ' affected component has no owner, or its owner team has no notification channel --'
-            + " check those before the subscription's filter or a route's minimum-severity gate."
+        causes.push('a route delivers to the component owner, so the affected component may have no'
+            + ' owner, or its owner team no notification channel')
+    }
+    if (isTeamRouted(row.routes)) {
+        causes.push('a route targets a team, which contributes nothing while it is archived or has'
+            + ' no notification channels')
+    }
+    if (causes.length) {
+        return `${base} Check these first: ${causes.join('; and ')}.`
+            + " Only then the subscription's filter or a route's minimum-severity gate."
     }
     return `${base} Its filter, or a route's minimum-severity gate, likely excluded it.`
 }

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -21,6 +21,7 @@ import {
     classifySubscriptionTest,
     TERMINAL_OUTBOX_STATUSES,
     isOwnerRouted,
+    isTeamRouted,
     ownerRoutedSuccessCaveat,
     routeCount,
     hasUneditableMultiRoute,
@@ -418,5 +419,29 @@ describe('one-route editor guard', () => {
             expect(hasUneditableMultiRoute(shape), `shape: ${JSON.stringify(shape)}`).toBe(false)
         }
         expect(routeCount('{"a":1}')).toBe(0)  // an object is not a route list
+    })
+})
+
+describe('isTeamRouted', () => {
+    // The reason this exists: archiving a targeted team made the test say
+    // "your filter or severity gate excluded it", and both were innocent.
+    it('detects an explicit team target', () => {
+        expect(isTeamRouted(JSON.stringify([{ channels: [], teams: ['t-1'] }]))).toBe(true)
+    })
+
+    it('is false for a route that only names channels', () => {
+        expect(isTeamRouted(JSON.stringify([{ channels: ['c-1'], teams: [] }]))).toBe(false)
+    })
+
+    it('is false for a null/empty team entry rather than truthy-by-array', () => {
+        // routes[].teams arrives as [null] from some saved rows; an array with
+        // nothing usable in it is not a team target.
+        expect(isTeamRouted(JSON.stringify([{ channels: ['c-1'], teams: [null] }]))).toBe(false)
+    })
+
+    it('falls back to the generic wording on unparseable routes', () => {
+        for (const bad of [null, undefined, '', 'not json', '{"a":1}']) {
+            expect(isTeamRouted(bad as any)).toBe(false)
+        }
     })
 })

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -23,6 +23,10 @@ import {
     isOwnerRouted,
     isTeamRouted,
     ownerRoutedSuccessCaveat,
+    noDeliveryExplanation,
+    severityAppliesTo,
+    SEVERITY_BEARING_EVENT_TYPES,
+    clearInapplicableSeverity,
     routeCount,
     hasUneditableMultiRoute,
     LIST_GROUPS_QUERY, LIST_GROUPS_CORE_QUERY,
@@ -443,9 +447,91 @@ describe('isTeamRouted', () => {
         expect(isTeamRouted(JSON.stringify([{ channels: ['c-1'], teams: [null] }]))).toBe(false)
     })
 
-    it('falls back to the generic wording on unparseable routes', () => {
+    it('is false for null, empty and unparseable routes rather than throwing', () => {
         for (const bad of [null, undefined, '', 'not json', '{"a":1}']) {
             expect(isTeamRouted(bad as any)).toBe(false)
         }
+    })
+})
+
+describe('noDeliveryExplanation', () => {
+    const teamRoute = JSON.stringify([{ channels: [], teams: ['t-1'] }])
+    const ownerRoute = JSON.stringify([{ channels: [], notifyComponentOwner: true }])
+    const bothRoute = JSON.stringify([{ channels: [], teams: ['t-1'], notifyComponentOwner: true }])
+    const channelRoute = JSON.stringify([{ channels: ['c-1'], teams: [] }])
+
+    it('leads with the resolving target, not the filter, for a team route', () => {
+        const msg = noDeliveryExplanation(teamRoute)
+        expect(msg).toContain('a route targets a team')
+        expect(msg).toContain('Check these first')
+        // The filter and the gate are still mentioned -- demoted, not deleted.
+        expect(msg.indexOf('targets a team')).toBeLessThan(msg.indexOf('filter'))
+    })
+
+    it('leads with the owner cause for an owner-routed subscription', () => {
+        expect(noDeliveryExplanation(ownerRoute)).toContain('delivers to the component owner')
+    })
+
+    it('names BOTH causes when a route resolves through owner and team', () => {
+        const msg = noDeliveryExplanation(bothRoute)
+        expect(msg).toContain('delivers to the component owner')
+        expect(msg).toContain('targets a team')
+        expect(msg).toContain('; and ')
+    })
+
+    it('keeps the plain filter/severity wording for a fixed-channel route', () => {
+        const msg = noDeliveryExplanation(channelRoute)
+        expect(msg).toContain('likely excluded it')
+        expect(msg).not.toContain('Check these first')
+    })
+})
+
+describe('severity gating', () => {
+    // Pinned against NotificationFanOutService.extractEventSeverity: only these
+    // two event types resolve a severity, and severityGateMatches counts a null
+    // severity as NO MATCH -- so a gate left on anything else silently suppresses
+    // every event rather than doing nothing.
+    it('lists exactly the two severity-bearing event types', () => {
+        expect([...SEVERITY_BEARING_EVENT_TYPES].sort())
+            .toEqual(['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED'])
+    })
+
+    it('applies when any selected event type carries a severity', () => {
+        expect(severityAppliesTo(['NEW_VULN_AFFECTS_RELEASES'])).toBe(true)
+        expect(severityAppliesTo(['VULNERABILITY_RECORD_UPDATED'])).toBe(true)
+        expect(severityAppliesTo(['RELEASE_CREATED', 'NEW_VULN_AFFECTS_RELEASES'])).toBe(true)
+    })
+
+    it('does not apply to release, approval or VEX events, or to nothing at all', () => {
+        for (const types of [['RELEASE_CREATED'], ['RELEASE_LIFECYCLE_CHANGED'],
+            ['RELEASE_BOM_DIFF'], ['APPROVAL_REQUESTED'], ['APPROVAL_RESOLVED'],
+            ['VEX_STATE_CHANGED'], [], null, undefined]) {
+            expect(severityAppliesTo(types as any)).toBe(false)
+        }
+    })
+
+    it('clears an inapplicable gate on EVERY route, not just the first', () => {
+        // The editor only exposes one route, but saveSubscription maps them all.
+        const routes = [{ whenSeverityAtLeast: 'HIGH' }, { whenSeverityAtLeast: 'LOW' }]
+        expect(clearInapplicableSeverity(routes, ['RELEASE_CREATED'])).toBe(true)
+        expect(routes.map(r => r.whenSeverityAtLeast)).toEqual([null, null])
+    })
+
+    it('leaves a gate alone when it can still match', () => {
+        const routes = [{ whenSeverityAtLeast: 'HIGH' }]
+        expect(clearInapplicableSeverity(routes, ['NEW_VULN_AFFECTS_RELEASES'])).toBe(false)
+        expect(routes[0].whenSeverityAtLeast).toBe('HIGH')
+    })
+
+    it('reports nothing cleared when no gate was set', () => {
+        // Distinguishes "there was nothing to clear" from "we cleared something",
+        // which is what a caller would key a warning off.
+        const routes = [{ whenSeverityAtLeast: null }]
+        expect(clearInapplicableSeverity(routes, ['RELEASE_CREATED'])).toBe(false)
+    })
+
+    it('survives null routes and null entries', () => {
+        expect(clearInapplicableSeverity(null, ['RELEASE_CREATED'])).toBe(false)
+        expect(clearInapplicableSeverity([null as any], ['RELEASE_CREATED'])).toBe(false)
     })
 })

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -69,12 +69,16 @@ describe('unselectable options without a backend implementation', () => {
     const option = (opts: Array<{ value: string, disabled?: boolean }>, value: string) =>
         opts.find(o => o.value === value)
 
-    it('keeps PREVIEW unselectable while fan-out matches ACTIVE only', () => {
+    it('does not offer PREVIEW at all while fan-out matches ACTIVE only', () => {
         // NotificationSubscriptionRepository.findActiveByOrgString filters on
         // status='ACTIVE', so a PREVIEW subscription never reaches fan-out and
         // behaves exactly like DISABLED. Reproduced on the sandbox: ACTIVE -> 1
         // delivery row, PREVIEW -> 0, DISABLED -> 0.
-        expect(option(subscriptionStatusOptions, 'PREVIEW')?.disabled).toBe(true)
+        //
+        // Stronger than the previous assertion, which only required it to be
+        // present-and-disabled: a greyed row plus a paragraph explaining why it
+        // is useless is still shelf space spent on a non-feature. Absent.
+        expect(option(subscriptionStatusOptions, 'PREVIEW')).toBeUndefined()
     })
 
     it('leaves the implemented subscription statuses selectable', () => {

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -130,22 +130,16 @@ export const webhookAuthOptions = [
     { label: 'HMAC-SHA256', value: 'HMAC_SHA256' },
 ]
 
-// PREVIEW has no fan-out implementation, so it behaves exactly like DISABLED:
-// NotificationSubscriptionRepository.findActiveByOrgString matches
-// status='ACTIVE' only, so a PREVIEW subscription never reaches fan-out, no
-// delivery row is ever written, and NotificationDeliveryStatus.PREVIEW has no
-// writer at all. Offering it is a silent trap: a user sets PREVIEW, sees
-// nothing arrive, and concludes their filter matches nothing -- when fan-out
-// never consulted the subscription in the first place. Keep it unselectable
-// until fan-out honours it (same treatment as VEX_STATE_CHANGED below). The
-// enum values are deliberately kept on both sides.
-// Status is a single select, so unlike the multiple-select VEX case this needs
-// no unselect-guard computed: a legacy PREVIEW value still renders and can be
-// changed away, it just can't be re-selected.
+// PREVIEW is deliberately ABSENT rather than present-but-disabled. It has no
+// fan-out implementation -- findActiveByOrgString matches status='ACTIVE' only,
+// so a PREVIEW subscription never reaches fan-out and no delivery row is ever
+// written. Showing a greyed row plus an explanation of why it is useless is
+// still shelf space spent on a non-feature; a legacy PREVIEW value still
+// renders on an existing subscription and can be switched to ACTIVE or
+// DISABLED, which is the only path that matters.
 export const subscriptionStatusOptions = [
     { label: 'Active (deliveries go out)', value: 'ACTIVE' },
     { label: 'Disabled (no dispatch)', value: 'DISABLED' },
-    { label: 'Preview (not yet available)', value: 'PREVIEW', disabled: true },
 ]
 
 // VEX_STATE_CHANGED has no event producer in the backend yet, so a

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -555,6 +555,29 @@ export function isOwnerRouted (routesJson: string | null | undefined): boolean {
 }
 
 /**
+ * True when any route targets a TEAM explicitly (as opposed to naming channels
+ * or delivering to the component owner).
+ *
+ * <p>A team target resolves to that team's channels at fan-out, and resolution
+ * drops a team that is archived, cross-org, unreadable, or simply has no
+ * channels. Every one of those yields zero deliveries with the subscription's
+ * filter and severity gate working perfectly -- so a diagnosis that names only
+ * the filter and the gate sends the operator to audit two innocent things.
+ *
+ * <p>Observed live: archiving a targeted team, then testing, produced exactly
+ * that misdirection.
+ */
+export function isTeamRouted (routesJson: string | null | undefined): boolean {
+    try {
+        const routes = routesJson ? JSON.parse(routesJson) : []
+        return Array.isArray(routes)
+            && routes.some((r: any) => Array.isArray(r?.teams) && r.teams.some((t: any) => !!t))
+    } catch {
+        return false  // unparseable routes: fall back to the generic wording
+    }
+}
+
+/**
  * Caveat shown on a SUCCESSFUL owner-routed test.
  *
  * Injection deliberately stamps the event onto a component that HAS a routable

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -190,6 +190,48 @@ export const severityOptions = [
     { label: 'INFO', value: 'INFO' },
 ]
 
+/**
+ * The only event types that carry a severity.
+ *
+ * <p>Mirrors NotificationFanOutService.extractEventSeverity, which returns null
+ * for everything else -- release events, approvals and VEX. That matters
+ * because severityGateMatches treats "gate set, severity null" as NO MATCH: a
+ * minimum severity on a subscription with no vuln event type does not merely
+ * have no effect, it silently gates out EVERY event, and the operator sees a
+ * subscription that never fires with nothing on screen explaining why.
+ */
+export const SEVERITY_BEARING_EVENT_TYPES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED']
+
+/** True when a minimum-severity gate can ever match, given these event types. */
+export function severityAppliesTo (eventTypes: string[] | null | undefined): boolean {
+    return (eventTypes || []).some(t => SEVERITY_BEARING_EVENT_TYPES.includes(t))
+}
+
+/**
+ * Drops a severity gate that can never match, in place, on every route.
+ *
+ * <p>The editor hides the control when {@link severityAppliesTo} is false, so
+ * without this a stored gate becomes UNREACHABLE rather than harmless -- worse
+ * than before it was hidden, since the operator can no longer see or clear the
+ * thing silently suppressing every delivery. Call it wherever the form is
+ * populated AND on the way out, not just on an event-type edit: the common path
+ * is opening an already-broken subscription, where nothing changes and a
+ * change-driven watcher never runs.
+ *
+ * @returns true when something was actually cleared
+ */
+export function clearInapplicableSeverity (
+    routes: Array<Record<string, any>> | null | undefined,
+    eventTypes: string[] | null | undefined,
+): boolean {
+    if (severityAppliesTo(eventTypes)) return false
+    let cleared = false
+    for (const r of routes || []) {
+        if (r && r.whenSeverityAtLeast) { r.whenSeverityAtLeast = null; cleared = true }
+    }
+    return cleared
+}
+
 // Which of these the backend can actually WRITE, checked rather than assumed
 // (an earlier cut of this list exempted ACKED on a guess and was wrong).
 // Sweeping every write path across the backend -- setStatus() call sites, the
@@ -208,8 +250,11 @@ export const severityOptions = [
 // ACKED to see what has been acknowledged, gets zero rows, and reads that as a
 // fact about their data rather than about the schema. On a diagnostic surface
 // a false negative is worse than a missing control. Left visible-but-disabled
-// rather than deleted so the reason is on screen -- same treatment as the
-// PREVIEW subscription status and VEX_STATE_CHANGED.
+// rather than deleted so the reason is on screen -- same treatment as
+// VEX_STATE_CHANGED. NOTE this is deliberately the OPPOSITE of the PREVIEW
+// subscription status above, which is deleted outright: a FILTER that quietly
+// omits a status misrepresents the data, whereas an unselectable CONFIGURATION
+// option is only ever shelf space for a non-feature.
 //
 // Re-enable each ONE alongside the backend change that starts producing it.
 // The spec pins both directions against the backend source, so adding a writer
@@ -586,6 +631,44 @@ export function ownerRoutedSuccessCaveat (routesJson: string | null | undefined)
         + ' so an owner-routed subscription will usually pass this test. A real event lands on'
         + ' whichever component actually carries the finding, which may be unowned -- check the'
         + ' ownership report for coverage rather than relying on this result.'
+}
+
+/**
+ * Why a test produced no delivery.
+ *
+ * <p>The default answer names the filter and the severity gate, which is right
+ * for every route target that resolves to a fixed channel. It is WRONG whenever
+ * a route resolves through something else, because then the filter and the gate
+ * can both be working perfectly:
+ *
+ * <ul>
+ *   <li>OWNER-routed: an unowned affected component, or an owner team with no
+ *       channel, yields nothing.</li>
+ *   <li>TEAM-targeted: resolution drops a team that is archived, cross-org,
+ *       unreadable, or has no channels. Observed live -- archiving a targeted
+ *       team produced this message blaming the filter and the gate, both
+ *       innocent.</li>
+ * </ul>
+ *
+ * <p>Sending the operator to audit the wrong thing is worse than saying
+ * nothing, so each resolving target names its own likely causes FIRST.
+ */
+export function noDeliveryExplanation (routesJson: string | null | undefined): string {
+    const base = 'The synthetic event was injected but produced no delivery for this subscription.'
+    const causes: string[] = []
+    if (isOwnerRouted(routesJson)) {
+        causes.push('a route delivers to the component owner, so the affected component may have no'
+            + ' owner, or its owner team no notification channel')
+    }
+    if (isTeamRouted(routesJson)) {
+        causes.push('a route targets a team, which contributes nothing while it is archived or has'
+            + ' no notification channels')
+    }
+    if (causes.length) {
+        return `${base} Check these first: ${causes.join('; and ')}.`
+            + " Only then the subscription's filter or a route's minimum-severity gate."
+    }
+    return `${base} Its filter, or a route's minimum-severity gate, likely excluded it.`
 }
 
 /**


### PR DESCRIPTION
Three commits that were meant to be part of #281 but landed on the branch
after it merged. #281 was merged at 09:06Z carrying only its first two
commits; these three were pushed at 10:12, 10:38 and 11:20 to a branch whose
PR was already closed, so GitHub was never going to pick them up. Verified by
pointing the sandbox at the released `rearm-ui:26.08.19` (the #281 merge
build) and re-running the probe: 7 of 12 checks failed there -- PREVIEW back
in the status list, the rate-limit control back, `Notify Component Owner`
gone. Cherry-picked onto main; the resulting tree is byte-identical to the
branch head that was validated on the sandbox (`git diff b6501591 HEAD` is
empty).

## What is in here

**1. Stop surfacing durability (74301743).** The component Owner block showed
an ownership status chip -- OWNED / NON_DURABLE / DEGRADED / ORPHANED -- plus
a reason line explaining why a team was not durable. rhythm asked for the
label to go, then clarified: hide the distinction entirely, not collapse it
to "Owned". Both the word and the colour are gone, since a colour difference
leaks the distinction just as well as the word did. The owner NAME still
renders.

Also in this commit: when a subscription test produces no delivery, the
diagnosis now names TEAM targets. rhythm archived a targeted team and was
told "its filter, or a route's minimum-severity gate, likely excluded it" --
both innocent. The team cause now leads and the filter/severity guesses are
demoted.

**2. Remove the ownership status chip entirely (fd0f25f4).** The follow-up to
the clarification above.

**3. Tidy the subscription editor (b6501591).** Six items from rhythm's
walkthrough:

- PREVIEW removed from the status select, along with its apology paragraph.
  PREVIEW is silently identical to DISABLED (t20260811-030648-23714); a spec
  is filed as t20260717-120722-18192 if it is ever wanted.
- Filter mode already defaulted to Preset -- verified rather than "fixed".
  The subscription rhythm saw in ADVANCED is genuinely stored that way.
- Minimum severity is shown only for the two event types that carry a
  severity. This is the one worth reading closely: `severityGateMatches`
  treats "gate set, severity null" as NO MATCH, so a minimum severity on a
  release-or-approval subscription does not do nothing -- it silently gates
  out every event. Hiding the control alone would have preserved the trap
  somewhere unreachable, so the stored value is cleared when the control
  hides.
- Teams and Notify Component Owner descriptions moved to label tooltips
  (`InfoCircle`, matching the house pattern).
- The rate-limit control is hidden. `rateLimit` is parsed, stored and echoed
  back, and never read at fan-out (t20260702-065833-25754, decided
  leave-as-is). The form still loads and re-sends the stored value, so an
  existing limit round-trips rather than being silently cleared by an
  unrelated edit, and the control returns when enforcement lands.

One thing deliberately NOT moved to a tooltip: the conditional caveat under
the owner checkbox ("this org has no teams yet, so this delivers nothing").
That is not a description, it is a statement that ticking the box achieves
nothing right now. A caveat behind a hover is a caveat nobody reads.

## Validation

- `npm run test`: 136 passed (12 files). Nothing in CI runs this suite
  (t20260811-061400-10264), so it is part of manual validation.
- `npm run build` green; `validate-graphql.mjs` 0 Pro failures, warnings are
  the expected CE-mirror lag on Team (backend is rearm-saas only).
- Sandbox: `probe-subscription-editor-tidy.js` 12/12, and
  `probe-durability-hidden-and-team-hint.js` for the chip removal, driven
  through a team that the backend still computes NON_DURABLE so the check
  cannot pass vacuously.

## Reviews

Layer 1 and Layer 2 ran on #281 at `331bf8c7` -- which predates all three of
these commits. Both layers are being re-run against this diff.
