### PR TITLE
fix(ui): tolerate approval roles missing from the org role list

### DIFF
--- a/ui/src/components/CreateApprovalPolicy.vue
+++ b/ui/src/components/CreateApprovalPolicy.vue
@@ -32,6 +32,7 @@ import { FormInst, NCard, NForm, NFormItem, NInput, NButton, NSelect, NSwitch, N
 import graphqlClient from '@/utils/graphql'
 import gql from 'graphql-tag'
 import {ApprovalEntry} from '@/utils/commonTypes'
+import { resolveApprovalRoles } from '@/utils/approvalRoles'
 
 const props = defineProps<{
     orgProp: string,
@@ -64,7 +65,7 @@ const approvalEntityFields: DataTableColumns<any> = [
 
 const approvalEntityTableData: ComputedRef<any[]> = computed((): any => {
     const data = orgApprovalEntries.value.map(oae => {
-        const approvalRoles = oae.approvalRequirements.map(oaear => oaear.allowedApprovalRoleIdExpanded[0].displayView)
+        const approvalRoles = oae.approvalRequirements.flatMap(oaear => resolveApprovalRoles(oaear).map(r => r.displayView))
         return {
             uuid: oae.uuid,
             approvalName: oae.approvalName,
@@ -82,6 +83,7 @@ async function fetchApprovalEntries () {
                     uuid
                     approvalName
                     approvalRequirements {
+                        allowedApprovalRoleIds
                         allowedApprovalRoleIdExpanded {
                             id
                             displayView

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1145,6 +1145,7 @@ import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
 import constants from '../utils/constants'
 import { buildUserGroupUpdateInput } from '../utils/userGroupUpdateInput'
+import { resolveApprovalRoles } from '../utils/approvalRoles'
 import { InputTriggerEvent, OutputTriggerEvent } from '../utils/triggerTypes'
 import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerValidation'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
@@ -4954,7 +4955,7 @@ const orgApprovalEntries: Ref<ApprovalEntry[]> = ref([])
 
 const approvalEntryTableData: ComputedRef<any[]> = computed((): any => {
     const data = orgApprovalEntries.value.map(oae => {
-        const approvalRoles = oae.approvalRequirements.map(oaear => oaear.allowedApprovalRoleIdExpanded[0].displayView)
+        const approvalRoles = oae.approvalRequirements.flatMap(oaear => resolveApprovalRoles(oaear).map(r => r.displayView))
         return {
             uuid: oae.uuid,
             approvalName: oae.approvalName,
@@ -4972,6 +4973,7 @@ async function fetchApprovalEntries () {
                     uuid
                     approvalName
                     approvalRequirements {
+                        allowedApprovalRoleIds
                         allowedApprovalRoleIdExpanded {
                             id
                             displayView

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1320,6 +1320,7 @@ import constants from '@/utils/constants'
 import { DownloadLink} from '@/utils/commonTypes'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
 import { getReleaseScanStatus, isDtrackConfiguredForOrg, collectArtifactsForStatus } from '@/utils/releaseScanStatus'
+import { resolveApprovalRoles } from '@/utils/approvalRoles'
 import { processMetricsData } from '@/utils/metrics'
 import { annotateKnownExploited, fetchArtifactKevVulnIds } from '@/utils/kevService'
 import { exportFindingsToPdf } from '@/utils/pdfExport'
@@ -2029,13 +2030,15 @@ async function fetchRelease () {
         approvalEntries.value.forEach(ae => {
             approvalMatrixCheckboxes.value[ae.uuid] = {}
             ae.approvalRequirements.forEach((ar: any) => {
-                availableApprovalIds.value[ar.allowedApprovalRoleIdExpanded[0].id] = ar.allowedApprovalRoleIdExpanded[0].displayView
+                const role = resolveApprovalRoles(ar)[0]
+                if (!role) return
+                availableApprovalIds.value[role.id] = role.displayView
                 let checkBoxValue = 'UNSET'
-                if (givenApprovals.value[ae.uuid] && (givenApprovals.value[ae.uuid][ar.allowedApprovalRoleIdExpanded[0].id] === 'APPROVED' || 
-                    givenApprovals.value[ae.uuid][ar.allowedApprovalRoleIdExpanded[0].id] === 'DISAPPROVED')) {
-                    checkBoxValue = givenApprovals.value[ae.uuid][ar.allowedApprovalRoleIdExpanded[0].id]
+                if (givenApprovals.value[ae.uuid] && (givenApprovals.value[ae.uuid][role.id] === 'APPROVED' ||
+                    givenApprovals.value[ae.uuid][role.id] === 'DISAPPROVED')) {
+                    checkBoxValue = givenApprovals.value[ae.uuid][role.id]
                 }
-                approvalMatrixCheckboxes.value[ae.uuid][ar.allowedApprovalRoleIdExpanded[0].id] = checkBoxValue
+                approvalMatrixCheckboxes.value[ae.uuid][role.id] = checkBoxValue
             })
         })
     }
@@ -5373,7 +5376,8 @@ const releaseApprovalTableData: ComputedRef<any[]> = computed((): any[] => {
 
             }
             ae.approvalRequirements.forEach((ar: any) => {
-                aeObj[ar.allowedApprovalRoleIdExpanded[0].id] = true
+                const role = resolveApprovalRoles(ar)[0]
+                if (role) aeObj[role.id] = true
             })
             return aeObj
         })

--- a/ui/src/utils/approvalRoles.spec.ts
+++ b/ui/src/utils/approvalRoles.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalRoles } from './approvalRoles'
+
+describe('resolveApprovalRoles', () => {
+    it('returns the expanded roles when present', () => {
+        const expanded = [{ id: 'PM', displayView: 'Project Management' }]
+        expect(resolveApprovalRoles({
+            allowedApprovalRoleIdExpanded: expanded,
+            allowedApprovalRoleIds: ['PM'],
+        })).toEqual(expanded)
+    })
+
+    it('falls back to raw ids when expansion is empty (role undefined on the org)', () => {
+        expect(resolveApprovalRoles({
+            allowedApprovalRoleIdExpanded: [],
+            allowedApprovalRoleIds: ['QA_UAT'],
+        })).toEqual([{ id: 'QA_UAT', displayView: 'QA_UAT' }])
+    })
+
+    it('falls back when expansion is missing entirely', () => {
+        expect(resolveApprovalRoles({
+            allowedApprovalRoleIds: ['PM', 'QA_AUTO'],
+        })).toEqual([
+            { id: 'PM', displayView: 'PM' },
+            { id: 'QA_AUTO', displayView: 'QA_AUTO' },
+        ])
+    })
+
+    it('returns empty for a requirement with no roles at all', () => {
+        expect(resolveApprovalRoles({})).toEqual([])
+        expect(resolveApprovalRoles({
+            allowedApprovalRoleIdExpanded: null,
+            allowedApprovalRoleIds: null,
+        })).toEqual([])
+    })
+})

--- a/ui/src/utils/approvalRoles.ts
+++ b/ui/src/utils/approvalRoles.ts
@@ -1,0 +1,26 @@
+import type { ApprovalRole } from './commonTypes'
+
+/**
+ * Resolve the approval roles of an approval requirement for display.
+ *
+ * The backend expands `allowedApprovalRoleIds` against the organization's
+ * defined approval roles and silently drops ids that are not (or no longer)
+ * defined there — e.g. after an org admin deletes a role that an approval
+ * entry still references, or on imported data. In that case
+ * `allowedApprovalRoleIdExpanded` comes back empty and dereferencing `[0]`
+ * crashes the view.
+ *
+ * Fall back to the raw role ids as their own display name: approvals keep
+ * working through such roles (the wire format and the backend's
+ * authorization both use the raw id string), they just render without a
+ * friendly display name.
+ */
+export function resolveApprovalRoles(ar: {
+    allowedApprovalRoleIdExpanded?: ApprovalRole[] | null,
+    allowedApprovalRoleIds?: string[] | null
+}): ApprovalRole[] {
+    if (ar.allowedApprovalRoleIdExpanded && ar.allowedApprovalRoleIdExpanded.length) {
+        return ar.allowedApprovalRoleIdExpanded
+    }
+    return (ar.allowedApprovalRoleIds ?? []).map(id => ({ id, displayView: id }))
+}

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -652,6 +652,7 @@ const singleReleaseDataNoParent = `
                 uuid
                 approvalName
                 approvalRequirements {
+                    allowedApprovalRoleIds
                     allowedApprovalRoleIdExpanded {
                         id
                         displayView
@@ -1127,6 +1128,7 @@ const singleReleaseProductNoParent = `
                 uuid
                 approvalName
                 approvalRequirements {
+                    allowedApprovalRoleIds
                     allowedApprovalRoleIdExpanded {
                         id
                         displayView


### PR DESCRIPTION
## Problem

The release view crashes with `TypeError: can't access property "id", allowedApprovalRoleIdExpanded[0] is undefined` when an approval entry references a role id that is not (or no longer) defined in the organization's approval roles — e.g. after deleting an approval role that an entry still uses. The approval policy editor and org settings render the same dereference.

Root cause is two-layered: the backend expands `allowedApprovalRoleIds` against the org's defined roles and silently drops unknown ids (so the expanded list comes back empty), and the UI dereferences `[0]` unguarded in four places.

## Fix

- new `resolveApprovalRoles` helper (`ui/src/utils/approvalRoles.ts`): returns the expanded roles when present, otherwise falls back to the raw ids rendered as their own display name. Approvals remain fully functional through fallback roles — the wire format and backend authorization both use the raw id string; only the friendly display name is lost.
- all four dereference sites guarded (ReleaseView approval matrix + approvals table, CreateApprovalPolicy and OrgSettings role display strings).
- the GraphQL selections now fetch `allowedApprovalRoleIds` alongside the expanded form (the schema has always exposed both).
- vitest spec for the helper.

## Testing

- `npm test`: 170 tests, new spec passes; the one failing spec (`routeInputSchemaDrift`) fails identically on main and is unrelated.
- `npm run build` clean.
- Reproduced the original crash against an org whose entries referenced undefined role ids; with this change the release page renders and approvals through the fallback role work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)