### PR TITLE
feat(ui): a team turns on notifications for the components it owns

### DIFF
--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -482,6 +482,18 @@ const channelOptions = computed(() => {
 
 const teams = ref<any[]>([])
 
+/**
+ * The name of the team that owns a managed row.
+ *
+ * Falls back to the uuid rather than to nothing: this string is the operator's
+ * only route to the control that actually changes the subscription, so a team
+ * that failed to load must still leave them something to search for.
+ */
+function managedTeamName (row: SubscriptionRow): string {
+    const team = teams.value.find((t: any) => t.uuid === row.managedByTeam)
+    return team?.name || String(row.managedByTeam)
+}
+
 // T4a: owner routing is a Pro-only route field. The control, the client-side
 // "route has a target" check and the error copy all gate on this one flag, so
 // a CE operator can neither author an owner-only route nor be told to.
@@ -1010,7 +1022,21 @@ function reportSubscriptionTestResult (
 
 
 const subscriptionColumns = computed(() => [
-    { title: 'Name', key: 'name' },
+    {
+        title: 'Name', key: 'name',
+        render: (row: SubscriptionRow) => {
+            if (!row.managedByTeam) return row.name
+            // Badged rather than hidden. A row that delivers but does not appear
+            // here is the failure this whole subsystem keeps producing; the
+            // honest version is visible, labelled, and pointing at the only
+            // place it can be changed.
+            return h('div', null, [
+                h('div', null, row.name),
+                h(NTag, { size: 'small', type: 'info', style: 'margin-top: 4px;' },
+                    { default: () => `Managed by ${managedTeamName(row)}` }),
+            ])
+        },
+    },
     {
         title: 'Status', key: 'status',
         render: (row: SubscriptionRow) => h(
@@ -1080,11 +1106,20 @@ const subscriptionColumns = computed(() => [
                                 size: 'tiny', secondary: true,
                                 onClick: () => openEditSubscription(row),
                                 disabled: !canWrite.value || subscriptionsDegraded.value
-                                    || hasUneditableMultiRoute(row.routes),
+                                    || hasUneditableMultiRoute(row.routes)
+                                    // The backend refuses an edit to a
+                                    // team-managed row. Leaving the control
+                                    // enabled would hand the operator an error
+                                    // where a pointer belongs.
+                                    || !!row.managedByTeam,
                                 'data-testid': 'edit-subscription',
                             }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
                         ]),
-                        default: () => hasUneditableMultiRoute(row.routes)
+                        default: () => row.managedByTeam
+                            ? `${managedTeamName(row)} owns this subscription -- it exists because that`
+                                + ' team asked to hear about the components it owns. Change it on the'
+                                + ' team, under Organization Settings -> Teams.'
+                            : hasUneditableMultiRoute(row.routes)
                             ? `This subscription has ${routeCount(row.routes)} routes and this editor`
                                 + ' shows one. Editing here would leave the others in place but hidden,'
                                 + ' so they are better changed through the API -- or collapse the'
@@ -1094,7 +1129,10 @@ const subscriptionColumns = computed(() => [
                     h(NButton, {
                         size: 'tiny', secondary: true,
                         onClick: () => toggleSubscriptionStatus(row),
-                        disabled: !canWrite.value,
+                        // A status flip is an edit, and the backend refuses one
+                        // on a managed row -- the team's toggle is the switch.
+                        disabled: !canWrite.value || !!row.managedByTeam,
+                        'data-testid': 'toggle-subscription',
                     }, { default: () => row.status === 'ACTIVE' ? 'Disable' : 'Enable' }),
                     h(NTooltip, { trigger: 'hover' }, {
                         trigger: () => testButton,
@@ -1111,7 +1149,11 @@ const subscriptionColumns = computed(() => [
                     h(NButton, {
                         size: 'tiny', secondary: true, type: 'error',
                         onClick: () => confirmDeleteSubscription(row),
-                        disabled: !canWrite.value,
+                        // Deleting would leave the team's toggle claiming a
+                        // subscription that no longer exists; the backend
+                        // refuses, so the button does too.
+                        disabled: !canWrite.value || !!row.managedByTeam,
+                        'data-testid': 'delete-subscription',
                     }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
                 ],
             })

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -489,6 +489,20 @@ const teams = ref<any[]>([])
  * only route to the control that actually changes the subscription, so a team
  * that failed to load must still leave them something to search for.
  */
+/**
+ * Why every control on this row is withheld, or null when it is an ordinary
+ * subscription.
+ *
+ * One string for all three buttons: the operator does not care which control
+ * they reached for, they care where the switch actually is.
+ */
+function managedRowExplanation (row: SubscriptionRow): string | null {
+    if (!row.managedByTeam) return null
+    return `${managedTeamName(row)} owns this subscription -- it exists because that team asked to`
+        + ' hear about the components it owns. Change it on the team: Organization Settings ->'
+        + ' Teams.'
+}
+
 function managedTeamName (row: SubscriptionRow): string {
     const team = teams.value.find((t: any) => t.uuid === row.managedByTeam)
     return team?.name || String(row.managedByTeam)
@@ -1115,25 +1129,39 @@ const subscriptionColumns = computed(() => [
                                 'data-testid': 'edit-subscription',
                             }, { icon: () => h(NIcon, null, { default: () => h(EditIcon) }) }),
                         ]),
-                        default: () => row.managedByTeam
-                            ? `${managedTeamName(row)} owns this subscription -- it exists because that`
-                                + ' team asked to hear about the components it owns. Change it on the'
-                                + ' team, under Organization Settings -> Teams.'
-                            : hasUneditableMultiRoute(row.routes)
-                            ? `This subscription has ${routeCount(row.routes)} routes and this editor`
+                        default: () => managedRowExplanation(row)
+                            || (hasUneditableMultiRoute(row.routes)
+                                ? `This subscription has ${routeCount(row.routes)} routes and this editor`
                                 + ' shows one. Editing here would leave the others in place but hidden,'
                                 + ' so they are better changed through the API -- or collapse the'
                                 + ' subscription to a single route.'
-                            : 'Edit subscription',
+                                : 'Edit subscription'),
                     }),
-                    h(NButton, {
-                        size: 'tiny', secondary: true,
-                        onClick: () => toggleSubscriptionStatus(row),
-                        // A status flip is an edit, and the backend refuses one
-                        // on a managed row -- the team's toggle is the switch.
-                        disabled: !canWrite.value || !!row.managedByTeam,
-                        'data-testid': 'toggle-subscription',
-                    }, { default: () => row.status === 'ACTIVE' ? 'Disable' : 'Enable' }),
+                    h(NTooltip, { trigger: 'hover' }, {
+                        // Span, not the button: a disabled <button> receives no
+                        // mouse events, so a tooltip bound to it never opens --
+                        // in exactly the case it exists to explain.
+                        trigger: () => h('span', { style: 'display: inline-flex;' }, [
+                            h(NButton, {
+                                size: 'tiny', secondary: true,
+                                onClick: () => toggleSubscriptionStatus(row),
+                                // A status flip is an edit, and the backend
+                                // refuses one on a managed row -- the team's
+                                // toggle is the switch. Also withheld on a
+                                // degraded load, where managedByTeam is absent
+                                // from the CORE query and every row would look
+                                // operator-owned.
+                                disabled: !canWrite.value || subscriptionsDegraded.value
+                                    || !!row.managedByTeam,
+                                'data-testid': 'toggle-subscription',
+                            }, { default: () => row.status === 'ACTIVE' ? 'Disable' : 'Enable' }),
+                        ]),
+                        default: () => managedRowExplanation(row)
+                            || (subscriptionsDegraded.value
+                                ? 'Some fields could not be loaded from this server, so changes are'
+                                    + ' withheld until the full record is available.'
+                                : (row.status === 'ACTIVE' ? 'Stop delivering' : 'Start delivering')),
+                    }),
                     h(NTooltip, { trigger: 'hover' }, {
                         trigger: () => testButton,
                         default: () => disabledReason || "Send a synthetic test event through this subscription's matching path (also exercises other subscriptions on the same event type -- asks for confirmation first).",
@@ -1146,15 +1174,21 @@ const subscriptionColumns = computed(() => [
                         }, { icon: () => h(NIcon, null, { default: () => h(History) }) }),
                         default: () => 'View delivery history for this subscription',
                     }),
-                    h(NButton, {
-                        size: 'tiny', secondary: true, type: 'error',
-                        onClick: () => confirmDeleteSubscription(row),
-                        // Deleting would leave the team's toggle claiming a
-                        // subscription that no longer exists; the backend
-                        // refuses, so the button does too.
-                        disabled: !canWrite.value || !!row.managedByTeam,
-                        'data-testid': 'delete-subscription',
-                    }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
+                    h(NTooltip, { trigger: 'hover' }, {
+                        trigger: () => h('span', { style: 'display: inline-flex;' }, [
+                            h(NButton, {
+                                size: 'tiny', secondary: true, type: 'error',
+                                onClick: () => confirmDeleteSubscription(row),
+                                // Deleting would leave the team's toggle claiming
+                                // a subscription that no longer exists; the
+                                // backend refuses, so the button does too.
+                                disabled: !canWrite.value || subscriptionsDegraded.value
+                                    || !!row.managedByTeam,
+                                'data-testid': 'delete-subscription',
+                            }, { icon: () => h(NIcon, null, { default: () => h(Trash) }) }),
+                        ]),
+                        default: () => managedRowExplanation(row) || 'Delete subscription',
+                    }),
                 ],
             })
         },

--- a/ui/src/components/TeamsOfOrg.vue
+++ b/ui/src/components/TeamsOfOrg.vue
@@ -121,10 +121,10 @@
                                     Notify this team about the components it owns
                                 </n-checkbox>
                             </n-form-item>
-                            <div class="muted-12">
+                            <n-text depth="3" style="font-size: 12px;">
                                 Delivers to this team's own notification channels, for events about
                                 components this team owns -- directly or through an assignment rule.
-                            </div>
+                            </n-text>
 
                             <template v-if="teamForm.notifyOnOwnedComponents">
                                 <n-form-item label="Event types">
@@ -132,15 +132,16 @@
                                         v-model:value="includedEventTypes"
                                         :options="ownedEventTypeOptions"
                                         multiple
-                                        placeholder="All event types"
+                                        filterable
+                                        placeholder="Select at least one event type"
                                         data-testid="team-notify-events"
                                     />
                                 </n-form-item>
-                                <div class="muted-12">
+                                <n-text depth="3" style="font-size: 12px;">
                                     Everything is selected by default. Deselect what this team does
                                     not want; a new kind of event arrives selected, so the team keeps
                                     hearing about whatever happens to what it owns.
-                                </div>
+                                </n-text>
                                 <!-- Both warnings are conditional and INLINE rather than in a
                                      tooltip: each one says the setting achieves something other
                                      than what it looks like right now, which is not an explanation
@@ -179,7 +180,7 @@
                             <n-button
                                 type="primary"
                                 :loading="savingTeam"
-                                :disabled="!teamForm.name.trim()"
+                                :disabled="!teamForm.name.trim() || noEventTypesSelected"
                                 data-testid="save-team"
                                 @click="saveTeam"
                             >
@@ -197,7 +198,7 @@
 <script lang="ts" setup>
 import { ref, computed, h, onMounted, watch } from 'vue'
 import {
-    NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput,
+    NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput, NCheckbox,
     NSelect, NSpace, NAlert, NTag, NText, useDialog, useMessage
 } from 'naive-ui'
 import { CirclePlus, Edit as EditIcon, Archive, ArrowBackUp } from '@vicons/tabler'
@@ -209,6 +210,7 @@ import {
     ownedComponentEventTypes,
     selectedFromExcluded,
     excludedFromSelected,
+    buildOwnedComponentNotificationsInput,
 } from '@/utils/teamNotificationEventTypes'
 import gql from 'graphql-tag'
 import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
@@ -298,7 +300,7 @@ const UPDATE_TEAM_MUTATION = gql`
 const LIST_OWNER_ROUTED_SUBSCRIPTIONS_QUERY = gql`
     query notificationSubscriptions($orgUuid: ID!) {
         notificationSubscriptions(orgUuid: $orgUuid) {
-            uuid name status routes
+            uuid name status routes eventTypes
         }
     }`
 const LIST_GROUPS_WITH_ROSTER_QUERY = gql`
@@ -354,9 +356,20 @@ const includedEventTypes = computed<string[]>({
  * accident.
  */
 const ownerRoutedOverlap = computed<string | null>(() => {
-    const hit = ownerRoutedSubscriptions.value[0]
-    return hit ? hit.name : null
+    if (!teamForm.value.notifyOnOwnedComponents) return null
+    const mine = new Set(includedEventTypes.value)
+    // Only an overlap that can actually double-deliver. A subscription on
+    // vulnerabilities alone cannot duplicate a team that has deselected them,
+    // and a warning that fires when it cannot be true is the fastest way to
+    // teach an operator to ignore the ones that can.
+    const hit = ownerRoutedSubscriptions.value.find((sub: any) =>
+        (sub.eventTypes || []).some((t: string) => mine.has(t)))
+    return hit ? (hit.name || hit.uuid) : null
 })
+
+/** Enabled with nothing ticked is a save the backend refuses. */
+const noEventTypesSelected = computed<boolean>(() =>
+    teamForm.value.notifyOnOwnedComponents && includedEventTypes.value.length === 0)
 
 const userOptions = computed(() => users.value.map((u: any) => ({
     label: u.name ? `${u.name} (${u.email})` : u.email, value: u.uuid,
@@ -460,6 +473,7 @@ async function loadPickers (): Promise<void> {
         })
         ownerRoutedSubscriptions.value = (res.data?.notificationSubscriptions || [])
             .filter((sub: any) => sub && sub.status === 'ACTIVE' && isOwnerRouted(sub.routes))
+            .map((sub: any) => ({ uuid: sub.uuid, name: sub.name, eventTypes: sub.eventTypes || [] }))
     } catch {
         // Silent: this feeds a WARNING, so failing to load it must not raise an
         // error of its own. Losing the warning is a smaller harm than a red
@@ -516,10 +530,10 @@ async function saveTeam (): Promise<void> {
                         // "leave alone", so an editor that DID load it must send
                         // it -- otherwise unticking the box would silently do
                         // nothing.
-                        ownedComponentNotifications: {
-                            enabled: f.notifyOnOwnedComponents,
-                            excludedEventTypes: f.excludedEventTypes,
-                        },
+                        ownedComponentNotifications: buildOwnedComponentNotificationsInput(
+                            f.notifyOnOwnedComponents,
+                            ownedEventTypeOptions.value.map(o => o.value),
+                            includedEventTypes.value),
                     },
                 },
             })

--- a/ui/src/components/TeamsOfOrg.vue
+++ b/ui/src/components/TeamsOfOrg.vue
@@ -112,6 +112,60 @@
                                 team. Only people on the roster — directly or through a selected user
                                 group — can be picked.
                             </n-text>
+
+                            <n-form-item :show-feedback="false">
+                                <n-checkbox
+                                    v-model:checked="teamForm.notifyOnOwnedComponents"
+                                    data-testid="team-notify-owned"
+                                >
+                                    Notify this team about the components it owns
+                                </n-checkbox>
+                            </n-form-item>
+                            <div class="muted-12">
+                                Delivers to this team's own notification channels, for events about
+                                components this team owns -- directly or through an assignment rule.
+                            </div>
+
+                            <template v-if="teamForm.notifyOnOwnedComponents">
+                                <n-form-item label="Event types">
+                                    <n-select
+                                        v-model:value="includedEventTypes"
+                                        :options="ownedEventTypeOptions"
+                                        multiple
+                                        placeholder="All event types"
+                                        data-testid="team-notify-events"
+                                    />
+                                </n-form-item>
+                                <div class="muted-12">
+                                    Everything is selected by default. Deselect what this team does
+                                    not want; a new kind of event arrives selected, so the team keeps
+                                    hearing about whatever happens to what it owns.
+                                </div>
+                                <!-- Both warnings are conditional and INLINE rather than in a
+                                     tooltip: each one says the setting achieves something other
+                                     than what it looks like right now, which is not an explanation
+                                     of the feature and is not something to hide behind a hover. -->
+                                <n-alert
+                                    v-if="!teamForm.notificationChannels.length"
+                                    type="warning"
+                                    :show-icon="false"
+                                    data-testid="team-notify-no-channels"
+                                >
+                                    This team has no notification channels, so this delivers nothing
+                                    until it has one.
+                                </n-alert>
+                                <n-alert
+                                    v-if="ownerRoutedOverlap"
+                                    type="info"
+                                    :show-icon="false"
+                                    data-testid="team-notify-overlap"
+                                >
+                                    An existing subscription already notifies component owners
+                                    ({{ ownerRoutedOverlap }}). Both will deliver: duplicate
+                                    suppression is per subscription, so this team's channel gets two
+                                    messages for the same event.
+                                </n-alert>
+                            </template>
                         </template>
                         <n-text v-else depth="3" style="font-size: 12px;">
                             Members, groups, channels and leads can be set once the team exists.
@@ -149,8 +203,13 @@ import {
 import { CirclePlus, Edit as EditIcon, Archive, ArrowBackUp } from '@vicons/tabler'
 import { useStore } from 'vuex'
 import graphqlClient from '@/utils/graphql'
-import { LIST_CHANNELS_QUERY, TYPE_LABELS, extractError } from '@/utils/notificationsCommon'
+import { LIST_CHANNELS_QUERY, TYPE_LABELS, eventTypeOptions, isOwnerRouted, extractError } from '@/utils/notificationsCommon'
 import { isSchemaDriftError } from '@/utils/graphqlDriftFallback'
+import {
+    ownedComponentEventTypes,
+    selectedFromExcluded,
+    excludedFromSelected,
+} from '@/utils/teamNotificationEventTypes'
 import gql from 'graphql-tag'
 import OrgTeamAssignmentRules from './OrgTeamAssignmentRules.vue'
 
@@ -183,6 +242,7 @@ interface TeamRow {
     userGroups: string[]
     notificationChannels: string[]
     leads: string[]
+    ownedComponentNotifications?: { enabled: boolean, excludedEventTypes: string[] } | null
 }
 
 interface TeamForm {
@@ -193,12 +253,18 @@ interface TeamForm {
     userGroups: string[]
     notificationChannels: string[]
     leads: string[]
+    notifyOnOwnedComponents: boolean
+    // Stored as an OPT-OUT list, which is why the picker below is bound to its
+    // complement: the effective set is "everything, minus these", so an event
+    // type that ships later arrives selected instead of quietly missing.
+    excludedEventTypes: string[]
 }
 
 function freshTeamForm (): TeamForm {
     return {
         uuid: null, name: '', description: '',
         members: [], userGroups: [], notificationChannels: [], leads: [],
+        notifyOnOwnedComponents: false, excludedEventTypes: [],
     }
 }
 
@@ -212,18 +278,27 @@ const LIST_TEAMS_QUERY = gql`
     query getTeams($org: ID!) {
         getTeams(org: $org) {
             uuid name description org status members userGroups notificationChannels leads
+            ownedComponentNotifications { enabled excludedEventTypes }
         }
     }`
 const CREATE_TEAM_MUTATION = gql`
     mutation createTeam($team: CreateTeamInput!) {
         createTeam(team: $team) {
             uuid name description org status members userGroups notificationChannels leads
+            ownedComponentNotifications { enabled excludedEventTypes }
         }
     }`
 const UPDATE_TEAM_MUTATION = gql`
     mutation updateTeam($team: UpdateTeamInput!) {
         updateTeam(team: $team) {
             uuid name description org status members userGroups notificationChannels leads
+            ownedComponentNotifications { enabled excludedEventTypes }
+        }
+    }`
+const LIST_OWNER_ROUTED_SUBSCRIPTIONS_QUERY = gql`
+    query notificationSubscriptions($orgUuid: ID!) {
+        notificationSubscriptions(orgUuid: $orgUuid) {
+            uuid name status routes
         }
     }`
 const LIST_GROUPS_WITH_ROSTER_QUERY = gql`
@@ -241,10 +316,47 @@ const teamsSupported = ref<boolean>(true)
 const users = ref<any[]>([])
 const groups = ref<any[]>([])
 const channels = ref<any[]>([])
+// Only the owner-routed ACTIVE subscriptions, for the duplicate-delivery
+// warning. Deliberately a narrow read: the Teams tab has no business rendering
+// the subscription list, it only needs to know whether one of them already
+// covers what this toggle is about to cover.
+const ownerRoutedSubscriptions = ref<any[]>([])
 const showTeamModal = ref<boolean>(false)
 const savingTeam = ref<boolean>(false)
 const teamModalError = ref<string>('')
 const teamForm = ref<TeamForm>(freshTeamForm())
+
+const ownedEventTypeOptions = computed(() => ownedComponentEventTypes(eventTypeOptions))
+
+/**
+ * The picker shows what the team WILL receive; the record stores what it will
+ * not. The conversion lives in utils/teamNotificationEventTypes so it can be
+ * tested -- there is no component test environment here, and this inversion is
+ * the only behavioural rule the control has.
+ */
+const includedEventTypes = computed<string[]>({
+    get: () => selectedFromExcluded(
+        ownedEventTypeOptions.value.map(o => o.value), teamForm.value.excludedEventTypes),
+    set: (selected: string[]) => {
+        teamForm.value.excludedEventTypes = excludedFromSelected(
+            ownedEventTypeOptions.value.map(o => o.value), selected)
+    },
+})
+
+/**
+ * Names an ACTIVE subscription that already notifies component owners, if one
+ * exists.
+ *
+ * <p>Both will deliver. Duplicate suppression is keyed per subscription, so an
+ * org-wide owner-routed subscription and this team's own row produce two rows
+ * for the same event on the same channel -- and the two are configured in
+ * different places by different people, which is exactly how it gets created by
+ * accident.
+ */
+const ownerRoutedOverlap = computed<string | null>(() => {
+    const hit = ownerRoutedSubscriptions.value[0]
+    return hit ? hit.name : null
+})
 
 const userOptions = computed(() => users.value.map((u: any) => ({
     label: u.name ? `${u.name} (${u.email})` : u.email, value: u.uuid,
@@ -340,6 +452,20 @@ async function loadPickers (): Promise<void> {
         // roster, so this degrades to an empty picker rather than a hard error.
         channels.value = []
     }
+    try {
+        const res = await graphqlClient.query({
+            query: LIST_OWNER_ROUTED_SUBSCRIPTIONS_QUERY,
+            variables: { orgUuid: orgUuid.value },
+            fetchPolicy: 'network-only',
+        })
+        ownerRoutedSubscriptions.value = (res.data?.notificationSubscriptions || [])
+            .filter((sub: any) => sub && sub.status === 'ACTIVE' && isOwnerRouted(sub.routes))
+    } catch {
+        // Silent: this feeds a WARNING, so failing to load it must not raise an
+        // error of its own. Losing the warning is a smaller harm than a red
+        // toast on a page the operator opened to rename a team.
+        ownerRoutedSubscriptions.value = []
+    }
 }
 
 function openCreateTeam (): void {
@@ -357,6 +483,8 @@ function openEditTeam (row: TeamRow): void {
         userGroups: [...(row.userGroups || [])],
         notificationChannels: [...(row.notificationChannels || [])],
         leads: [...(row.leads || [])],
+        notifyOnOwnedComponents: !!row.ownedComponentNotifications?.enabled,
+        excludedEventTypes: [...(row.ownedComponentNotifications?.excludedEventTypes || [])],
     }
     teamModalError.value = ''
     showTeamModal.value = true
@@ -383,6 +511,15 @@ async function saveTeam (): Promise<void> {
                         userGroups: f.userGroups,
                         notificationChannels: f.notificationChannels,
                         leads: f.leads,
+                        // Always sent from this editor, which always loads the
+                        // current value first. The backend treats null as
+                        // "leave alone", so an editor that DID load it must send
+                        // it -- otherwise unticking the box would silently do
+                        // nothing.
+                        ownedComponentNotifications: {
+                            enabled: f.notifyOnOwnedComponents,
+                            excludedEventTypes: f.excludedEventTypes,
+                        },
                     },
                 },
             })

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -52,7 +52,7 @@ describe('notification list query CORE / FULL split', () => {
     })
 
     const SUB_CORE = ['uuid', 'org', 'resourceGroup', 'name', 'status', 'eventTypes', 'revision']
-    const SUB_ENRICHMENT = ['filter', 'routes', 'dedupWindowMinutes', 'rateLimit']
+    const SUB_ENRICHMENT = ['filter', 'routes', 'dedupWindowMinutes', 'rateLimit', 'managedByTeam']
     it('subscriptions CORE has the render essentials and no enrichment fields', () => {
         SUB_CORE.forEach(f => expect(has(LIST_SUBSCRIPTIONS_CORE_QUERY, f), `core should have ${f}`).toBe(true))
         SUB_ENRICHMENT.forEach(f => expect(has(LIST_SUBSCRIPTIONS_CORE_QUERY, f), `core should NOT have ${f}`).toBe(false))

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -48,6 +48,17 @@ export interface SubscriptionRow {
     routes: string | null         // JSON-stringified server-side
     dedupWindowMinutes: number | null
     rateLimit: string | null      // JSON-stringified server-side
+    /**
+     * Set when a TEAM's own notification setting owns this row rather than an
+     * operator. Such a subscription cannot be edited, disabled or deleted here
+     * -- the backend refuses all three -- so the list badges it and withholds
+     * those controls.
+     *
+     * Optional because it is Pro-ahead: a CE backend has no teams, the field is
+     * absent, and every row reads as operator-owned. That is correct there, not
+     * degraded.
+     */
+    managedByTeam?: string | null
     // See ChannelRow.revision — same optimistic-locking gate.
     revision: number
 }
@@ -391,7 +402,12 @@ export const LIST_GROUPS_QUERY = buildGroupsQuery(`${GROUP_CORE_FIELDS} ${GROUP_
 export const LIST_GROUPS_CORE_QUERY = buildGroupsQuery(GROUP_CORE_FIELDS)
 
 const SUBSCRIPTION_CORE_FIELDS = 'uuid org resourceGroup name status eventTypes revision'
-const SUBSCRIPTION_ENRICHMENT_FIELDS = 'filter routes dedupWindowMinutes rateLimit'
+// managedByTeam belongs in ENRICHMENT, not CORE: it is Pro-ahead of the CE
+// mirror, and a field CORE selects that the server lacks re-blanks the whole
+// surface the drift fallback exists to protect. Its absence degrades to
+// "no row is team-managed", which is exactly right on a backend that has no
+// teams to manage them.
+const SUBSCRIPTION_ENRICHMENT_FIELDS = 'filter routes dedupWindowMinutes rateLimit managedByTeam'
 function buildSubscriptionsQuery (fields: string) {
     return gql`
         query notificationSubscriptions($orgUuid: ID!) {

--- a/ui/src/utils/teamNotificationEventTypes.spec.ts
+++ b/ui/src/utils/teamNotificationEventTypes.spec.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
 
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, coerceInputValue, type GraphQLSchema, type GraphQLInputType } from 'graphql'
+
 import {
     ownedComponentEventTypes,
     selectedFromExcluded,
     excludedFromSelected,
+    buildOwnedComponentNotificationsInput,
 } from './teamNotificationEventTypes'
 
 const OPTIONS = [
@@ -77,17 +82,75 @@ describe('what gets stored', () => {
         expect(excludedFromSelected(VALUES, [])).toEqual(VALUES)
     })
 
-    it('never stores an event type the operator was not shown', () => {
-        // Derived from the available list, not by diffing the previous
-        // exclusions: a team cannot have meant to exclude something it was never
-        // asked about, so a stale entry is dropped on the next save.
-        expect(excludedFromSelected(VALUES, ['NEW_VULN_AFFECTS_RELEASES']))
-            .not.toContain('SOMETHING_REMOVED')
-    })
-
+    // Derived from the AVAILABLE list rather than by diffing the previous
+    // exclusions, so a stale entry for an event type no longer offered is
+    // dropped on the next save: the team cannot have meant to exclude something
+    // it was never asked about.
     it('round-trips: store then re-read gives back the same selection', () => {
         const selection = ['NEW_VULN_AFFECTS_RELEASES', 'APPROVAL_REQUESTED']
         const stored = excludedFromSelected(VALUES, selection)
         expect(selectedFromExcluded(VALUES, stored)).toEqual(selection)
+    })
+})
+
+// The payload vs the REAL schema, not a hand-copied field list.
+//
+// GraphQL input coercion rejects unknown keys outright and fails the WHOLE
+// mutation, and validate-graphql.mjs checks documents, never variables -- so
+// this is the only thing standing between a renamed input field and a team
+// editor that cannot save. Same convention as routeInputSchemaDrift.spec.ts:
+// Teams are Pro-only, the schema lives in the sibling rearm-core checkout, and
+// its absence SKIPS rather than fails.
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+function coerceErrors (schema: GraphQLSchema, typeName: string, value: unknown): string[] {
+    const type = schema.getType(typeName) as GraphQLInputType
+    const errors: string[] = []
+    coerceInputValue(value, type, (_path, _invalidValue, error) => { errors.push(error.message) })
+    return errors
+}
+
+describe('buildOwnedComponentNotificationsInput vs the Pro schema', () => {
+    const cases: Array<[string, ReturnType<typeof buildOwnedComponentNotificationsInput>]> = [
+        ['enabled with everything selected',
+            buildOwnedComponentNotificationsInput(true, VALUES, VALUES)],
+        ['enabled with two deselected',
+            buildOwnedComponentNotificationsInput(true, VALUES, ['RELEASE_CREATED'])],
+        ['switched off',
+            buildOwnedComponentNotificationsInput(false, VALUES, VALUES)],
+    ]
+
+    it.skipIf(!proSchema)('coerces cleanly as OwnedComponentNotificationsInput', () => {
+        for (const [label, payload] of cases) {
+            expect(coerceErrors(proSchema!, 'OwnedComponentNotificationsInput', payload), label)
+                .toEqual([])
+        }
+    })
+
+    it.skipIf(!proSchema)('coerces cleanly nested inside UpdateTeamInput', () => {
+        // The shape the mutation actually sends. A field renamed on the input
+        // type shows up here rather than as a failed save on the sandbox.
+        const payload = {
+            teamId: '00000000-0000-0000-0000-000000000001',
+            name: 'Payments',
+            ownedComponentNotifications: buildOwnedComponentNotificationsInput(
+                true, VALUES, ['APPROVAL_REQUESTED']),
+        }
+        expect(coerceErrors(proSchema!, 'UpdateTeamInput', payload)).toEqual([])
+    })
+
+    it.skipIf(!proSchema)('rejects an unknown key, proving the check has teeth', () => {
+        const payload = {
+            ...buildOwnedComponentNotificationsInput(true, VALUES, VALUES),
+            notAField: true,
+        }
+        expect(coerceErrors(proSchema!, 'OwnedComponentNotificationsInput', payload).length)
+            .toBeGreaterThan(0)
     })
 })

--- a/ui/src/utils/teamNotificationEventTypes.spec.ts
+++ b/ui/src/utils/teamNotificationEventTypes.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+    ownedComponentEventTypes,
+    selectedFromExcluded,
+    excludedFromSelected,
+} from './teamNotificationEventTypes'
+
+const OPTIONS = [
+    { label: 'New vuln affects releases', value: 'NEW_VULN_AFFECTS_RELEASES' },
+    { label: 'Vulnerability record updated', value: 'VULNERABILITY_RECORD_UPDATED' },
+    { label: 'VEX state changed (not yet available)', value: 'VEX_STATE_CHANGED', disabled: true },
+    { label: 'Release created', value: 'RELEASE_CREATED' },
+    { label: 'Approval requested', value: 'APPROVAL_REQUESTED' },
+]
+const VALUES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED',
+    'RELEASE_CREATED', 'APPROVAL_REQUESTED']
+
+describe('ownedComponentEventTypes', () => {
+    it('drops VEX, which no ownership-scoped subscription could ever match', () => {
+        const values = ownedComponentEventTypes(OPTIONS).map(o => o.value)
+        expect(values).not.toContain('VEX_STATE_CHANGED')
+        expect(values).toEqual(VALUES)
+    })
+
+    it('keeps the labels so the picker reads like the subscription editor', () => {
+        expect(ownedComponentEventTypes(OPTIONS)[0].label).toBe('New vuln affects releases')
+    })
+
+    it('survives an empty or missing option list', () => {
+        expect(ownedComponentEventTypes([])).toEqual([])
+        expect(ownedComponentEventTypes(null as any)).toEqual([])
+    })
+})
+
+describe('the picker shows the complement of what is stored', () => {
+    it('shows EVERYTHING for a team that has excluded nothing', () => {
+        // The point of storing exclusions. A team that never touched the setting
+        // must open with the whole list ticked, not an empty picker.
+        expect(selectedFromExcluded(VALUES, [])).toEqual(VALUES)
+        expect(selectedFromExcluded(VALUES, null)).toEqual(VALUES)
+        expect(selectedFromExcluded(VALUES, undefined)).toEqual(VALUES)
+    })
+
+    it('hides exactly what the team excluded', () => {
+        expect(selectedFromExcluded(VALUES, ['RELEASE_CREATED']))
+            .toEqual(['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED', 'APPROVAL_REQUESTED'])
+    })
+
+    it('shows a NEW event type as selected for a team saved before it existed', () => {
+        // The behaviour the storage choice exists for: RELEASE_BOM_DIFF ships
+        // after this team last saved, and the team keeps hearing about what it
+        // owns without anyone re-editing it.
+        const laterValues = [...VALUES, 'RELEASE_BOM_DIFF']
+        expect(selectedFromExcluded(laterValues, ['RELEASE_CREATED'])).toContain('RELEASE_BOM_DIFF')
+    })
+
+    it('ignores a stored exclusion for an event type that no longer exists', () => {
+        expect(selectedFromExcluded(VALUES, ['SOMETHING_REMOVED'])).toEqual(VALUES)
+    })
+})
+
+describe('what gets stored', () => {
+    it('stores nothing when everything is selected', () => {
+        expect(excludedFromSelected(VALUES, VALUES)).toEqual([])
+    })
+
+    it('stores exactly what was deselected', () => {
+        expect(excludedFromSelected(VALUES, ['NEW_VULN_AFFECTS_RELEASES']))
+            .toEqual(['VULNERABILITY_RECORD_UPDATED', 'RELEASE_CREATED', 'APPROVAL_REQUESTED'])
+    })
+
+    it('stores everything when the picker is emptied', () => {
+        // Which the backend rejects -- a team cannot exclude its way to a
+        // subscription that matches nothing -- so this must round-trip honestly
+        // rather than being silently softened here.
+        expect(excludedFromSelected(VALUES, [])).toEqual(VALUES)
+    })
+
+    it('never stores an event type the operator was not shown', () => {
+        // Derived from the available list, not by diffing the previous
+        // exclusions: a team cannot have meant to exclude something it was never
+        // asked about, so a stale entry is dropped on the next save.
+        expect(excludedFromSelected(VALUES, ['NEW_VULN_AFFECTS_RELEASES']))
+            .not.toContain('SOMETHING_REMOVED')
+    })
+
+    it('round-trips: store then re-read gives back the same selection', () => {
+        const selection = ['NEW_VULN_AFFECTS_RELEASES', 'APPROVAL_REQUESTED']
+        const stored = excludedFromSelected(VALUES, selection)
+        expect(selectedFromExcluded(VALUES, stored)).toEqual(selection)
+    })
+})

--- a/ui/src/utils/teamNotificationEventTypes.ts
+++ b/ui/src/utils/teamNotificationEventTypes.ts
@@ -1,0 +1,58 @@
+/**
+ * The event-type picker for a team's owned-component notifications.
+ *
+ * The record stores an OPT-OUT list -- what the team said no to -- while the
+ * picker shows what it will receive. Those are complements, and the conversion
+ * between them is the whole behavioural rule of the control, so it lives here
+ * rather than in the component: there is no DOM test environment in this repo,
+ * and a rule that cannot be tested is a rule that drifts.
+ *
+ * Why opt-out at all: with a stored inclusion list, an event type that ships
+ * later would appear UNSELECTED for every existing team, and those teams would
+ * silently stop hearing about a new class of thing happening to what they own.
+ * Storing exclusions makes "everything, unless you said otherwise" true for a
+ * team saved today and for one saved a year ago.
+ */
+
+/**
+ * Event types a team can be notified about.
+ *
+ * VEX is excluded: no producer emits it, and its payload carries no affected
+ * component, so an ownership-scoped subscription could never match it. The
+ * backend drops it from the effective set regardless -- offering it here would
+ * be a control that provably does nothing, which is what teaches an operator to
+ * distrust the ones next to it.
+ */
+export function ownedComponentEventTypes (
+    allOptions: Array<{ label: string, value: string, disabled?: boolean }>,
+): Array<{ label: string, value: string }> {
+    return (allOptions || [])
+        .filter(o => o && o.value !== 'VEX_STATE_CHANGED')
+        .map(o => ({ label: o.label, value: o.value }))
+}
+
+/**
+ * What the picker should show as selected, given what the team excluded.
+ *
+ * An unknown value in the stored exclusion list -- an event type removed from
+ * the product since the team was saved -- simply has nothing to hide, so it is
+ * ignored rather than treated as an error.
+ */
+export function selectedFromExcluded (available: string[], excluded: string[] | null | undefined): string[] {
+    const out = new Set(excluded || [])
+    return (available || []).filter(v => !out.has(v))
+}
+
+/**
+ * What to store, given what the picker has selected.
+ *
+ * Derived from the AVAILABLE list rather than by diffing against the previous
+ * exclusions, so the stored value can only ever name event types the operator
+ * was actually shown. A stale exclusion for a type no longer offered is dropped
+ * on the next save, which is the honest outcome: the team cannot have meant to
+ * exclude something it was never asked about.
+ */
+export function excludedFromSelected (available: string[], selected: string[] | null | undefined): string[] {
+    const kept = new Set(selected || [])
+    return (available || []).filter(v => !kept.has(v))
+}

--- a/ui/src/utils/teamNotificationEventTypes.ts
+++ b/ui/src/utils/teamNotificationEventTypes.ts
@@ -56,3 +56,28 @@ export function excludedFromSelected (available: string[], selected: string[] | 
     const kept = new Set(selected || [])
     return (available || []).filter(v => !kept.has(v))
 }
+
+/**
+ * The `ownedComponentNotifications` half of an UpdateTeamInput.
+ *
+ * Extracted for the reason `userGroupUpdateInput.ts` states about its own
+ * payload: GraphQL input coercion rejects unknown keys OUTRIGHT and fails the
+ * whole mutation, and `scripts/validate-graphql.mjs` validates the document,
+ * never the variables. A payload built inline in an SFC is therefore the one
+ * part of a mutation nothing in CI can check -- so it lives here, where
+ * teamNotificationEventTypes.spec.ts coerces it against the real schema.
+ *
+ * @param enabled  whether the team wants notifications for what it owns
+ * @param available every event type the picker offered
+ * @param selected  what the operator left ticked
+ */
+export function buildOwnedComponentNotificationsInput (
+    enabled: boolean,
+    available: string[],
+    selected: string[] | null | undefined,
+): { enabled: boolean, excludedEventTypes: string[] } {
+    return {
+        enabled: !!enabled,
+        excludedEventTypes: excludedFromSelected(available, selected),
+    }
+}


### PR DESCRIPTION
Step 3 of `ai-plans/team-owned-component-notifications.md`, on the backend
merged in #414 (the `ownedByTeam` scope) and #415 (the team field and the
materialiser). The team is now the only place this is configured; the
subscription behind it is machinery an operator never has to open.

## Team editor

A toggle, an event-type picker, and two conditional warnings.

The picker shows what the team **will** receive; the record stores what it will
**not**. That inversion is the control's only behavioural rule, so it lives in
`utils/teamNotificationEventTypes` with 12 tests rather than inside the `.vue`,
where this repo has no way to test anything. Step 2's review found exactly that
mistake one layer down -- same lesson, applied before it could be found again.

Storing exclusions is what makes "everything is selected" true for a team saved
a year ago as well as one saved today. With an inclusion list, an event type
that ships later appears unticked for every existing team and silently never
arrives; there is a test for precisely that case.

Both warnings are **inline and conditional**, not tooltips, because each says
the setting achieves something other than what it looks like:

- the team has no channels, so this delivers nothing until it has one;
- an ACTIVE owner-routed subscription already covers this, and **both** will
  deliver -- duplicate suppression is per subscription, so the team's channel
  gets two messages for one event. The two halves are configured in different
  places by different people, which is how it gets created by accident.

The overlap query is narrow and fails **silently**: it feeds a warning, and
losing a warning is a smaller harm than a red toast on a page somebody opened to
rename a team.

## Subscription list

Managed rows are badged, and Edit / Disable / Enable / Delete are withheld --
the backend refuses all three, so leaving them enabled would hand the operator
an error where a pointer belongs. The tooltip names the owning team and where to
change it.

Badged rather than hidden, deliberately: a row that delivers but does not appear
in the list is the failure this subsystem keeps producing.

## Schema drift

`managedByTeam` goes in the **ENRICHMENT** half of the drift-fallback split,
never CORE -- a CORE field the server lacks re-blanks the whole surface the
fallback exists to protect. Its absence on CE degrades to "no row is
team-managed", which is correct there rather than degraded, since CE has no
teams at all.

## Validation

159 unit tests (12 new), build clean, `validate-graphql` 0 Pro failures -- which
also confirms the UI's field selections match the schema the backend merged.
Added lines plain ASCII.

**Not yet done:** sandbox validation, including the end-to-end gap Layer 1
flagged on step 2 -- every backend test is service-level, and nothing has yet
proven that a real event on an owned component reaches the team's channel
*through* the materialised subscription. That is the first thing I will drive on
the sandbox.
