### PR TITLE
Surface the device-support-risk verdict in the release SBOM table

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -953,8 +953,26 @@
                             <span
                                 v-if="supportCoverageLoaded"
                                 style="font-size: 12px; color: #666; margin-left: 4px;"
-                                title="Components in this org with a manufacturer (manual) support attestation -- a pre-submission disclosure-completeness signal.">
-                                Support attested: {{ supportCoverageAttested }} / {{ supportCoverageTotal }}
+                                title="Components across this whole organization that carry a manufacturer (manual) support attestation -- a pre-submission disclosure-completeness signal. Counted org-wide, not for this release alone.">
+                                Support attested (org-wide): {{ supportCoverageAttested }} / {{ supportCoverageTotal }}
+                            </span>
+                            <span
+                                v-if="deviceRiskSummary && deviceRiskSummary.kind === 'assessed' && deviceRiskSummary.count > 0"
+                                style="font-size: 12px; color: #d03050; font-weight: 600;"
+                                title="Components whose support ends before this device's own declared support window -- they go unsupported while the device is still fielded. Section 524B expects these to be disclosed and addressed.">
+                                {{ deviceRiskSummary.count }} outlived by this device
+                            </span>
+                            <span
+                                v-else-if="deviceRiskSummary && deviceRiskSummary.kind === 'assessed'"
+                                style="font-size: 12px; color: #18a058;"
+                                title="Every assessed component's support window reaches this device's own support horizon.">
+                                None outlived by this device
+                            </span>
+                            <span
+                                v-else-if="deviceRiskSummary && deviceRiskSummary.kind === 'noHorizon'"
+                                style="font-size: 12px; color: #f0a020;"
+                                title="This device release declares neither an end-of-support nor an end-of-life date, so component support windows cannot be compared against it. Set the device's support window on the release to enable this check.">
+                                Device declares no support window -- not checked
                             </span>
                         </n-space>
                         <div v-if="sbomComponentsLoading && !sbomComponentsLoaded">
@@ -2092,6 +2110,16 @@ async function goToRelease (uuid: string) {
     // right query (and its artifact handling) is used, and reset the lazy
     // product-artifacts flag.
     productArtifactsLoaded.value = false
+    // Same for the SBOM caches: this component is reused across releases rather than
+    // remounted, and loadSbomComponents() early-returns while sbomComponentsLoaded is true,
+    // so without this the next release renders the previous one's components. That was
+    // merely stale before; now the device-risk summary would state "N outlived by this
+    // device" about a device whose SBOM we are not showing.
+    sbomComponentsLoaded.value = false
+    sbomComponents.value = []
+    sbomGraphLoaded.value = false
+    sbomGraphByUuid.value = {}
+    sbomGraphDirty.value = true
     isLoading.value = true
     loadingBar.start()
     try {
@@ -2837,13 +2865,33 @@ const sbomGraphDirty: Ref<boolean> = ref(false)
 // group, type, or canonical purl (case-insensitive substring).
 const sbomSearchQueryInput: Ref<string> = ref('')
 const sbomSupportFilter: Ref<string> = ref('all')
-const supportFilterOptions = [
-    { label: 'All support', value: 'all' },
-    { label: 'Attested', value: 'attested' },
-    { label: 'Not attested', value: 'notAttested' },
-    { label: 'Past end-of-support', value: 'pastEos' },
-    { label: 'Approaching EOS (90d)', value: 'approaching' }
-]
+// The device-risk option is offered only where the verdict can exist at all -- otherwise it
+// filters to an empty table that reads as "nothing at risk" when the truth is "never
+// checked". Two ways it cannot exist: the backend gates the verdict to PRODUCT (device)
+// releases, and a backend too old to serve the field drops us to the CORE selection where it
+// was never requested. Same reasoning as deviceRiskSummary, which withholds on both.
+const deviceRiskAssessable: ComputedRef<boolean> = computed(
+    () => isProductRelease.value && !sbomFullSelectionUnsupported.value)
+const supportFilterOptions: ComputedRef<any[]> = computed(() => {
+    const opts: any[] = [
+        { label: 'All support', value: 'all' },
+        { label: 'Attested', value: 'attested' },
+        { label: 'Not attested', value: 'notAttested' },
+        { label: 'Past end-of-support', value: 'pastEos' },
+        { label: 'Approaching EOS (90d)', value: 'approaching' }
+    ]
+    if (deviceRiskAssessable.value) {
+        opts.push({ label: 'Outlived by this device', value: 'deviceRisk' })
+    }
+    return opts
+})
+// That option can vanish underneath a live selection (navigating to a component release, or
+// a load degrading to CORE), leaving the select rendering a value no longer in its options
+// and the table filtered on a verdict that cannot occur -- an empty table reading as a clean
+// bill of health. Fall back to showing everything instead.
+watch(deviceRiskAssessable, (assessable: boolean) => {
+    if (!assessable && sbomSupportFilter.value === 'deviceRisk') sbomSupportFilter.value = 'all'
+})
 function eosTimestamp (c: any): number | null {
     // Reuse the edit path's local-time conversion so the filter interprets the date identically.
     return isoDateToTs(c?.endOfSupportDate)
@@ -2869,6 +2917,7 @@ const filteredSbomComponents: ComputedRef<any[]> = computed((): any[] => {
             const t = eosTimestamp(c)
             if (t === null || t <= now || t > soon) return false
         }
+        if (f === 'deviceRisk' && !isDeviceRiskFlagged(c.deviceSupportRisk)) return false
         return true
     })
 })
@@ -2999,14 +3048,54 @@ async function loadSupportCoverage (force: boolean = false) {
 }
 
 // CORE selection: fields present on every deployed backend, including a CE mirror
-// lagging behind Pro. FULL adds supportSuggestion, which only exists once the backend
-// carries the suggestion surface. Without this split, selecting it against a lagging
-// CE backend fails validation for the WHOLE document and blanks the entire SBOM
-// components tab -- the enrichment field is advisory, so degrading to CORE (table
-// renders, no suggestion chips) is strictly better than showing nothing.
-// Set once a load proves the deployed backend rejects the suggestion field, so later
-// loads skip the reject-then-retry round-trip.
-const sbomSuggestionUnsupported: Ref<boolean> = ref(false)
+// lagging behind Pro. FULL adds supportSuggestion and deviceSupportRisk, which only exist
+// once the backend carries those surfaces. Without this split, selecting them against a
+// lagging CE backend fails validation for the WHOLE document and blanks the entire SBOM
+// components tab -- both are advisory, so degrading to CORE (table renders, no suggestion
+// chips and no device-risk flags) is strictly better than showing nothing.
+// Set once a load proves the deployed backend rejects the FULL selection, so later loads
+// skip the reject-then-retry round-trip.
+const sbomFullSelectionUnsupported: Ref<boolean> = ref(false)
+
+/**
+ * The device-risk summary shown beside the coverage counter, or null when there is nothing
+ * honest to say.
+ *
+ * Deliberately does NOT collapse to a bare count, because "0 at risk" and "we could not
+ * assess this" look identical to a reader and mean opposite things. Two cases produce zero
+ * flags for entirely different reasons:
+ *
+ *  - the device declares no support window, so every verdict is UNKNOWN and NOTHING was
+ *    checked -- reporting "0 at risk" there is a false all-clear on a regulatory screen;
+ *  - the device declares one and every assessed component outlasts it -- a real all-clear.
+ *
+ * We tell them apart without another round-trip: DeviceSupportRisk resolves to UNKNOWN only
+ * when the device has no horizon or the component carries no dates. So among components that
+ * DO carry a date, an all-UNKNOWN result can only mean the device declares no horizon.
+ *
+ * Counts the whole release, not the filtered view: whether a device outlives its components
+ * is a fact about the device, not about the reader's current search.
+ */
+const deviceRiskSummary: ComputedRef<{ kind: 'assessed' | 'noHorizon', count: number } | null> = computed(() => {
+    if (!isProductRelease.value || !sbomComponentsLoaded.value) return null
+    // Degraded to CORE: deviceSupportRisk was never selected, so every value is undefined.
+    // Reporting "no support window" from absent data would be a lie about the device.
+    if (sbomFullSelectionUnsupported.value) return null
+    const dated = sbomComponents.value.filter((row: any) => {
+        const c = row.component || {}
+        return !!(c.endOfSupportDate || c.endOfLifeDate)
+    })
+    if (!dated.length) return null
+    const assessed = dated.filter((row: any) => {
+        const risk = row.component?.deviceSupportRisk
+        return risk && risk !== 'UNKNOWN'
+    })
+    if (!assessed.length) return { kind: 'noHorizon', count: 0 }
+    return {
+        kind: 'assessed',
+        count: dated.filter((row: any) => isDeviceRiskFlagged(row.component?.deviceSupportRisk)).length
+    }
+})
 
 async function loadSbomComponents (forceRefresh: boolean = false) {
     if (!updatedRelease.value?.uuid) return
@@ -3014,8 +3103,8 @@ async function loadSbomComponents (forceRefresh: boolean = false) {
     sbomComponentsLoading.value = true
     try {
         const result = await loadSbomComponentsForRelease(
-            graphqlClient as any, updatedRelease.value.uuid, sbomSuggestionUnsupported.value)
-        if (result.degraded) sbomSuggestionUnsupported.value = true
+            graphqlClient as any, updatedRelease.value.uuid, sbomFullSelectionUnsupported.value)
+        if (result.degraded) sbomFullSelectionUnsupported.value = true
         sbomComponents.value = result.rows
         sbomComponentsLoaded.value = true
         loadSupportCoverage(forceRefresh)
@@ -3128,6 +3217,54 @@ const SUPPORT_TAG: Record<string, { type: SupportTagType, label: string }> = {
     UNKNOWN: { type: 'default', label: 'Unknown' }
 }
 
+// DeviceSupportRisk (FDA-Readiness-1 PR5). A SEPARATE axis from the support status above,
+// and the reason it gets its own marker rather than folding into that tag: the status tag
+// answers "is this supported TODAY", the risk answers "does its support end before the
+// DEVICE's own horizon". A component can be Actively supported today and still fail the
+// device check -- e.g. support to 2030 inside a device fielded to 2031 -- which is exactly
+// the section-524B case a manufacturer must disclose, and which a status-only column shows
+// in reassuring green.
+//
+// Only the two flagged values render. OK needs no marker, and UNKNOWN must never render as
+// OK: it means "not assessed" (no device horizon, or no dates on the component).
+const DEVICE_RISK_LABEL: Record<string, string> = {
+    EOS_BEFORE_DEVICE: 'EOS before device',
+    EOL_BEFORE_DEVICE: 'EOL before device'
+}
+const DEVICE_RISK_DETAIL: Record<string, string> = {
+    EOS_BEFORE_DEVICE: 'This component stops receiving support before this device\'s declared'
+        + ' support window ends, so it goes unsupported while the device is still fielded.',
+    EOL_BEFORE_DEVICE: 'This component reaches end-of-life before this device\'s declared'
+        + ' support window ends, so it is out of life while the device is still fielded.'
+}
+// Derived from the label map rather than re-listing its keys: the map IS the set of flagged
+// verdicts, and a hand-maintained second copy fails silently -- a third flagged value would
+// render a tag while the summary counted zero and the filter hid the row.
+function isDeviceRiskFlagged (risk: any): boolean {
+    return !!risk && risk in DEVICE_RISK_LABEL
+}
+/**
+ * The risk marker, or null when this component is not flagged.
+ *
+ * Keyed on the verdict alone, deliberately -- NOT on supportSource. The backend derives the
+ * verdict from the dates and ignores the source, and the summary count and the filter are
+ * likewise source-agnostic. Rendering this only alongside an attested row would make the
+ * header count rows whose cell shows no marker the moment a non-MANUAL writer lands dates.
+ */
+function deviceRiskBadge (c: any): any {
+    if (!isDeviceRiskFlagged(c.deviceSupportRisk)) return null
+    return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 420px;' }, {
+        trigger: () => h(NTag, { size: 'small', type: 'error', round: true, bordered: true },
+            () => DEVICE_RISK_LABEL[c.deviceSupportRisk]),
+        default: () => h('div', { style: 'font-size: 12px;' }, [
+            h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, 'Outlived by this device'),
+            h('div', DEVICE_RISK_DETAIL[c.deviceSupportRisk]),
+            h('div', { style: 'margin-top: 4px;' },
+                'Disclose and address it, or plan a replacement before the device ships.')
+        ])
+    })
+}
+
 const sbomComponentsTableFields: DataTableColumns<any> = [
     {
         key: 'name',
@@ -3174,11 +3311,18 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
             // stored is a MANUAL attestation by the reviewer, never a machine assertion.
             if (!c.supportSource) {
                 const sug = c.supportSuggestion
+                // A component can carry dates (hence a device verdict) without a source once a
+                // non-MANUAL writer exists, so the marker rides along here too -- see
+                // deviceRiskBadge. Today this is unreachable and costs one null check.
+                const unattestedRisk = deviceRiskBadge(c)
                 // Same gate as the Edit-support action below: a viewer who cannot attest
                 // must not be walked through a review that fails on save, and root
                 // components are excluded from manual attestation entirely.
                 const canAttest = isWritable.value && !c.isRoot
-                if (!sug || !canAttest) return h('span', { style: 'color: #999;' }, '—')
+                if (!sug || !canAttest) {
+                    return h('div', [h('span', { style: 'color: #999;' }, '—'),
+                        unattestedRisk ? h('div', { style: 'margin-top: 3px;' }, [unattestedRisk]) : null])
+                }
                 return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 460px;' }, {
                     trigger: () => h(NTag, {
                         size: 'small',
@@ -3205,6 +3349,13 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
             const els: any[] = [h(NTag, { size: 'small', type: tag.type, round: true }, () => tag.label)]
             if (c.endOfSupportDate) {
                 els.push(h('span', { style: 'margin-left: 6px; font-size: 11px; color: #999;' }, `EOS ${c.endOfSupportDate}`))
+            }
+            // The device check is a second, independent verdict -- see DEVICE_RISK_LABEL. The
+            // backend only ever returns a flagged value on a PRODUCT (device) release, so this
+            // needs no release-type gate of its own.
+            const risk = deviceRiskBadge(c)
+            if (risk) {
+                els.push(h('div', { style: 'margin-top: 3px;' }, [risk]))
             }
             return h('div', els)
         }

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -1,11 +1,13 @@
 // Release SBOM-components query, split CORE / FULL for schema-drift tolerance.
 //
 // The SAME UI ships to a Pro backend and to CE installs whose backend is a delayed
-// mirror of Pro. `supportSuggestion` (FDA-Readiness-1 PR4) exists on Pro before it
-// reaches the CE mirror, and GraphQL validates the WHOLE document -- so selecting it
-// against a lagging CE backend would reject the entire query and blank the whole SBOM
-// components tab, not just the suggestion chips. Suggestions are advisory, so degrading
-// to CORE (table renders, no chips) is strictly better than showing nothing.
+// mirror of Pro. `supportSuggestion` (FDA-Readiness-1 PR4) and `deviceSupportRisk`
+// (PR5) both exist on Pro before they reach the CE mirror, and GraphQL validates the
+// WHOLE document -- so selecting either against a lagging CE backend would reject the
+// entire query and blank the whole SBOM components tab, not just those two surfaces.
+// Both are advisory reads over facts the CORE selection already carries, so degrading
+// to CORE (table renders, no chips and no risk flags) is strictly better than showing
+// nothing.
 //
 // Both documents are written out in full rather than composed from a shared fragment
 // string, so both stay statically analysable: ui/scripts/validate-graphql.mjs skips
@@ -60,6 +62,7 @@ export const SBOM_COMPONENTS_FULL_QUERY = gql`
                 endOfLifeDate
                 supportSource
                 supportNotes
+                deviceSupportRisk
                 supportSuggestion {
                     endOfSupportDate
                     basis
@@ -80,13 +83,15 @@ export const SBOM_COMPONENTS_FULL_QUERY = gql`
 
 export interface SbomComponentsLoad {
     rows: any[]
-    // True when only CORE was served: rows render, suggestion chips are absent.
+    // True when only CORE was served: rows render, but suggestion chips and device-risk
+    // flags are absent. Callers must treat an absent device verdict as "not checked" rather
+    // than "not at risk".
     degraded: boolean
 }
 
 /**
  * Load a release's SBOM components, falling back to the CORE selection when the
- * deployed backend does not know the suggestion field.
+ * deployed backend does not know the FULL-only fields (suggestion, device-risk).
  *
  * @param skipFull set once a prior load proved the backend rejects FULL, to avoid
  *                 paying the reject-then-retry round-trip on every later load.

--- a/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { buildSchema, validate, print, type GraphQLSchema } from 'graphql'
 import { SBOM_COMPONENTS_CORE_QUERY, SBOM_COMPONENTS_FULL_QUERY } from './sbomComponentsQuery'
 
 // Sibling of notificationInboxSchemaDrift.spec.ts, and load-bearing for the same
@@ -46,6 +46,18 @@ describe('SBOM components core selection vs the CE mirror schema (in-repo, alway
         if (!ceSchema) return
         const errors = validate(ceSchema, SBOM_COMPONENTS_FULL_QUERY).map(e => e.message)
         expect(errors.join(' ')).toMatch(/supportSuggestion/)
+    })
+
+    // Both Pro-ahead fields must sit in FULL. deviceSupportRisk is the one most likely to be
+    // "helpfully" promoted into CORE later -- it is a plain scalar, unlike the nested
+    // suggestion object -- and doing so would blank the whole tab on every lagging CE
+    // install. Pin it explicitly so that move fails here rather than in a customer's browser.
+    // No CE-schema guard here on purpose: this pin is pure text, so it must still fire in a
+    // checkout where the mirrored schema is missing -- that is exactly when the other checks
+    // go quiet and a CORE promotion would otherwise sail through.
+    it('deviceSupportRisk is in FULL only, never in CORE', () => {
+        expect(print(SBOM_COMPONENTS_FULL_QUERY)).toMatch(/deviceSupportRisk/)
+        expect(print(SBOM_COMPONENTS_CORE_QUERY)).not.toMatch(/deviceSupportRisk/)
     })
 })
 


### PR DESCRIPTION
> **Stacked on #303** -- base branch is `2026-08-fda-readiness-support-suggestions`, not
> `main`, because this reuses the CORE/FULL schema-drift split that PR introduces. Merge #303
> first; GitHub will retarget this to `main` automatically. Reviewing the 3-file diff shown
> here reviews only this change.

The device-support-risk verdict has been derived by the backend since that slice landed, and
it rides the exported CycloneDX BOM -- but nothing rendered it. A reviewer working in the
browser could not see which components go unsupported while the device is still fielded,
which is the headline signal of the Feb-2026 premarket guidance. Everything else in this
feature family has a UI surface; the one carrying the regulatory signal did not.

### Three read-only surfaces

**A marker in the Support column**, deliberately a *second* tag rather than folded into the
support status. The two answer different questions: the status tag says whether a component
is supported *today*, the verdict says whether its support outlasts *the device*. A component
can be actively supported now and still fail the device check -- support to 2030 inside a
device fielded to 2031 -- and that case renders in reassuring green under a status-only
column.

**A count beside the coverage counter**, scoped to the whole release rather than the filtered
view: whether a device outlives its components is a fact about the device, not about the
reader's current search.

**A filter**, so a reviewer can go straight to the rows that need disclosure.

### The care is in not reporting a clean bill of health we have not earned

Zero flags has two very different causes -- the device declares no support window so *nothing
was checked*, or everything checked genuinely outlasts it -- and they look identical to a
reader. The summary tells them apart without another round-trip: the verdict resolves to
`UNKNOWN` only when the device has no horizon or the component carries no dates, so among
components that *do* carry a date, an all-`UNKNOWN` result can only mean the device declares
no horizon. It says exactly that instead of showing a count.

Count and filter are both withheld entirely on a non-device release, and when the load
degrades to the CORE selection where the field was never requested. An absent verdict means
"not checked", never "not at risk".

### A pre-existing bug this would have made dangerous

This view is reused across releases rather than remounted, and the SBOM cache was never reset
on navigation -- the loader early-returned and rendered the *previous* release's components.
Merely stale for a table; for the new counter it would have stated "N outlived by this device"
about a device whose SBOM was not on screen. Fixed here alongside the existing
per-release cache resets, and covered by a live assertion.

### Schema drift

The field is Pro-ahead of the CE mirror, so it joins the FULL selection behind the existing
CORE/FULL fallback, plus a drift-spec pin that fails if it is ever promoted into CORE --
which would blank the entire SBOM tab on every lagging CE install. That pin is intentionally
*not* behind the CE-schema guard: it is pure text and must still fire in a checkout where the
mirrored schema is absent, which is exactly when the other checks go quiet.

### Testing

- 6 drift tests green; UI suite 171/172, the one failure being `routeInputSchemaDrift.spec.ts`,
  verified pre-existing (both that spec and the CE schema it validates against are
  byte-identical to `main`, and this diff touches neither).
- Live-verified on a sandbox against a real device fixture -- a PRODUCT release declaring
  support to 2031 over a Debian 12 base attested to EOS 2026-07-11 -- with a 10-assertion
  Playwright probe. It covers the negative cases too: no summary and no filter option on a
  non-device release, and no leakage of the device's verdict across a release switch.
- Two-layer self-review. Both layers found real problems, fixed here: the filter option was
  offered on a degraded CORE load (producing an empty table that reads as a clean bill of
  health), the badge rendered only alongside an attested row while the count and filter were
  source-agnostic, a hand-maintained second copy of the flagged-value set, and two structural
  test pins sitting behind a guard that could silently skip them.

### Dropped from this PR

An earlier revision also passed `releaseUuid` on the artifact download URL. Review caught that
it is a **regression**: the backend takes the `releaseUuid` branch whenever the parameter is
present, so sending the currently-viewed release for an artifact owned by a *different*
release makes it match nothing and stamp no device disclosure at all -- where the existing
sole-product-release fallback would have stamped one. Doing it correctly needs per-call-site
release attribution (the Underlying Artifacts tab lists artifacts of other releases), which is
separate work. The fallback already covers the common single-device case; only artifacts
shared across several device releases are affected, and they are unaffected by this PR.

### Also here

The adjacent coverage counter now says "Support attested (org-wide)". It has always counted
the whole organization while sitting above a single release's table; on a screen used for
submission review that ambiguity is worth a word. Nothing keys on the old string.
