### PR TITLE
Remove endoflife.date support-suggestion UI (paired with rearm-saas #468)

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1010,20 +1010,6 @@
                                 <div style="margin-bottom: 10px; font-family: monospace; font-size: 12px; word-break: break-all;">
                                     {{ sbomSupportEditRow.component?.name }}<span v-if="sbomSupportEditRow.component?.version">@{{ sbomSupportEditRow.component?.version }}</span>
                                 </div>
-                                <div
-                                    v-if="supportSuggestionInUse"
-                                    style="margin-bottom: 12px; padding: 8px 10px; border: 1px dashed #d0d0d0; border-radius: 4px; font-size: 12px;">
-                                    <div style="font-weight: 600; margin-bottom: 2px;">Pre-filled from a suggestion - review before saving</div>
-                                    <div>{{ supportSuggestionBasisLabel(supportSuggestionInUse.basis) }}</div>
-                                    <div style="color: #999;">
-                                        {{ supportSuggestionInUse.product }} {{ supportSuggestionInUse.cycle }}<span v-if="supportSuggestionInUse.catalogAsOf">, catalog as of {{ supportSuggestionInUse.catalogAsOf }}</span>
-                                        <a v-if="supportSuggestionInUse.upstreamUrl" :href="supportSuggestionInUse.upstreamUrl" target="_blank" rel="noopener noreferrer" style="margin-left: 6px;">check upstream</a>
-                                    </div>
-                                    <div v-if="supportSuggestionInUse.extendedSupportDate" style="margin-top: 4px;">
-                                        Extended/LTS support runs to {{ supportSuggestionInUse.extendedSupportDate }} - use that date instead only if you hold that subscription or support contract.
-                                    </div>
-                                    <div style="margin-top: 4px;">Saving records this as <strong>your</strong> attestation, not the catalog's.</div>
-                                </div>
                                 <n-form-item label="End-of-support date">
                                     <n-date-picker v-model:value="supportEosInput" type="date" clearable style="width: 100%;" />
                                 </n-form-item>
@@ -2932,9 +2918,6 @@ const sbomSupportEditRow: Ref<any> = ref(null)
 const supportEosInput: Ref<number | null> = ref(null)
 const supportEolInput: Ref<number | null> = ref(null)
 const supportNotesInput: Ref<string> = ref('')
-// The suggestion the editor was opened from, if any. Drives the review banner, and is
-// cleared on a plain edit so an existing attestation is never re-framed as a suggestion.
-const supportSuggestionInUse: Ref<any> = ref(null)
 const supportSavePending: Ref<boolean> = ref(false)
 
 // Org-wide support disclosure completeness -- a pre-submission readiness signal
@@ -2960,35 +2943,12 @@ function tsToIsoDate (ts: number | null): string | null {
     return `${y}-${m}-${day}`
 }
 
-const SUPPORT_SUGGESTION_BASIS_LABEL: Record<string, string> = {
-    DISTRO_RELEASE_LIFECYCLE: 'Lifecycle of the distribution release that ships this package (not the upstream project - distributions backport fixes, so the two disagree).',
-    EXACT_COORDINATE: 'Published lifecycle of this exact project and release cycle.'
-}
-
-function supportSuggestionBasisLabel (basis: string): string {
-    return SUPPORT_SUGGESTION_BASIS_LABEL[basis] || 'Derived from the public lifecycle catalog.'
-}
-
-/**
- * Open the attestation editor. When a suggestion is passed the dates are pre-filled
- * from it and its provenance is pre-written into the (internal-only) note, so whatever
- * the reviewer saves records what they were shown. The note stays editable and the
- * reviewer can override either date - accepting is a decision, not a formality.
- */
-function openSupportEdit (row: any, suggestion?: any) {
+function openSupportEdit (row: any) {
     sbomSupportEditRow.value = row
     const c = row.component || {}
-    supportSuggestionInUse.value = suggestion || null
-    supportEosInput.value = suggestion
-        ? isoDateToTs(suggestion.endOfSupportDate)
-        : isoDateToTs(c.endOfSupportDate)
+    supportEosInput.value = isoDateToTs(c.endOfSupportDate)
     supportEolInput.value = isoDateToTs(c.endOfLifeDate)
-    supportNotesInput.value = c.supportNotes
-        || (suggestion
-            ? `Accepted suggestion from endoflife.date: ${suggestion.product} ${suggestion.cycle}`
-                + `${suggestion.matchedOn ? ` (matched on ${suggestion.matchedOn})` : ''}`
-                + `${suggestion.catalogAsOf ? `, catalog as of ${suggestion.catalogAsOf}` : ''}.`
-            : '')
+    supportNotesInput.value = c.supportNotes || ''
     sbomSupportModalOpen.value = true
 }
 
@@ -3051,11 +3011,11 @@ async function loadSupportCoverage (force: boolean = false) {
 }
 
 // CORE selection: fields present on every deployed backend, including a CE mirror
-// lagging behind Pro. FULL adds supportSuggestion and deviceSupportRisk, which only exist
-// once the backend carries those surfaces. Without this split, selecting them against a
-// lagging CE backend fails validation for the WHOLE document and blanks the entire SBOM
-// components tab -- both are advisory, so degrading to CORE (table renders, no suggestion
-// chips and no device-risk flags) is strictly better than showing nothing.
+// lagging behind Pro. FULL adds deviceSupportRisk, which only exists once the backend
+// carries that surface. Without this split, selecting it against a lagging CE backend
+// fails validation for the WHOLE document and blanks the entire SBOM components tab --
+// it is advisory, so degrading to CORE (table renders, no device-risk flags) is
+// strictly better than showing nothing.
 // Set once a load proves the deployed backend rejects the FULL selection, so later loads
 // skip the reject-then-retry round-trip.
 const sbomFullSelectionUnsupported: Ref<boolean> = ref(false)
@@ -3308,45 +3268,13 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
         render: (row: any) => {
             const c = row.component || {}
             // Un-attested components have no supportSource -> a neutral dash, not UNKNOWN.
-            // Where the backend can propose a date from the public lifecycle catalog we
-            // offer it here instead, clearly marked as a suggestion rather than a fact:
-            // accepting it opens the ordinary attestation editor pre-filled, so what gets
-            // stored is a MANUAL attestation by the reviewer, never a machine assertion.
             if (!c.supportSource) {
-                const sug = c.supportSuggestion
                 // A component can carry dates (hence a device verdict) without a source once a
                 // non-MANUAL writer exists, so the marker rides along here too -- see
                 // deviceRiskBadge. Today this is unreachable and costs one null check.
                 const unattestedRisk = deviceRiskBadge(c)
-                // Same gate as the Edit-support action below: a viewer who cannot attest
-                // must not be walked through a review that fails on save, and root
-                // components are excluded from manual attestation entirely.
-                const canAttest = isWritable.value && !c.isRoot
-                if (!sug || !canAttest) {
-                    return h('div', [h('span', { style: 'color: #999;' }, '—'),
-                        unattestedRisk ? h('div', { style: 'margin-top: 3px;' }, [unattestedRisk]) : null])
-                }
-                return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 460px;' }, {
-                    trigger: () => h(NTag, {
-                        size: 'small',
-                        round: true,
-                        bordered: true,
-                        style: 'border-style: dashed; cursor: pointer; color: #888;',
-                        onClick: () => openSupportEdit(row, sug)
-                    }, () => `Suggested EOS ${sug.endOfSupportDate}`),
-                    default: () => h('div', { style: 'font-size: 12px;' }, [
-                        h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, 'Not attested - suggestion only'),
-                        h('div', supportSuggestionBasisLabel(sug.basis)),
-                        h('div', `Source: ${sug.product} ${sug.cycle}`),
-                        sug.matchedOn ? h('div', { style: 'color: #999;' }, `Matched on ${sug.matchedOn}`) : null,
-                        sug.extendedSupportDate
-                            ? h('div', { style: 'margin-top: 4px;' },
-                                `Extended/LTS support runs to ${sug.extendedSupportDate} - applies only if you hold that subscription or contract.`)
-                            : null,
-                        sug.catalogAsOf ? h('div', { style: 'color: #999; margin-top: 4px;' }, `Catalog as of ${sug.catalogAsOf}`) : null,
-                        h('div', { style: 'margin-top: 4px;' }, 'Click to review and attest.')
-                    ])
-                })
+                return h('div', [h('span', { style: 'color: #999;' }, '—'),
+                    unattestedRisk ? h('div', { style: 'margin-top: 3px;' }, [unattestedRisk]) : null])
             }
             const tag = SUPPORT_TAG[c.supportStatus] || SUPPORT_TAG.UNKNOWN
             const els: any[] = [h(NTag, { size: 'small', type: tag.type, round: true }, () => tag.label)]

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -1,13 +1,12 @@
 // Release SBOM-components query, split CORE / FULL for schema-drift tolerance.
 //
 // The SAME UI ships to a Pro backend and to CE installs whose backend is a delayed
-// mirror of Pro. `supportSuggestion` (FDA-Readiness-1 PR4) and `deviceSupportRisk`
-// (PR5) both exist on Pro before they reach the CE mirror, and GraphQL validates the
-// WHOLE document -- so selecting either against a lagging CE backend would reject the
-// entire query and blank the whole SBOM components tab, not just those two surfaces.
-// Both are advisory reads over facts the CORE selection already carries, so degrading
-// to CORE (table renders, no chips and no risk flags) is strictly better than showing
-// nothing.
+// mirror of Pro. `deviceSupportRisk` (FDA-Readiness-1 PR5) exists on Pro before it
+// reaches the CE mirror, and GraphQL validates the WHOLE document -- so selecting it
+// against a lagging CE backend would reject the entire query and blank the whole SBOM
+// components tab, not just that one field. It is an advisory read over facts the CORE
+// selection already carries, so degrading to CORE (table renders, no risk flags) is
+// strictly better than showing nothing.
 //
 // Both documents are written out in full rather than composed from a shared fragment
 // string, so both stay statically analysable: ui/scripts/validate-graphql.mjs skips
@@ -63,16 +62,6 @@ export const SBOM_COMPONENTS_FULL_QUERY = gql`
                 supportSource
                 supportNotes
                 deviceSupportRisk
-                supportSuggestion {
-                    endOfSupportDate
-                    basis
-                    product
-                    cycle
-                    matchedOn
-                    extendedSupportDate
-                    catalogAsOf
-                    upstreamUrl
-                }
             }
             artifactParticipations {
                 artifact
@@ -83,15 +72,14 @@ export const SBOM_COMPONENTS_FULL_QUERY = gql`
 
 export interface SbomComponentsLoad {
     rows: any[]
-    // True when only CORE was served: rows render, but suggestion chips and device-risk
-    // flags are absent. Callers must treat an absent device verdict as "not checked" rather
-    // than "not at risk".
+    // True when only CORE was served: rows render, but device-risk flags are absent.
+    // Callers must treat an absent device verdict as "not checked" rather than "not at risk".
     degraded: boolean
 }
 
 /**
  * Load a release's SBOM components, falling back to the CORE selection when the
- * deployed backend does not know the FULL-only fields (suggestion, device-risk).
+ * deployed backend does not know the FULL-only fields (device-risk).
  *
  * @param skipFull set once a prior load proved the backend rejects FULL, to avoid
  *                 paying the reject-then-retry round-trip on every later load.

--- a/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
@@ -45,13 +45,13 @@ describe('SBOM components core selection vs the CE mirror schema (in-repo, alway
     it('the FULL selection is NOT yet valid against the CE mirror (split is load-bearing)', () => {
         if (!ceSchema) return
         const errors = validate(ceSchema, SBOM_COMPONENTS_FULL_QUERY).map(e => e.message)
-        expect(errors.join(' ')).toMatch(/supportSuggestion/)
+        expect(errors.join(' ')).toMatch(/deviceSupportRisk/)
     })
 
-    // Both Pro-ahead fields must sit in FULL. deviceSupportRisk is the one most likely to be
-    // "helpfully" promoted into CORE later -- it is a plain scalar, unlike the nested
-    // suggestion object -- and doing so would blank the whole tab on every lagging CE
-    // install. Pin it explicitly so that move fails here rather than in a customer's browser.
+    // The Pro-ahead field must sit in FULL. deviceSupportRisk is a plain scalar, which makes
+    // it an easy target to "helpfully" promote into CORE later -- doing so would blank the
+    // whole tab on every lagging CE install. Pin it explicitly so that move fails here rather
+    // than in a customer's browser.
     // No CE-schema guard here on purpose: this pin is pure text, so it must still fire in a
     // checkout where the mirrored schema is missing -- that is exactly when the other checks
     // go quiet and a CORE promotion would otherwise sail through.


### PR DESCRIPTION
## Summary
- Paired UI half of the core-side removal in relizaio/rearm-saas #468 -- **must merge together**, since this UI selects a `supportSuggestion` GraphQL field the backend will stop serving.
- Drops the suggestion selection from the FULL SBOM-components query, the suggestion review panel in the attestation-edit modal, the suggestion-chip in the table's Support column, and the now-dead `supportSuggestionInUse` ref / basis-label helper / `openSupportEdit` second parameter.
- Updates the schema-drift canary test to match the new (and now sole) FULL-only drift point, `deviceSupportRisk`, since `supportSuggestion` no longer exists in either schema to drift against.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` -- 273 pre-existing errors, identical count before/after this change (verified via `git stash` comparison); zero new issues
- [x] `npx vitest run` -- 175/176 pass; the 1 failure (`notifyComponentOwner` CE-mirror canary) is pre-existing and unrelated (confirmed on `origin/main` baseline), tracked separately
- [x] `sbomComponentsSchemaDrift.spec.ts` (6/6) validates both the CE-mirror-lag split and, via the sibling `rearm-core` checkout, the Pro schema -- confirms this PR and rearm-saas#468 are mutually consistent
- [x] Layer 1 (`/code-review`) + Layer 2 (skeptical-senior-ReARM-engineer conventions pass) both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)