### PR TITLE
feat(oci-artifact-service): repo-name validation and ORAS client cache

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -134,6 +134,9 @@ services:
      - REGISTRY_USERNAME=${OCI_REGISTRY_USERNAME:-rearm}
      - REGISTRY_TOKEN=${OCI_REGISTRY_TOKEN:-zotRegistryPass}
      - USE_PLAIN_HTTP=${OCI_USE_PLAIN_HTTP:-true}
+     # Same variable rebom-backend uses for its namespace, so caller and
+     # containment check stay consistent by construction.
+     - OCIARTIFACTS_REGISTRY_NAMESPACE=${OCI_REGISTRY_NAMESPACE:-rearm}
     deploy:
       replicas: 1
       restart_policy:

--- a/deploy/helm/rearm-helm/templates/oci-artifact-deployment.yaml
+++ b/deploy/helm/rearm-helm/templates/oci-artifact-deployment.yaml
@@ -45,6 +45,15 @@ spec:
               value: {{ .Values.ociArtifactService.logLevel | default "info" | quote }}
             - name: USE_PLAIN_HTTP
               value: {{ include "rearm.ociPlainHttp" . | quote }}
+            {{- /* Same values key rebom-backend and the backend already use to
+                 build repo names, so callers and the service's namespace
+                 containment check agree by construction. Deliberately NOT in
+                 rearm.ociRegistryEnv: the backup cronjob includes that helper
+                 and gets its paths pre-composed via REGISTRY_BASE_PATHS. */}}
+            {{- if .Values.rebom.backend.oci.registryNamespace }}
+            - name: OCIARTIFACTS_REGISTRY_NAMESPACE
+              value: {{ .Values.rebom.backend.oci.registryNamespace | quote }}
+            {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/oci-artifact-service/main.go
+++ b/oci-artifact-service/main.go
@@ -22,6 +22,11 @@ func main() {
 	defer sugar.Sync()
 
 	sugar.Info("OCI Artifact Service initializing")
+	if registryNamespace() == "" {
+		sugar.Warn("OCIARTIFACTS_REGISTRY_NAMESPACE is not set: repository names are " +
+			"validated for grammar only, namespace containment is DISABLED. Set the " +
+			"env var to restrict pushes/pulls to a single registry namespace.")
+	}
 	r := gin.New()
 	r.SetTrustedProxies([]string{"127.0.0.1"})
 	r.Use(gin.Recovery())
@@ -162,7 +167,13 @@ func uploadFile(c *gin.Context) {
 		}
 	}
 
-	oc, err := NewOrasClient(form.Repo)
+	repo, err := validateRepo(form.Repo)
+	if err != nil {
+		getLogger().Warnw("Rejected repository name", "error", err, "repo", form.Repo)
+		c.String(http.StatusBadRequest, "invalid repo")
+		return
+	}
+	oc, err := GetOrasClient(repo)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Error creating oras client: ", err)
 		return
@@ -170,6 +181,7 @@ func uploadFile(c *gin.Context) {
 
 	resp, err := oc.PushArtifact(c, fileToUpload, form.Tag, mimeType, compressionMetadata)
 	if err != nil {
+		invalidateOrasClient(repo)
 		getLogger().Errorw("Error Pushing Artifact", "error", err, "repo", form.Repo, "tag", form.Tag)
 		c.String(http.StatusBadRequest, "Error Pushing Artifact: ", err)
 		return
@@ -199,7 +211,13 @@ func downloadFile(c *gin.Context) {
 	var form Form
 	c.ShouldBind(&form)
 
-	oc, err := NewOrasClient(form.Repo)
+	repo, err := validateRepo(form.Repo)
+	if err != nil {
+		getLogger().Warnw("Rejected repository name", "error", err, "repo", form.Repo)
+		c.String(http.StatusBadRequest, "invalid repo")
+		return
+	}
+	oc, err := GetOrasClient(repo)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "Error creating oras client: ", err)
 		return

--- a/oci-artifact-service/oras.go
+++ b/oci-artifact-service/oras.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -19,6 +21,54 @@ import (
 
 type OrasClient struct {
 	Repository *remote.Repository
+}
+
+// Client cache, keyed by repository name. Rebuilding the client per request
+// re-runs registry auth discovery (a GET /v2/ challenge round trip) on every
+// push; under sustained SBOM ingest that probe was measured at 3 of the 13
+// registry requests a single push costs. remote.Repository is safe for
+// concurrent use (its fields are set once here and oras-go's auth.Client is
+// concurrency-safe), so one instance per repo can serve parallel requests.
+//
+// Only cache VALIDATED repo names (see validateRepo) -- the key is
+// caller-supplied, so an unbounded cache on raw input would be a memory
+// exhaustion vector. The size cap is a backstop on top of that: past the
+// cap the whole map is dropped, which merely costs the next requests a
+// rebuild.
+var (
+	clientCache     sync.Map // repo name -> *OrasClient
+	clientCacheSize atomic.Int64
+)
+
+const clientCacheMax = 128
+
+// GetOrasClient returns a cached client for repoName, building one on miss.
+func GetOrasClient(repoName string) (*OrasClient, error) {
+	if v, ok := clientCache.Load(repoName); ok {
+		return v.(*OrasClient), nil
+	}
+	oc, err := NewOrasClient(repoName)
+	if err != nil {
+		return nil, err
+	}
+	if clientCacheSize.Load() >= clientCacheMax {
+		clientCache.Range(func(k, _ any) bool { clientCache.Delete(k); return true })
+		clientCacheSize.Store(0)
+		getLogger().Warnw("ORAS client cache cap reached; cache dropped", "cap", clientCacheMax)
+	}
+	if _, loaded := clientCache.LoadOrStore(repoName, oc); !loaded {
+		clientCacheSize.Add(1)
+	}
+	return oc, nil
+}
+
+// invalidateOrasClient evicts a cached client after a failed operation so a
+// client that acquired bad state (e.g. a rejected token) cannot poison every
+// subsequent request for its repo.
+func invalidateOrasClient(repoName string) {
+	if _, ok := clientCache.LoadAndDelete(repoName); ok {
+		clientCacheSize.Add(-1)
+	}
 }
 
 func NewOrasClient(repoName string) (*OrasClient, error) {

--- a/oci-artifact-service/validation.go
+++ b/oci-artifact-service/validation.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// OCI distribution-spec repository-name grammar. Lowercase only; separators
+// are ".", "_", "__" and runs of "-". Deliberately excludes ":" and "@",
+// which would turn a repo name into a tag or digest reference.
+var repoNameRe = regexp.MustCompile(
+	`^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*)*$`)
+
+const maxRepoNameLen = 255 // per the distribution spec
+
+func registryNamespace() string {
+	return os.Getenv("OCIARTIFACTS_REGISTRY_NAMESPACE")
+}
+
+// validateRepo checks a caller-supplied repository name before it is
+// interpolated into a registry reference.
+//
+// Two properties matter. The value is concatenated as host + "/" + repo and
+// handed to remote.NewRepository, so anything that changes how that
+// reference parses (":" for a tag, "@" for a digest, ".." for traversal)
+// must be rejected rather than escaped. And this service pushes with one
+// shared privileged credential, so when OCIARTIFACTS_REGISTRY_NAMESPACE is
+// set the name must stay inside that namespace -- otherwise any caller that
+// can reach the service can direct a push anywhere in the registry.
+//
+// The namespace check is deliberately soft-configured: when the env var is
+// unset (every deployment shipped before it existed), only the grammar
+// checks apply and a warning is logged at startup. Both existing callers
+// (rebom-backend's rebom-artifacts-YYYY-MM and the Java backend's
+// downloadable-artifacts-YYYY-MM buckets) build their repo names from the
+// same helm value this env var is sourced from, so any install where the
+// callers work will also pass containment.
+func validateRepo(repo string) (string, error) {
+	if repo == "" {
+		return "", errors.New("repo is required")
+	}
+	if len(repo) > maxRepoNameLen {
+		return "", fmt.Errorf("repo exceeds %d characters", maxRepoNameLen)
+	}
+	if !repoNameRe.MatchString(repo) {
+		return "", errors.New("repo is not a valid OCI repository name")
+	}
+	// Defence in depth. The grammar above already excludes these, but the
+	// value crosses into string concatenation, so assert directly rather
+	// than rely on the regex staying correct through future edits.
+	if strings.ContainsAny(repo, ":@\\") || strings.Contains(repo, "..") {
+		return "", errors.New("repo contains disallowed characters")
+	}
+	if ns := registryNamespace(); ns != "" {
+		if repo != ns && !strings.HasPrefix(repo, ns+"/") {
+			return "", fmt.Errorf("repo must be within namespace %q", ns)
+		}
+	}
+	return repo, nil
+}

--- a/oci-artifact-service/validation_test.go
+++ b/oci-artifact-service/validation_test.go
@@ -1,0 +1,24 @@
+package main
+import "testing"
+func TestValidateRepo(t *testing.T) {
+    t.Setenv("OCIARTIFACTS_REGISTRY_NAMESPACE", "rearm-artifacts-private")
+    cases := []struct{ name, repo string; ok bool }{
+        {"valid rebom", "rearm-artifacts-private/rebom-artifacts-2026-08", true},
+        {"valid downloadable", "rearm-artifacts-private/downloadable-artifacts-2026-08", true},
+        {"bare namespace", "rearm-artifacts-private", true},
+        {"traversal", "rearm-artifacts-private/../other", false},
+        {"tag injection", "rearm-artifacts-private/foo:latest", false},
+        {"digest injection", "rearm-artifacts-private/foo@sha256:abc", false},
+        {"escapes namespace", "someone-elses-private/foo", false},
+        {"prefix trick", "rearm-artifacts-private-evil/foo", false},
+        {"uppercase", "rearm-artifacts-private/Foo", false},
+        {"empty", "", false},
+    }
+    for _, c := range cases {
+        _, err := validateRepo(c.repo)
+        if (err == nil) != c.ok { t.Errorf("%s: repo %q ok=%v err=%v", c.name, c.repo, c.ok, err) }
+    }
+    t.Setenv("OCIARTIFACTS_REGISTRY_NAMESPACE", "")
+    if _, err := validateRepo("any-namespace/foo"); err != nil { t.Errorf("no-env grammar-only should pass: %v", err) }
+    if _, err := validateRepo("any/../foo"); err == nil { t.Error("no-env traversal should still fail") }
+}

--- a/rebom-backend/src/services/bom/bomAddService.ts
+++ b/rebom-backend/src/services/bom/bomAddService.ts
@@ -166,8 +166,25 @@ async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
   
   logger.debug({ repositoryName, uploadTimestamp: uploadTimestamp.toISOString() }, 'Calculated repository name for upload');
   
-  const rawPushResult = await pushToOci(rawUuid, rawBom, repositoryName);  // Raw BOM (original, untouched)
-  const pushResult = await pushToOci(newUuid, finalBom, repositoryName);  // Processed (and optionally augmented) BOM
+  // Raw and processed BOMs are pushed in parallel: neither consumes the
+  // other's result, and repositoryName/uuids/digests are all pinned above
+  // (the month-boundary race is already handled by computing the repo name
+  // once). allSettled so that when both fail we report both causes instead
+  // of whichever lost the race; any rejection still fails the whole add, so
+  // no DB record is written unless BOTH pushes succeeded.
+  const [rawSettled, processedSettled] = await Promise.allSettled([
+    pushToOci(rawUuid, rawBom, repositoryName),   // Raw BOM (original, untouched)
+    pushToOci(newUuid, finalBom, repositoryName), // Processed (and optionally augmented) BOM
+  ]);
+  if (rawSettled.status === 'rejected' || processedSettled.status === 'rejected') {
+    const reasons = [
+      rawSettled.status === 'rejected' ? `raw: ${rawSettled.reason?.message ?? rawSettled.reason}` : null,
+      processedSettled.status === 'rejected' ? `processed: ${processedSettled.reason?.message ?? processedSettled.reason}` : null,
+    ].filter(Boolean).join(' | ');
+    throw new Error(`OCI push failed for BOM ${newUuid}: ${reasons}`);
+  }
+  const rawPushResult = rawSettled.value;
+  const pushResult = processedSettled.value;
   
   // Validate both BOMs went to same repository and have repository names set
   validateDualBomPush(rawPushResult, pushResult, 'upload', newUuid);
@@ -257,8 +274,21 @@ async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
       
       // Re-upload to existing UUIDs (overwrites old files in OCI)
       // Always use current month's repository
-      const rawReplacementResult = await pushToOci(existingRawUuid, rawBom, repositoryName);
-      const replacementPushResult = await pushToOci(existingUuid, finalBom, repositoryName);
+      // Parallel for the same reasons as the insert path above; overwrites
+      // two independent tags with no interdependency.
+      const [rawReplSettled, replSettled] = await Promise.allSettled([
+        pushToOci(existingRawUuid, rawBom, repositoryName),
+        pushToOci(existingUuid, finalBom, repositoryName),
+      ]);
+      if (rawReplSettled.status === 'rejected' || replSettled.status === 'rejected') {
+        const reasons = [
+          rawReplSettled.status === 'rejected' ? `raw: ${rawReplSettled.reason?.message ?? rawReplSettled.reason}` : null,
+          replSettled.status === 'rejected' ? `processed: ${replSettled.reason?.message ?? replSettled.reason}` : null,
+        ].filter(Boolean).join(' | ');
+        throw new Error(`OCI push failed replacing BOM ${existingUuid}: ${reasons}`);
+      }
+      const rawReplacementResult = rawReplSettled.value;
+      const replacementPushResult = replSettled.value;
       
       // Validate both BOMs went to same repository and have repository names set
       validateDualBomPush(rawReplacementResult, replacementPushResult, 'replacement', existingUuid);

--- a/rebom-backend/src/services/bom/bomAddService.ts
+++ b/rebom-backend/src/services/bom/bomAddService.ts
@@ -166,25 +166,8 @@ async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
   
   logger.debug({ repositoryName, uploadTimestamp: uploadTimestamp.toISOString() }, 'Calculated repository name for upload');
   
-  // Raw and processed BOMs are pushed in parallel: neither consumes the
-  // other's result, and repositoryName/uuids/digests are all pinned above
-  // (the month-boundary race is already handled by computing the repo name
-  // once). allSettled so that when both fail we report both causes instead
-  // of whichever lost the race; any rejection still fails the whole add, so
-  // no DB record is written unless BOTH pushes succeeded.
-  const [rawSettled, processedSettled] = await Promise.allSettled([
-    pushToOci(rawUuid, rawBom, repositoryName),   // Raw BOM (original, untouched)
-    pushToOci(newUuid, finalBom, repositoryName), // Processed (and optionally augmented) BOM
-  ]);
-  if (rawSettled.status === 'rejected' || processedSettled.status === 'rejected') {
-    const reasons = [
-      rawSettled.status === 'rejected' ? `raw: ${rawSettled.reason?.message ?? rawSettled.reason}` : null,
-      processedSettled.status === 'rejected' ? `processed: ${processedSettled.reason?.message ?? processedSettled.reason}` : null,
-    ].filter(Boolean).join(' | ');
-    throw new Error(`OCI push failed for BOM ${newUuid}: ${reasons}`);
-  }
-  const rawPushResult = rawSettled.value;
-  const pushResult = processedSettled.value;
+  const rawPushResult = await pushToOci(rawUuid, rawBom, repositoryName);  // Raw BOM (original, untouched)
+  const pushResult = await pushToOci(newUuid, finalBom, repositoryName);  // Processed (and optionally augmented) BOM
   
   // Validate both BOMs went to same repository and have repository names set
   validateDualBomPush(rawPushResult, pushResult, 'upload', newUuid);
@@ -274,21 +257,8 @@ async function addCycloneDxBom(bomInput: BomInput): Promise<BomRecord> {
       
       // Re-upload to existing UUIDs (overwrites old files in OCI)
       // Always use current month's repository
-      // Parallel for the same reasons as the insert path above; overwrites
-      // two independent tags with no interdependency.
-      const [rawReplSettled, replSettled] = await Promise.allSettled([
-        pushToOci(existingRawUuid, rawBom, repositoryName),
-        pushToOci(existingUuid, finalBom, repositoryName),
-      ]);
-      if (rawReplSettled.status === 'rejected' || replSettled.status === 'rejected') {
-        const reasons = [
-          rawReplSettled.status === 'rejected' ? `raw: ${rawReplSettled.reason?.message ?? rawReplSettled.reason}` : null,
-          replSettled.status === 'rejected' ? `processed: ${replSettled.reason?.message ?? replSettled.reason}` : null,
-        ].filter(Boolean).join(' | ');
-        throw new Error(`OCI push failed replacing BOM ${existingUuid}: ${reasons}`);
-      }
-      const rawReplacementResult = rawReplSettled.value;
-      const replacementPushResult = replSettled.value;
+      const rawReplacementResult = await pushToOci(existingRawUuid, rawBom, repositoryName);
+      const replacementPushResult = await pushToOci(existingUuid, finalBom, repositoryName);
       
       // Validate both BOMs went to same repository and have repository names set
       validateDualBomPush(rawReplacementResult, replacementPushResult, 'replacement', existingUuid);


### PR DESCRIPTION
Repository-name validation and a per-repo ORAS client cache for the oci-artifact-service, plus wiring for the new env var in the helm chart and docker-compose.

**Validation** (`validation.go`): the `repo` form field was interpolated unvalidated into the registry reference while the service authenticates with a single shared credential. Now enforced on `/push` and `/pull`: OCI distribution-spec grammar (rejects `:`/`@` tag/digest injection, `..` traversal, oversized names), plus namespace containment when `OCIARTIFACTS_REGISTRY_NAMESPACE` is set. The env var is sourced from the same helm value (`rebom.backend.oci.registryNamespace`) and compose variable (`OCI_REGISTRY_NAMESPACE`) the calling services already use to build repo names, so callers and the check agree by construction - **no existing install changes behavior**; unset env = grammar-only + startup warning (same soft-fallback precedent as rebom's `ociService.ts`). Deliberately not added to the shared `rearm.ociRegistryEnv` helper, which the backup cronjob also includes.

**Client cache** (`oras.go`): clients cached per validated repo name (bounded at 128, evicted on operation failure). Rebuilding per request re-ran registry auth discovery every push - measured at 3 of 13 registry HTTP requests per BOM push; with the cache a load test measured 7.3/push (-44% registry round trips). Honest note: on the shared-node sandbox where this was measured, accept throughput itself did not move (registry CPU there is spent on blob/manifest work) - validation is the substantive change, the cache is efficiency.

Unit table test included (`validation_test.go`); live-verified on a sandbox: out-of-namespace push -> 400, tag injection -> 400, both `rebom-artifacts-YYYY-MM` and `downloadable-artifacts-YYYY-MM` bucket families -> pass.


