### PR TITLE
docs: document Teams, and correct what the Team work changed

### DIFF
--- a/documentation_site/docs/.vitepress/config.mjs
+++ b/documentation_site/docs/.vitepress/config.mjs
@@ -32,6 +32,7 @@ function sidebar() {
         ]},
         {text: 'Configure', link: '/configure/', items: [
           {text: 'Users and User Groups Permissions', link: '/configure/user-and-user-group-permissions'},
+          {text: 'Teams', link: '/configure/teams'},
           {text: 'Component Ownership', link: '/configure/component-ownership'},
           {text: 'Notifications', link: '/configure/notifications'},
           {text: 'Approval Queues', link: '/configure/approval-queues'}

--- a/documentation_site/docs/configure/component-ownership.md
+++ b/documentation_site/docs/configure/component-ownership.md
@@ -27,9 +27,10 @@ person leaves, and only a team can be a notification target -- a user has no
 channels of their own, so a route that notifies the component owner will not
 deliver for a user-owned component.
 
-The picker offers active teams only. If the component is already owned by a team
-that has since been archived, that team is still shown -- labelled as archived --
-so the stale owner is visible and replaceable rather than an empty field.
+The picker offers active teams only, so an archived team cannot be chosen as a
+new owner. A component already owned by a team that was archived since keeps
+that owner on record -- it reports `DEGRADED` and stops receiving owner-routed
+notifications until you point it somewhere else.
 
 ## Ownership status
 
@@ -107,11 +108,11 @@ When more than one source could decide an owner, ReARM resolves in this order:
 
 ## Finding components at risk
 
-On an individual component, the **Settings** panel names the current owner. It
-does not report durability: that is a fleet-level question -- "which components
-have nobody durable behind them" -- and answering it one component at a time
-invites reading a single `NON_DURABLE` as a fault to fix rather than as coverage
-to plan.
+On an individual component, the **Settings** panel names the current owner.
+
+Durability, though, is a fleet-level question -- "which components have nobody
+durable behind them" -- and answering it one component at a time invites reading
+a single `NON_DURABLE` as a fault to fix rather than as coverage to plan.
 
 Organization-wide, an **ownership report** returns every component that is not
 cleanly `OWNED`, together with its computed status. This is the practical

--- a/documentation_site/docs/configure/component-ownership.md
+++ b/documentation_site/docs/configure/component-ownership.md
@@ -14,17 +14,22 @@ have nobody durable behind them.
 Ownership is deliberately **separate from access**. Owning a component does not
 grant permissions on it, and holding permissions does not make you the owner.
 Access is configured under
-[Users and User Groups Permissions](./user-and-user-group-permissions).
+[Users and User Groups Permissions](./user-and-user-group-permissions);
+accountability is carried by a [team](./teams).
 
 ## Setting an owner
 
 Open a component, go to **Settings**, and use the **Owner** picker. You can
-name a team or an individual user.
+name a [team](./teams) or an individual user.
 
 Prefer a **team**. An individual owner is valid and ReARM records it, but a
 person leaves, and only a team can be a notification target -- a user has no
 channels of their own, so a route that notifies the component owner will not
 deliver for a user-owned component.
+
+The picker offers active teams only. If the component is already owned by a team
+that has since been archived, that team is still shown -- labelled as archived --
+so the stale owner is visible and replaceable rather than an empty field.
 
 ## Ownership status
 
@@ -34,7 +39,7 @@ it always reflects the current state of the owner it points at.
 | Status | Meaning |
 |---|---|
 | `OWNED` | A stored owner that is valid and durable. The healthy state. |
-| `NON_DURABLE` | Valid, but resting on a single point of failure: an individual owner, or a team with fewer than two direct members that is not SSO-backed. |
+| `NON_DURABLE` | Valid, but resting on a single point of failure: an individual owner, or a team whose roster is smaller than two people and that contains no SSO-backed group. |
 | `DEGRADED` | The owner still resolves but has weakened -- typically the owner team has been archived or made inactive. |
 | `UNSET` | No owner has been chosen, but ReARM can suggest a candidate team. |
 | `ORPHANED` | No owner and nothing to suggest, or a stored owner that no longer resolves. Needs a human. |
@@ -57,13 +62,21 @@ becomes orphaned silently. `NON_DURABLE` names that risk without treating it as
 a failure, which is why those components still receive notifications while
 still showing up on the at-risk report.
 
-A team counts as durable when it has at least **two** direct members, or when
-it is backed by an SSO group.
+A team counts as durable when its **roster** has at least **two** people, or
+when one of the [user groups it contains](./teams#what-a-team-holds) is
+SSO-backed. The roster is individual members plus everyone contributed by those
+groups, so a team of one named person that contains a five-person group is
+durable -- the five are on the team.
+
+The SSO clause exists because roster size alone would misjudge a team whose
+membership is managed elsewhere: an SSO-backed group can be one person today and
+ten tomorrow without anyone editing ReARM, so it is not a single point of
+failure in the way one hand-added name is.
 
 ## Assignment rules
 
 Setting an owner component by component does not scale. **Team assignment
-rules** (Organization Settings -> User Groups, org admins only) assign
+rules** (Organization Settings -> [Teams](./teams), org admins only) assign
 ownership in bulk: each rule pairs a regular expression against the component
 **name** with an owner team, and can optionally restrict itself to components
 only or products only.
@@ -94,10 +107,11 @@ When more than one source could decide an owner, ReARM resolves in this order:
 
 ## Finding components at risk
 
-On an individual component, the **Settings** panel shows the computed status
-next to the owner picker, along with the reason behind it -- for example that
-the owner team has fewer than two members, or that it was assigned by a
-particular rule rather than chosen directly.
+On an individual component, the **Settings** panel names the current owner. It
+does not report durability: that is a fleet-level question -- "which components
+have nobody durable behind them" -- and answering it one component at a time
+invites reading a single `NON_DURABLE` as a fault to fix rather than as coverage
+to plan.
 
 Organization-wide, an **ownership report** returns every component that is not
 cleanly `OWNED`, together with its computed status. This is the practical

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -15,9 +15,10 @@ Subscriptions, routes, and channel groups are available on **both** editions,
 as are the **Slack**, **Microsoft Teams**, and **Webhook** channel types.
 
 Pro adds two channel types -- **Email** and
-[**Microsoft Sentinel**](../integrations/sentinel) -- [**teams**](./teams) and
-the two route targets that depend on them, **teams** and **notify the component
-owner**, and [subscription filtering](#filters-severity-and-routes).
+[**Microsoft Sentinel**](../integrations/sentinel) -- [**teams**](./teams)
+themselves, the two route targets that depend on them (**team** and **notify the
+component owner**), and
+[subscription filtering](#filters-severity-and-routes).
 :::
 
 ## How it fits together
@@ -88,9 +89,9 @@ severity gate its event types can never satisfy, and keep vulnerability events
 on their own subscription when you want to gate by severity.
 :::
 
-Perspectives do **not** behave that way, despite the similar shape. Every event
-type -- release, approval and vulnerability alike -- carries its affected
-releases, so a perspective-scoped route matches on any of them. What it needs is
+Perspectives do **not** behave that way, despite the similar shape. Release,
+approval and vulnerability events all carry their affected releases, so a
+perspective-scoped route matches on any of them. What it needs is
 that the affected release's **component** actually belongs to one of the named
 perspectives; a component with no perspectives set matches no perspective-scoped
 route, whatever the event type.

--- a/documentation_site/docs/configure/notifications.md
+++ b/documentation_site/docs/configure/notifications.md
@@ -15,9 +15,9 @@ Subscriptions, routes, and channel groups are available on **both** editions,
 as are the **Slack**, **Microsoft Teams**, and **Webhook** channel types.
 
 Pro adds two channel types -- **Email** and
-[**Microsoft Sentinel**](../integrations/sentinel) -- two route targets,
-**teams** and **notify the component owner**, and
-[subscription filtering](#filters-severity-and-routes).
+[**Microsoft Sentinel**](../integrations/sentinel) -- [**teams**](./teams) and
+the two route targets that depend on them, **teams** and **notify the component
+owner**, and [subscription filtering](#filters-severity-and-routes).
 :::
 
 ## How it fits together
@@ -75,6 +75,26 @@ A subscription's `eventTypes` list controls what it can match:
   perspectives. This gates **delivery only** -- it does not change what appears
   in the in-app inbox or the bell.
 
+::: warning A minimum severity on a non-vulnerability subscription silences it entirely
+Only two event types carry a severity: `NEW_VULN_AFFECTS_RELEASES` and
+`VULNERABILITY_RECORD_UPDATED`. Release and approval events carry none, and a
+gate then compares against *nothing* rather than against zero -- so it does not
+match. A minimum severity on a release-only subscription therefore does not
+merely fail to narrow it, it **stops every event on that route**.
+
+This does not error and writes no delivery row you could go looking for. If a
+subscription you believe is correct has never fired, check whether it carries a
+severity gate its event types can never satisfy, and keep vulnerability events
+on their own subscription when you want to gate by severity.
+:::
+
+Perspectives do **not** behave that way, despite the similar shape. Every event
+type -- release, approval and vulnerability alike -- carries its affected
+releases, so a perspective-scoped route matches on any of them. What it needs is
+that the affected release's **component** actually belongs to one of the named
+perspectives; a component with no perspectives set matches no perspective-scoped
+route, whatever the event type.
+
 ::: warning Filters are not applied on Community Edition
 Filter evaluation is a Pro capability. On CE the evaluator is absent, and
 rather than dropping subscriptions it cannot evaluate, ReARM delivers them
@@ -95,12 +115,18 @@ delivers nothing, so the editor will not let you save one.
 |---|---|---|
 | **Channels** | The channels you name explicitly | CE and Pro |
 | **Channel groups** | Every channel in the named group | CE and Pro |
-| **Teams** | The named team's own notification channels | Pro |
+| **Teams** | The named [team](./teams)'s own notification channels | Pro |
 | **Notify the component owner** | The channels of whichever team owns the affected component | Pro |
 
 The last two are what let a route describe *who* should hear about something
 rather than *where* to send it. That distinction matters most for owner
 routing, described next.
+
+Both are resolved when the event fires, not when you save the subscription. A
+team that changes its channel, or a component that changes hands, is followed
+automatically -- and a team that is **archived** contributes nothing, so a route
+targeting only that team goes quiet without failing. See
+[Archiving a team](./teams#archiving-a-team).
 
 ### Notifying the component owner
 
@@ -138,6 +164,18 @@ default), so a flapping upstream signal won't repeat-fire the same alert to
 the same channel over and over. Test/synthetic events (see
 [Testing](#testing-channels-and-subscriptions) below) intentionally bypass
 dedup, so a test always produces a visible delivery.
+
+Setting the window to **0** turns dedup off for that subscription: every
+matching event is delivered, repeats included. That is the right setting for a
+low-volume signal you never want collapsed, and the wrong one if you are
+wondering why a repeated alert arrives repeatedly.
+
+::: tip You cannot demonstrate dedup with the Test button
+Because synthetic events skip dedup by design, testing a subscription twice
+always produces two deliveries no matter what the window is -- which reads
+exactly like dedup being broken. To see it working, cause the same *real* event
+twice inside the window and watch the second produce no row.
+:::
 
 ::: warning Per-subscription rate limit is not enforced yet
 The subscription rate-limit fields (`maxPerWindow` / `windowMinutes`) are
@@ -320,12 +358,19 @@ release-lifecycle or approval subscription can only be verified by causing the
 real event: transition a release, or open an actual approval request.
 :::
 
-::: tip A test on an owner-routed subscription can legitimately show nothing
-If the only route on the subscription
-[notifies the component owner](#notifying-the-component-owner), a test that
-reports no delivery usually means the component the test event landed on has no
-owner, or its owner team has no channel -- not that your filter or severity
-gate is wrong. Check ownership first; the result dialog says so too.
+::: tip A test can legitimately show nothing when the route resolves through something
+A route that names channels directly either delivers or has a filter or gate
+problem. A route that resolves through *something else* has a third
+possibility, and it is the likeliest one:
+
+- **Owner-routed** -- the component the test event landed on has no owner, or
+  its owner team has no channel.
+- **Team-targeted** -- the [team](./teams) is archived, or has no notification
+  channels of its own.
+
+In both cases your filter and severity gate are working perfectly and auditing
+them is wasted effort. The result dialog names the resolving target first for
+that reason.
 :::
 
 ::: warning A passing owner-routing test does not mean production will deliver

--- a/documentation_site/docs/configure/teams.md
+++ b/documentation_site/docs/configure/teams.md
@@ -15,8 +15,9 @@ holding permissions does not put you on a team. Access is configured with
 
 ::: tip Teams are a ReARM Pro capability
 On Community Edition the Teams tab reports that teams are not available on this
-server version, and the rest of Organization Settings works normally. Routes and
-components on CE address channels directly instead.
+server version, and the rest of Organization Settings works normally. Notification
+routes on CE address [channels and channel groups](./notifications#route-targets)
+directly, both of which are available on either edition.
 :::
 
 Only **organization admins** can see or edit teams.
@@ -85,9 +86,10 @@ of doing it explicitly:
 - A component owned by the team reports its ownership as `DEGRADED` -- the
   owner still resolves, but is no longer a usable notification target. See
   [Component ownership](./component-ownership#ownership-status).
-- The team is no longer offered when picking a *new* owner or route target.
-  Where it is already stored, it is shown labelled `(archived)` so you can see
-  what to replace.
+- The team is no longer offered when picking a *new* owner or route target,
+  while everywhere it is already stored keeps pointing at it. Archiving stops
+  the team being chosen again; it does not detach it from what it already owns
+  or serves, which is why the two consequences above are yours to clean up.
 
 ::: warning Archiving a team is a quiet way to stop notifications
 Nothing errors when a targeted team is archived: the subscription stays active,

--- a/documentation_site/docs/configure/teams.md
+++ b/documentation_site/docs/configure/teams.md
@@ -48,13 +48,14 @@ leads carry authority.
 1. Open **Organization Settings -> Teams** and click **Add team**.
 2. Give it a name (and optionally a description).
 3. Save, then edit it to add members, user groups, notification channels, and
-   leads. Those are only offered once the team exists, since each one is a
-   reference that has to resolve against a saved record.
+   leads. Creation deliberately takes a name and description only: everything
+   else arrives through the same update path, so each reference is validated by
+   exactly one piece of code rather than two that can drift.
 
-A team name must be unique within the organization, and archived teams still
-hold their names -- so if a name is refused and you cannot see the team using
-it, an archived team has it. Restore that team rather than working around the
-name.
+A team name must be unique within the organization, and archived teams keep
+their names. Try to reuse one and ReARM says so explicitly -- restore the
+archived team rather than working around the name. Archived teams stay listed
+on the Teams tab with status `INACTIVE`, so there is nothing hidden to hunt for.
 
 ## Why contain a user group instead of listing people
 
@@ -73,8 +74,9 @@ roster.
 
 ## Archiving a team
 
-Set a team to **inactive** rather than deleting it, and the record and its
-history stay intact. Archiving has real routing consequences, which is the point
+Use the **Archive** action on the team's row rather than deleting it -- there is
+no delete -- and the record and its history stay intact, with the team's status
+shown as `INACTIVE`. Archiving has real routing consequences, which is the point
 of doing it explicitly:
 
 - Notification routes that target the team **stop delivering**. The team
@@ -84,8 +86,8 @@ of doing it explicitly:
   owner still resolves, but is no longer a usable notification target. See
   [Component ownership](./component-ownership#ownership-status).
 - The team is no longer offered when picking a *new* owner or route target.
-  Where it is already stored it stays visible, labelled as archived, so you can
-  see it and replace it rather than finding an empty field.
+  Where it is already stored, it is shown labelled `(archived)` so you can see
+  what to replace.
 
 ::: warning Archiving a team is a quiet way to stop notifications
 Nothing errors when a targeted team is archived: the subscription stays active,

--- a/documentation_site/docs/configure/teams.md
+++ b/documentation_site/docs/configure/teams.md
@@ -1,0 +1,108 @@
+---
+sidebarDepth: 2
+---
+
+# Teams
+
+A **team** is the unit ReARM addresses when it needs to reach *people* rather
+than a destination: the owner of a component, or the target of a notification
+route. Teams live under **Organization Settings -> Teams**.
+
+Teams are deliberately **not** about access. A team grants no permissions, and
+holding permissions does not put you on a team. Access is configured with
+[user groups](./user-and-user-group-permissions); a team says who is
+*accountable*, a group says who can *do* things.
+
+::: tip Teams are a ReARM Pro capability
+On Community Edition the Teams tab reports that teams are not available on this
+server version, and the rest of Organization Settings works normally. Routes and
+components on CE address channels directly instead.
+:::
+
+Only **organization admins** can see or edit teams.
+
+## What a team holds
+
+| Field | What it does |
+|---|---|
+| **Name** and description | How the team is identified in pickers and reports |
+| **Members** | People added to this team individually |
+| **User groups** | Permission groups whose members are *also* on this team. Members arrive through the group, so a team can track an SSO-managed roster without anyone re-entering names |
+| **Notification channels** | Where this team is reachable -- its Slack channel, an email channel, and so on. This is what a [route targeting the team](./notifications#route-targets) and [owner routing](./notifications#notifying-the-component-owner) deliver to |
+| **Leads** | People who administer the team. **Recorded only today** -- leads grant no ability to edit the team yet |
+
+A team's **roster** is its individual members plus everyone contributed by its
+user groups. The roster is what durability is measured against, and it is
+recomputed on read, so a person joining an SSO group joins every team that
+contains it without anyone touching the team.
+
+Only people on the roster can be named as leads, and that is enforced against
+the roster the team will have *after* your edit. In the editor, dropping someone
+from members or removing a group drops them from the leads picker as you go; the
+same edit sent through the API is rejected rather than silently keeping them.
+A lead who is no longer on the team is a stale grant waiting to matter once
+leads carry authority.
+
+## Creating a team
+
+1. Open **Organization Settings -> Teams** and click **Add team**.
+2. Give it a name (and optionally a description).
+3. Save, then edit it to add members, user groups, notification channels, and
+   leads. Those are only offered once the team exists, since each one is a
+   reference that has to resolve against a saved record.
+
+A team name must be unique within the organization, and archived teams still
+hold their names -- so if a name is refused and you cannot see the team using
+it, an archived team has it. Restore that team rather than working around the
+name.
+
+## Why contain a user group instead of listing people
+
+Both work, and most teams use a mix. The distinction is where the roster is
+maintained:
+
+- **Members** are the right answer for people who belong to this team
+  specifically -- the two engineers who actually carry the pager for it.
+- **A contained user group** is the right answer when the roster is already
+  maintained somewhere else, usually an SSO group. Then joining and leaving is
+  handled by whoever manages that group, and the team follows.
+
+A group contained by a team still grants exactly the permissions it always did.
+Containing it changes nothing about access; it only adds its members to the
+roster.
+
+## Archiving a team
+
+Set a team to **inactive** rather than deleting it, and the record and its
+history stay intact. Archiving has real routing consequences, which is the point
+of doing it explicitly:
+
+- Notification routes that target the team **stop delivering**. The team
+  contributes no channels, and a route left with nothing else produces no
+  delivery at all -- silently, since nothing failed.
+- A component owned by the team reports its ownership as `DEGRADED` -- the
+  owner still resolves, but is no longer a usable notification target. See
+  [Component ownership](./component-ownership#ownership-status).
+- The team is no longer offered when picking a *new* owner or route target.
+  Where it is already stored it stays visible, labelled as archived, so you can
+  see it and replace it rather than finding an empty field.
+
+::: warning Archiving a team is a quiet way to stop notifications
+Nothing errors when a targeted team is archived: the subscription stays active,
+the event fans out, and zero deliveries are written. If notifications from a
+subscription stop for no apparent reason, check whether a team it targets was
+archived -- and note that a
+[subscription test](./notifications#testing-channels-and-subscriptions) will
+report no delivery without necessarily blaming the right thing.
+:::
+
+## Where teams are used
+
+- **[Notification routes](./notifications#route-targets)** can name a team as a
+  target, delivering to whatever channels that team currently has.
+- **[Component ownership](./component-ownership)** points at a team, directly or
+  through an assignment rule, which is what makes "notify the component owner"
+  resolvable.
+- **Durability** -- a team owning a component counts as durable when its roster
+  has at least two people, or when one of its contained groups is SSO-backed.
+  See [why durability is its own state](./component-ownership#why-durable-is-its-own-state).

--- a/documentation_site/docs/configure/user-and-user-group-permissions.md
+++ b/documentation_site/docs/configure/user-and-user-group-permissions.md
@@ -11,6 +11,14 @@ This guide describes administrator actions in **Organization Settings** for mana
 - Active/inactive user groups
 - Scoped permission behavior (organization, perspective, product/component)
 
+::: tip Groups grant access; teams carry accountability
+A user group decides what its members may *do*. It is not a notification target
+and it does not own anything. If you are looking for the thing a notification
+route or a component owner points at, that is a [team](./teams) -- which can
+contain a user group, so an SSO-managed roster serves both without being
+maintained twice.
+:::
+
 ## Prerequisites
 
 - You must be an **Organization Admin**.

--- a/documentation_site/docs/integrations/slack.md
+++ b/documentation_site/docs/integrations/slack.md
@@ -55,8 +55,8 @@ A channel on its own delivers nothing. Add a subscription under
 **Integrations -> Subscriptions** with the event types you care about and a
 route pointing at this channel. See
 [Notifications](../configure/notifications) for event types, filters, and the
-other route targets (channel groups, teams, and the affected component's
-owner).
+other route targets (channel groups, [teams](../configure/teams), and the
+affected component's owner).
 
 ::: tip Editing later
 Leave **Incoming-webhook URL** blank when editing an existing channel to keep


### PR DESCRIPTION
The notification and ownership pages were written before Teams became a
first-class entity. They referenced teams as something the reader was assumed
to already know, pointed at a tab that no longer hosts assignment rules, and
described durability by a rule that has since changed.

## New page: Teams

`configure/teams.md` -- what a team is (accountability, not access), what it
holds, why you would contain a user group instead of listing people, and what
archiving one actually does. That last part is the one worth writing down:
archiving a team silently stops delivery on every route targeting it and
degrades ownership of every component it owns, and nothing fails anywhere while
that happens.

## Corrected, each checked against the code rather than carried over

- Assignment rules live under **Organization Settings -> Teams** now, not User
  Groups (they moved with #281).
- Durability is measured against the team's **roster** -- members plus everyone
  contributed by contained user groups -- or a contained SSO-backed group. The
  old text said "two direct members", which now understates a team of one that
  contains a ten-person group.
- The component Settings panel no longer reports a durability status, so the
  page no longer says it does; it points at the ownership report, which is where
  a fleet-level question belongs.
- The owner picker offers active teams only but still shows an already-stored
  archived owner, labelled. Documented because the alternative reading of an
  empty picker is "this component has no owner".

## Added -- existing behaviour, undocumented, easy to get wrong

- A minimum severity on a subscription whose event types carry no severity does
  not narrow it, it **silences it completely**. Verified against
  `extractEventSeverity` and `severityGateMatches`.
- A dedup window of 0 means "deliver everything", and dedup **cannot** be
  demonstrated with the Test button, because synthetic events skip it by design.
  Testing twice always produces two deliveries, which reads exactly like dedup
  being broken.
- A test that reports no delivery has a third explanation beyond filter and gate
  whenever a route resolves through a team or an owner.

## One claim I set out to document and found to be false

The UI hint and the `perspectiveGateMatches` javadoc both say perspectives make
release and approval events "match nothing", because only vulnerability events
carry `affectedReleases`. They do carry them: `ReleaseChangeHookImpl` (created /
lifecycle / bom-diff) and `ApprovalEventNotifierImpl` (requested / resolved)
both stamp `buildAffectedReleases`, and that helper copies the component's
perspectives onto each entry. A perspective-scoped route matches those event
types fine -- what it needs is a component that belongs to the perspective.

The page now says that. The stale UI hint is fixed in #282; the identical
javadoc claim lives in rearm-saas and is on the board
(`t20260812-121545-31450`).

## Validation

`npm run docs:build` clean, with VitePress dead-link checking on (no
`ignoreDeadLinks`), so every new cross-reference and anchor resolves. Added
lines are plain ASCII.
