### PR TITLE
fix(landing_site): resolve ogImage paths against the correct asset folder

### DIFF
--- a/landing_site/src/content/news/2026-04-10-rearm-at-cis-summit-ottawa.md
+++ b/landing_site/src/content/news/2026-04-10-rearm-at-cis-summit-ottawa.md
@@ -1,7 +1,7 @@
 ---
 title: "ReARM will be presented at CIS Summit in Ottawa"
 date: "2026-04-10"
-ogImage: "2026-04-10-reliza_cis.png"
+ogImage: "/news_images/2026-04-10-reliza_cis.png"
 ---
 
 We are excited to announce that ReARM will be presented at the [CIS Summit](https://cis-events.com/) in Ottawa!

--- a/landing_site/src/content/news/2026-08-24-reliza-medware-cyber-partnership.md
+++ b/landing_site/src/content/news/2026-08-24-reliza-medware-cyber-partnership.md
@@ -1,7 +1,7 @@
 ---
 title: "Reliza and MedWare Cyber Announce Strategic Partnership to Streamline Medical Device Compliance"
 date: "2026-08-24"
-ogImage: "2026-08-24-medware-cyber-partnership-linkedin-1200x627.png"
+ogImage: "/news_images/2026-08-24-medware-cyber-partnership-linkedin-1200x627.png"
 ---
 
 **Ottawa, ON, August 24, 2026** — Reliza Incorporated, the company behind ReARM, an open-core release governance and SBOM/xBOM lifecycle management platform, today announced a strategic partnership with MedWare Cyber, a leading provider of end-to-end cybersecurity and regulatory consulting for medical devices under FDA and EU MDR frameworks.

--- a/landing_site/src/content/posts/2025-12-15-rearm-securesbom-integration.md
+++ b/landing_site/src/content/posts/2025-12-15-rearm-securesbom-integration.md
@@ -1,7 +1,7 @@
 ---
 title: "Press Release: Reliza and ShiftLeftCyber Announce Integration of SecureSBOM Signing into ReARM Platform"
 date: "2025-12-15"
-ogImage: "2025-12-15-ReARM-ShiftLeftCyber2.png"
+ogImage: "/blog_images/2025-12-15-ReARM-ShiftLeftCyber2.png"
 ---
 
 **Ottawa, Ontario, Canada, 2025-12-15** - Reliza, the Canadian creator of the ReARM Software and Hardware Release-Level Supply Chain Evidence Platform, and ShiftLeftCyber, a Canadian innovator in SBOM authenticity and integrity solutions, today announced a new integration that enables seamless use of SecureSBOM signing inside Reliza's ReARM platform.

--- a/landing_site/src/content/posts/2026-01-14-dockerfile-sbom.md
+++ b/landing_site/src/content/posts/2026-01-14-dockerfile-sbom.md
@@ -1,7 +1,7 @@
 ---
 title: "Dockerfile.sbom"
 date: "2026-01-14"
-ogImage: "2026-01-14-dockerfile-sbom.png"
+ogImage: "/blog_images/2026-01-14-dockerfile-sbom.png"
 ---
 
 With the recent [ReARM release](https://github.com/relizaio/rearm/releases/tag/26.01.34), and updated [GitHub Actions](https://github.com/relizaio/rearm-actions), and our brand new [Azure Extension](https://marketplace.visualstudio.com/items?itemName=Reliza.rearm-cli-tasks), we would like to discuss a great workflow feature that is natively supported by ReARM tooling but should also be useful for a wider ecosystem.

--- a/landing_site/src/content/posts/2026-03-29-using-evidence-platform-as-cicd-security-layer.md
+++ b/landing_site/src/content/posts/2026-03-29-using-evidence-platform-as-cicd-security-layer.md
@@ -1,7 +1,7 @@
 ---
 title: "Using Evidence Platform as CI/CD Security Layer"
 date: "2026-03-29"
-ogImage: "2026-03-29-evidence-store-github-actions-security.png"
+ogImage: "/blog_images/2026-03-29-evidence-store-github-actions-security.png"
 ---
 
 Following the recent Trivy and LiteLLM compromises, it has become clear that we still lack a good way to protect our CI/CD layer, specifically GitHub Actions, from supply chain attacks.


### PR DESCRIPTION
## Problem

`Base.astro` builds the social image URL as:

```js
const socialImage = new URL(ogImage ?? '/rearm.png', siteUrl).href;
```

A bare filename therefore resolves against the **site root**, not the folder the asset lives in. All five `ogImage` entries in the repo used bare filenames, so every one of them emitted an `og:image` / `twitter:image` URL that 404s.

Confirmed against production for the newest one:

```
404  https://rearmhq.com/2026-08-24-medware-cyber-partnership-linkedin-1200x627.png   <- what we emit
200  https://rearmhq.com/news_images/2026-08-24-medware-cyber-partnership-linkedin-1200x627.png   <- where it lives
```

This is why LinkedIn's Post Inspector reports "no image found" for the MedWare Cyber partnership announcement. Note the failure mode is worse than having no `ogImage` at all: because the override is set but unresolvable, the page never falls back to the site-wide `/rearm.png`.

## Fix

Prefix each value with its real folder, matching the convention the markdown bodies already use for inline images (`![alt](/news_images/foo.png)`):

| File | New value |
|---|---|
| `news/2026-08-24-reliza-medware-cyber-partnership.md` | `/news_images/2026-08-24-medware-cyber-partnership-linkedin-1200x627.png` |
| `news/2026-04-10-rearm-at-cis-summit-ottawa.md` | `/news_images/2026-04-10-reliza_cis.png` |
| `posts/2025-12-15-rearm-securesbom-integration.md` | `/blog_images/2025-12-15-ReARM-ShiftLeftCyber2.png` |
| `posts/2026-01-14-dockerfile-sbom.md` | `/blog_images/2026-01-14-dockerfile-sbom.png` |
| `posts/2026-03-29-using-evidence-platform-as-cicd-security-layer.md` | `/blog_images/2026-03-29-evidence-store-github-actions-security.png` |

Each path was derived from where the file actually sits under `public/`, not assumed from the collection name.

## Verification

Production `astro build`, then cross-checked every emitted `og:image` against the build output — all five now point at a file that exists in `dist` (previously all five were dangling):

```
OK  /blog_images/2025-12-15-ReARM-ShiftLeftCyber2.png
OK  /blog_images/2026-01-14-dockerfile-sbom.png
OK  /blog_images/2026-03-29-evidence-store-github-actions-security.png
OK  /news_images/2026-04-10-reliza_cis.png
OK  /news_images/2026-08-24-medware-cyber-partnership-linkedin-1200x627.png
```

Pages without an `ogImage` are unaffected and still fall back to `/rearm.png`.

## After merge

LinkedIn caches aggressively (~7 days), so the announcement URL will need a re-scrape through Post Inspector once this deploys.