### PR TITLE
fix(ui): tag product rows in the needs-my-approval tab

### DIFF
--- a/ui/src/components/NotificationInbox.vue
+++ b/ui/src/components/NotificationInbox.vue
@@ -1135,7 +1135,17 @@ const approvalsColumns = computed(() => [
                 : approvalLink(
                     `/${row.componentType === 'PRODUCT' ? 'productsOfOrg' : 'componentsOfOrg'}/${orgUuid.value}/${row.componentUuid}`,
                     row.componentName || row.componentUuid)
-            return h('span', { 'data-testid': 'approval-pending-row' }, inner)
+            // A product and a component may legitimately share a name (the
+            // repair identity is name+vcs over components only), and their
+            // releases can even share version strings — two visually
+            // identical rows. Tag products so same-named rows are tellable
+            // apart. Absent componentType (CE drift fallback) shows no tag.
+            const children: any[] = [inner]
+            if (row.componentType === 'PRODUCT') {
+                children.push(h(NTag, { size: 'tiny', style: 'margin-left: 6px' },
+                    { default: () => 'Product' }))
+            }
+            return h('span', { 'data-testid': 'approval-pending-row' }, children)
         },
     },
     {


### PR DESCRIPTION
## Problem

A field report of a release "appearing twice" in the Needs-my-approval tab turned out to be two *distinct* releases: a PRODUCT and a COMPONENT legitimately sharing a name (name uniqueness is only enforced across components), whose releases also shared a version string. The tab renders only the component name, so the rows were visually identical.

## Fix

Render a small `Product` tag next to the name for product rows. `componentType` already rides on the DTO (the row link is already type-aware); the CE schema-drift fallback query lacks the field and simply renders no tag, as before.

## Testing

`npm test` — 176 tests, only the pre-existing `routeInputSchemaDrift` failure that fails identically on main; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)