### PR TITLE
feat(landing): Black Hat India 2026 Arsenal news post + announcement bar

### DIFF
--- a/landing_site/src/components/AnnounceBar.astro
+++ b/landing_site/src/components/AnnounceBar.astro
@@ -1,0 +1,66 @@
+---
+// Site-wide dismissible announcement bar above the header. One campaign at a
+// time: update the id, href and message together. Dismissal is remembered
+// per-campaign in localStorage, so a new id re-shows the bar for everyone.
+const id = 'bh-india-2026';
+const href = '/news/2026-08-18-rearm-ce-at-black-hat-india-2026-arsenal/';
+---
+
+<div class="announce" id="announce-bar" hidden>
+  <a class="announce-link" href={href}>
+    Meet us at Black Hat India 2026 in Bengaluru, Oct 29&ndash;30. Catch a live ReARM CE demo at Arsenal.
+  </a>
+  <button class="announce-close" id="announce-close" aria-label="Dismiss announcement">&#10005;</button>
+</div>
+
+<style>
+  .announce {
+    position: relative;
+    background: linear-gradient(90deg, var(--navy) 0%, var(--navy-grad-end) 60%, var(--navy-panel) 100%);
+    text-align: center;
+    padding: 9px 56px;
+  }
+  .announce-link {
+    color: #FFFFFF;
+    font-size: 14px;
+    font-weight: 600;
+    text-decoration: none;
+  }
+  .announce-link:hover { color: var(--mint); text-decoration: underline; }
+  .announce-close {
+    position: absolute;
+    right: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--dark-muted-2);
+    font-size: 15px;
+    line-height: 1;
+    padding: 6px;
+  }
+  .announce-close:hover { color: #FFFFFF; }
+  @media (max-width: 900px) {
+    .announce { padding: 8px 44px; }
+    .announce-link { font-size: 13px; }
+  }
+</style>
+
+<script is:inline define:vars={{ id }}>
+  (() => {
+    const key = 'rearm-announce-dismissed-' + id;
+    const bar = document.getElementById('announce-bar');
+    if (!bar) return;
+    try {
+      if (localStorage.getItem(key)) return;
+    } catch {}
+    bar.hidden = false;
+    document.getElementById('announce-close')?.addEventListener('click', () => {
+      bar.hidden = true;
+      try {
+        localStorage.setItem(key, '1');
+      } catch {}
+    });
+  })();
+</script>

--- a/landing_site/src/content/news/2026-08-18-rearm-ce-at-black-hat-india-2026-arsenal.md
+++ b/landing_site/src/content/news/2026-08-18-rearm-ce-at-black-hat-india-2026-arsenal.md
@@ -1,0 +1,18 @@
+---
+title: "ReARM CE at Black Hat India 2026"
+date: "2026-08-18"
+---
+
+We are excited to announce that ReARM CE has been selected for the **Arsenal** at [Black Hat India 2026](https://www.blackhat-india.com/arsenal-schedule#rearm-ce-answer-the-2-am-where-is-this-cve-shipping-question-across-your-whole-portfolio-60007) in Bengaluru!
+
+Rhythm Garg, who leads core engineering for ReARM at Reliza, will demo **ReARM CE: answer the 2 AM "where is this CVE shipping?" question across your whole portfolio** live on **Thursday, October 29, 12:00 PM at Arsenal Station 2 in the Black Hat Business Hall**, as part of the **Vulnerability Assessment** track.
+
+Three years into the SBOM mandate era, every build emits a CycloneDX or SPDX document - and almost nobody can query them. When a critical CVE drops, most teams still answer "is this dependency anywhere in our supply chain, and in which releases?" by grepping a bucket of JSON and asking around on Slack. Coverage without queryability is compliance theater. ReARM CE turns an accumulating pile of SBOMs, xBOMs, and security findings into a queryable, auditable evidence store, and at this Arsenal station attendees will drive it hands-on across three things tooling consistently can't do:
+
+- **Portfolio forensics** - paste a PURL and get every affected release across a multi-component portfolio in seconds, including products affected only through bundling; batch a real multi-package advisory; answer "what did we ship to customer X in March?"
+- **VEX as a workflow** - import a deliberately contradictory multi-statement CycloneDX VEX and watch it accept, stage, and reject statement by statement through a trust gate, then export your own triage downstream.
+- **Posture over time + agent observability** - diff a release's security posture between two points in time, and inspect ReARM CE's records of what autonomous agents did in the pipeline.
+
+Everything demoed is fully open source (AGPL-3.0), self-hostable, and reproducible against a public portfolio - you can manually install [ReARM CE](https://github.com/relizaio/rearm) and run every demo yourself.
+
+If you are attending Black Hat India 2026 (October 29-30, Sheraton Grand at Brigade Gateway, Bengaluru), stop by Arsenal Station 2 on October 29 - Rhythm would love to show you how ReARM turns SBOM compliance artifacts into a queryable, auditable release governance platform.

--- a/landing_site/src/layouts/Base.astro
+++ b/landing_site/src/layouts/Base.astro
@@ -1,4 +1,5 @@
 ---
+import AnnounceBar from '../components/AnnounceBar.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
@@ -74,6 +75,7 @@ const jsonLd = {
     />
   </head>
   <body>
+    <AnnounceBar />
     <Header active={active} />
     <main>
       <slot />


### PR DESCRIPTION
## Summary

- New news post: **ReARM CE at Black Hat India 2026** — Rhythm Garg demos *"ReARM CE: answer the 2 AM 'where is this CVE shipping?' question across your whole portfolio"* on Thursday, October 29, 12:00 PM at Arsenal Station 2, Black Hat Business Hall (conference days October 29-30, Sheraton Grand at Brigade Gateway, Bengaluru), with a link to the [Arsenal schedule entry](https://www.blackhat-india.com/arsenal-schedule#rearm-ce-answer-the-2-am-where-is-this-cve-shipping-question-across-your-whole-portfolio-60007).
- New `AnnounceBar.astro` component: dismissible site-wide announcement bar above the header on every page, linking to the news post. Dismissal is remembered per-campaign in localStorage (change the `id` in the component to launch a new campaign and re-show the bar). Styled with the existing design-system tokens (navy gradient, mint hover, square corners).
- Wired into `Base.astro` above `Header`.

## Validation

- `npm run build` clean (48 pages).
- Deployed to the local landing sandbox and verified live: banner renders on every page and links to the post, post renders correctly, dismissal persists across reloads, banner text/dates match the conference days (Oct 29-30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)