### PR TITLE
chore(oci-artifact-service): Go 1.26.6 and a scratch release image

### DIFF
--- a/oci-artifact-service/Dockerfile
+++ b/oci-artifact-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build-stage
+FROM golang:1.26.6-alpine3.24@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build-stage
 WORKDIR /build
 ENV CGO_ENABLED=0
 COPY go.mod go.sum ./
@@ -8,19 +8,41 @@ COPY . .
 RUN go version
 RUN go build -o ./ ./...
 
-FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS release-stage
+# Skeleton for the scratch release image: the service only ever needs a
+# writable /tmp (os.CreateTemp for uploads and compression), a passwd entry so
+# it keeps running as uid 1000, and CA certificates for HTTPS to registries.
+# Prepared here because scratch has no shell for mkdir/adduser/echo.
 ARG CI_ENV=noci
 ARG GIT_COMMIT=git_commit_undefined
 ARG GIT_BRANCH=git_branch_undefined
 ARG VERSION=not_versioned
-RUN mkdir /app
-RUN adduser -u 1000 -D apprunner && chown apprunner:apprunner /app
-COPY --from=build-stage --chown=apprunner:apprunner /build/reliza-oci-artifacts-client /app/app
-RUN mkdir /indir && chown apprunner:apprunner -R /indir
-RUN mkdir /outdir && chown apprunner:apprunner -R /outdir
+RUN apk add --no-cache ca-certificates && \
+    mkdir -p /skel/app /skel/tmp && chmod 1777 /skel/tmp && \
+    echo "version=$VERSION" > /skel/app/version && \
+    echo "commit=$GIT_COMMIT" >> /skel/app/version && \
+    echo "branch=$GIT_BRANCH" >> /skel/app/version && \
+    echo "apprunner:x:1000:1000:apprunner:/app:/sbin/nologin" > /skel-passwd && \
+    echo "apprunner:x:1000:" > /skel-group && \
+    chown -R 1000:1000 /skel/app
+
+# The binary is static (CGO_ENABLED=0) and the service shells out to nothing,
+# so the release image carries no distro: FROM scratch drops every Alpine
+# package finding along with the shell and package manager. /indir, /outdir and
+# /app/localdata are not referenced anywhere in the service -- they were
+# inherited from the CLI's Dockerfile -- so they are dropped rather than
+# recreated.
+FROM scratch AS release-stage
+ARG CI_ENV=noci
+ARG GIT_COMMIT=git_commit_undefined
+ARG GIT_BRANCH=git_branch_undefined
+ARG VERSION=not_versioned
+COPY --from=build-stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build-stage /skel-passwd /etc/passwd
+COPY --from=build-stage /skel-group /etc/group
+COPY --from=build-stage /skel/ /
+COPY --from=build-stage --chown=1000:1000 /build/reliza-oci-artifacts-client /app/app
 USER apprunner
-RUN echo "version=$VERSION" > /app/version && echo "commit=$GIT_COMMIT" >> /app/version && echo "branch=$GIT_BRANCH" >> /app/version
-RUN mkdir /app/localdata
+ENV TMPDIR=/tmp HOME=/app
 
 LABEL org.opencontainers.image.revision=$GIT_COMMIT
 LABEL git_branch=$GIT_BRANCH


### PR DESCRIPTION
## What

The same pair of base-image changes that took `rearm-cli`'s container to zero findings, applied to the OCI artifact service.

1. **Build on Go 1.26.6** — 1.26.5's stdlib carries `CVE-2026-39821` (critical), `CVE-2026-46600` and six further CVEs.
2. **Ship `FROM scratch`** — the binary is static (`CGO_ENABLED=0`) and the service shells out to nothing, so the Alpine stage existed only to run `mkdir`/`adduser`/`echo` at build time. Dropping it removes every Alpine package finding along with the shell and package manager.

## Measured effect

`syft --scope all-layers` + OSV, on images built from `main` vs this branch:

| | components | advisories | size |
|---|---|---|---|
| `main` (go1.26.5 + alpine) | 45 | 9 | 20.0 MB |
| this branch | 29 | **1** | 16.5 MB |

The one remaining is `GO-2026-5932` against `golang.org/x/crypto`: the standing *"the openpgp package is unmaintained and unsafe by design"* advisory. Worth being precise about it — `x/crypto` **is** linked (gin's validator pulls in `sha3`, plus `chacha20poly1305` via TLS), but `go list -deps` confirms the flagged `openpgp` subpackage is **not** compiled in, and the advisory has no fixed version in any release including the latest. So there is nothing to bump and nothing reachable; it's a VEX candidate, not work.

## What the scratch image carries

Only what the service actually uses: CA certificates (ORAS talks HTTPS to registries unless `USE_PLAIN_HTTP`), a writable `/tmp` (`os.CreateTemp` on the upload and compression paths), a passwd entry so it still runs as uid 1000, and the `/app/version` file. `/indir`, `/outdir` and `/app/localdata` are dropped — nothing in the service references them; they were inherited from the CLI's Dockerfile.

## Verification

Behaviour was exercised on the built image, not assumed:

- Service boots and serves; `GET /health` → **200** with registry env set.
- `POST /push` reaches request validation (**400**) with no filesystem errors in the log — the `os.CreateTemp` path works as uid 1000 on scratch's `/tmp`.
- Without registry env vars, `/health` terminates the process via `sugar.Fatal`. That is **pre-existing and unchanged** — the alpine baseline image behaves identically. Flagging it because a health endpoint that kills the process on missing config will crashloop a misconfigured deployment, but it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)