### PR TITLE
fix(build): stop pinning the flyway plugin's Postgres driver to 42.7.11

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -334,10 +334,16 @@
                 <schemas>rearm</schemas>
             </configuration>
             <dependencies>
+                <!-- Driver the plugin uses to reach Postgres for migrate/info.
+                     Tracks the Spring Boot BOM's postgresql.version rather than
+                     a literal: a hardcoded version here is invisible to
+                     `mvn dependency:list` (plugin deps are not project deps),
+                     so it silently went stale at 42.7.11 while the project
+                     dependency moved to a patched release. -->
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
-                    <version>42.7.11</version>
+                    <version>${postgresql.version}</version>
                 </dependency>
             </dependencies>
         </plugin>


### PR DESCRIPTION
Fixes the pin behind **Dependabot alert #267** — *PostgreSQL JDBC Driver: silent channel-binding authentication downgrade via unsupported certificate algorithms* (affected `>= 42.7.4, < 42.7.12`; fixed `42.7.12`).

## Why the recent dependency sweep missed it

The sweep checked with `mvn dependency:list`, which resolves `org.postgresql:postgresql:42.7.13` — patched. But that command lists **project** dependencies only, and this pin is a **plugin** dependency on `flyway-maven-plugin`:

```xml
<plugin>
  <artifactId>flyway-maven-plugin</artifactId>
  <dependencies>
    <dependency>
      <groupId>org.postgresql</groupId>
      <artifactId>postgresql</artifactId>
      <version>42.7.11</version>   <!-- vulnerable -->
```

So the project resolved a patched driver while the plugin quietly kept loading the vulnerable one to connect to Postgres for `migrate` / `info`. Dependabot parses the pom statically and was right; my all-clear was based on the wrong instrument.

## Fix

The plugin dependency now uses **`${postgresql.version}`** — the property the Spring Boot parent BOM already defines (`42.7.13` today) — rather than another literal, so it follows future BOM bumps. That matters more in this block than elsewhere, precisely because a stale value here is invisible to the dependency listing everyone reaches for.

## Verified

- `${postgresql.version}` resolves to **42.7.13**.
- `mvn flyway:info` connects to a local Postgres and reports schema state with the patched driver.

The identical block existed in the Pro backend and is fixed there in a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)