### PR TITLE
chore(backend): sync per-component support feature from Pro (V82)

### DIFF
--- a/backend/src/main/java/io/reliza/model/SbomComponent.java
+++ b/backend/src/main/java/io/reliza/model/SbomComponent.java
@@ -4,6 +4,7 @@
 package io.reliza.model;
 
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +12,8 @@ import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
@@ -85,6 +88,32 @@ public class SbomComponent implements Serializable, RelizaEntity {
 	// SyntheticSbomService.submitOrg.
 	@Column
 	private Integer syntheticBucketIndex;
+
+	// Per-component support disclosure (FDA-Readiness-1). First-class columns
+	// because they are mutable (manufacturer attestation / enrichment refresh) and
+	// queried (the approaching/past-EOS filter) -- unlike the parse-time-immutable
+	// recordData. The support STATUS is DERIVED at read time (see SupportStatus),
+	// never stored here. supportSource is set server-side per write path and drives
+	// the MANUAL > SUPPLIER > ENRICHED precedence; the reconcile path load-merges and
+	// leaves these columns untouched. supportNotes is internal-only (never exported).
+	@Column(name = "end_of_support_date")
+	private LocalDate endOfSupportDate;
+
+	@Column(name = "end_of_life_date")
+	private LocalDate endOfLifeDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "support_source")
+	private SupportSource supportSource;
+
+	@Column(name = "support_last_assessed")
+	private ZonedDateTime supportLastAssessed;
+
+	@Column(name = "support_asserted_by")
+	private UUID supportAssertedBy;
+
+	@Column(name = "support_notes")
+	private String supportNotes;
 
 	@Override
 	public UUID getUuid() {
@@ -205,5 +234,53 @@ public class SbomComponent implements Serializable, RelizaEntity {
 
 	public void setSyntheticBucketIndex(Integer syntheticBucketIndex) {
 		this.syntheticBucketIndex = syntheticBucketIndex;
+	}
+
+	public LocalDate getEndOfSupportDate() {
+		return endOfSupportDate;
+	}
+
+	public void setEndOfSupportDate(LocalDate endOfSupportDate) {
+		this.endOfSupportDate = endOfSupportDate;
+	}
+
+	public LocalDate getEndOfLifeDate() {
+		return endOfLifeDate;
+	}
+
+	public void setEndOfLifeDate(LocalDate endOfLifeDate) {
+		this.endOfLifeDate = endOfLifeDate;
+	}
+
+	public SupportSource getSupportSource() {
+		return supportSource;
+	}
+
+	public void setSupportSource(SupportSource supportSource) {
+		this.supportSource = supportSource;
+	}
+
+	public ZonedDateTime getSupportLastAssessed() {
+		return supportLastAssessed;
+	}
+
+	public void setSupportLastAssessed(ZonedDateTime supportLastAssessed) {
+		this.supportLastAssessed = supportLastAssessed;
+	}
+
+	public UUID getSupportAssertedBy() {
+		return supportAssertedBy;
+	}
+
+	public void setSupportAssertedBy(UUID supportAssertedBy) {
+		this.supportAssertedBy = supportAssertedBy;
+	}
+
+	public String getSupportNotes() {
+		return supportNotes;
+	}
+
+	public void setSupportNotes(String supportNotes) {
+		this.supportNotes = supportNotes;
 	}
 }

--- a/backend/src/main/java/io/reliza/model/SbomComponentSupportAudit.java
+++ b/backend/src/main/java/io/reliza/model/SbomComponentSupportAudit.java
@@ -1,0 +1,141 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Append-only attestation history for per-component support facts: the
+ * ALCOA input-side record of record (who asserted what, when). One row is
+ * written per {@code setSbomComponentSupport} edit, capturing the AFTER-image
+ * (the asserted values) plus the attester. Shaped after {@link MetricsAudit}:
+ * surrogate uuid PK, entity_uuid + revision + org, no FK. Written ONLY on an
+ * input edit (operator/enrichment), never by the BOM reconcile path.
+ */
+@Entity
+@Table(schema = ModelProperties.DB_SCHEMA, name = "sbom_component_support_audit")
+public class SbomComponentSupportAudit implements Serializable {
+	private static final long serialVersionUID = 234737L;
+
+	@Id
+	private UUID uuid = UUID.randomUUID();
+
+	@Column(name = "sbom_component_uuid", nullable = false)
+	private UUID sbomComponentUuid;
+
+	@Column(name = "org", nullable = false)
+	private UUID org;
+
+	@Column(name = "support_revision", nullable = false)
+	private int supportRevision = 0;
+
+	@Column(name = "end_of_support_date")
+	private LocalDate endOfSupportDate;
+
+	@Column(name = "end_of_life_date")
+	private LocalDate endOfLifeDate;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "support_source", nullable = false)
+	private SupportSource supportSource;
+
+	@Column(name = "support_notes")
+	private String supportNotes;
+
+	@Column(name = "support_asserted_by")
+	private UUID supportAssertedBy;
+
+	@Column(name = "asserted_date", nullable = false)
+	private ZonedDateTime assertedDate = ZonedDateTime.now();
+
+	public UUID getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(UUID uuid) {
+		this.uuid = uuid;
+	}
+
+	public UUID getSbomComponentUuid() {
+		return sbomComponentUuid;
+	}
+
+	public void setSbomComponentUuid(UUID sbomComponentUuid) {
+		this.sbomComponentUuid = sbomComponentUuid;
+	}
+
+	public UUID getOrg() {
+		return org;
+	}
+
+	public void setOrg(UUID org) {
+		this.org = org;
+	}
+
+	public int getSupportRevision() {
+		return supportRevision;
+	}
+
+	public void setSupportRevision(int supportRevision) {
+		this.supportRevision = supportRevision;
+	}
+
+	public LocalDate getEndOfSupportDate() {
+		return endOfSupportDate;
+	}
+
+	public void setEndOfSupportDate(LocalDate endOfSupportDate) {
+		this.endOfSupportDate = endOfSupportDate;
+	}
+
+	public LocalDate getEndOfLifeDate() {
+		return endOfLifeDate;
+	}
+
+	public void setEndOfLifeDate(LocalDate endOfLifeDate) {
+		this.endOfLifeDate = endOfLifeDate;
+	}
+
+	public SupportSource getSupportSource() {
+		return supportSource;
+	}
+
+	public void setSupportSource(SupportSource supportSource) {
+		this.supportSource = supportSource;
+	}
+
+	public String getSupportNotes() {
+		return supportNotes;
+	}
+
+	public void setSupportNotes(String supportNotes) {
+		this.supportNotes = supportNotes;
+	}
+
+	public UUID getSupportAssertedBy() {
+		return supportAssertedBy;
+	}
+
+	public void setSupportAssertedBy(UUID supportAssertedBy) {
+		this.supportAssertedBy = supportAssertedBy;
+	}
+
+	public ZonedDateTime getAssertedDate() {
+		return assertedDate;
+	}
+
+	public void setAssertedDate(ZonedDateTime assertedDate) {
+		this.assertedDate = assertedDate;
+	}
+}

--- a/backend/src/main/java/io/reliza/model/SupportSource.java
+++ b/backend/src/main/java/io/reliza/model/SupportSource.java
@@ -1,0 +1,15 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+/**
+ * Provenance of a per-component support/EOS assertion. Set SERVER-SIDE per write
+ * path, never read from client input or from an ingested BOM: MANUAL in the
+ * setSbomComponentSupport mutation, SUPPLIER at BOM reconcile (later slice),
+ * ENRICHED by the endoflife.date puller (later slice). Precedence for the merge
+ * is MANUAL greater-than SUPPLIER greater-than ENRICHED.
+ */
+public enum SupportSource {
+	MANUAL, SUPPLIER, ENRICHED
+}

--- a/backend/src/main/java/io/reliza/model/SupportStatus.java
+++ b/backend/src/main/java/io/reliza/model/SupportStatus.java
@@ -1,0 +1,64 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+/**
+ * Per-component support level. DERIVED, never persisted (see the FDA-Readiness-1
+ * scope): computed from the stored support facts plus an asOf clock by
+ * {@link #derive} so the value can never rot or contradict its own dates. Every
+ * read and export surface calls this one method (single source of truth).
+ *
+ * <p>Values align to FDA's support adjectives and IMDRF N60's lifecycle stages.
+ * SECURITY_ONLY (IMDRF Limited Support) and ABANDONED (inferred, no declared
+ * date) are valid values reserved for later slices: SECURITY_ONLY needs a
+ * security-only boundary date and ABANDONED an ENRICHED inference, so neither is
+ * produced from the two stored dates alone. PR1 derives the four date-driven
+ * states plus UNKNOWN.
+ */
+public enum SupportStatus {
+	ACTIVELY_SUPPORTED,
+	SECURITY_ONLY,
+	END_OF_SUPPORT,
+	END_OF_LIFE,
+	ABANDONED,
+	UNKNOWN;
+
+	/**
+	 * Single source of truth for the derived status. Pure: identical inputs
+	 * always yield the same value. {@code asOf} is the clock (now for the live
+	 * view; a cutoff for a future frozen snapshot). {@code source} is reserved
+	 * for the ENRICHED-only ABANDONED inference (later slice) and does not affect
+	 * the date-driven states.
+	 *
+	 * @param endOfSupportDate when all support ceases (transfer of risk), or null
+	 * @param endOfLifeDate    when the component reaches end of life, or null
+	 * @param source           provenance of the assertion (reserved), or null
+	 * @param asOf             the clock the status is read against
+	 * @return the derived status; UNKNOWN when no dates are on record
+	 */
+	public static SupportStatus derive(LocalDate endOfSupportDate, LocalDate endOfLifeDate,
+			SupportSource source, LocalDate asOf) {
+		// asOf is the clock every read/export/snapshot surface passes; a null here is a
+		// caller contract violation, not a data state -- fail loud rather than NPE deep inside.
+		Objects.requireNonNull(asOf, "asOf");
+		// Boundaries are inclusive: a milestone takes effect ON its date (asOf == date
+		// -> the milestone status). EOL outranks EOS when both have passed. A future EOS
+		// (or a lone future EOL) reads as ACTIVELY_SUPPORTED -- the manufacturer has
+		// declared a horizon but support is current. (The coherence guard forbids EOS
+		// after EOL, so "EOL past while EOS future" cannot be stored.)
+		if (endOfLifeDate != null && !asOf.isBefore(endOfLifeDate)) {
+			return END_OF_LIFE;
+		}
+		if (endOfSupportDate != null && !asOf.isBefore(endOfSupportDate)) {
+			return END_OF_SUPPORT;
+		}
+		if (endOfSupportDate != null || endOfLifeDate != null) {
+			return ACTIVELY_SUPPORTED;
+		}
+		return UNKNOWN;
+	}
+}

--- a/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/SbomComponentRepository.java
@@ -347,4 +347,46 @@ public interface SbomComponentRepository extends CrudRepository<SbomComponent, U
 		nativeQuery = true)
 	String findOldestStaleUnbucketedPurl(@Param("orgUuidAsString") String orgUuidAsString,
 			@Param("cutoff") java.time.ZonedDateTime cutoff);
+
+	/**
+	 * Cheap existence probe for the export-injection hot path: does the org have ANY component
+	 * carrying a support assertion? Lets a zero-support org skip the per-component resolution on
+	 * every BOM download (the injector still runs to strip forged props + stamp the marker).
+	 */
+	@Query(value = """
+			SELECT EXISTS(
+				SELECT 1 FROM rearm.sbom_components sc
+				WHERE sc.org = CAST(:orgUuidAsString AS uuid)
+				  AND sc.support_source IS NOT NULL)
+			""", nativeQuery = true)
+	boolean existsSupportByOrg(@Param("orgUuidAsString") String orgUuidAsString);
+
+	/**
+	 * Support-disclosure coverage denominator: the org's non-root components (roots
+	 * are the app itself, not third-party dependencies to attest).
+	 */
+	@Query(value = """
+			SELECT count(*) FROM rearm.sbom_components sc
+			WHERE sc.org = CAST(:orgUuidAsString AS uuid)
+			  AND (sc.record_data->>'isRoot') IS DISTINCT FROM 'true'
+			""", nativeQuery = true)
+	long countNonRootByOrg(@Param("orgUuidAsString") String orgUuidAsString);
+
+	/**
+	 * Coverage numerator: non-root components carrying a MANUFACTURER (MANUAL)
+	 * attestation. Deliberately NOT {@code support_source IS NOT NULL}: later slices
+	 * auto-stamp SUPPLIER (at reconcile) and ENRICHED (endoflife.date puller), which
+	 * are machine/vendor-sourced, not a manufacturer disclosure -- counting them
+	 * would silently inflate the pre-submission readiness signal toward 100%. A
+	 * MANUAL row with no dates still counts: an explicit "assessed, indeterminate"
+	 * attestation is a disclosure. Per-source breakdown fields can be added to the
+	 * coverage type additively if a caller later needs them.
+	 */
+	@Query(value = """
+			SELECT count(*) FROM rearm.sbom_components sc
+			WHERE sc.org = CAST(:orgUuidAsString AS uuid)
+			  AND (sc.record_data->>'isRoot') IS DISTINCT FROM 'true'
+			  AND sc.support_source = 'MANUAL'
+			""", nativeQuery = true)
+	long countAttestedNonRootByOrg(@Param("orgUuidAsString") String orgUuidAsString);
 }

--- a/backend/src/main/java/io/reliza/repositories/SbomComponentSupportAuditRepository.java
+++ b/backend/src/main/java/io/reliza/repositories/SbomComponentSupportAuditRepository.java
@@ -1,0 +1,17 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.repositories;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.repository.CrudRepository;
+
+import io.reliza.model.SbomComponentSupportAudit;
+
+public interface SbomComponentSupportAuditRepository extends CrudRepository<SbomComponentSupportAudit, UUID> {
+
+	/** Full attestation history for a component, newest first. */
+	List<SbomComponentSupportAudit> findBySbomComponentUuidOrderByAssertedDateDesc(UUID sbomComponentUuid);
+}

--- a/backend/src/main/java/io/reliza/service/SbomComponentService.java
+++ b/backend/src/main/java/io/reliza/service/SbomComponentService.java
@@ -4,6 +4,7 @@
 package io.reliza.service;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +53,8 @@ import io.reliza.model.ReleaseSbomComponent;
 import io.reliza.model.SbomComponent;
 import io.reliza.model.SbomComponentData;
 import io.reliza.model.SbomComponentFlowControl;
+import io.reliza.model.SbomComponentSupportAudit;
+import io.reliza.model.SupportSource;
 import io.reliza.model.WhoUpdated;
 import io.reliza.model.tea.Rebom.ParsedBom;
 import io.reliza.model.tea.Rebom.ParsedBomComponent;
@@ -61,6 +65,7 @@ import io.reliza.repositories.ArtifactSbomComponentRepository;
 import io.reliza.repositories.ReleaseArtifactIndexRepository;
 import io.reliza.repositories.ReleaseRepository;
 import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.repositories.SbomComponentSupportAuditRepository;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -202,16 +207,19 @@ public class SbomComponentService {
 	private final ArtifactSbomComponentRepository artifactSbomComponentRepository;
 	private final ReleaseArtifactIndexRepository releaseArtifactIndexRepository;
 	private final ArtifactCanonicalMapRepository artifactCanonicalMapRepository;
+	private final SbomComponentSupportAuditRepository sbomComponentSupportAuditRepository;
 
 	SbomComponentService(
 			SbomComponentRepository sbomComponentRepository,
 			ArtifactSbomComponentRepository artifactSbomComponentRepository,
 			ReleaseArtifactIndexRepository releaseArtifactIndexRepository,
-			ArtifactCanonicalMapRepository artifactCanonicalMapRepository) {
+			ArtifactCanonicalMapRepository artifactCanonicalMapRepository,
+			SbomComponentSupportAuditRepository sbomComponentSupportAuditRepository) {
 		this.sbomComponentRepository = sbomComponentRepository;
 		this.artifactSbomComponentRepository = artifactSbomComponentRepository;
 		this.releaseArtifactIndexRepository = releaseArtifactIndexRepository;
 		this.artifactCanonicalMapRepository = artifactCanonicalMapRepository;
+		this.sbomComponentSupportAuditRepository = sbomComponentSupportAuditRepository;
 	}
 
 	// ===================================================================
@@ -2386,4 +2394,93 @@ private static int currentReconcileFailureCount(Release r) {
 	private record ParentKey(String sourceCanonical, String relationshipType) {}
 
 	private record ParentEdge(String sourceFullPurl, String targetFullPurl) {}
+
+	/**
+	 * Manufacturer (MANUAL) attestation of a component's support facts. Sets the
+	 * dates, stamps supportSource=MANUAL plus the attester and supportLastAssessed,
+	 * and appends an after-image row to the attestation history -- all in one tx.
+	 * The derived status is computed on read, never written here. Throws
+	 * {@link OptimisticLockingFailureException} if a concurrent reconcile bumped the
+	 * row's revision; the caller retries. The reconcile path load-merges and leaves
+	 * these columns untouched, so it never clobbers an attestation.
+	 *
+	 * @param assertedBy the authenticated user making the attestation
+	 */
+	@Transactional
+	public SbomComponent setSbomComponentSupport(UUID sbomComponentUuid, LocalDate endOfSupportDate,
+			LocalDate endOfLifeDate, String supportNotes, UUID assertedBy) {
+		return applySupport(sbomComponentUuid, endOfSupportDate, endOfLifeDate, supportNotes,
+				SupportSource.MANUAL, assertedBy);
+	}
+
+	/**
+	 * Shared write core for every support provenance (MANUAL now; SUPPLIER / ENRICHED
+	 * writers in later slices call this same path so they cannot drift on the
+	 * stamp / save / audit-revision semantics). Validates the date invariant for
+	 * every caller (not just the web layer), stamps the facts + source + attester,
+	 * saves, and appends the after-image to the attestation history in one tx. The
+	 * status is derived on read, never written. A concurrent reconcile that bumps the
+	 * row's @Version makes the version-checked UPDATE fail at COMMIT, surfacing as
+	 * {@link OptimisticLockingFailureException} for the caller to retry; the reconcile
+	 * path load-merges and never touches these columns. Runs in the caller's tx.
+	 */
+	private SbomComponent applySupport(UUID sbomComponentUuid, LocalDate endOfSupportDate,
+			LocalDate endOfLifeDate, String supportNotes, SupportSource source, UUID assertedBy) {
+		if (endOfSupportDate != null && endOfLifeDate != null && endOfSupportDate.isAfter(endOfLifeDate)) {
+			throw new IllegalArgumentException("endOfSupportDate must not be after endOfLifeDate");
+		}
+		SbomComponent sc = sbomComponentRepository.findById(sbomComponentUuid)
+				.orElseThrow(() -> new IllegalArgumentException(
+						"sbom component not found: " + sbomComponentUuid));
+		ZonedDateTime now = ZonedDateTime.now();
+		sc.setEndOfSupportDate(endOfSupportDate);
+		sc.setEndOfLifeDate(endOfLifeDate);
+		sc.setSupportSource(source);
+		sc.setSupportNotes(supportNotes);
+		sc.setSupportAssertedBy(assertedBy);
+		sc.setSupportLastAssessed(now);
+		sc.setLastUpdatedDate(now);
+		SbomComponent saved = sbomComponentRepository.save(sc);
+		// Flush now to apply the version-checked UPDATE and read the TRUE post-update
+		// revision (rather than predicting a bump that a no-op rewrite would skip). A
+		// mid-@Service flush throws the untranslated jakarta OptimisticLockException, so
+		// convert it to Spring's type here -- otherwise the caller's retry (which catches
+		// OptimisticLockingFailureException) would miss a concurrent-reconcile conflict.
+		try {
+			entityManager.flush();
+		} catch (jakarta.persistence.OptimisticLockException ole) {
+			throw new ObjectOptimisticLockingFailureException(SbomComponent.class, sbomComponentUuid, ole);
+		}
+		writeSupportAudit(saved, saved.getRevision(), now);
+		return saved;
+	}
+
+	/** Append the asserted (after-image) values plus attester to the history table. */
+	private void writeSupportAudit(SbomComponent sc, int supportRevision, ZonedDateTime assertedDate) {
+		SbomComponentSupportAudit audit = new SbomComponentSupportAudit();
+		audit.setSbomComponentUuid(sc.getUuid());
+		audit.setOrg(sc.getOrg());
+		audit.setSupportRevision(supportRevision);
+		audit.setEndOfSupportDate(sc.getEndOfSupportDate());
+		audit.setEndOfLifeDate(sc.getEndOfLifeDate());
+		audit.setSupportSource(sc.getSupportSource());
+		audit.setSupportNotes(sc.getSupportNotes());
+		audit.setSupportAssertedBy(sc.getSupportAssertedBy());
+		audit.setAssertedDate(assertedDate);
+		sbomComponentSupportAuditRepository.save(audit);
+	}
+
+	/**
+	 * Support-disclosure coverage for an org: how many non-root components carry a
+	 * support attestation, of the total. A mostly-unattested export is an
+	 * incomplete disclosure, so this feeds a pre-submission readiness signal.
+	 */
+	public SupportCoverage getSupportCoverage(UUID orgUuid) {
+		long total = sbomComponentRepository.countNonRootByOrg(orgUuid.toString());
+		long attested = sbomComponentRepository.countAttestedNonRootByOrg(orgUuid.toString());
+		return new SupportCoverage(total, attested);
+	}
+
+	/** Coverage counts for the support-disclosure completeness metric. */
+	public record SupportCoverage(long total, long attested) {}
 }

--- a/backend/src/main/java/io/reliza/service/SharedArtifactService.java
+++ b/backend/src/main/java/io/reliza/service/SharedArtifactService.java
@@ -46,7 +46,10 @@ import io.reliza.repositories.ArtifactRepository;
 import io.reliza.repositories.MetricsAuditRepository;
 import io.reliza.util.BackoffPolicy;
 import lombok.extern.slf4j.Slf4j;
+import java.nio.charset.StandardCharsets;
+
 import reactor.core.publisher.Mono;
+import tools.jackson.databind.JsonNode;
 
 @Service
 @Slf4j
@@ -91,6 +94,9 @@ public class SharedArtifactService {
 	
 	@Autowired
     private RebomService rebomService;
+
+	@Autowired
+	private SupportInjectionService supportInjectionService;
 
 	/**
 	 * What a conditional carry-forward seed write did. Three outcomes, not a boolean, because a scan
@@ -232,9 +238,10 @@ public class SharedArtifactService {
         log.info("download artifacts for ad: {}", ad);
 
 		if(null != ad.getInternalBom()){
-			String rebom;
+			byte[] byteArray;
 			// For SPDX, augmented BOM is the converted CycloneDX
 			if(ad.getBomFormat().equals(BomFormat.SPDX)){
+				String rebom;
 				// Support version parameter for SPDX augmented downloads
 				if (ad.getVersion() != null && !ad.getVersion().isEmpty()) {
 					try {
@@ -248,18 +255,45 @@ public class SharedArtifactService {
 					// No version specified, return latest converted CycloneDX
 					rebom = (rebomService.findRawBomById(ad.getInternalBom().id(), ad.getOrg(), BomFormat.CYCLONEDX)).toString();
 				}
-			} else if (ad.getVersion() != null && !ad.getVersion().isEmpty()) {
-				try {
-					Integer version = Integer.parseInt(ad.getVersion());
-					rebom = rebomService.findBomByVersion(ad.getInternalBom().id(), ad.getOrg(), version).toString();
-				} catch (NumberFormatException e) {
-					// Version is not numeric, fall back to latest
-					rebom = rebomService.findBomByIdJson(ad.getInternalBom().id(), ad.getOrg()).toString();
-				}
+				// Support injection into the SPDX-augmented (converted CycloneDX) download is a
+				// later slice; served as-is for now.
+				byteArray = rebom.getBytes();
 			} else {
-				rebom = rebomService.findBomByIdJson(ad.getInternalBom().id(), ad.getOrg()).toString();
+				// Native CycloneDX: fetch the BOM as a JsonNode, inject the CURRENT (derived,
+				// non-attested, current-state) per-component support facts, then serialize. The
+				// rebom fetch is already blocked, so this is a synchronous tree edit; the signed
+				// raw original served by downloadRawArtifact is a separate path and untouched.
+				JsonNode bomNode;
+				if (ad.getVersion() != null && !ad.getVersion().isEmpty()) {
+					try {
+						Integer version = Integer.parseInt(ad.getVersion());
+						bomNode = rebomService.findBomByVersion(ad.getInternalBom().id(), ad.getOrg(), version);
+					} catch (NumberFormatException e) {
+						// Version is not numeric, fall back to latest
+						bomNode = rebomService.findBomByIdJson(ad.getInternalBom().id(), ad.getOrg());
+					}
+				} else {
+					bomNode = rebomService.findBomByIdJson(ad.getInternalBom().id(), ad.getOrg());
+				}
+				try {
+					supportInjectionService.injectCurrentSupport(bomNode, ad.getOrg());
+				} catch (Exception supportEx) {
+					// Support injection is an add-on -- never fail the core BOM download because
+					// of a support-resolution error (transient DB, unexpected node shape). Serve
+					// the un-injected BOM and alert (this path had no DB dependency before PR2a).
+					log.error("Support injection failed for artifact {} (org {}); serving un-injected BOM: {}",
+							ad.getUuid(), ad.getOrg(), supportEx.getMessage(), supportEx);
+					// Still run the DB-free strip so an uploader-forged reliza:support:* cannot
+					// survive a resolution outage, and the disclosure marker is still stamped.
+					try {
+						supportInjectionService.stripForgedProvenanceAndMark(bomNode);
+					} catch (Exception stripEx) {
+						log.error("Support strip fallback also failed for artifact {}: {}",
+								ad.getUuid(), stripEx.getMessage(), stripEx);
+					}
+				}
+				byteArray = bomNode.toString().getBytes(StandardCharsets.UTF_8);
 			}
-			byte[] byteArray = rebom.getBytes();
 			String bomFileName = ad.getTags().stream()
 				.filter(t -> t.key().equals(CommonVariables.FILE_NAME_FIELD))
 				.map(t -> t.value())

--- a/backend/src/main/java/io/reliza/service/SupportBomInjector.java
+++ b/backend/src/main/java/io/reliza/service/SupportBomInjector.java
@@ -1,0 +1,266 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import java.time.LocalDate;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+
+import io.reliza.common.Utils;
+import io.reliza.model.SbomComponent;
+import io.reliza.model.SupportSource;
+import io.reliza.model.SupportStatus;
+
+/**
+ * Pure, DB-free injector that weaves per-component support disclosure into a CycloneDX BOM
+ * JSON tree at read time (FDA-Readiness-1 PR2a). Two entry points:
+ *
+ * <ul>
+ *   <li>{@link #collectKeys} -- the identity key of every component node, so the caller
+ *       (a service with repository access) can resolve them to {@code sbom_components} rows;</li>
+ *   <li>{@link #inject} -- append the support properties onto each matched component node.</li>
+ * </ul>
+ *
+ * <p>The split keeps this class pure: the caller does the encoding-aware two-pass match and
+ * hands back a {@code Map} keyed by {@link #componentKey}, so PR6's frozen snapshot can reuse
+ * the exact same injection with {@code asOf} pinned to a cutoff instead of now.
+ *
+ * <p>Mutates the tree in place via Jackson (append onto any existing {@code properties} array,
+ * never overwrite; never re-serialize through the CycloneDX object model, which would rewrite
+ * specVersion and drop unknown fields). NEVER emits the internal {@code supportNotes} field.
+ */
+public final class SupportBomInjector {
+
+	private SupportBomInjector() {}
+
+	static final String PROP_STATUS = "reliza:support:status";
+	static final String PROP_SOURCE = "reliza:support:source";
+	static final String PROP_LAST_ASSESSED = "reliza:support:lastAssessed";
+	static final String PROP_EOS = "cdx:lifecycle:milestone:endOfSupport";
+	static final String PROP_EOL = "cdx:lifecycle:milestone:endOfLife";
+	static final String PROP_DISCLOSURE = "reliza:support:disclosure";
+	static final String DISCLOSURE_CURRENT_STATE = "derived-non-attested-current-state";
+
+	/** Server-owned namespace: any reliza:support:* an uploader baked into the BOM is stripped. */
+	static final String RELIZA_SUPPORT_PREFIX = "reliza:support:";
+	/** Standard milestone keys we replace (never duplicate) on a component we attest. */
+	private static final Set<String> MILESTONE_KEYS = Set.of(PROP_EOS, PROP_EOL);
+
+	/**
+	 * Identity key of a component node: the preserving-canonical purl (byte-compatible with
+	 * how rebom persists {@code sbom_components.canonical_purl}), else the raw cpe, else null
+	 * (a component with neither cannot match a stored row).
+	 */
+	public static String componentKey(JsonNode component) {
+		if (component == null || !component.isObject()) {
+			return null;
+		}
+		JsonNode purl = component.get("purl");
+		if (purl != null && purl.isTextual() && !purl.asText().isBlank()) {
+			try {
+				String canonical = Utils.canonicalizePurlPreservingEncoding(purl.asText());
+				if (canonical != null) {
+					return canonical;
+				}
+				// A non-pkg / unparseable purl yields null -- fall through to cpe.
+			} catch (RuntimeException malformed) {
+				// fall through to cpe
+			}
+		}
+		JsonNode cpe = component.get("cpe");
+		if (cpe != null && cpe.isTextual() && !cpe.asText().isBlank()) {
+			return cpe.asText();
+		}
+		return null;
+	}
+
+	/**
+	 * Every resolvable component identity key in the BOM. Recurses nested
+	 * {@code components[].components[]} and includes {@code metadata.component} (the root
+	 * self-component) -- the flat extraction loop used elsewhere would miss nested children.
+	 */
+	public static Set<String> collectKeys(JsonNode bom) {
+		Set<String> keys = new LinkedHashSet<>();
+		if (bom == null || !bom.isObject()) {
+			return keys;
+		}
+		collectFrom(bom.get("components"), keys);
+		JsonNode metadata = bom.get("metadata");
+		if (metadata != null && metadata.isObject()) {
+			JsonNode root = metadata.get("component");
+			addKey(root, keys);
+			if (root != null) {
+				collectFrom(root.get("components"), keys);
+			}
+		}
+		return keys;
+	}
+
+	private static void collectFrom(JsonNode components, Set<String> keys) {
+		if (components == null || !components.isArray()) {
+			return;
+		}
+		for (JsonNode c : components) {
+			addKey(c, keys);
+			collectFrom(c.get("components"), keys);
+		}
+	}
+
+	private static void addKey(JsonNode component, Set<String> keys) {
+		String key = componentKey(component);
+		if (key != null) {
+			keys.add(key);
+		}
+	}
+
+	/**
+	 * Append per-component support properties onto every matched component node, and a
+	 * document-level disclosure marker on {@code metadata.properties} labelling this as the
+	 * derived, non-attested, current-state view (not the frozen attested record). Mutates and
+	 * returns the same tree. {@code factsByKey} is keyed by {@link #componentKey}; a component
+	 * with no entry, or whose row carries no {@code supportSource}, gets nothing (absence is
+	 * not a benign "supported"). {@code asOf} is the derivation clock (now for the live view).
+	 */
+	public static JsonNode inject(JsonNode bom, Map<String, SbomComponent> factsByKey, LocalDate asOf) {
+		if (bom == null || !bom.isObject() || factsByKey == null) {
+			return bom;
+		}
+		// reliza:support:* is a server-owned namespace. Strip EVERY occurrence anywhere in the
+		// tree BEFORE we write our own -- not just the component array but pedigree, services,
+		// metadata.tools.components, vulnerabilities, etc. -- so any reliza:support:* in the
+		// served BOM was provably written HERE and an uploader cannot spoof our provenance.
+		stripReservedEverywhere(bom);
+		injectInto(bom.get("components"), factsByKey, asOf);
+		// metadata.component is the root self-component (injected too if matched). The
+		// document-level disclosure marker is ALWAYS stamped so the download is labelled
+		// non-attested current-state -- creating metadata if the BOM somehow lacks it.
+		JsonNode metadata = bom.get("metadata");
+		ObjectNode metaObj;
+		if (metadata != null && metadata.isObject()) {
+			metaObj = (ObjectNode) metadata;
+			JsonNode root = metaObj.get("component");
+			if (root != null && root.isObject()) {
+				applyToComponent((ObjectNode) root, factsByKey, asOf);
+				injectInto(root.get("components"), factsByKey, asOf);
+			}
+		} else {
+			metaObj = ((ObjectNode) bom).putObject("metadata");
+		}
+		// Exactly one disclosure marker (the global sweep already removed any forged one).
+		addProperty(properties(metaObj), PROP_DISCLOSURE, DISCLOSURE_CURRENT_STATE);
+		return bom;
+	}
+
+	/**
+	 * Recursively remove every reliza:support:* property from every node's {@code properties}
+	 * array, everywhere in the tree -- the server-owned-namespace guarantee must hold document
+	 * wide, not just on the primary component surface.
+	 */
+	private static void stripReservedEverywhere(JsonNode node) {
+		if (node == null) {
+			return;
+		}
+		if (node.isObject()) {
+			stripByPrefix((ObjectNode) node, RELIZA_SUPPORT_PREFIX);
+		}
+		// Iterating a value node yields nothing, so this safely recurses only containers.
+		for (JsonNode child : node) {
+			stripReservedEverywhere(child);
+		}
+	}
+
+	private static void injectInto(JsonNode components, Map<String, SbomComponent> factsByKey, LocalDate asOf) {
+		if (components == null || !components.isArray()) {
+			return;
+		}
+		for (JsonNode c : components) {
+			if (c.isObject()) {
+				applyToComponent((ObjectNode) c, factsByKey, asOf);
+			}
+			injectInto(c.get("components"), factsByKey, asOf);
+		}
+	}
+
+	private static void applyToComponent(ObjectNode component, Map<String, SbomComponent> factsByKey, LocalDate asOf) {
+		// reliza:support:* was already stripped tree-wide by stripReservedEverywhere; here we
+		// only (re)write on a component we actually attest.
+		String key = componentKey(component);
+		SbomComponent sc = key == null ? null : factsByKey.get(key);
+		if (sc == null || sc.getSupportSource() == null) {
+			return;
+		}
+		LocalDate eos = sc.getEndOfSupportDate();
+		LocalDate eol = sc.getEndOfLifeDate();
+		SupportSource source = sc.getSupportSource();
+		SupportStatus status = SupportStatus.derive(eos, eol, source, asOf);
+		// We own the standard milestone keys for a component we attest: replace any existing
+		// (incl. an upstream-supplied one) so there is never a duplicate/conflict. Provenance is
+		// ALWAYS co-emitted as reliza:support:source. (PR4 must reconsider emitting the bare
+		// cdx: milestone for non-MANUAL sources -- today only MANUAL exists.)
+		stripByNames(component, MILESTONE_KEYS);
+		ArrayNode props = properties(component);
+		if (eos != null) {
+			addProperty(props, PROP_EOS, eos.toString());
+		}
+		if (eol != null) {
+			addProperty(props, PROP_EOL, eol.toString());
+		}
+		addProperty(props, PROP_STATUS, status.name());
+		addProperty(props, PROP_SOURCE, source.name());
+		if (sc.getSupportLastAssessed() != null) {
+			addProperty(props, PROP_LAST_ASSESSED, sc.getSupportLastAssessed().toInstant().toString());
+		}
+		// supportNotes is internal-only and is DELIBERATELY never emitted.
+	}
+
+	/** Remove every property whose name starts with {@code prefix} from a node's array. */
+	private static void stripByPrefix(ObjectNode node, String prefix) {
+		JsonNode props = node.get("properties");
+		if (props == null || !props.isArray()) {
+			return;
+		}
+		ArrayNode arr = (ArrayNode) props;
+		for (int i = arr.size() - 1; i >= 0; i--) {
+			JsonNode name = arr.get(i).get("name");
+			if (name != null && name.isTextual() && name.asText().startsWith(prefix)) {
+				arr.remove(i);
+			}
+		}
+	}
+
+	/** Remove every property whose name is in {@code names} from a node's array. */
+	private static void stripByNames(ObjectNode node, Set<String> names) {
+		JsonNode props = node.get("properties");
+		if (props == null || !props.isArray()) {
+			return;
+		}
+		ArrayNode arr = (ArrayNode) props;
+		for (int i = arr.size() - 1; i >= 0; i--) {
+			JsonNode name = arr.get(i).get("name");
+			if (name != null && name.isTextual() && names.contains(name.asText())) {
+				arr.remove(i);
+			}
+		}
+	}
+
+	private static ArrayNode properties(ObjectNode node) {
+		JsonNode existing = node.get("properties");
+		if (existing != null && existing.isArray()) {
+			return (ArrayNode) existing;
+		}
+		return node.putArray("properties");
+	}
+
+	private static void addProperty(ArrayNode props, String name, String value) {
+		ObjectNode prop = Utils.OM.createObjectNode();
+		prop.put("name", name);
+		prop.put("value", value);
+		props.add(prop);
+	}
+}

--- a/backend/src/main/java/io/reliza/service/SupportInjectionService.java
+++ b/backend/src/main/java/io/reliza/service/SupportInjectionService.java
@@ -1,0 +1,138 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+
+import io.reliza.common.Utils;
+import io.reliza.model.SbomComponent;
+import io.reliza.repositories.SbomComponentRepository;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Weaves stored per-component support facts into a served CycloneDX BOM at read time
+ * (FDA-Readiness-1 PR2a). Owns the encoding-aware match; the pure {@link SupportBomInjector}
+ * owns the tree edit. Depends only on {@link SbomComponentRepository}, so it introduces no
+ * cycle with {@code SharedArtifactService} / {@code SbomComponentService}.
+ */
+@Service
+public class SupportInjectionService {
+
+	private final SbomComponentRepository sbomComponentRepository;
+
+	SupportInjectionService(SbomComponentRepository sbomComponentRepository) {
+		this.sbomComponentRepository = sbomComponentRepository;
+	}
+
+	/**
+	 * Inject the CURRENT support facts (status derived as-of now, UTC) into a served CycloneDX
+	 * BOM tree, in place. This is the living, non-attested current-state view. Orgs with no
+	 * support attestations skip the per-component resolution entirely -- the injector still
+	 * runs (with no facts) to strip any uploader-forged reliza:support:* properties and stamp
+	 * the document-level disclosure marker.
+	 *
+	 * <p>Note: PR6's attested snapshot does NOT reuse {@link #resolveSupportFactsForBom} (that
+	 * returns LIVE rows); it builds its facts map from the attestation history as-of a cutoff
+	 * and calls {@link SupportBomInjector#inject} directly with that map and the cutoff clock.
+	 */
+	public JsonNode injectCurrentSupport(JsonNode bom, UUID orgUuid) {
+		Map<String, SbomComponent> facts = sbomComponentRepository.existsSupportByOrg(orgUuid.toString())
+				? resolveSupportFactsForBom(bom, orgUuid)
+				: Map.of();
+		return SupportBomInjector.inject(bom, facts, LocalDate.now(ZoneOffset.UTC));
+	}
+
+	/**
+	 * DB-free fallback for when fact resolution fails (e.g. a transient DB error): strip any
+	 * uploader-forged reliza:support:* tree-wide and stamp the disclosure marker with NO facts,
+	 * so a resolution outage cannot leave a forged server-owned property in the served BOM.
+	 */
+	public JsonNode stripForgedProvenanceAndMark(JsonNode bom) {
+		return SupportBomInjector.inject(bom, Map.of(), LocalDate.now(ZoneOffset.UTC));
+	}
+
+	/**
+	 * Resolve the stored (LIVE) support facts for every component in a BOM, keyed by
+	 * {@link SupportBomInjector#componentKey}. Read-only. Two-pass match mirroring
+	 * {@code SbomComponentService.stampEnrichedLicenses}: a byte-exact pass, then an
+	 * encoding-safe fallback for the Debian/rpm {@code +}/{@code %2B} canonical-purl drift.
+	 * Unlike the license stamper it uses the qualifier-aware IDENTITY comparator
+	 * ({@link Utils#purlsSemanticallyEqual}), not {@code purlsSameCoordinates} (license-scope
+	 * only). Ties among fallback candidates resolve to the most recently assessed row so the
+	 * result is reproducible.
+	 */
+	public Map<String, SbomComponent> resolveSupportFactsForBom(JsonNode bom, UUID orgUuid) {
+		Map<String, SbomComponent> byKey = new HashMap<>();
+		Set<String> keys = SupportBomInjector.collectKeys(bom);
+		if (keys.isEmpty()) return byKey;
+
+		// Byte-exact pass (catches the common case, incl. all cpe-only keys).
+		Set<String> byteMatched = new HashSet<>();
+		for (SbomComponent sc :
+				sbomComponentRepository.findByOrgAndCanonicalPurlIn(orgUuid.toString(), new ArrayList<>(keys))) {
+			byteMatched.add(sc.getCanonicalPurl());
+			byKey.put(sc.getCanonicalPurl(), sc);
+		}
+
+		// Encoding-safe fallback for purl keys the byte pass missed. cpe keys and malformed
+		// purls do not parse here, so they stay byte-only -- exactly the desired behavior.
+		Map<String, List<String>> unmatchedByName = new HashMap<>();
+		for (String key : keys) {
+			if (byteMatched.contains(key)) continue;
+			try {
+				PackageURL parsed = new PackageURL(key.replace("+", "%2B"));
+				if (parsed.getName() == null) continue;
+				unmatchedByName.computeIfAbsent(parsed.getName(), k -> new ArrayList<>()).add(key);
+			} catch (MalformedPackageURLException ignored) {
+			}
+		}
+		if (unmatchedByName.isEmpty()) return byKey;
+
+		for (SbomComponent candidate :
+				sbomComponentRepository.findCandidatesByOrgAndNames(orgUuid, unmatchedByName.keySet())) {
+			String candName = candidate.getRecordData() != null
+					&& candidate.getRecordData().get("name") instanceof String cn ? cn : null;
+			if (candName == null && candidate.getCanonicalPurl() != null) {
+				try {
+					candName = new PackageURL(candidate.getCanonicalPurl().replace("+", "%2B")).getName();
+				} catch (MalformedPackageURLException ignored) {
+				}
+			}
+			List<String> sameName = candName != null ? unmatchedByName.get(candName) : null;
+			if (sameName == null) continue;
+			for (String key : sameName) {
+				if (!Utils.purlsSemanticallyEqual(key, candidate.getCanonicalPurl())) continue;
+				// Deterministic tie-break: newest assessment wins (the query has no ORDER BY, and
+				// an org could hold >1 encoding-variant row for the same identity).
+				SbomComponent existing = byKey.get(key);
+				if (existing == null || moreRecentlyAssessed(candidate, existing)) {
+					byKey.put(key, candidate);
+				}
+			}
+		}
+		return byKey;
+	}
+
+	private static boolean moreRecentlyAssessed(SbomComponent a, SbomComponent b) {
+		ZonedDateTime la = a.getSupportLastAssessed();
+		ZonedDateTime lb = b.getSupportLastAssessed();
+		if (la == null) return false;
+		if (lb == null) return true;
+		return la.isAfter(lb);
+	}
+}

--- a/backend/src/main/java/io/reliza/ws/SbomComponentDataFetcher.java
+++ b/backend/src/main/java/io/reliza/ws/SbomComponentDataFetcher.java
@@ -3,6 +3,9 @@
 */
 package io.reliza.ws;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -19,6 +22,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -37,6 +41,7 @@ import io.reliza.model.ReleaseData;
 import io.reliza.model.ReleaseSbomComponent;
 import io.reliza.model.RelizaObject;
 import io.reliza.model.SbomComponent;
+import io.reliza.model.SupportStatus;
 import io.reliza.model.UserPermission.PermissionFunction;
 import io.reliza.model.UserPermission.PermissionScope;
 import io.reliza.model.dto.CveSearchResultDto.ComponentWithBranches;
@@ -355,6 +360,82 @@ public class SbomComponentDataFetcher {
 		return sbomComponentService.searchSbomComponentByPurl(purl, orgUuid);
 	}
 
+	/**
+	 * FDA-Readiness-1: manufacturer (MANUAL) attestation of a component's support
+	 * level / EOS-EOL dates. Org-scoped WRITE; the org is derived from the loaded
+	 * component (IDOR guard), never from client input. supportSource is set
+	 * server-side to MANUAL and the attester is the authenticated user; the derived
+	 * status is computed on read, not set here. Retries a concurrent-reconcile
+	 * optimistic-lock conflict a bounded number of times.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Mutation", field = "setSbomComponentSupport")
+	public Map<String, Object> setSbomComponentSupport(
+			@InputArgument("sbomComponentUuid") UUID sbomComponentUuid,
+			@InputArgument("endOfSupportDate") String endOfSupportDate,
+			@InputArgument("endOfLifeDate") String endOfLifeDate,
+			@InputArgument("supportNotes") String supportNotes) throws RelizaException {
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		SbomComponent sc = sbomComponentService.getSbomComponent(sbomComponentUuid)
+				.orElseThrow(() -> new RelizaException("sbom component not found"));
+		UUID orgUuid = sc.getOrg();
+		RelizaObject ro = getOrganizationService.getOrganizationData(orgUuid)
+				.orElseThrow(() -> new RelizaException("organization not found"));
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.WRITE);
+
+		LocalDate eos = parseIsoDate(endOfSupportDate, "endOfSupportDate");
+		LocalDate eol = parseIsoDate(endOfLifeDate, "endOfLifeDate");
+		if (eos != null && eol != null && eos.isAfter(eol)) {
+			throw new RelizaException("endOfSupportDate must not be after endOfLifeDate");
+		}
+		UUID assertedBy = oud.get().getUuid();
+		// Bounded retry against a concurrent-reconcile optimistic-lock conflict.
+		for (int attempt = 0; attempt < 3; attempt++) {
+			try {
+				SbomComponent updated = sbomComponentService.setSbomComponentSupport(
+						sbomComponentUuid, eos, eol, supportNotes, assertedBy);
+				return toComponentDto(updated);
+			} catch (OptimisticLockingFailureException ole) {
+				// retry
+			}
+		}
+		throw new RelizaException("concurrent update in progress, please retry");
+	}
+
+	/**
+	 * FDA-Readiness-1: support-disclosure coverage for an org (attested vs total
+	 * non-root components) -- a pre-submission completeness signal.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@DgsData(parentType = "Query", field = "sbomComponentSupportCoverage")
+	public Map<String, Object> sbomComponentSupportCoverage(
+			@InputArgument("orgUuid") UUID orgUuid) throws RelizaException {
+		JwtAuthenticationToken auth = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+		var oud = userService.getUserDataByAuth(auth);
+		// orgUuid is client-supplied: a non-existent id must not reach List.of(null)
+		// (which NPEs) -- resolve to not-found first.
+		RelizaObject ro = getOrganizationService.getOrganizationData(orgUuid)
+				.orElseThrow(() -> new RelizaException("organization not found"));
+		authorizationService.isUserAuthorizedForObjectGraphQL(oud.get(), PermissionFunction.RESOURCE,
+				PermissionScope.ORGANIZATION, orgUuid, List.of(ro), CallType.READ);
+		SbomComponentService.SupportCoverage cov = sbomComponentService.getSupportCoverage(orgUuid);
+		Map<String, Object> dto = new LinkedHashMap<>();
+		dto.put("total", (int) cov.total());
+		dto.put("attested", (int) cov.attested());
+		return dto;
+	}
+
+	private static LocalDate parseIsoDate(String value, String field) throws RelizaException {
+		if (value == null || value.isBlank()) return null;
+		try {
+			return LocalDate.parse(value.trim());
+		} catch (DateTimeParseException dtpe) {
+			throw new RelizaException(field + " must be an ISO-8601 date (YYYY-MM-DD)");
+		}
+	}
+
 	@DgsData(parentType = "ReleaseSbomComponent", field = "component")
 	public Map<String, Object> getComponent(DgsDataFetchingEnvironment dfe) {
 		ReleaseGraphContext ctx = dfe.getLocalContext();
@@ -491,6 +572,20 @@ public class SbomComponentDataFetcher {
 		} else {
 			dto.put("isRoot", false);
 		}
+		// Support disclosure. supportStatus is DERIVED from the dates + now (never
+		// stored). Dates emitted as ISO-8601 (YYYY-MM-DD); supportLastAssessed as a
+		// UTC RFC-3339 instant (trailing Z), never ZonedDateTime.toString().
+		LocalDate endOfSupport = sc.getEndOfSupportDate();
+		LocalDate endOfLife = sc.getEndOfLifeDate();
+		SupportStatus supportStatus = SupportStatus.derive(
+				endOfSupport, endOfLife, sc.getSupportSource(), LocalDate.now(ZoneOffset.UTC));
+		dto.put("supportStatus", supportStatus.name());
+		dto.put("endOfSupportDate", endOfSupport == null ? null : endOfSupport.toString());
+		dto.put("endOfLifeDate", endOfLife == null ? null : endOfLife.toString());
+		dto.put("supportSource", sc.getSupportSource() == null ? null : sc.getSupportSource().name());
+		dto.put("supportLastAssessed", sc.getSupportLastAssessed() == null
+				? null : sc.getSupportLastAssessed().toInstant().toString());
+		dto.put("supportNotes", sc.getSupportNotes());
 		return dto;
 	}
 

--- a/backend/src/main/resources/db/migration/V82__sbom_component_support.sql
+++ b/backend/src/main/resources/db/migration/V82__sbom_component_support.sql
@@ -1,0 +1,36 @@
+-- FDA-Readiness-1 PR1: per-component support-status + EOS/EOL storage and attestation.
+-- Support facts are mutable and queried (the approaching/past-EOS filter), so they are
+-- first-class columns (mirrors licenses / enriched_at), NOT record_data JSONB. The support
+-- STATUS is derived at read time from these dates and is never stored.
+ALTER TABLE rearm.sbom_components
+    ADD COLUMN IF NOT EXISTS end_of_support_date date,
+    ADD COLUMN IF NOT EXISTS end_of_life_date date,
+    ADD COLUMN IF NOT EXISTS support_source text,
+    ADD COLUMN IF NOT EXISTS support_last_assessed timestamptz,
+    ADD COLUMN IF NOT EXISTS support_asserted_by uuid,
+    ADD COLUMN IF NOT EXISTS support_notes text;
+
+-- Partial btree for the "approaching / past EOS" filter. Partial because most rows are null
+-- pre-attestation, keeping the index small (mirrors the V25 / V73 partial-index pattern).
+CREATE INDEX IF NOT EXISTS sbom_components_eos_idx
+    ON rearm.sbom_components (org, end_of_support_date)
+    WHERE end_of_support_date IS NOT NULL;
+
+-- Append-only attestation history (ALCOA input-side record of record). Shaped after
+-- metrics_audit: surrogate uuid PK, entity_uuid + revision + org, no FK. One row per
+-- setSbomComponentSupport edit, capturing the asserted (after-image) values + attester.
+CREATE TABLE IF NOT EXISTS rearm.sbom_component_support_audit (
+    uuid uuid NOT NULL PRIMARY KEY default gen_random_uuid(),
+    sbom_component_uuid uuid NOT NULL,
+    org uuid NOT NULL,
+    support_revision integer NOT NULL,
+    end_of_support_date date,
+    end_of_life_date date,
+    support_source text NOT NULL,
+    support_notes text,
+    support_asserted_by uuid,
+    asserted_date timestamptz NOT NULL default now()
+);
+
+CREATE INDEX IF NOT EXISTS sbom_component_support_audit_component_idx
+    ON rearm.sbom_component_support_audit (sbom_component_uuid);

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -155,6 +155,8 @@ type Query {
 	releasesBySbomComponents(orgUuid: ID!, sbomComponentUuids: [ID]!, perspectiveUuid: ID): [ComponentWithBranches]
 	sbomComponentSearchNative(orgUuid: ID!, queries: [SbomComponentSearchInput!]!, perspectiveUuid: ID): [ComponentPurlToSbom]
 	searchSbomComponentByPurl(orgUuid: ID!, purl: String!): ID
+	# FDA-Readiness-1: support-disclosure completeness for an org (attested vs total non-root components).
+	sbomComponentSupportCoverage(orgUuid: ID!): SbomComponentSupportCoverage
 	
 	getAllOrganizations: [Organization]
 	
@@ -740,6 +742,10 @@ type Mutation {
 	# (e.g. an earlier async reconcile failed). Returns true on success; throws on failure so the
 	# caller sees the underlying error.
 	reconcileReleaseSbomComponents(releaseUuid: ID!): Boolean
+	# FDA-Readiness-1: manufacturer attests a component's support level / EOS-EOL dates.
+	# Server-set source=MANUAL, attester recorded, appended to the append-only attestation
+	# history. supportStatus is derived on read, not set here. Dates are ISO-8601 (YYYY-MM-DD).
+	setSbomComponentSupport(sbomComponentUuid: ID!, endOfSupportDate: String, endOfLifeDate: String, supportNotes: String): SbomComponent
 	"""
 	Recompute a release's findings metrics from CURRENT scan and KEV state:
 	re-gathers the release's artifacts, merges their (fan-out-maintained)
@@ -6074,6 +6080,45 @@ type SbomComponent {
 	name: String
 	version: String
 	isRoot: Boolean
+	# FDA-Readiness-1 per-component support disclosure. supportStatus is DERIVED
+	# from the dates and the current date (never stored). Dates are ISO-8601
+	# (YYYY-MM-DD); supportLastAssessed is a UTC RFC-3339 instant. supportNotes is
+	# internal-only (shown to authorized org users, never injected into an export).
+	supportStatus: SupportStatus
+	endOfSupportDate: String
+	endOfLifeDate: String
+	supportSource: SupportSource
+	supportLastAssessed: String
+	supportNotes: String
+}
+
+# Per-component support level. Derived from the support dates + current date; the
+# manufacturer attests the DATES, not this value. Aligns to FDA support adjectives
+# and IMDRF N60 lifecycle stages. SECURITY_ONLY and ABANDONED are reserved for
+# later slices (not yet produced from the two stored dates alone).
+enum SupportStatus {
+	ACTIVELY_SUPPORTED
+	SECURITY_ONLY
+	END_OF_SUPPORT
+	END_OF_LIFE
+	ABANDONED
+	UNKNOWN
+}
+
+# Provenance of a support assertion, set server-side per write path.
+enum SupportSource {
+	MANUAL
+	SUPPLIER
+	ENRICHED
+}
+
+# Support-disclosure completeness for an org. attested = non-root components with a
+# MANUFACTURER (MANUAL) attestation (excludes machine ENRICHED / supplier-declared
+# provenance, which are not a manufacturer disclosure). total = all non-root components.
+# Per-source counts can be added as new fields additively if needed.
+type SbomComponentSupportCoverage {
+	total: Int!
+	attested: Int!
 }
 
 # One row per (release, canonical component). artifactParticipations lists

--- a/backend/src/test/java/io/reliza/model/SupportStatusTest.java
+++ b/backend/src/test/java/io/reliza/model/SupportStatusTest.java
@@ -1,0 +1,63 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the SupportStatus.derive contract -- the single source of truth every read /
+ * export / snapshot surface calls. Covers the inclusive-boundary and EOL-precedence
+ * decisions and the null-asOf guard so downstream slices cannot silently change them.
+ */
+class SupportStatusTest {
+
+	private static final LocalDate TODAY = LocalDate.of(2026, 8, 26);
+
+	@Test
+	void unknownWhenNoDates() {
+		assertEquals(SupportStatus.UNKNOWN, SupportStatus.derive(null, null, null, TODAY));
+	}
+
+	@Test
+	void activelySupportedWhenEosInFuture() {
+		assertEquals(SupportStatus.ACTIVELY_SUPPORTED,
+				SupportStatus.derive(TODAY.plusYears(1), null, SupportSource.MANUAL, TODAY));
+	}
+
+	@Test
+	void endOfSupportOnceEosPast() {
+		assertEquals(SupportStatus.END_OF_SUPPORT,
+				SupportStatus.derive(TODAY.minusDays(1), null, SupportSource.MANUAL, TODAY));
+	}
+
+	@Test
+	void boundaryEosIsInclusive() {
+		// asOf exactly on the EOS date -> the milestone takes effect that day.
+		assertEquals(SupportStatus.END_OF_SUPPORT,
+				SupportStatus.derive(TODAY, null, SupportSource.MANUAL, TODAY));
+	}
+
+	@Test
+	void boundaryEolIsInclusive() {
+		assertEquals(SupportStatus.END_OF_LIFE,
+				SupportStatus.derive(TODAY.minusYears(1), TODAY, SupportSource.MANUAL, TODAY));
+	}
+
+	@Test
+	void eolOutranksEosWhenBothPast() {
+		assertEquals(SupportStatus.END_OF_LIFE,
+				SupportStatus.derive(TODAY.minusDays(10), TODAY.minusDays(5), SupportSource.MANUAL, TODAY));
+	}
+
+	@Test
+	void nullAsOfIsRejected() {
+		assertThrows(NullPointerException.class,
+				() -> SupportStatus.derive(TODAY, null, SupportSource.MANUAL, null));
+	}
+}

--- a/backend/src/test/java/io/reliza/service/SbomComponentEnrichmentPullerTest.java
+++ b/backend/src/test/java/io/reliza/service/SbomComponentEnrichmentPullerTest.java
@@ -37,6 +37,7 @@ import io.reliza.repositories.ArtifactSbomComponentRepository;
 import io.reliza.repositories.ReleaseArtifactIndexRepository;
 import io.reliza.repositories.ReleaseRepository;
 import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.repositories.SbomComponentSupportAuditRepository;
 
 /** Unit tests for the BEAR-enrichment puller in {@link SbomComponentService}. */
 @ExtendWith(MockitoExtension.class)
@@ -46,6 +47,7 @@ class SbomComponentEnrichmentPullerTest {
 	@Mock private ArtifactSbomComponentRepository artifactSbomComponentRepository;
 	@Mock private ReleaseArtifactIndexRepository releaseArtifactIndexRepository;
 	@Mock private ArtifactCanonicalMapRepository artifactCanonicalMapRepository;
+	@Mock private SbomComponentSupportAuditRepository sbomComponentSupportAuditRepository;
 	@Mock private ReleaseRepository releaseRepository;
 	@Mock private RebomService rebomService;
 	@Mock private ArtifactService artifactService;
@@ -58,7 +60,8 @@ class SbomComponentEnrichmentPullerTest {
 	void setUp() {
 		service = new SbomComponentService(
 				sbomComponentRepository, artifactSbomComponentRepository,
-				releaseArtifactIndexRepository, artifactCanonicalMapRepository);
+				releaseArtifactIndexRepository, artifactCanonicalMapRepository,
+				sbomComponentSupportAuditRepository);
 		ReflectionTestUtils.setField(service, "releaseRepository", releaseRepository);
 		ReflectionTestUtils.setField(service, "rebomService", rebomService);
 		ReflectionTestUtils.setField(service, "artifactService", artifactService);

--- a/backend/src/test/java/io/reliza/service/SbomComponentPurlSearchTest.java
+++ b/backend/src/test/java/io/reliza/service/SbomComponentPurlSearchTest.java
@@ -27,6 +27,7 @@ import io.reliza.repositories.ArtifactCanonicalMapRepository;
 import io.reliza.repositories.ArtifactSbomComponentRepository;
 import io.reliza.repositories.ReleaseArtifactIndexRepository;
 import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.repositories.SbomComponentSupportAuditRepository;
 import io.reliza.service.SbomComponentService.ComponentPurlToSbom;
 import io.reliza.service.SbomComponentService.SbomComponentSearchQuery;
 
@@ -46,6 +47,7 @@ class SbomComponentPurlSearchTest {
 	@Mock private ArtifactSbomComponentRepository artifactSbomComponentRepository;
 	@Mock private ReleaseArtifactIndexRepository releaseArtifactIndexRepository;
 	@Mock private ArtifactCanonicalMapRepository artifactCanonicalMapRepository;
+	@Mock private SbomComponentSupportAuditRepository sbomComponentSupportAuditRepository;
 
 	private SbomComponentService service;
 
@@ -55,7 +57,8 @@ class SbomComponentPurlSearchTest {
 	void setUp() {
 		service = new SbomComponentService(
 				sbomComponentRepository, artifactSbomComponentRepository,
-				releaseArtifactIndexRepository, artifactCanonicalMapRepository);
+				releaseArtifactIndexRepository, artifactCanonicalMapRepository,
+				sbomComponentSupportAuditRepository);
 	}
 
 	private SbomComponent comp(String canonicalPurl) {

--- a/backend/src/test/java/io/reliza/service/SbomComponentSupportServiceIntegrationTest.java
+++ b/backend/src/test/java/io/reliza/service/SbomComponentSupportServiceIntegrationTest.java
@@ -1,0 +1,121 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.model.Organization;
+import io.reliza.model.SbomComponent;
+import io.reliza.model.SbomComponentSupportAudit;
+import io.reliza.model.SupportSource;
+import io.reliza.model.SupportStatus;
+import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.repositories.SbomComponentSupportAuditRepository;
+import io.reliza.service.SbomComponentService.SupportCoverage;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Behavioral validation for FDA-Readiness-1 PR1 (per-component support-status +
+ * EOS/EOL). Boots the app against the shared rearm-test-pg so the V82 migration
+ * actually applies, then exercises the attestation write end-to-end: columns
+ * persist, the derived status is computed from the stored dates, the append-only
+ * attestation history captures the after-image + attester (and a second
+ * attestation APPENDS rather than overwrites), and the coverage counts move.
+ * Uses a fresh per-test org so the shared DB cannot contaminate the assertions.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class SbomComponentSupportServiceIntegrationTest {
+
+	@Autowired private SbomComponentService sbomComponentService;
+	@Autowired private SbomComponentRepository sbomComponentRepository;
+	@Autowired private SbomComponentSupportAuditRepository auditRepository;
+	@Autowired private TestInitializer testInitializer;
+
+	private SbomComponent newComponent(UUID org, String canonicalPurl) {
+		SbomComponent sc = new SbomComponent();
+		sc.setOrg(org);
+		sc.setCanonicalPurl(canonicalPurl);
+		return sbomComponentRepository.save(sc);
+	}
+
+	@Test
+	void attestationPersistsDerivesAuditsAndCountsCoverage() {
+		Organization org = testInitializer.obtainOrganization();
+		UUID orgUuid = org.getUuid();
+		String purl = "pkg:maven/org.example/lib@1.2.3?t=" + UUID.randomUUID();
+		SbomComponent sc = newComponent(orgUuid, purl);
+
+		UUID attester = UUID.randomUUID();
+		LocalDate pastEos = LocalDate.now().minusDays(30);
+		sbomComponentService.setSbomComponentSupport(
+				sc.getUuid(), pastEos, null, "vendor announced EOS", attester);
+
+		// Persisted facts.
+		SbomComponent reloaded = sbomComponentRepository.findById(sc.getUuid()).orElseThrow();
+		assertEquals(pastEos, reloaded.getEndOfSupportDate());
+		assertNull(reloaded.getEndOfLifeDate());
+		assertEquals(SupportSource.MANUAL, reloaded.getSupportSource());
+		assertEquals(attester, reloaded.getSupportAssertedBy());
+		assertNotNull(reloaded.getSupportLastAssessed());
+		assertEquals("vendor announced EOS", reloaded.getSupportNotes());
+
+		// Derived status: past EOS, no EOL -> END_OF_SUPPORT.
+		assertEquals(SupportStatus.END_OF_SUPPORT, SupportStatus.derive(
+				reloaded.getEndOfSupportDate(), reloaded.getEndOfLifeDate(),
+				reloaded.getSupportSource(), LocalDate.now()));
+
+		// Append-only history: one after-image row with the attester.
+		List<SbomComponentSupportAudit> hist = auditRepository
+				.findBySbomComponentUuidOrderByAssertedDateDesc(sc.getUuid());
+		assertEquals(1, hist.size());
+		assertEquals(pastEos, hist.get(0).getEndOfSupportDate());
+		assertEquals(SupportSource.MANUAL, hist.get(0).getSupportSource());
+		assertEquals(attester, hist.get(0).getSupportAssertedBy());
+		assertEquals(reloaded.getRevision(), hist.get(0).getSupportRevision(),
+				"audit revision should match the committed component revision");
+
+		// A second attestation APPENDS (never overwrites) and moves the derived status.
+		LocalDate futureEos = LocalDate.now().plusYears(1);
+		sbomComponentService.setSbomComponentSupport(sc.getUuid(), futureEos, null, null, attester);
+		List<SbomComponentSupportAudit> hist2 = auditRepository
+				.findBySbomComponentUuidOrderByAssertedDateDesc(sc.getUuid());
+		assertEquals(2, hist2.size());
+
+		SbomComponent reloaded2 = sbomComponentRepository.findById(sc.getUuid()).orElseThrow();
+		assertEquals(SupportStatus.ACTIVELY_SUPPORTED, SupportStatus.derive(
+				reloaded2.getEndOfSupportDate(), reloaded2.getEndOfLifeDate(),
+				reloaded2.getSupportSource(), LocalDate.now()));
+
+		// Coverage counts the (only, non-root) MANUAL-attested component in this fresh org.
+		SupportCoverage cov = sbomComponentService.getSupportCoverage(orgUuid);
+		assertEquals(1, cov.total(), "the one non-root component is counted in total");
+		assertEquals(1, cov.attested(), "the MANUAL attestation is counted");
+
+		// Discriminating: a SUPPLIER-sourced row is NOT a manufacturer attestation, so it
+		// counts toward total but MUST NOT count as attested (pins the MANUAL-only numerator).
+		SbomComponent supplierComp = newComponent(orgUuid,
+				"pkg:maven/org.example/other@2.0.0?t=" + UUID.randomUUID());
+		supplierComp.setSupportSource(SupportSource.SUPPLIER);
+		sbomComponentRepository.save(supplierComp);
+		SupportCoverage cov2 = sbomComponentService.getSupportCoverage(orgUuid);
+		assertEquals(2, cov2.total(), "both non-root components counted in total");
+		assertEquals(1, cov2.attested(), "SUPPLIER provenance excluded; only MANUAL attested");
+	}
+}

--- a/backend/src/test/java/io/reliza/service/SupportBomInjectorTest.java
+++ b/backend/src/test/java/io/reliza/service/SupportBomInjectorTest.java
@@ -1,0 +1,260 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.parsers.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+
+import io.reliza.common.Utils;
+import io.reliza.model.SbomComponent;
+import io.reliza.model.SupportSource;
+
+/**
+ * Pure behavior tests for the read-time support-property injector: matching by canonical
+ * purl / cpe, recursion into nested components, append-not-overwrite of existing properties,
+ * the never-emit-supportNotes invariant, never-assessed skipping, and the document-level
+ * disclosure marker. No Spring / DB.
+ */
+class SupportBomInjectorTest {
+
+	private static final LocalDate ASOF = LocalDate.of(2026, 6, 1);
+
+	private SbomComponent manual(LocalDate eos, LocalDate eol, String notes) {
+		SbomComponent sc = new SbomComponent();
+		sc.setSupportSource(SupportSource.MANUAL);
+		sc.setEndOfSupportDate(eos);
+		sc.setEndOfLifeDate(eol);
+		sc.setSupportNotes(notes);
+		sc.setSupportLastAssessed(ZonedDateTime.of(2026, 8, 26, 12, 0, 0, 0, ZoneOffset.UTC));
+		return sc;
+	}
+
+	private JsonNode parse(String json) throws Exception {
+		return Utils.OM.readTree(json);
+	}
+
+	/** Flatten a component/metadata properties array into name -> value. */
+	private Map<String, String> propMap(JsonNode component) {
+		Map<String, String> out = new HashMap<>();
+		JsonNode props = component.get("properties");
+		if (props == null || !props.isArray()) {
+			return out;
+		}
+		for (JsonNode p : props) {
+			out.put(p.get("name").asText(), p.get("value").asText());
+		}
+		return out;
+	}
+
+	@Test
+	void appendsSupportPropertiesAndPreservesExistingAndSpecVersion() throws Exception {
+		JsonNode bom = parse("""
+			{"bomFormat":"CycloneDX","specVersion":"1.5","components":[
+			  {"type":"library","name":"lib","purl":"pkg:maven/org.example/lib@1.2.3",
+			   "properties":[{"name":"existing","value":"keep"}]},
+			  {"type":"library","name":"other","purl":"pkg:npm/other@2.0.0"}
+			]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		Map<String, SbomComponent> facts = Map.of(
+				key, manual(LocalDate.of(2026, 1, 1), null, "SECRET internal note"));
+
+		SupportBomInjector.inject(bom, facts, ASOF);
+
+		Map<String, String> p0 = propMap(bom.get("components").get(0));
+		assertEquals("keep", p0.get("existing"), "existing property preserved");
+		assertEquals("MANUAL", p0.get(SupportBomInjector.PROP_SOURCE));
+		assertEquals("END_OF_SUPPORT", p0.get(SupportBomInjector.PROP_STATUS)); // EOS 2026-01-01 < asOf
+		assertEquals("2026-01-01", p0.get(SupportBomInjector.PROP_EOS));
+		assertTrue(p0.containsKey(SupportBomInjector.PROP_LAST_ASSESSED));
+		assertNull(p0.get(SupportBomInjector.PROP_EOL), "no EOL date -> no EOL property");
+		// specVersion untouched (no object-model round-trip).
+		assertEquals("1.5", bom.get("specVersion").asText());
+		// Unmatched component gets nothing.
+		assertNull(bom.get("components").get(1).get("properties"));
+	}
+
+	@Test
+	void neverEmitsSupportNotes() throws Exception {
+		JsonNode bom = parse("""
+			{"specVersion":"1.6","components":[
+			  {"name":"lib","purl":"pkg:maven/org.example/lib@1.2.3"}]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		SupportBomInjector.inject(bom, Map.of(key, manual(null, null, "DO NOT LEAK")), ASOF);
+
+		Map<String, String> p = propMap(bom.get("components").get(0));
+		assertFalse(p.containsKey("supportNotes"));
+		assertFalse(p.values().stream().anyMatch(v -> v.contains("DO NOT LEAK")),
+				"internal notes must never reach the exported BOM");
+		// A MANUAL row with no dates still emits status (UNKNOWN) + source.
+		assertEquals("UNKNOWN", p.get(SupportBomInjector.PROP_STATUS));
+		assertEquals("MANUAL", p.get(SupportBomInjector.PROP_SOURCE));
+	}
+
+	@Test
+	void skipsNeverAssessedComponents() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[{"name":"lib","purl":"pkg:maven/org.example/lib@1.2.3"}]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		// Row present but no supportSource -> not assessed -> no properties.
+		SupportBomInjector.inject(bom, Map.of(key, new SbomComponent()), ASOF);
+		assertNull(bom.get("components").get(0).get("properties"));
+	}
+
+	@Test
+	void recursesNestedComponents() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[
+			  {"name":"parent","purl":"pkg:maven/org.example/parent@1.0.0","components":[
+			    {"name":"child","purl":"pkg:maven/org.example/child@2.0.0"}]}]}""");
+		JsonNode child = bom.get("components").get(0).get("components").get(0);
+		String childKey = SupportBomInjector.componentKey(child);
+		SupportBomInjector.inject(bom, Map.of(childKey, manual(null, null, null)), ASOF);
+		Map<String, String> pc = propMap(child);
+		assertEquals("MANUAL", pc.get(SupportBomInjector.PROP_SOURCE), "nested child is injected");
+	}
+
+	@Test
+	void matchesCpeOnlyComponentByCpeKey() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[{"name":"thing","cpe":"cpe:2.3:a:vendor:thing:1.0:*:*:*:*:*:*:*"}]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		assertEquals("cpe:2.3:a:vendor:thing:1.0:*:*:*:*:*:*:*", key);
+		SupportBomInjector.inject(bom, Map.of(key, manual(LocalDate.of(2030, 1, 1), null, null)), ASOF);
+		Map<String, String> p = propMap(bom.get("components").get(0));
+		assertEquals("ACTIVELY_SUPPORTED", p.get(SupportBomInjector.PROP_STATUS)); // future EOS
+	}
+
+	@Test
+	void componentWithNeitherPurlNorCpeIsUnmatchable() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[{"name":"mystery","type":"library"}]}""");
+		assertNull(SupportBomInjector.componentKey(bom.get("components").get(0)));
+		assertTrue(SupportBomInjector.collectKeys(bom).isEmpty());
+	}
+
+	@Test
+	void stampsDocumentLevelDisclosureMarker() throws Exception {
+		JsonNode bom = parse("""
+			{"specVersion":"1.5","metadata":{"component":{"name":"root","purl":"pkg:oci/app@1.0.0"}},
+			 "components":[]}""");
+		SupportBomInjector.inject(bom, Map.of(), ASOF);
+		Map<String, String> meta = propMap(bom.get("metadata"));
+		assertEquals(SupportBomInjector.DISCLOSURE_CURRENT_STATE,
+				meta.get(SupportBomInjector.PROP_DISCLOSURE));
+	}
+
+	private long count(ArrayNode props, String name) {
+		long n = 0;
+		for (JsonNode p : props) {
+			if (name.equals(p.get("name").asText())) n++;
+		}
+		return n;
+	}
+
+	@Test
+	void stripsForgedRelizaSupportOnUnmatchedComponent() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[
+			  {"name":"evil","purl":"pkg:npm/evil@1.0.0","properties":[
+			    {"name":"reliza:support:source","value":"MANUAL"},
+			    {"name":"reliza:support:status","value":"ACTIVELY_SUPPORTED"},
+			    {"name":"keep:me","value":"ok"}]}]}""");
+		// No facts -> unmatched; forged provenance must not survive.
+		SupportBomInjector.inject(bom, Map.of(), ASOF);
+		Map<String, String> p = propMap(bom.get("components").get(0));
+		assertFalse(p.containsKey("reliza:support:source"), "forged provenance stripped");
+		assertFalse(p.containsKey("reliza:support:status"), "forged status stripped");
+		assertEquals("ok", p.get("keep:me"), "non-reliza properties preserved");
+	}
+
+	@Test
+	void replacesForgedAndPreExistingOnMatchedComponent() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[
+			  {"name":"lib","purl":"pkg:maven/org.example/lib@1.2.3","properties":[
+			    {"name":"reliza:support:source","value":"MANUAL"},
+			    {"name":"cdx:lifecycle:milestone:endOfSupport","value":"2099-01-01"}]}]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		SupportBomInjector.inject(bom, Map.of(key, manual(LocalDate.of(2026, 1, 1), null, null)), ASOF);
+		ArrayNode props = (ArrayNode) bom.get("components").get(0).get("properties");
+		assertEquals(1, count(props, SupportBomInjector.PROP_EOS), "single milestone -- forged one replaced");
+		assertEquals(1, count(props, SupportBomInjector.PROP_SOURCE), "single provenance");
+		Map<String, String> p = propMap(bom.get("components").get(0));
+		assertEquals("2026-01-01", p.get(SupportBomInjector.PROP_EOS), "our value, not the forged 2099-01-01");
+	}
+
+	@Test
+	void stampsExactlyOneDisclosureEvenIfForged() throws Exception {
+		JsonNode bom = parse("""
+			{"metadata":{"properties":[{"name":"reliza:support:disclosure","value":"attested-forged"}]},
+			 "components":[]}""");
+		SupportBomInjector.inject(bom, Map.of(), ASOF);
+		ArrayNode props = (ArrayNode) bom.get("metadata").get("properties");
+		assertEquals(1, count(props, SupportBomInjector.PROP_DISCLOSURE), "exactly one disclosure marker");
+		Map<String, String> meta = propMap(bom.get("metadata"));
+		assertEquals(SupportBomInjector.DISCLOSURE_CURRENT_STATE, meta.get(SupportBomInjector.PROP_DISCLOSURE));
+	}
+
+	@Test
+	void componentKeyFallsThroughToCpeWhenPurlUnparseable() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[{"name":"x","purl":"not-a-purl","cpe":"cpe:2.3:a:v:x:1:*:*:*:*:*:*:*"}]}""");
+		assertEquals("cpe:2.3:a:v:x:1:*:*:*:*:*:*:*",
+				SupportBomInjector.componentKey(bom.get("components").get(0)));
+	}
+
+	@Test
+	void stripsForgedRelizaSupportEverywhereInTree() throws Exception {
+		JsonNode bom = parse("""
+			{"components":[
+			  {"name":"c","purl":"pkg:npm/c@1.0.0","pedigree":{"variants":[
+			    {"name":"variant","purl":"pkg:npm/v@1.0.0","properties":[
+			      {"name":"reliza:support:source","value":"MANUAL"}]}]}}],
+			 "services":[{"name":"svc","properties":[
+			   {"name":"reliza:support:status","value":"ACTIVELY_SUPPORTED"}]}],
+			 "metadata":{"tools":{"components":[{"name":"tool","properties":[
+			   {"name":"reliza:support:source","value":"MANUAL"}]}]}}}""");
+		SupportBomInjector.inject(bom, Map.of(), ASOF);
+		JsonNode variant = bom.get("components").get(0).get("pedigree").get("variants").get(0);
+		assertTrue(propMap(variant).keySet().stream().noneMatch(k -> k.startsWith("reliza:support:")),
+				"forged prop in pedigree.variants stripped");
+		JsonNode svc = bom.get("services").get(0);
+		assertTrue(propMap(svc).keySet().stream().noneMatch(k -> k.startsWith("reliza:support:")),
+				"forged prop in services stripped");
+		JsonNode tool = bom.get("metadata").get("tools").get("components").get(0);
+		assertTrue(propMap(tool).keySet().stream().noneMatch(k -> k.startsWith("reliza:support:")),
+				"forged prop in metadata.tools.components stripped");
+	}
+
+	@Test
+	void injectedOutputIsCycloneDxParseable() throws Exception {
+		JsonNode bom = parse("""
+			{"bomFormat":"CycloneDX","specVersion":"1.5","version":1,
+			 "metadata":{"component":{"type":"application","name":"root","purl":"pkg:oci/app@1.0.0"}},
+			 "components":[{"type":"library","name":"lib","purl":"pkg:maven/org.example/lib@1.2.3"}]}""");
+		String key = SupportBomInjector.componentKey(bom.get("components").get(0));
+		SupportBomInjector.inject(bom, Map.of(key, manual(LocalDate.of(2026, 1, 1), null, null)), ASOF);
+		byte[] bytes = bom.toString().getBytes(StandardCharsets.UTF_8);
+		Bom parsed = new JsonParser().parse(bytes);
+		assertNotNull(parsed, "injected BOM is still CycloneDX-parseable");
+		assertFalse(parsed.getComponents().isEmpty(), "components survived the injection");
+	}
+}

--- a/backend/src/test/java/io/reliza/service/SupportInjectionServiceIntegrationTest.java
+++ b/backend/src/test/java/io/reliza/service/SupportInjectionServiceIntegrationTest.java
@@ -1,0 +1,113 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.common.Utils;
+import io.reliza.model.Organization;
+import io.reliza.model.SbomComponent;
+import io.reliza.model.SupportSource;
+import io.reliza.repositories.SbomComponentRepository;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+import tools.jackson.databind.JsonNode;
+
+/**
+ * Integration test for the read-time support-injection MATCH against a real Postgres: the
+ * byte-exact pass, the encoding-safe fallback for the {@code +}/{@code %2B} canonical-purl
+ * drift, and that unmatched components get nothing. Exercises the actual repository queries
+ * ({@code findByOrgAndCanonicalPurlIn} / {@code findCandidatesByOrgAndNames}) +
+ * {@code Utils.purlsSemanticallyEqual}. Uses a fresh per-test org.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class SupportInjectionServiceIntegrationTest {
+
+	@Autowired private SupportInjectionService supportInjectionService;
+	@Autowired private SbomComponentRepository sbomComponentRepository;
+	@Autowired private TestInitializer testInitializer;
+
+	private SbomComponent supported(UUID org, String canonicalPurl, String name, String version, LocalDate eos) {
+		SbomComponent sc = new SbomComponent();
+		sc.setOrg(org);
+		sc.setCanonicalPurl(canonicalPurl);
+		Map<String, Object> rd = new HashMap<>();
+		rd.put("name", name);
+		rd.put("version", version);
+		sc.setRecordData(rd);
+		sc.setSupportSource(SupportSource.MANUAL);
+		sc.setEndOfSupportDate(eos);
+		sc.setSupportLastAssessed(ZonedDateTime.now());
+		return sbomComponentRepository.save(sc);
+	}
+
+	private Map<String, String> propMap(JsonNode component) {
+		Map<String, String> out = new HashMap<>();
+		JsonNode props = component.get("properties");
+		if (props == null || !props.isArray()) return out;
+		for (JsonNode p : props) {
+			out.put(p.get("name").asText(), p.get("value").asText());
+		}
+		return out;
+	}
+
+	@Test
+	void injectsByteMatchedAndEncodingDriftedAndSkipsUnmatched() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		UUID orgUuid = org.getUuid();
+		String salt = UUID.randomUUID().toString().substring(0, 8);
+
+		// recordData 'name' must equal the purl's name -- the encoding-safe fallback resolves
+		// candidates by that decoded name. The salted namespace keeps canonical_purl unique
+		// across reruns on the shared DB without perturbing the name.
+		// (A) byte-exact: stored canonical == the node's preserving-canonical.
+		supported(orgUuid, "pkg:maven/org.reliza.test." + salt + "/lib@1.2.3", "lib", "1.2.3",
+				LocalDate.now().minusDays(10)); // past EOS -> END_OF_SUPPORT
+		// (B) encoding drift: stored with %2B, the BOM node carries a raw + -> byte pass misses,
+		// the name + purlsSemanticallyEqual fallback must catch it.
+		supported(orgUuid, "pkg:maven/org.reliza.test." + salt + "/thing@1.0.0%2Br1", "thing", "1.0.0+r1",
+				LocalDate.now().plusYears(1)); // future EOS -> ACTIVELY_SUPPORTED
+
+		JsonNode bom = Utils.OM.readTree("""
+			{"bomFormat":"CycloneDX","specVersion":"1.5","components":[
+			  {"type":"library","name":"lib","purl":"pkg:maven/org.reliza.test.%s/lib@1.2.3"},
+			  {"type":"library","name":"thing","purl":"pkg:maven/org.reliza.test.%s/thing@1.0.0+r1"},
+			  {"type":"library","name":"nope","purl":"pkg:npm/nope-%s@9.9.9"}
+			]}""".formatted(salt, salt, salt));
+
+		supportInjectionService.injectCurrentSupport(bom, orgUuid);
+
+		JsonNode comps = bom.get("components");
+		Map<String, String> a = propMap(comps.get(0));
+		assertEquals("MANUAL", a.get(SupportBomInjector.PROP_SOURCE), "byte-exact component matched");
+		assertEquals("END_OF_SUPPORT", a.get(SupportBomInjector.PROP_STATUS));
+
+		Map<String, String> b = propMap(comps.get(1));
+		assertEquals("MANUAL", b.get(SupportBomInjector.PROP_SOURCE),
+				"encoding-drifted (+ vs %2B) component matched via the fallback");
+		assertEquals("ACTIVELY_SUPPORTED", b.get(SupportBomInjector.PROP_STATUS));
+
+		assertTrue(propMap(comps.get(2)).isEmpty(), "unmatched component gets no support properties");
+
+		// Document-level disclosure marker is always stamped (metadata created since the
+		// fixture had none).
+		Map<String, String> meta = propMap(bom.get("metadata"));
+		assertEquals(SupportBomInjector.DISCLOSURE_CURRENT_STATE, meta.get(SupportBomInjector.PROP_DISCLOSURE));
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/SupportEnumsSchemaEnumSyncTest.java
+++ b/backend/src/test/java/io/reliza/ws/SupportEnumsSchemaEnumSyncTest.java
@@ -1,0 +1,93 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.SupportSource;
+import io.reliza.model.SupportStatus;
+
+/**
+ * Regression guard for the FDA-Readiness-1 support enums (sibling of
+ * {@code FindingChangeKindSchemaEnumSyncTest}). {@code SupportStatus} and
+ * {@code SupportSource} are declared in BOTH the Java model and the GraphQL
+ * schema and round-tripped over the wire on {@code SbomComponent}, so a value
+ * present on one side but not the other silently breaks serialization. Parses
+ * the raw {@code schema.graphqls} (no Spring / DGS bootstrap) and asserts each
+ * schema enum's value set equals the Java enum's.
+ */
+class SupportEnumsSchemaEnumSyncTest {
+
+	/** "enum Foo { ... }" block -- captures the body between the braces. */
+	private static final Pattern ENUM_BLOCK = Pattern.compile(
+			"enum\\s+(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+	@Test
+	void supportStatusEnumIsInSync() {
+		Set<String> javaValues = Arrays.stream(SupportStatus.values()).map(Enum::name)
+				.collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+		Set<String> schemaValues = readSchemaEnum("SupportStatus");
+		assertEquals(javaValues, schemaValues,
+				"GraphQL enum SupportStatus drifted from Java enum;"
+						+ " missing in schema: " + diff(javaValues, schemaValues)
+						+ "; extra in schema: " + diff(schemaValues, javaValues));
+	}
+
+	@Test
+	void supportSourceEnumIsInSync() {
+		Set<String> javaValues = Arrays.stream(SupportSource.values()).map(Enum::name)
+				.collect(java.util.stream.Collectors.toCollection(TreeSet::new));
+		Set<String> schemaValues = readSchemaEnum("SupportSource");
+		assertEquals(javaValues, schemaValues,
+				"GraphQL enum SupportSource drifted from Java enum;"
+						+ " missing in schema: " + diff(javaValues, schemaValues)
+						+ "; extra in schema: " + diff(schemaValues, javaValues));
+	}
+
+	private static Set<String> diff(Set<String> a, Set<String> b) {
+		Set<String> r = new LinkedHashSet<>(a);
+		r.removeAll(b);
+		return r;
+	}
+
+	/** Returns the enum values declared in the GraphQL schema file. */
+	private static Set<String> readSchemaEnum(String enumName) {
+		String schema = readSchema();
+		Matcher m = ENUM_BLOCK.matcher(schema);
+		while (m.find()) {
+			if (!enumName.equals(m.group(1))) continue;
+			Set<String> out = new TreeSet<>();
+			for (String raw : m.group(2).split("\\R")) {
+				String line = raw.trim();
+				int hash = line.indexOf('#');
+				if (hash >= 0) line = line.substring(0, hash).trim();
+				if (line.isEmpty()) continue;
+				out.add(line);
+			}
+			return out;
+		}
+		throw new AssertionError("Did not find enum " + enumName + " in schema.graphqls");
+	}
+
+	private static String readSchema() {
+		try (InputStream in = SupportEnumsSchemaEnumSyncTest.class.getResourceAsStream(
+				"/schema/schema.graphqls")) {
+			if (in == null) throw new IllegalStateException("schema.graphqls not on test classpath");
+			return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+		} catch (java.io.IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
## What

Incremental CE backend sync via `backend/copy-src.sh` from `rearm-core` (rearm-saas) `origin/main`. Brings **only the per-component support feature** (FDA-Readiness-1, migration **V82**).

**Not** the broad V76-V82 multi-feature activation the tracking ticket described: V76-V81 already landed via #298, so CE `main` was already at V81. This is a targeted V82 sync.

## Delta (checksum-verified, **zero deletions**)

- **New:** `SupportStatus`/`SupportSource` enums, `SbomComponentSupportAudit`(+repo), `SupportBomInjector`, `SupportInjectionService`, `V82__sbom_component_support.sql`, 5 support tests.
- **Changed:** `SbomComponent`(+repo,+service), `SharedArtifactService`, `SbomComponentDataFetcher`, `schema.graphqls` (additive: support enums/fields, `sbomComponentSupportCoverage` query, `setSbomComponentSupport` mutation — zero removals), 2 SbomComponent tests.

## What activates on CE

Backend only. New GraphQL surface (`setSbomComponentSupport`, support fields on `SbomComponent`, `sbomComponentSupportCoverage`) + per-component support properties injected into exported CycloneDX BOMs at read time (`supportNotes` never injected; uploader `reliza:support:*` stripped). V82 adds 6 nullable columns + an append-only audit table. No UI in this sync — support UI is a separate forward-compatible change, Pro-gated until activated on CE.

## Verification

- `mvn clean compile` — OK
- Support tests: **24/24 green** (`Support*`, `SbomComponentSupport*`)
- Tree-wide `mvn test-compile` — OK
- `mvn clean package -DskipTests` — OK (JAR built)
- V82 applies clean (V81->V82, no gap/collision)
- schema overwrite additive — CE UI unbroken
- No non-ASCII introduced by the diff; no invisible/exit-123-class chars

### Known flake (not a defect)
`SbomComponentSupportServiceIntegrationTest` errored once with `OptimisticLockException` when run in the full `SbomComponent*` group; **passes deterministically in isolation (3x)**. Root cause is the shared-Postgres + live-scheduler race inherent to this `@SpringBootTest` suite (a background job bumps the freshly-created row's revision mid-test), same family as the known full-suite flakes. Code is byte-identical to Pro's merged #453, so not touched (mirror-integrity contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)