### PR TITLE
fix(ui): branchless dependencies render as exclusions and require IGNORED to save

### DIFF
--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -777,6 +777,19 @@ async function saveModifiedBranch () {
             )
         }
         
+        // A dependency without a branch is only legal when IGNORED (matches
+        // backend updateBranch validation) - fail fast with a pointed message
+        // instead of a server-side rejection.
+        const branchlessInvalid = (modifiedBranch.value.dependencies || []).find(
+            (d: any) => !d.branch && d.status !== 'IGNORED'
+        )
+        if (branchlessInvalid) {
+            const compName = store.getters.componentById(branchlessInvalid.uuid)?.name || branchlessInvalid.uuid
+            notify('error', 'Branch Required',
+                `Dependency on ${compName} has no branch selected. Select a branch or set its status to Excluded.`)
+            return
+        }
+
         // Track if branch type was changed to BASE
         const wasChangedToBase = modifiedBranch.value.type === 'BASE' && branchData.value.type !== 'BASE'
         
@@ -1323,7 +1336,14 @@ const effectiveDepTableFields: DataTableColumns<any> = [
                 })
             }
             
-            if (!row.branch) return 'Unknown'
+            if (!row.branch) {
+                // A branchless (component-level) dependency is only legal as an
+                // exclusion; render it as such. Anything else is pre-validation
+                // data - label it so the fix (pick a branch or exclude) is clear.
+                return row.status === 'IGNORED'
+                    ? h('span', { style: 'opacity: 0.5' }, '— (excluded)')
+                    : h('span', { class: 'muted-12' }, 'No branch — select one or exclude')
+            }
 
             const isExcluded = row.status === 'IGNORED'
             const link = renderDependencyBranchLink(row.component, row.branch, row.branch.name)


### PR DESCRIPTION
Companion to the backend rule that a dependency without a branch pin is only legal when its status is IGNORED.

## Changes (BranchView)

- **Branch column**: an IGNORED branchless row renders as `— (excluded)` with the existing excluded styling; a non-ignored branchless row (data predating the rule) shows `No branch — select one or exclude` instead of `Unknown`, telling the operator exactly how to fix it.
- **Save validation**: saving with a non-excluded dependency lacking a branch fails fast client-side, naming the component and the two ways out (select a branch / set Excluded), instead of a server-side rejection after the round-trip.

Requires the backend schema change making `EffectiveDependency.branch` nullable to be deployed first — until then the whole `effectiveDependencies` block nulls out at the GraphQL layer regardless of UI handling.

## Testing

`npm test` — 176 tests, only the pre-existing `routeInputSchemaDrift` failure that fails identically on main; `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)