### PR TITLE
Offer support-date suggestions for un-attested SBOM components

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -992,6 +992,20 @@
                                 <div style="margin-bottom: 10px; font-family: monospace; font-size: 12px; word-break: break-all;">
                                     {{ sbomSupportEditRow.component?.name }}<span v-if="sbomSupportEditRow.component?.version">@{{ sbomSupportEditRow.component?.version }}</span>
                                 </div>
+                                <div
+                                    v-if="supportSuggestionInUse"
+                                    style="margin-bottom: 12px; padding: 8px 10px; border: 1px dashed #d0d0d0; border-radius: 4px; font-size: 12px;">
+                                    <div style="font-weight: 600; margin-bottom: 2px;">Pre-filled from a suggestion - review before saving</div>
+                                    <div>{{ supportSuggestionBasisLabel(supportSuggestionInUse.basis) }}</div>
+                                    <div style="color: #999;">
+                                        {{ supportSuggestionInUse.product }} {{ supportSuggestionInUse.cycle }}<span v-if="supportSuggestionInUse.catalogAsOf">, catalog as of {{ supportSuggestionInUse.catalogAsOf }}</span>
+                                        <a v-if="supportSuggestionInUse.upstreamUrl" :href="supportSuggestionInUse.upstreamUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 6px;">check upstream</a>
+                                    </div>
+                                    <div v-if="supportSuggestionInUse.extendedSupportDate" style="margin-top: 4px;">
+                                        Extended/LTS support runs to {{ supportSuggestionInUse.extendedSupportDate }} - use that date instead only if you hold that subscription or support contract.
+                                    </div>
+                                    <div style="margin-top: 4px;">Saving records this as <strong>your</strong> attestation, not the catalog's.</div>
+                                </div>
                                 <n-form-item label="End-of-support date">
                                     <n-date-picker v-model:value="supportEosInput" type="date" clearable style="width: 100%;" />
                                 </n-form-item>
@@ -1304,6 +1318,7 @@ import graphqlClient from '../utils/graphql'
 import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
+import { loadSbomComponentsForRelease } from '@/utils/sbomComponentsQuery'
 import { GlobeAdd24Regular, Info24Regular, Edit24Regular } from '@vicons/fluent'
 import { Bell, Check, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh, X } from '@vicons/tabler'
 import { Icon } from '@vicons/utils'
@@ -2865,6 +2880,9 @@ const sbomSupportEditRow: Ref<any> = ref(null)
 const supportEosInput: Ref<number | null> = ref(null)
 const supportEolInput: Ref<number | null> = ref(null)
 const supportNotesInput: Ref<string> = ref('')
+// The suggestion the editor was opened from, if any. Drives the review banner, and is
+// cleared on a plain edit so an existing attestation is never re-framed as a suggestion.
+const supportSuggestionInUse: Ref<any> = ref(null)
 const supportSavePending: Ref<boolean> = ref(false)
 
 // Org-wide support disclosure completeness -- a pre-submission readiness signal
@@ -2890,12 +2908,35 @@ function tsToIsoDate (ts: number | null): string | null {
     return `${y}-${m}-${day}`
 }
 
-function openSupportEdit (row: any) {
+const SUPPORT_SUGGESTION_BASIS_LABEL: Record<string, string> = {
+    DISTRO_RELEASE_LIFECYCLE: 'Lifecycle of the distribution release that ships this package (not the upstream project - distributions backport fixes, so the two disagree).',
+    EXACT_COORDINATE: 'Published lifecycle of this exact project and release cycle.'
+}
+
+function supportSuggestionBasisLabel (basis: string): string {
+    return SUPPORT_SUGGESTION_BASIS_LABEL[basis] || 'Derived from the public lifecycle catalog.'
+}
+
+/**
+ * Open the attestation editor. When a suggestion is passed the dates are pre-filled
+ * from it and its provenance is pre-written into the (internal-only) note, so whatever
+ * the reviewer saves records what they were shown. The note stays editable and the
+ * reviewer can override either date - accepting is a decision, not a formality.
+ */
+function openSupportEdit (row: any, suggestion?: any) {
     sbomSupportEditRow.value = row
     const c = row.component || {}
-    supportEosInput.value = isoDateToTs(c.endOfSupportDate)
+    supportSuggestionInUse.value = suggestion || null
+    supportEosInput.value = suggestion
+        ? isoDateToTs(suggestion.endOfSupportDate)
+        : isoDateToTs(c.endOfSupportDate)
     supportEolInput.value = isoDateToTs(c.endOfLifeDate)
-    supportNotesInput.value = c.supportNotes || ''
+    supportNotesInput.value = c.supportNotes
+        || (suggestion
+            ? `Accepted suggestion from endoflife.date: ${suggestion.product} ${suggestion.cycle}`
+                + `${suggestion.matchedOn ? ` (matched on ${suggestion.matchedOn})` : ''}`
+                + `${suggestion.catalogAsOf ? `, catalog as of ${suggestion.catalogAsOf}` : ''}.`
+            : '')
     sbomSupportModalOpen.value = true
 }
 
@@ -2957,41 +2998,25 @@ async function loadSupportCoverage (force: boolean = false) {
     }
 }
 
+// CORE selection: fields present on every deployed backend, including a CE mirror
+// lagging behind Pro. FULL adds supportSuggestion, which only exists once the backend
+// carries the suggestion surface. Without this split, selecting it against a lagging
+// CE backend fails validation for the WHOLE document and blanks the entire SBOM
+// components tab -- the enrichment field is advisory, so degrading to CORE (table
+// renders, no suggestion chips) is strictly better than showing nothing.
+// Set once a load proves the deployed backend rejects the suggestion field, so later
+// loads skip the reject-then-retry round-trip.
+const sbomSuggestionUnsupported: Ref<boolean> = ref(false)
+
 async function loadSbomComponents (forceRefresh: boolean = false) {
     if (!updatedRelease.value?.uuid) return
     if (sbomComponentsLoaded.value && !forceRefresh) return
     sbomComponentsLoading.value = true
     try {
-        const resp = await graphqlClient.query({
-            query: gql`
-                query getReleaseSbomComponentsList($releaseUuid: ID!) {
-                    getReleaseSbomComponents(releaseUuid: $releaseUuid) {
-                        uuid
-                        sbomComponentUuid
-                        component {
-                            uuid
-                            canonicalPurl
-                            type
-                            group
-                            name
-                            version
-                            isRoot
-                            supportStatus
-                            endOfSupportDate
-                            endOfLifeDate
-                            supportSource
-                            supportNotes
-                        }
-                        artifactParticipations {
-                            artifact
-                            exactPurls
-                        }
-                    }
-                }`,
-            variables: { releaseUuid: updatedRelease.value.uuid },
-            fetchPolicy: forceRefresh ? 'network-only' : 'cache-first'
-        })
-        sbomComponents.value = (resp.data as any).getReleaseSbomComponents || []
+        const result = await loadSbomComponentsForRelease(
+            graphqlClient as any, updatedRelease.value.uuid, sbomSuggestionUnsupported.value)
+        if (result.degraded) sbomSuggestionUnsupported.value = true
+        sbomComponents.value = result.rows
         sbomComponentsLoaded.value = true
         loadSupportCoverage(forceRefresh)
         // Refresh invalidates the deeper graph too — rows may have changed.
@@ -3142,8 +3167,40 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
         sorter: (a: any, b: any) => (a.component?.supportStatus || '').localeCompare(b.component?.supportStatus || ''),
         render: (row: any) => {
             const c = row.component || {}
-            // Un-attested components have no supportSource -> show a neutral dash, not UNKNOWN.
-            if (!c.supportSource) return h('span', { style: 'color: #999;' }, '—')
+            // Un-attested components have no supportSource -> a neutral dash, not UNKNOWN.
+            // Where the backend can propose a date from the public lifecycle catalog we
+            // offer it here instead, clearly marked as a suggestion rather than a fact:
+            // accepting it opens the ordinary attestation editor pre-filled, so what gets
+            // stored is a MANUAL attestation by the reviewer, never a machine assertion.
+            if (!c.supportSource) {
+                const sug = c.supportSuggestion
+                // Same gate as the Edit-support action below: a viewer who cannot attest
+                // must not be walked through a review that fails on save, and root
+                // components are excluded from manual attestation entirely.
+                const canAttest = isWritable.value && !c.isRoot
+                if (!sug || !canAttest) return h('span', { style: 'color: #999;' }, '—')
+                return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 460px;' }, {
+                    trigger: () => h(NTag, {
+                        size: 'small',
+                        round: true,
+                        bordered: true,
+                        style: 'border-style: dashed; cursor: pointer; color: #888;',
+                        onClick: () => openSupportEdit(row, sug)
+                    }, () => `Suggested EOS ${sug.endOfSupportDate}`),
+                    default: () => h('div', { style: 'font-size: 12px;' }, [
+                        h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, 'Not attested - suggestion only'),
+                        h('div', supportSuggestionBasisLabel(sug.basis)),
+                        h('div', `Source: ${sug.product} ${sug.cycle}`),
+                        sug.matchedOn ? h('div', { style: 'color: #999;' }, `Matched on ${sug.matchedOn}`) : null,
+                        sug.extendedSupportDate
+                            ? h('div', { style: 'margin-top: 4px;' },
+                                `Extended/LTS support runs to ${sug.extendedSupportDate} - applies only if you hold that subscription or contract.`)
+                            : null,
+                        sug.catalogAsOf ? h('div', { style: 'color: #999; margin-top: 4px;' }, `Catalog as of ${sug.catalogAsOf}`) : null,
+                        h('div', { style: 'margin-top: 4px;' }, 'Click to review and attest.')
+                    ])
+                })
+            }
             const tag = SUPPORT_TAG[c.supportStatus] || SUPPORT_TAG.UNKNOWN
             const els: any[] = [h(NTag, { size: 'small', type: tag.type, round: true }, () => tag.label)]
             if (c.endOfSupportDate) {

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -1,0 +1,107 @@
+// Release SBOM-components query, split CORE / FULL for schema-drift tolerance.
+//
+// The SAME UI ships to a Pro backend and to CE installs whose backend is a delayed
+// mirror of Pro. `supportSuggestion` (FDA-Readiness-1 PR4) exists on Pro before it
+// reaches the CE mirror, and GraphQL validates the WHOLE document -- so selecting it
+// against a lagging CE backend would reject the entire query and blank the whole SBOM
+// components tab, not just the suggestion chips. Suggestions are advisory, so degrading
+// to CORE (table renders, no chips) is strictly better than showing nothing.
+//
+// Both documents are written out in full rather than composed from a shared fragment
+// string, so both stay statically analysable: ui/scripts/validate-graphql.mjs skips
+// dynamically built documents, and sbomComponentsSchemaDrift.spec.ts hard-gates CORE
+// against the in-repo CE schema. A CORE selection that silently drifted off CE would
+// defeat the entire point of having a fallback.
+
+import gql from 'graphql-tag'
+import { loadWithSchemaDriftFallback, type DriftFallbackClient } from '@/utils/graphqlDriftFallback'
+
+export const SBOM_COMPONENTS_CORE_QUERY = gql`
+    query getReleaseSbomComponentsCore($releaseUuid: ID!) {
+        getReleaseSbomComponents(releaseUuid: $releaseUuid) {
+            uuid
+            sbomComponentUuid
+            component {
+                uuid
+                canonicalPurl
+                type
+                group
+                name
+                version
+                isRoot
+                supportStatus
+                endOfSupportDate
+                endOfLifeDate
+                supportSource
+                supportNotes
+            }
+            artifactParticipations {
+                artifact
+                exactPurls
+            }
+        }
+    }`
+
+export const SBOM_COMPONENTS_FULL_QUERY = gql`
+    query getReleaseSbomComponentsList($releaseUuid: ID!) {
+        getReleaseSbomComponents(releaseUuid: $releaseUuid) {
+            uuid
+            sbomComponentUuid
+            component {
+                uuid
+                canonicalPurl
+                type
+                group
+                name
+                version
+                isRoot
+                supportStatus
+                endOfSupportDate
+                endOfLifeDate
+                supportSource
+                supportNotes
+                supportSuggestion {
+                    endOfSupportDate
+                    basis
+                    product
+                    cycle
+                    matchedOn
+                    extendedSupportDate
+                    catalogAsOf
+                    upstreamUrl
+                }
+            }
+            artifactParticipations {
+                artifact
+                exactPurls
+            }
+        }
+    }`
+
+export interface SbomComponentsLoad {
+    rows: any[]
+    // True when only CORE was served: rows render, suggestion chips are absent.
+    degraded: boolean
+}
+
+/**
+ * Load a release's SBOM components, falling back to the CORE selection when the
+ * deployed backend does not know the suggestion field.
+ *
+ * @param skipFull set once a prior load proved the backend rejects FULL, to avoid
+ *                 paying the reject-then-retry round-trip on every later load.
+ */
+export async function loadSbomComponentsForRelease (
+    client: DriftFallbackClient,
+    releaseUuid: string,
+    skipFull = false,
+): Promise<SbomComponentsLoad> {
+    const result = await loadWithSchemaDriftFallback(client, {
+        fullQuery: SBOM_COMPONENTS_FULL_QUERY,
+        coreQuery: SBOM_COMPONENTS_CORE_QUERY,
+        variables: { releaseUuid },
+        extractPath: (d: any) => d?.getReleaseSbomComponents,
+        skipFull,
+    })
+    return { rows: result.data || [], degraded: result.degraded }
+}

--- a/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { SBOM_COMPONENTS_CORE_QUERY, SBOM_COMPONENTS_FULL_QUERY } from './sbomComponentsQuery'
+
+// Sibling of notificationInboxSchemaDrift.spec.ts, and load-bearing for the same
+// reason: validate-graphql.mjs only WARNS when a selection is Pro-valid but CE-invalid,
+// so nothing else in the build stops the CORE selection from quietly drifting off the
+// CE mirror -- which is the one thing the whole FULL/CORE fallback depends on.
+//
+// The CE mirror schema ships IN this repo, so its checks are unconditional. The Pro
+// schema lives in the sibling rearm-core checkout, absent from this repo's own CI, so
+// those checks skip rather than fail there.
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+describe('SBOM components core selection vs the CE mirror schema (in-repo, always runs)', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    // The invariant the fallback rests on: everything the SBOM components table
+    // HARD-REQUIRES exists on the CE mirror, so a CE install renders rows rather than
+    // blanking the tab. If this fails, move the offending field into the FULL-only
+    // selection -- do not "fix" it by deleting the assertion.
+    it('the CORE selection is valid against the CE mirror', () => {
+        if (!ceSchema) return
+        expect(validate(ceSchema, SBOM_COMPONENTS_CORE_QUERY).map(e => e.message)).toEqual([])
+    })
+
+    // Canary: while the mirror lags, FULL must be the only thing that fails there. When
+    // the CE mirror catches up this assertion fires, and retiring it is the correct
+    // response -- the split then goes dormant (FULL succeeds everywhere) but stays in
+    // place for the next Pro-first field. Do NOT retire it by widening CORE.
+    it('the FULL selection is NOT yet valid against the CE mirror (split is load-bearing)', () => {
+        if (!ceSchema) return
+        const errors = validate(ceSchema, SBOM_COMPONENTS_FULL_QUERY).map(e => e.message)
+        expect(errors.join(' ')).toMatch(/supportSuggestion/)
+    })
+})
+
+describe('both selections vs the Pro schema (skipped when rearm-core is absent)', () => {
+    it.runIf(proSchema)('the CORE selection is valid against Pro', () => {
+        expect(validate(proSchema as GraphQLSchema, SBOM_COMPONENTS_CORE_QUERY).map(e => e.message)).toEqual([])
+    })
+
+    it.runIf(proSchema)('the FULL selection is valid against Pro', () => {
+        expect(validate(proSchema as GraphQLSchema, SBOM_COMPONENTS_FULL_QUERY).map(e => e.message)).toEqual([])
+    })
+})


### PR DESCRIPTION
UI half of the per-component support-date suggestions (FDA-Readiness-1). Backend PR:
relizaio/rearm-saas#461 -- this degrades gracefully without it, so merge order does not matter.

### What a reviewer sees

An un-attested component whose date the backend can propose shows a dashed grey chip,
`Suggested EOS <date>` -- deliberately styled as *not* a fact. Hovering discloses everything
needed to disagree with it: how it was derived, the source product and cycle, exactly what was
matched on, the catalog's age, and an explicit note that any extended/LTS date applies only if
you hold that subscription or contract.

Clicking opens the ordinary attestation editor, pre-filled, with a banner marking the values as
pre-filled-for-review and a pre-filled audit note recording the provenance. Saving stores an
ordinary `MANUAL` attestation by the reviewer -- the machine never authors the claim. The chip
is withheld entirely for viewers who cannot attest, so nobody is walked through a review that
fails on save.

### Schema-drift split (the load-bearing part)

`supportSuggestion` exists on Pro before it reaches the CE mirror, and GraphQL validates the
*whole* document -- so selecting it against a lagging backend would reject the entire query and
blank the whole SBOM components tab, not just the chips. The query is therefore split
CORE/FULL behind the existing `loadWithSchemaDriftFallback`: suggestions are advisory, so
degrading to CORE (table renders, no chips) is strictly better than showing nothing.

Both documents are written out in full rather than composed from a shared fragment, because
the repo's `validate-graphql` script skips dynamically built documents -- composing them
silently removed the query from validation coverage.

`sbomComponentsSchemaDrift.spec.ts` hard-gates the invariant the fallback rests on: CORE must
stay valid against the in-repo CE schema (unconditional), and FULL must remain the only thing
that fails there. The latter is a canary -- when the CE mirror catches up it fires, and
retiring it is the correct response.

### Testing

- 5 new drift tests; UI suite green (one unrelated pre-existing failure in
  `routeInputSchemaDrift.spec.ts`, confirmed present on `main` before this branch).
- Live-validated against a sandbox with a 16-assertion Playwright probe covering chip render,
  tooltip provenance, pre-filled editor, accept-writes-MANUAL, and the withholding of chips on
  already-attested rows.

### Not included

No bulk accept -- a reviewer still accepts one component at a time, which is the natural
follow-up given the point of the feature is to cut manual burden.
