### PR TITLE
feat(notifications): instance-event subscription UI

### DIFF
--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -10,6 +10,7 @@
                         <n-icon class="clickable icons" title="Export as CycloneDX JSON" size="20" @click="exportCycloneDx"><Download /></n-icon>
                         <n-icon class="clickable icons" :title="instanceWord + ' Settings'" @click="showInstSettingsModal = true" size="20"><Tool /></n-icon>
                         <n-icon class="clickable icons" title="Refresh Instance Data" @click="onCreate" size="20"><Refresh /></n-icon>
+                        <n-icon v-if="canSubscribeToDeploymentNotifications" class="clickable icons" title="Subscribe to deployment notifications" @click="subscribeToDeploymentNotifications" size="20" data-testid="instance-subscribe"><Bell /></n-icon>
                     </h4>
                     <span v-if="updatedInstance.instanceType === InstanceType.CLUSTER_INSTANCE"> Part of Cluster: <router-link :to="{ name: 'Instance', params: {orguuid: orguuid, instuuid: cluster.uuid }}">{{ cluster.name }}</router-link></span>
                     <span v-if="updatedInstance.instanceType === InstanceType.CLUSTER_INSTANCE"> Namespace: {{updatedInstance.namespace}}</span>
@@ -447,6 +448,7 @@ import CreateRelease from '@/components/CreateRelease.vue'
 import SideBySide from '@/components/SideBySide.vue'
 import commonFunctions from '@/utils/commonFunctions'
 import { SwalData } from '@/utils/commonFunctions'
+import { isProEdition } from '@/utils/editionCapabilities'
 import { CaretDownFilled } from '@vicons/antd'
 import { Icon } from '@vicons/utils'
 import Swal from 'sweetalert2'
@@ -457,7 +459,7 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-json';
 import 'prismjs/themes/prism-tomorrow.css';
 import { AlertOff24Regular, AlertOn24Regular, Edit24Regular, Target20Regular, DismissCircle20Regular} from '@vicons/fluent'
-import { Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History } from '@vicons/tabler'
+import { Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History, Bell } from '@vicons/tabler'
 import { Commit } from '@vicons/carbon'
 import constants from '@/utils/constants'
 import CreateInstance from '@/components/CreateInstance.vue'
@@ -493,6 +495,29 @@ if (route.params.orguuid) {
 }
 
 const updatedInstance: Ref<any> = ref({})
+
+// The Subscribe deep-link lands on OrgSettings -> Integrations -> Subscriptions,
+// which is org-admin-only (integrations is an adminOnlyTab) and Pro-only
+// (instance events don't exist on CE). Gate the affordance on both so a
+// non-admin / CE user is never sent to a tab they can't open -- a control that
+// provably does nothing is worse than no control.
+const canSubscribeToDeploymentNotifications = computed<boolean>(() =>
+    isProEdition(myUser?.installationType) && commonFunctions.isAdmin(orguuid.value, myUser))
+
+// Deep-link to the org's notification subscriptions, pre-filled to notify on
+// this instance's deployments. SubscriptionsOfOrg reads newInstanceSub on mount
+// (Pro-only there) and opens a pre-filled create modal.
+function subscribeToDeploymentNotifications (): void {
+    router.push({
+        name: 'OrgSettings',
+        params: { orguuid: orguuid.value },
+        query: {
+            tab: 'integrations',
+            integrationsTab: 'subscriptions',
+            newInstanceSub: updatedInstance.value?.uri,
+        },
+    })
+}
 const envs: Ref<any[]> = ref([])
 
 // --- Tab state (URL-synced) ---

--- a/ui/src/components/SubscriptionsOfOrg.vue
+++ b/ui/src/components/SubscriptionsOfOrg.vue
@@ -59,45 +59,77 @@
                             </n-gi>
                         </n-grid>
 
-                        <n-form-item label="Event types">
-                            <n-select
-                                v-model:value="subForm.eventTypes"
-                                :options="eventTypeOptionsForForm"
-                                multiple
-                                placeholder="Pick one or more event types"
-                                data-testid="sub-eventtypes"
-                            />
-                        </n-form-item>
-                        <div class="field-hint">This subscription fires only when a selected event type is actually emitted. "VEX state changed" is reserved and not emitted yet, so it isn't selectable (an existing selection can still be removed).</div>
+                        <!-- ===== Section: which events ===== -->
+                        <div class="routes-section">
+                            <div class="routes-title">Events</div>
+                            <div class="routes-hint">Which events this subscription listens for.</div>
+                            <n-form-item label="Event types" :show-feedback="false">
+                                <n-select
+                                    v-model:value="subForm.eventTypes"
+                                    :options="eventTypeOptionsForForm"
+                                    multiple
+                                    placeholder="Pick one or more event types"
+                                    data-testid="sub-eventtypes"
+                                />
+                            </n-form-item>
+                            <div class="field-hint">Fires only when a selected event type is actually emitted. "VEX state changed" is reserved and not emitted yet, so it isn't selectable (an existing selection can still be removed).</div>
 
-                        <n-form-item label="Filter mode">
-                            <n-radio-group v-model:value="subForm.filterMode">
-                                <n-radio-button value="PRESET">Preset (match all selected event types)</n-radio-button>
-                                <n-radio-button value="ADVANCED">Advanced (CEL)</n-radio-button>
-                            </n-radio-group>
-                        </n-form-item>
-                        <n-form-item v-if="subForm.filterMode === 'ADVANCED'" label="CEL expression">
-                            <n-input
-                                v-model:value="subForm.celExpression"
-                                type="textarea"
-                                :autosize="{ minRows: 3, maxRows: 8 }"
-                                style="font-family: monospace; font-size: 12px;"
-                                placeholder='e.g. event.severity == "CRITICAL" && size(event.affectedReleases) > 0'
-                            />
-                        </n-form-item>
-                        <div v-if="subForm.filterMode === 'ADVANCED'" class="field-hint">
-                            A CEL boolean over the event. Examples:
-                            <code>event.severity == "CRITICAL"</code>,
-                            <code>event.kevListed == true</code>,
-                            <code>size(event.affectedReleases) &gt; 0</code>.
-                            Leave Preset mode to match on event type alone.
+                            <!-- Contextual: only for instance-deployment subscriptions, so
+                                 vuln/release subscriptions never see an irrelevant control. -->
+                            <template v-if="hasInstanceEventType">
+                                <n-form-item label="Instance-deployment templates" :show-feedback="false">
+                                    <n-select
+                                        v-model:value="selectedInstancePreset"
+                                        :options="instancePresetOptions"
+                                        placeholder="Optional: one-click setup for a common case"
+                                        clearable
+                                        @update:value="onInstancePresetPick"
+                                        data-testid="instance-preset"
+                                    />
+                                </n-form-item>
+                                <div class="field-hint">One-click filters for common instance-deployment setups (e.g. fully-converged only, or failures only). Adjust anything afterward.</div>
+                            </template>
                         </div>
 
-                        <!-- Severity and Perspectives live on the route in the
-                             backend model, but they are filters, not
-                             destinations, so they are grouped with the other
-                             filters here and written back onto the single
-                             route on save. -->
+                        <!-- ===== Section: when to deliver (filter) ===== -->
+                        <!-- Severity and Perspectives live on the route in the backend model,
+                             but they are filters (not destinations), so they are grouped with
+                             the other filters here and written back onto the route on save. -->
+                        <div class="routes-section">
+                            <div class="routes-title">When to deliver</div>
+                            <div class="routes-hint">By default every event of the selected types is delivered. Add filters below to narrow that down.</div>
+                            <n-form-item :show-feedback="false">
+                                <template #label>
+                                    <span style="display: inline-flex; align-items: center; gap: 6px;">
+                                        Custom filter (CEL)
+                                        <n-tooltip trigger="hover" style="max-width: 360px;">
+                                            <template #trigger>
+                                                <n-icon size="16" class="clickable"><InfoCircle /></n-icon>
+                                            </template>
+                                            Off: deliver every event of the selected types. On: only deliver events
+                                            matching a CEL boolean expression you provide.
+                                        </n-tooltip>
+                                    </span>
+                                </template>
+                                <n-switch v-model:value="advancedFilter" data-testid="filter-advanced-toggle" />
+                            </n-form-item>
+                            <div v-if="!advancedFilter" class="field-hint">Off — delivering every event of the selected types. Turn on to match only some events with an expression.</div>
+                            <n-form-item v-if="advancedFilter" label="CEL expression" :show-feedback="false">
+                                <n-input
+                                    v-model:value="subForm.celExpression"
+                                    type="textarea"
+                                    :autosize="{ minRows: 3, maxRows: 8 }"
+                                    style="font-family: monospace; font-size: 12px;"
+                                    placeholder='e.g. event.severity == "CRITICAL" && size(event.affectedReleases) > 0'
+                                />
+                            </n-form-item>
+                            <div v-if="advancedFilter" class="field-hint">
+                                A CEL boolean over the event. Examples:
+                                <code>event.severity == "CRITICAL"</code>,
+                                <code>event.kevListed == true</code>,
+                                <code>"CONVERGED" in event.statuses</code>.
+                            </div>
+
                         <n-grid :cols="2" :x-gap="12">
                             <n-gi v-if="severityApplies">
                                 <n-form-item label="Minimum severity">
@@ -144,6 +176,9 @@
                              resolves a severity outside the two vuln types -- which is why that one
                              is hidden and this one is not. -->
 
+                        </div>
+
+                        <!-- ===== Section: where (destination) ===== -->
                         <div class="routes-section">
                             <div class="routes-title">Destination</div>
                             <div class="routes-hint">
@@ -247,6 +282,9 @@
                             </div>
                         </div>
 
+                        <!-- ===== Section: delivery options ===== -->
+                        <div class="routes-section">
+                            <div class="routes-title">Delivery options</div>
                         <n-grid :cols="2" :x-gap="12">
                             <n-gi>
                                 <n-form-item label="Dedup window (minutes, optional)">
@@ -274,6 +312,7 @@
                                  enforcement lands, the control comes back and no data was lost
                                  in the meantime. -->
                         </n-grid>
+                        </div>
 
                         <n-alert v-if="subModalError" type="error" :show-icon="false">
                             {{ subModalError }}
@@ -309,10 +348,10 @@ import { useStore } from 'vuex'
 import {
     NDataTable, NButton, NIcon, NModal, NCard, NForm, NFormItem, NInput,
     NInputNumber, NSelect, NSpace, NAlert, NGrid, NGi, NTag, NDropdown, NTooltip,
-    NRadioGroup, NRadioButton, NCheckbox, useDialog, useMessage
+    NCheckbox, NSwitch, useDialog, useMessage
 } from 'naive-ui'
 import { InfoCircle, CirclePlus, Trash, Edit as EditIcon, Send, History } from '@vicons/tabler'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import gql from 'graphql-tag'
 import graphqlClient from '@/utils/graphql'
 import { buildChannelOptions, withGhosts } from '@/utils/channelOptions'
@@ -333,6 +372,9 @@ import {
     ownerRoutedSuccessCaveat,
     routeCount,
     hasUneditableMultiRoute,
+    instanceDeploymentPresets,
+    instanceSubscriptionPrefillForUri,
+    type InstanceSubscriptionPrefill,
     type SubscriptionTestOutcome
 } from '@/utils/notificationsCommon'
 import { loadWithSchemaDriftFallback } from '@/utils/graphqlDriftFallback'
@@ -354,6 +396,7 @@ const dialog = useDialog()
 const message = useMessage()
 const store = useStore()
 const router = useRouter()
+const route = useRoute()
 
 // Deep-link into the Delivery History audit surface, pre-filtered to this
 // subscription, so a user can go from "this subscription" straight to "what did
@@ -469,11 +512,52 @@ watch(severityApplies, () => {
 // selected: unselectable for new subs, still removable when editing an
 // existing VEX subscription (after removal it re-disables, no re-add).
 const eventTypeOptionsForForm = computed(() =>
-    eventTypeOptions.map(o =>
-        o.value === 'VEX_STATE_CHANGED'
-            ? { ...o, disabled: !subForm.value.eventTypes.includes('VEX_STATE_CHANGED') }
-            : o)
+    eventTypeOptions.map(o => {
+        if (o.value === 'VEX_STATE_CHANGED') {
+            return { ...o, disabled: !subForm.value.eventTypes.includes('VEX_STATE_CHANGED') }
+        }
+        // Pro-only event types (instance deployment) are unselectable on CE, but
+        // stay removable if somehow already selected -- same non-trapping logic
+        // as the VEX row above.
+        if ((o as { proOnly?: boolean }).proOnly && !isPro.value) {
+            return { ...o, disabled: !subForm.value.eventTypes.includes(o.value) }
+        }
+        return o
+    })
 )
+
+// Instance-deployment quick-start presets (Pro-only). Picking one pre-fills the
+// event types + filter mode + CEL so the common intents are one click; the user
+// can still adjust everything afterward. The select is a launcher, not a stored
+// field -- it resets to null after applying, so re-picking the same preset
+// re-applies. Severity is reconciled by the severityApplies watcher above when
+// eventTypes changes.
+const instancePresetOptions = instanceDeploymentPresets.map(p => ({ label: p.label, value: p.key }))
+const selectedInstancePreset = ref<string | null>(null)
+// The instance-deployment templates are contextual: shown only once the
+// subscription actually targets an instance event type, so vuln/release
+// subscriptions never see an irrelevant instance control.
+const INSTANCE_EVENT_TYPES = ['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED']
+const hasInstanceEventType = computed(() =>
+    (subForm.value.eventTypes || []).some(t => INSTANCE_EVENT_TYPES.includes(t)))
+
+// The filter is off by default (deliver every matching event); flipping it on
+// switches the backend filterMode to ADVANCED and reveals the CEL box. Modelled
+// as a boolean toggle rather than a two-option radio because the "no filter"
+// choice was reading as a confusing "all events of these types".
+const advancedFilter = computed<boolean>({
+    get: () => subForm.value.filterMode === 'ADVANCED',
+    set: (on: boolean) => { subForm.value.filterMode = on ? 'ADVANCED' : 'PRESET' },
+})
+function onInstancePresetPick (key: string | null): void {
+    const preset = instanceDeploymentPresets.find(p => p.key === key)
+    if (preset) {
+        subForm.value.eventTypes = [...preset.prefill.eventTypes]
+        subForm.value.filterMode = preset.prefill.filterMode
+        subForm.value.celExpression = preset.prefill.celExpression
+    }
+    selectedInstancePreset.value = null
+}
 
 const channelOptions = computed(() => {
     // Ghost handling for already-referenced DISABLED/DELETED channels lives in
@@ -682,6 +766,16 @@ function openCreateSubscription (): void {
     subForm.value = freshSubscriptionForm()
     subModalError.value = ''
     showSubscriptionModal.value = true
+}
+
+// Deep-link entry: open the create modal pre-filled (e.g. from the Instance
+// page's "Subscribe" action). Kept separate from openCreateSubscription so a
+// template @click's MouseEvent can never be mistaken for a prefill.
+function openCreateSubscriptionPrefilled (prefill: InstanceSubscriptionPrefill): void {
+    openCreateSubscription()
+    subForm.value.eventTypes = [...prefill.eventTypes]
+    subForm.value.filterMode = prefill.filterMode
+    subForm.value.celExpression = prefill.celExpression
 }
 
 function openEditSubscription (row: SubscriptionRow): void {
@@ -1212,6 +1306,18 @@ onMounted(async () => {
         loadSubscriptions(),
         store.dispatch('fetchPerspectives', orgUuid.value),
     ])
+    // Instance-page "Subscribe" deep-link: ?newInstanceSub=<uri> opens the
+    // create modal pre-filled to notify on this instance's deployments. Pro-only
+    // (instance events don't exist on CE) and writable-only (create needs it).
+    const uri = route.query.newInstanceSub
+    if (typeof uri === 'string' && uri && isPro.value && props.isWritable) {
+        openCreateSubscriptionPrefilled(instanceSubscriptionPrefillForUri(uri))
+        // Consume the one-shot deep-link param: this component remounts on every
+        // subtab switch, so leaving it in the URL would re-pop the modal each time.
+        const q = { ...route.query }
+        delete q.newInstanceSub
+        router.replace({ path: route.path, query: q })
+    }
 })
 </script>
 

--- a/ui/src/utils/notificationsCommon.spec.ts
+++ b/ui/src/utils/notificationsCommon.spec.ts
@@ -26,6 +26,8 @@ import {
     noDeliveryExplanation,
     severityAppliesTo,
     SEVERITY_BEARING_EVENT_TYPES,
+    instanceDeploymentPresets,
+    instanceSubscriptionPrefillForUri,
     clearInapplicableSeverity,
     routeCount,
     hasUneditableMultiRoute,
@@ -92,6 +94,14 @@ describe('unselectable options without a backend implementation', () => {
 
     it('keeps VEX_STATE_CHANGED unselectable while it has no event producer', () => {
         expect(option(eventTypeOptions, 'VEX_STATE_CHANGED')?.disabled).toBe(true)
+    })
+
+    it('offers the Pro-only instance-deployment event types, flagged proOnly', () => {
+        for (const v of ['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED']) {
+            const o = option(eventTypeOptions, v) as { proOnly?: boolean } | undefined
+            expect(o, `${v} present in eventTypeOptions`).toBeTruthy()
+            expect(o?.proOnly, `${v} is proOnly (gated to Pro in the form)`).toBe(true)
+        }
     })
 
 })
@@ -491,15 +501,19 @@ describe('severity gating', () => {
     // two event types resolve a severity, and severityGateMatches counts a null
     // severity as NO MATCH -- so a gate left on anything else silently suppresses
     // every event rather than doing nothing.
-    it('lists exactly the two severity-bearing event types', () => {
+    it('lists exactly the severity-bearing event types', () => {
         expect([...SEVERITY_BEARING_EVENT_TYPES].sort())
-            .toEqual(['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED'])
+            .toEqual(['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED',
+                'NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED'])
     })
 
     it('applies when any selected event type carries a severity', () => {
         expect(severityAppliesTo(['NEW_VULN_AFFECTS_RELEASES'])).toBe(true)
         expect(severityAppliesTo(['VULNERABILITY_RECORD_UPDATED'])).toBe(true)
         expect(severityAppliesTo(['RELEASE_CREATED', 'NEW_VULN_AFFECTS_RELEASES'])).toBe(true)
+        // Instance-deployment events carry a computed severity (extractEventSeverity).
+        expect(severityAppliesTo(['INSTANCE_DEPLOYMENT_CHANGED'])).toBe(true)
+        expect(severityAppliesTo(['INSTANCE_DEPLOYMENT_FAILED'])).toBe(true)
     })
 
     it('does not apply to release, approval or VEX events, or to nothing at all', () => {
@@ -508,6 +522,53 @@ describe('severity gating', () => {
             ['VEX_STATE_CHANGED'], [], null, undefined]) {
             expect(severityAppliesTo(types as any)).toBe(false)
         }
+    })
+})
+
+describe('instance-deployment presets', () => {
+    it('offers the three quick-start presets with sensible prefills', () => {
+        const byKey = Object.fromEntries(instanceDeploymentPresets.map(p => [p.key, p]))
+        expect(Object.keys(byKey).sort()).toEqual(['ALL_DEPLOYS', 'FAILURES_ONLY', 'FULLY_CONVERGED'])
+
+        // Fully converged: only the CHANGED type, CEL that excludes errors.
+        expect(byKey.FULLY_CONVERGED.prefill.eventTypes).toEqual(['INSTANCE_DEPLOYMENT_CHANGED'])
+        expect(byKey.FULLY_CONVERGED.prefill.filterMode).toBe('ADVANCED')
+        expect(byKey.FULLY_CONVERGED.prefill.celExpression).toContain('"CONVERGED" in event.statuses')
+        expect(byKey.FULLY_CONVERGED.prefill.celExpression).toContain('!("ERROR" in event.statuses)')
+
+        // Failures only: the actionable FAILED type, no filter needed.
+        expect(byKey.FAILURES_ONLY.prefill.eventTypes).toEqual(['INSTANCE_DEPLOYMENT_FAILED'])
+        expect(byKey.FAILURES_ONLY.prefill.filterMode).toBe('PRESET')
+        expect(byKey.FAILURES_ONLY.prefill.celExpression).toBe('')
+
+        // All deploys: both types, no filter.
+        expect([...byKey.ALL_DEPLOYS.prefill.eventTypes].sort())
+            .toEqual(['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED'])
+        expect(byKey.ALL_DEPLOYS.prefill.filterMode).toBe('PRESET')
+    })
+
+    it('every preset targets only Pro instance-deployment event types', () => {
+        const allowed = new Set(['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED'])
+        for (const p of instanceDeploymentPresets) {
+            for (const t of p.prefill.eventTypes) expect(allowed.has(t)).toBe(true)
+        }
+    })
+})
+
+describe('instanceSubscriptionPrefillForUri (deep-link)', () => {
+    it('scopes both instance event types to the instance uri via a CEL literal', () => {
+        const pf = instanceSubscriptionPrefillForUri('test.relizahub.com')
+        expect([...pf.eventTypes].sort())
+            .toEqual(['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED'])
+        expect(pf.filterMode).toBe('ADVANCED')
+        expect(pf.celExpression).toBe('event.instance.uri == "test.relizahub.com"')
+    })
+
+    it('embeds the uri as a JSON string literal so a quote cannot break out of the CEL', () => {
+        const pf = instanceSubscriptionPrefillForUri('evil" || true || "x')
+        // JSON.stringify escapes the embedded quotes -> no CEL injection.
+        expect(pf.celExpression).toBe('event.instance.uri == "evil\\" || true || \\"x"')
+        expect(pf.celExpression.startsWith('event.instance.uri == ')).toBe(true)
     })
 
     it('clears an inapplicable gate on EVERY route, not just the first', () => {

--- a/ui/src/utils/notificationsCommon.ts
+++ b/ui/src/utils/notificationsCommon.ts
@@ -166,6 +166,13 @@ export const eventTypeOptions = [
     { label: 'Release BOM diff', value: 'RELEASE_BOM_DIFF' },
     { label: 'Approval requested', value: 'APPROVAL_REQUESTED' },
     { label: 'Approval resolved', value: 'APPROVAL_RESOLVED' },
+    // Instance-deployment events are Pro-only (the Instance model + producer
+    // live in rearm-core). proOnly gates them out of the form on CE, mirroring
+    // how the VEX row is disabled -- see eventTypeOptionsForForm in
+    // SubscriptionsOfOrg.vue. FAILED is a separate type (not a status on CHANGED)
+    // so it can be actionable/immediate; see ai-plans/instance-event-notifications.md.
+    { label: 'Instance deployment changed', value: 'INSTANCE_DEPLOYMENT_CHANGED', proOnly: true },
+    { label: 'Instance deployment failed', value: 'INSTANCE_DEPLOYMENT_FAILED', proOnly: true },
 ]
 
 // Mirrors SyntheticEventTemplates.Template in rearm-core (backend/src/main/
@@ -210,12 +217,87 @@ export const severityOptions = [
  * minimum severity on a subscription with no vuln event type does not merely
  * have no effect, it silently gates out EVERY event, and the operator sees a
  * subscription that never fires with nothing on screen explaining why.
+ *
+ * <p>Instance-deployment events carry a computed severity (extractEventSeverity
+ * reads the payload: ERROR->HIGH, terminal->MEDIUM, churn->LOW), so a severity
+ * gate is meaningful for them too.
  */
-export const SEVERITY_BEARING_EVENT_TYPES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED']
+export const SEVERITY_BEARING_EVENT_TYPES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED',
+    'INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED']
 
 /** True when a minimum-severity gate can ever match, given these event types. */
 export function severityAppliesTo (eventTypes: string[] | null | undefined): boolean {
     return (eventTypes || []).some(t => SEVERITY_BEARING_EVENT_TYPES.includes(t))
+}
+
+/**
+ * The subset of the subscription form a quick-start preset (or the Instance-page
+ * "Subscribe" deep-link) pre-fills. filterMode 'ADVANCED' pairs with a non-empty
+ * celExpression; 'PRESET' means "match every selected event type" (no filter).
+ */
+export interface InstanceSubscriptionPrefill {
+    eventTypes: string[]
+    filterMode: 'PRESET' | 'ADVANCED'
+    celExpression: string
+}
+
+/**
+ * Named quick-start presets for instance-deployment notifications (Pro-only).
+ * Because the producer emits ONE settled event per deploy (see
+ * ai-plans/instance-event-notifications.md), these are about WHICH deploys, not
+ * which transitions. "Fully converged" leans on the CEL surface
+ * (`event.statuses` is a list of UpdateStatus names); "Failures only" simply
+ * subscribes to the actionable FAILED type.
+ */
+export const instanceDeploymentPresets: Array<{
+    key: string
+    label: string
+    description: string
+    prefill: InstanceSubscriptionPrefill
+}> = [
+    {
+        key: 'FULLY_CONVERGED',
+        label: 'Fully converged only',
+        description: 'Notify when a deploy settles with everything converged and no errors.',
+        prefill: {
+            eventTypes: ['INSTANCE_DEPLOYMENT_CHANGED'],
+            filterMode: 'ADVANCED',
+            celExpression: '"CONVERGED" in event.statuses && !("ERROR" in event.statuses)',
+        },
+    },
+    {
+        key: 'FAILURES_ONLY',
+        label: 'Failures only',
+        description: 'Notify only when a deploy settles with one or more errors.',
+        prefill: {
+            eventTypes: ['INSTANCE_DEPLOYMENT_FAILED'],
+            filterMode: 'PRESET',
+            celExpression: '',
+        },
+    },
+    {
+        key: 'ALL_DEPLOYS',
+        label: 'All instance deploys',
+        description: 'Notify on every settled deploy (converged, undeployed, or failed).',
+        prefill: {
+            eventTypes: ['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED'],
+            filterMode: 'PRESET',
+            celExpression: '',
+        },
+    },
+]
+
+/**
+ * Prefill for the Instance-page "Subscribe" deep-link: all instance-deployment
+ * events scoped to one instance by uri. The uri is embedded as a CEL string
+ * literal via JSON.stringify so quotes/backslashes can't break out of it.
+ */
+export function instanceSubscriptionPrefillForUri (uri: string): InstanceSubscriptionPrefill {
+    return {
+        eventTypes: ['INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED'],
+        filterMode: 'ADVANCED',
+        celExpression: `event.instance.uri == ${JSON.stringify(uri || '')}`,
+    }
 }
 
 /**

--- a/ui/src/utils/teamNotificationEventTypes.spec.ts
+++ b/ui/src/utils/teamNotificationEventTypes.spec.ts
@@ -17,14 +17,18 @@ const OPTIONS = [
     { label: 'VEX state changed (not yet available)', value: 'VEX_STATE_CHANGED', disabled: true },
     { label: 'Release created', value: 'RELEASE_CREATED' },
     { label: 'Approval requested', value: 'APPROVAL_REQUESTED' },
+    { label: 'Instance deployment changed', value: 'INSTANCE_DEPLOYMENT_CHANGED' },
+    { label: 'Instance deployment failed', value: 'INSTANCE_DEPLOYMENT_FAILED' },
 ]
 const VALUES = ['NEW_VULN_AFFECTS_RELEASES', 'VULNERABILITY_RECORD_UPDATED',
     'RELEASE_CREATED', 'APPROVAL_REQUESTED']
 
 describe('ownedComponentEventTypes', () => {
-    it('drops VEX, which no ownership-scoped subscription could ever match', () => {
+    it('drops event types with no affected component (VEX + instance-deployment)', () => {
         const values = ownedComponentEventTypes(OPTIONS).map(o => o.value)
         expect(values).not.toContain('VEX_STATE_CHANGED')
+        expect(values).not.toContain('INSTANCE_DEPLOYMENT_CHANGED')
+        expect(values).not.toContain('INSTANCE_DEPLOYMENT_FAILED')
         expect(values).toEqual(VALUES)
     })
 

--- a/ui/src/utils/teamNotificationEventTypes.ts
+++ b/ui/src/utils/teamNotificationEventTypes.ts
@@ -17,17 +17,23 @@
 /**
  * Event types a team can be notified about.
  *
- * VEX is excluded: no producer emits it, and its payload carries no affected
- * component, so an ownership-scoped subscription could never match it. The
- * backend drops it from the effective set regardless -- offering it here would
- * be a control that provably does nothing, which is what teaches an operator to
+ * Excluded here are the event types whose payload carries no affected component,
+ * so an ownership-scoped subscription could never match them -- VEX, and the
+ * instance-deployment events (org/instance-scoped, not component-owner scoped).
+ * This mirrors NotificationEventType.carriesAffectedComponents on the backend,
+ * which drops them from the effective set regardless: offering one here would be
+ * a control that provably does nothing, which is what teaches an operator to
  * distrust the ones next to it.
  */
+export const EVENT_TYPES_WITHOUT_AFFECTED_COMPONENTS = new Set([
+    'VEX_STATE_CHANGED', 'INSTANCE_DEPLOYMENT_CHANGED', 'INSTANCE_DEPLOYMENT_FAILED',
+])
+
 export function ownedComponentEventTypes (
     allOptions: Array<{ label: string, value: string, disabled?: boolean }>,
 ): Array<{ label: string, value: string }> {
     return (allOptions || [])
-        .filter(o => o && o.value !== 'VEX_STATE_CHANGED')
+        .filter(o => o && !EVENT_TYPES_WITHOUT_AFFECTED_COMPONENTS.has(o.value))
         .map(o => ({ label: o.label, value: o.value }))
 }
 


### PR DESCRIPTION
## What

UI for instance-event deployment notifications. Backend companion: relizaio/rearm-saas#441.

- **Bell "subscribe" action** on `InstanceView`, Pro-gated + org-admin gated.
- **SubscriptionsOfOrg:** instance-deployment event types (`proOnly`); a presets-vs-custom CEL filter **toggle** replacing the confusing filter radio; regrouped into Events / When to deliver / Destination / Delivery options sections; a one-shot deep-link prefill from the instance view (CEL-injection-safe via `JSON.stringify`).
- Instance event types excluded from affected-components handling, mirroring the existing VEX non-trapping pattern.

## Validation

- **`vitest` suite green: 166/166** (13 files) -- run manually (no CI runs this suite).
- Verified live in the sandbox against the backend feature (subscription create + delivery to Slack).

## Self-review (two-layer gate)

- **Layer 1 (correctness):** clean. Minor noted: the CEL toggle leaves a previously-typed expression in `celExpression` when switched to PRESET -- confirmed `saveSubscription` drops CEL for PRESET mode, so it does not persist.
- **Layer 2 (ReARM conventions):** Pro-gating mirrors the VEX pattern; deep-link prefill is CEL-injection-safe and tested; explicit naive-ui imports (`NSwitch`); no new deps. User-facing UI copy em-dash left per the ASCII rule's UI-copy exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)