### PR TITLE
fix(ui): stop remounting the whole view on query-only navigation

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -358,7 +358,7 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { ComputedRef, computed, Ref, ref, h, watch } from 'vue'
+import { ComputedRef, computed, Ref, ref, h, watch, nextTick } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
 import { NButton, NCheckbox, NForm, NFormItem, NInput, NModal, NPagination, NPopover, NSelect, NotificationType, useNotification, SelectOption, NDataTable, NIcon, NSpace, NSpin, NTag, NTooltip, DataTableColumns, NSelect as NSelectComponent, NDropdown} from 'naive-ui'
@@ -498,6 +498,25 @@ if (route.query.release) {
     showReleaseUuid.value = route.query.release as string
     showReleaseModal.value = true
 }
+
+// Router navigations that only change ?release= no longer remount the view
+// (router-view keys on path), so apply them here. showRelease/close write
+// the URL via history.replaceState, which vue-router never sees — so this
+// watcher fires exclusively for real navigations (deep links from other
+// components, browser back/forward), never for local open/close.
+watch(() => route.query.release, (rel) => {
+    if (typeof rel === 'string' && rel) {
+        if (rel !== showReleaseUuid.value || !showReleaseModal.value) {
+            showReleaseUuid.value = rel
+            showReleaseModal.value = true
+        }
+    } else if (showReleaseModal.value) {
+        // Param removed by a navigation: mirror the old remount, which
+        // came back without the modal.
+        showReleaseModal.value = false
+        showReleaseUuid.value = ''
+    }
+})
 const showRelease = function(uuid: string) {
     showReleaseUuid.value = uuid
     showReleaseModal.value = true
@@ -2080,18 +2099,44 @@ async function handleRefreshVulnerabilityData() {
 
 const releaseRowkey = (row: any) => row.uuid
 
+// True while the URL watcher below writes the pagination refs: their
+// watchers must not push for URL-originated writes — restoring a
+// perPage entry would otherwise push a page-1 query and destroy the
+// forward history stack.
+let applyingPaginationFromUrl = false
+
 // Watch pagination changes and sync to route query parameters
 watch(currentPage, (newPage) => {
+    if (applyingPaginationFromUrl) return
     router.push({
         query: { ...route.query, branchReleasePage: newPage.toString() }
     })
 })
 
 watch(perPage, (newPerPage) => {
+    if (applyingPaginationFromUrl) return
     router.push({
         query: { ...route.query, branchReleasePerPage: newPerPage.toString(), branchReleasePage: '1' }
     })
     currentPage.value = 1
+})
+
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward re-applies URL pagination here; absent
+// params = the defaults, mirroring the old remount-initializer.
+watch(() => [route.query.branchReleasePage, route.query.branchReleasePerPage], async () => {
+    applyingPaginationFromUrl = true
+    try {
+        const page = parseInt(route.query.branchReleasePage as string) || 1
+        const size = parseInt(route.query.branchReleasePerPage as string) || 25
+        if (page !== currentPage.value) currentPage.value = page
+        if (size !== perPage.value) perPage.value = size
+        // Hold the flag through the watcher flush so the sync watchers
+        // above observe it.
+        await nextTick()
+    } finally {
+        applyingPaginationFromUrl = false
+    }
 })
 
 onCreated().then(() => {

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1082,7 +1082,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ComputedRef, ref, Ref, computed, h, onMounted } from 'vue'
+import { ComputedRef, ref, Ref, computed, h, onMounted, watch } from 'vue'
 import type { Component } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
@@ -1833,7 +1833,7 @@ function selectBranch (uuid: string) {
 function handleTabChange (tabName: string) {
     // Clear selected branch when switching tabs
     selectedBranchUuid.value = ''
-    
+
     router.push({
         name: isComponent.value ? 'ComponentsOfOrg' : 'ProductsOfOrg',
         params: {
@@ -1843,6 +1843,31 @@ function handleTabChange (tabName: string) {
         query: { ...route.query, tab: tabName }
     })
 }
+
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward across tab states must be applied to
+// local state here; absent param = the default tab, mirroring the old
+// remount-initializer. Local writes only — safe without a route guard.
+watch(() => route.query.tab, (t) => {
+    const next = (typeof t === 'string' && t) ? t : 'branches'
+    if (next !== selectedTab.value) {
+        selectedBranchUuid.value = ''
+        selectedTab.value = next
+    }
+})
+
+// Same for the settings-panel deep link. Open only while this view's route
+// is active (on route leave the param flips to the destination's and must
+// not trigger the async open cascade); closing on param removal mirrors
+// the old remount (which discarded the modal without an unsaved prompt).
+watch(() => route.query.componentSettingsView, async (v) => {
+    const here = route.name === 'ComponentsOfOrg' || route.name === 'ProductsOfOrg'
+    if (v === 'true' && here && !showComponentSettingsModal.value) {
+        await openComponentSettings()
+    } else if (v !== 'true' && showComponentSettingsModal.value) {
+        showComponentSettingsModal.value = false
+    }
+})
 
 const createBranchForm = ref<FormInst | null>(null)
 

--- a/ui/src/components/FindingAnalysisPage.vue
+++ b/ui/src/components/FindingAnalysisPage.vue
@@ -21,7 +21,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { NTabs, NTabPane } from 'naive-ui'
 import VulnerabilityAnalysis from './VulnerabilityAnalysis.vue'
@@ -39,9 +39,13 @@ function parseTab(q: unknown): TabKey {
     return 'findings'
 }
 
-onMounted(() => {
-    activeTab.value = parseTab(route.query.tab)
-})
+// The URL is the single source of tab truth: onTabChange only writes the
+// query, and this watcher applies it to local state. Immediate so the
+// deep-linked tab is honored on mount; reactive because query-only
+// navigations no longer remount the view (router-view keys on path).
+watch(() => route.query.tab, (q) => {
+    activeTab.value = parseTab(q)
+}, { immediate: true })
 
 function onTabChange(val: TabKey) {
     router.replace({ query: { ...route.query, tab: val } })

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -954,12 +954,25 @@ const fetchActualHistory = async function () {
 const switchTab = async function (t: InstTab) {
     activeTab.value = t
     await router.push({ query: { ...route.query, instTab: t } })
+    await lazyLoadTab(t)
+}
+
+async function lazyLoadTab(t: InstTab) {
     if (t === 'plan-history' && !planHistoryLoaded.value) {
         await fetchPlanHistory()
     } else if (t === 'actual-history' && !actualHistoryLoaded.value) {
         await fetchActualHistory()
     }
 }
+
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward must be applied to local state here.
+watch(() => route.query.instTab, async (t) => {
+    if ((t === 'instance' || t === 'plan-history' || t === 'actual-history') && t !== activeTab.value) {
+        activeTab.value = t
+        await lazyLoadTab(t)
+    }
+})
 
 // Auto-refetch when a date bound changes. Debounced so picking
 // both From and To in quick succession (or the picker emitting

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -966,11 +966,14 @@ async function lazyLoadTab(t: InstTab) {
 }
 
 // Query-only navigations no longer remount the view (router-view keys on
-// path), so browser back/forward must be applied to local state here.
+// path), so browser back/forward must be applied to local state here. An
+// absent/invalid param means the default tab, matching the pre-fix
+// remount-initializer behavior.
 watch(() => route.query.instTab, async (t) => {
-    if ((t === 'instance' || t === 'plan-history' || t === 'actual-history') && t !== activeTab.value) {
-        activeTab.value = t
-        await lazyLoadTab(t)
+    const next: InstTab = (t === 'instance' || t === 'plan-history' || t === 'actual-history') ? t : 'instance'
+    if (next !== activeTab.value) {
+        activeTab.value = next
+        await lazyLoadTab(next)
     }
 })
 

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -34,7 +34,15 @@
                          import is emitted into __returned__ as a VALUE. That defeats
                          esbuild's elision of vue's type-only `Component` export, and
                          the browser then rejects the module for a named export the
-                         optimized dep does not have. Keep the rename. -->
+                         optimized dep does not have. Keep the rename.
+
+                         Keyed by $route.path, NOT fullPath: query params carry
+                         UI state (sub-tabs, filters, deep-link modals), and a
+                         fullPath key forced a full view teardown + refetch on
+                         every query-only navigation — e.g. the Integrations
+                         active-count visibly re-counting on each sub-tab
+                         switch. Views that sync state to the query react to
+                         query changes with watchers instead. -->
                     <router-view v-slot="{ Component: RouteComponent }">
                         <template v-if="RouteComponent">
                             <Suspense>
@@ -43,7 +51,7 @@
                                     style="margin-left: 5px; margin-right: 5px;"
                                     class="nofloat viewWrapper"
                                     @routerViewEvent="routerViewEventHandle"
-                                    :key="$route.fullPath"
+                                    :key="$route.path"
                                 />
                             </Suspense>
                         </template>

--- a/ui/src/components/MostRecentReleasesPage.vue
+++ b/ui/src/components/MostRecentReleasesPage.vue
@@ -120,7 +120,7 @@ function syncUrl() {
     router.replace({ query: q })
 }
 
-onMounted(() => {
+function applyQueryToState() {
     if (route.query.fromDate) {
         const fromDate = new Date(route.query.fromDate as string)
         if (!isNaN(fromDate.getTime())) startDateValue.value = fromDate.getTime()
@@ -144,7 +144,15 @@ onMounted(() => {
     if (urlType === 'COMPONENT' || urlType === 'PRODUCT') {
         componentTypeValue.value = urlType
     }
-})
+}
+
+onMounted(applyQueryToState)
+
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward re-applies the URL here. Writing state
+// re-triggers syncUrl, but an identical query is a no-op navigation, so
+// this cannot loop.
+watch(() => [route.query.fromDate, route.query.toDate, route.query.limit, route.query.type], applyQueryToState)
 
 watch([startDateValue, endDateValue, effectiveLimit, componentTypeValue], syncUrl)
 </script>

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -946,6 +946,12 @@ async function switchSubTab(t: SubTab) {
     await router.push({ query: { ...route.query, integrationsTab: t } })
 }
 
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward must be applied to local state here.
+watch(() => route.query.integrationsTab, (t) => {
+    if (isSubTabAccessible(t) && t !== subTab.value) subTab.value = t
+})
+
 // ---- Data refs lifted from OrgSettings -------------------------------------
 const configuredIntegrations: Ref<string[]> = ref([])
 const ciIntegrations: Ref<any[]> = ref([])

--- a/ui/src/components/OrgIntegrations.vue
+++ b/ui/src/components/OrgIntegrations.vue
@@ -947,9 +947,13 @@ async function switchSubTab(t: SubTab) {
 }
 
 // Query-only navigations no longer remount the view (router-view keys on
-// path), so browser back/forward must be applied to local state here.
+// path), so browser back/forward must be applied to local state here. An
+// absent/invalid param means the default tab — the pre-fix remount re-ran
+// the initializer, and going back past the first sub-tab click must still
+// land on Catalog.
 watch(() => route.query.integrationsTab, (t) => {
-    if (isSubTabAccessible(t) && t !== subTab.value) subTab.value = t
+    const next: SubTab = isSubTabAccessible(t) ? t : 'catalog'
+    if (next !== subTab.value) subTab.value = next
 })
 
 // ---- Data refs lifted from OrgSettings -------------------------------------

--- a/ui/src/components/VulnerabilityAnalysis.vue
+++ b/ui/src/components/VulnerabilityAnalysis.vue
@@ -1516,6 +1516,25 @@ watch(selectedRelease, (newVal) => {
 watch([selectedType, selectedComponentProduct, selectedBranchFeatureSet, selectedRelease], () => {
     fetchAnalysisRecords()
 })
+
+// Query-only navigations no longer remount the view (router-view keys on
+// path), so browser back/forward re-applies the URL to the selectors here.
+// Each ref is only written when it differs, and the selector watchers above
+// re-push an identical query (a no-op navigation), so this cannot loop.
+watch(() => [route.query.type, route.query.componentProduct, route.query.branchFeatureSet, route.query.release, route.query.cveId], () => {
+    const qType = route.query.type as string
+    if ((qType === 'COMPONENT' || qType === 'PRODUCT') && qType !== selectedType.value) selectedType.value = qType
+    const qComp = (route.query.componentProduct as string) || ''
+    if (qComp !== selectedComponentProduct.value) selectedComponentProduct.value = qComp
+    const qBranch = (route.query.branchFeatureSet as string) || ''
+    if (qBranch !== selectedBranchFeatureSet.value) selectedBranchFeatureSet.value = qBranch
+    const qRelease = (route.query.release as string) || ''
+    if (qRelease !== selectedRelease.value) selectedRelease.value = qRelease
+    if (route.query.cveId && typeof route.query.cveId === 'string' && route.query.cveId !== selectedCveId.value) {
+        selectedCveId.value = route.query.cveId
+        showViewReleasesModal.value = true
+    }
+})
 </script>
 
 <style scoped>

--- a/ui/src/components/VulnerabilityAnalysis.vue
+++ b/ui/src/components/VulnerabilityAnalysis.vue
@@ -137,7 +137,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ref, computed, onMounted, watch, h, ComputedRef, Ref } from 'vue'
+import { ref, computed, onMounted, watch, nextTick, h, ComputedRef, Ref } from 'vue'
 import { NSpin, NDataTable, NTag, NSpace, NTooltip, NIcon, NInput, NSelect, NSkeleton, NSwitch, DataTableColumns } from 'naive-ui'
 import { useRoute, useRouter } from 'vue-router'
 import { Info20Regular } from '@vicons/fluent'
@@ -1477,14 +1477,24 @@ watch(myperspective, async () => {
     fetchAnalysisRecords()
 })
 
+// True while the URL watcher below is writing the selector refs. The
+// selector watchers must not run their clear-downstream + router.push
+// cascade for URL-originated writes: clearing would clobber sibling refs
+// applied in the same batch, and pushing would mutate history mid
+// back/forward (or, on route leave, append filter params to the
+// DESTINATION route's URL).
+let applyingFromUrl = false
+
 // Watch type changes
 watch(selectedType, () => {
+    if (applyingFromUrl) return
     clearDownstreamSelectors('type')
     router.push({ query: { ...route.query, type: selectedType.value, componentProduct: '', branchFeatureSet: '', release: '' } })
 })
 
 // Watch component/product changes
 watch(selectedComponentProduct, async (newVal) => {
+    if (applyingFromUrl) return
     clearDownstreamSelectors('component')
     if (newVal) {
         await fetchBranches()
@@ -1496,6 +1506,7 @@ watch(selectedComponentProduct, async (newVal) => {
 
 // Watch branch/feature set changes
 watch(selectedBranchFeatureSet, async (newVal) => {
+    if (applyingFromUrl) return
     clearDownstreamSelectors('branch')
     if (newVal) {
         await fetchReleases()
@@ -1507,32 +1518,58 @@ watch(selectedBranchFeatureSet, async (newVal) => {
 
 // Watch release changes
 watch(selectedRelease, (newVal) => {
+    if (applyingFromUrl) return
     const query = { ...route.query, release: newVal || undefined }
     if (!newVal) delete query.release
     router.push({ query })
 })
 
-// Watch any filter change to refetch analysis records
+// Watch any filter change to refetch analysis records. Deliberately NOT
+// gated on applyingFromUrl: back/forward must refetch for the restored
+// filters, and this watcher only fetches — it never pushes.
 watch([selectedType, selectedComponentProduct, selectedBranchFeatureSet, selectedRelease], () => {
     fetchAnalysisRecords()
 })
 
 // Query-only navigations no longer remount the view (router-view keys on
 // path), so browser back/forward re-applies the URL to the selectors here.
-// Each ref is only written when it differs, and the selector watchers above
-// re-push an identical query (a no-op navigation), so this cannot loop.
-watch(() => [route.query.type, route.query.componentProduct, route.query.branchFeatureSet, route.query.release, route.query.cveId], () => {
-    const qType = route.query.type as string
-    if ((qType === 'COMPONENT' || qType === 'PRODUCT') && qType !== selectedType.value) selectedType.value = qType
-    const qComp = (route.query.componentProduct as string) || ''
-    if (qComp !== selectedComponentProduct.value) selectedComponentProduct.value = qComp
-    const qBranch = (route.query.branchFeatureSet as string) || ''
-    if (qBranch !== selectedBranchFeatureSet.value) selectedBranchFeatureSet.value = qBranch
-    const qRelease = (route.query.release as string) || ''
-    if (qRelease !== selectedRelease.value) selectedRelease.value = qRelease
-    if (route.query.cveId && typeof route.query.cveId === 'string' && route.query.cveId !== selectedCveId.value) {
-        selectedCveId.value = route.query.cveId
-        showViewReleasesModal.value = true
+// Route-name guard: in-component route watchers also fire while NAVIGATING
+// AWAY (params flip to the destination's), and without the guard the leave
+// event would reset every selector against the dying component.
+watch(() => [route.query.type, route.query.componentProduct, route.query.branchFeatureSet, route.query.release, route.query.cveId], async () => {
+    if (route.name !== 'VulnerabilityAnalysis') return
+    applyingFromUrl = true
+    try {
+        const qType = route.query.type as string
+        const nextType = (qType === 'COMPONENT' || qType === 'PRODUCT') ? qType : 'COMPONENT'
+        if (nextType !== selectedType.value) selectedType.value = nextType
+        const qComp = (route.query.componentProduct as string) || ''
+        const compChanged = qComp !== selectedComponentProduct.value
+        if (compChanged) selectedComponentProduct.value = qComp
+        const qBranch = (route.query.branchFeatureSet as string) || ''
+        const branchChanged = qBranch !== selectedBranchFeatureSet.value
+        if (branchChanged) selectedBranchFeatureSet.value = qBranch
+        const qRelease = (route.query.release as string) || ''
+        if (qRelease !== selectedRelease.value) selectedRelease.value = qRelease
+        // The skipped selector watchers would have refreshed these option
+        // lists; do it here for the restored selection.
+        if (compChanged) {
+            branches.value = []
+            if (qComp) await fetchBranches()
+        }
+        if (compChanged || branchChanged) {
+            releases.value = []
+            if (qBranch) await fetchReleases()
+        }
+        if (route.query.cveId && typeof route.query.cveId === 'string' && route.query.cveId !== selectedCveId.value) {
+            selectedCveId.value = route.query.cveId
+            showViewReleasesModal.value = true
+        }
+        // Selector watchers flush after this async callback yields; keep the
+        // flag up through the flush so they see it, then release it.
+        await nextTick()
+    } finally {
+        applyingFromUrl = false
     }
 })
 </script>


### PR DESCRIPTION
## Problem

Switching Integrations sub-tabs (Catalog / Subscriptions / Channel groups) flickers the Catalog "N active" count (e.g. 5-6-7 back and forth). Same class of jank exists on every URL-synced tab/filter in the app.

## Root cause

`LeftNavBar`'s router-view is keyed by `$route.fullPath`, so **every query-only navigation destroys and remounts the entire route component**. Each Integrations sub-tab click remounted OrgSettings → OrgIntegrations, refiring the four catalog fetches (configured integrations, CI integrations, notification channels cached; BEAR always network-only) — the count climbs through their staggered arrivals on every click.

## Fix

- Key the router-view by `$route.path`. Entity identity lives in path params on every route, so entity→entity navigation still remounts; query changes leave the view alive.
- The five views that sync UI state to query params now apply query changes via watchers — this covers browser back/forward and cross-component query pushes, which previously worked only *because* of the remount:
  - `OrgIntegrations` (`integrationsTab`), `InstanceView` (`instTab` + lazy history fetch), `FindingAnalysisPage` (`tab` — its `onTabChange` wrote only the URL and depended on the remount entirely), `MostRecentReleasesPage` (date/limit/type), `VulnerabilityAnalysis` (filter chain + `cveId` modal deep-link, per-ref guards so identical re-pushes can't loop).
  - `OrgSettings` already watched its `tab`/`auditTab`/`policyTab` params — no change needed.

## Verification

- vue-tsc clean (pre-existing tsconfig deprecation notices aside), vitest 147/147, vite build green.
- psclaude smoke after branch image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)