### PR TITLE
fix(ui): correct the perspectives hint, and name one team state one way

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -126,19 +126,23 @@
                         <div class="field-hint">
                             Perspectives gate what this subscription <strong>delivers</strong> — they do
                             not affect the in-app inbox or the bell. Leave empty for no restriction.
-                            Note they are resolved from the affected releases, which only vulnerability
-                            events carry: with perspectives set, release and approval events match
-                            nothing. Keep those on their own subscription.
+                            They are resolved from the event's affected releases, so a route only
+                            fires when an affected release's component belongs to one of the chosen
+                            perspectives -- a component with no perspectives set matches none of them.
                         </div>
-                        <!-- Perspectives have the SAME shape of trap as the minimum-severity gate
-                             above -- perspectiveGateMatches returns false when the event carries no
-                             affectedReleases -- yet this one is still shown for every event type,
-                             with a hint, rather than hidden. That is a deliberate asymmetry, not an
-                             oversight: severity is hidden because it can NEVER apply to a
-                             release-only subscription, whereas which events carry affectedReleases
-                             has not been confirmed the same way, and hiding a control on an
-                             unverified premise removes a feature people may be using. Tracked on the
-                             board to be settled one way or the other. -->
+                        <!-- This hint used to say perspectives are carried by vulnerability events
+                             only, so "release and approval events match nothing" with one set. That
+                             is FALSE, and it was the stated reason to hide this control the way the
+                             severity one is hidden. ReleaseChangeHookImpl (created / lifecycle /
+                             bom-diff) and ApprovalEventNotifierImpl (requested / resolved) both
+                             stamp ReleaseNotificationSupport.buildAffectedReleases onto the outbox
+                             payload, and that helper copies the COMPONENT's perspectives onto each
+                             AffectedRelease. So every event family carries them and this gate works
+                             on all of them; what it needs is a component IN the perspective. The
+                             same claim survives in perspectiveGateMatches' javadoc (rearm-saas) and
+                             is tracked on the board. Severity is genuinely different -- no producer
+                             resolves a severity outside the two vuln types -- which is why that one
+                             is hidden and this one is not. -->
 
                         <div class="routes-section">
                             <div class="routes-title">Destination</div>

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -504,8 +504,13 @@ const teamOptions = computed(() => {
     for (const r of subForm.value.routes) for (const t of (r.teams || [])) referenced.add(t)
     // Same shared builder as the channel picker, so the "keep dangling refs
     // visible and removable" behaviour cannot drift between the two.
+    //
+    // "(archived)" rather than "(deactivated)": the Teams tab calls the action
+    // Archive and reports "Team archived", and the assignment-rule picker
+    // already says archived. Three words for one state across three pickers is
+    // how an operator ends up wondering whether they mean different things.
     return withGhosts(selectable, teams.value, referenced,
-        (t: any, uuid) => t ? `${t.name} (deactivated)` : `(deleted team) ${String(uuid).slice(0, 8)}`)
+        (t: any, uuid) => t ? `${t.name} (archived)` : `(deleted team) ${String(uuid).slice(0, 8)}`)
 })
 
 const channelGroupOptions = computed(() =>


### PR DESCRIPTION
Two commits that were meant to be part of #282 but landed on the branch after it
merged -- the same way two commits missed #281 earlier. Cherry-picked onto main
unchanged.

**1. The perspectives hint states the opposite of what the code does.**

It says perspectives are "resolved from the affected releases, which only
vulnerability events carry: with perspectives set, release and approval events
match nothing". Every part of that is wrong. `ReleaseChangeHookImpl` stamps
`buildAffectedReleases` on RELEASE_CREATED, RELEASE_LIFECYCLE_CHANGED and
RELEASE_BOM_DIFF; `ApprovalEventNotifierImpl` does the same for both approval
events; and that helper copies the component's perspectives onto each entry. A
perspective-scoped route matches those event types perfectly well -- what it
needs is a component that belongs to the perspective, which is what the hint now
says.

This matters beyond the wording: the same false claim was the stated reason to
consider hiding the perspectives control alongside the minimum-severity one.
Severity really is inapplicable outside the two vuln event types; perspectives
are not, and hiding them would have removed a working feature on the strength of
a wrong comment.

**Docs #283 already documents the corrected behaviour**, so until this lands the
product and the documentation contradict each other.

**2. One word for one state.** Three pickers named the same team state three
ways: `(deactivated)` on route targets, `(archived)` on the owner and
assignment-rule pickers, with `INACTIVE` stored underneath and an **Archive**
action producing it. Nothing was broken, which is why it survived -- but an
operator reading "deactivated" in one picker and "archived" in the next has no
way to know they are the same state. Aligned on the verb the feature's own
control uses.

The identical false claim also survives in `perspectiveGateMatches`' javadoc in
rearm-saas; it is comment-only and tracked on the board
(`t20260812-121545-31450`).

**Validation:** 147 unit tests pass, build clean, added lines plain ASCII.
