### PR TITLE
chore(keycloak): bump base image to 26.7.2

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.7.0@sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0 AS builder
+FROM quay.io/keycloak/keycloak:26.7.2@sha256:831330513f55695572286e521f94fcd3c7e285250ed5b848090265a33192f669 AS builder
 
 ENV KC_HEALTH_ENABLED=true
 ENV KC_METRICS_ENABLED=true
@@ -7,7 +7,7 @@ ENV KC_DB=postgres
 
 RUN /opt/keycloak/bin/kc.sh build --health-enabled=true --metrics-enabled=true
 
-FROM quay.io/keycloak/keycloak:26.7.0@sha256:2eb3cd316835c990e69e26ade292ffa78f6fb0db7d5fc6377463c162e1979ac0 AS deliverable
+FROM quay.io/keycloak/keycloak:26.7.2@sha256:831330513f55695572286e521f94fcd3c7e285250ed5b848090265a33192f669 AS deliverable
 ARG CI_ENV=noci
 ARG GIT_COMMIT=git_commit_undefined
 ARG GIT_BRANCH=git_branch_undefined


### PR DESCRIPTION
## What

Keycloak base image **26.7.0 → 26.7.2**, the current patch release.

## Measured effect

`syft --scope all-layers` + OSV on the two base images: **93 advisories across 28 components → 63 across 20.**

Cleared outright: `jackson-databind` (3), `jackson-core`, the whole netty codec set (http, http2, dns, haproxy, core — 9 advisories), `micrometer-core`, the `postgresql` JDBC driver, plus RPM updates to `glibc`, `java-21-openjdk-headless` and `p11-kit-trust`.

## What remains, and why it isn't ours

- **RHEL RPM advisories** (`glibc`, `libcap`, `ncurses`, `sqlite-libs`, `sed`, `coreutils`) — clear when Red Hat rebuilds the UBI base that Keycloak builds on.
- **`netty-codec-http`** — needs 4.1.137, which a future Keycloak release will pull in.
- **Three `org.keycloak` advisories** — worth flagging as likely false positives: their OSV entries list fixed versions *below* the version we ship (`26.3.4` and `26.0.6`), which is stale range data rather than live exposure. The third (`GHSA-794g-x443-36f7`, SAML encrypted assertions) has no fixed version in any release.

Unlike the Go services fixed recently, no scratch/distroless option applies here — this is a JVM service on UBI and the base is Keycloak's own image.

## Verification

On the built image: Keycloak **26.7.2** starts against Postgres using the deploy command (`kc.sh start --import-realm`), imports both realms, and serves `/realms/master` and `/realms/Reliza` (both 200).

One pre-existing quirk confirmed unchanged: the image needs `KC_DB=postgres` supplied from the environment (the helm chart and compose file both set it) because the builder stage's `ENV` does not cross into the deliverable stage. Reproduces identically on 26.7.0, so it is not introduced here — but it does mean the image cannot start standalone without that variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)