### PR TITLE
feat(ui): instance page tabs + deferred release-detail loading

### DIFF
--- a/ui/src/components/AddComponentBranch.vue
+++ b/ui/src/components/AddComponentBranch.vue
@@ -1,25 +1,21 @@
 <template>
     <div class="addComponentBranchGlobal">
-        <n-form :model="featureSetObj">
+        <!-- The parent organization is always the current org (there is no
+             way to link a product from another org), so it is not a field. -->
+        <n-form ref="featureSetForm" :model="featureSetObj" :rules="rules">
             <n-form-item
                         v-if="!props.productUuid"
-                        label="Parent Organization" >
-                <n-select
-                        v-model:value="org"
-                        v-on:update:value="onOrgChange"
-                        :options="orgWithExt" />
-            </n-form-item>
-            <n-form-item
-                        v-if="!props.productUuid"
-                        path="featureSetObj.product"
+                        path="product"
                         label="Parent Product">
                 <n-select
                             v-on:update:value="value => {onComponentChange(value)}"
                             v-model:value="featureSetObj.product"
-                            required
-                            :options="products" />
+                            filterable
+                            placeholder="Select or type to filter products"
+                            :options="products"
+                            data-testid="link-fs-product" />
             </n-form-item>
-            <n-form-item    path="featureSetObj.featureSet"
+            <n-form-item    path="featureSet"
                             v-if="featureSetObj.product"
                             :label="myorg?.terminology?.featureSetLabel || 'Feature Set'">
                 <n-select
@@ -29,15 +25,17 @@
             </n-form-item>
             <n-form-item
                         v-if="!props.productUuid"
-                        path="featureSetObj.type"
+                        path="type"
                         label="Integration Type">
                 <n-select
                     v-model:value="featureSetObj.type"
+                    placeholder="Select integration type"
+                    data-testid="link-fs-type"
                     :options="deploymentType === 'INDIVIDUAL' ? [{value: 'INTEGRATE', label: 'INTEGRATE'}, {value: 'NONE', label: 'NONE'}] : [{value: 'INTEGRATE', label: 'INTEGRATE'}, {value: 'TARGET', label: 'TARGET'}, {value: 'FOLLOW', label: 'FOLLOW'}, {value: 'NONE', label: 'NONE'}]" />
             </n-form-item>
             <n-form-item
                         v-if="!props.productUuid && !props.namespace"
-                        path="featureSetObj.namespace"
+                        path="namespace"
                         label="Namespace">
                 <n-input
                         placeholder="Enter namespace, defaults to 'default' if left blank"
@@ -45,34 +43,19 @@
             </n-form-item>
             <n-form-item
                             v-if="!props.productUuid"
-                            path="featureSetObj.configuration"
-                            label="Extra Configuration (i.e. Helm values file)">
+                            path="configuration"
+                            label="Extra Configuration (optional, e.g. Helm values file)">
                 <n-select
                         tag
                         filterable
+                        clearable
+                        placeholder="Optional - leave empty for none"
                         :options='[{value: "default", label: "default"}, {value: "values-reliza.yaml", label: "values-reliza.yaml"}]'
                         v-model:value="featureSetObj.configuration" />
             </n-form-item>
-            <n-form-item
-                v-if="!props.productUuid"
-                path="featureSetObj.alertsEnabled"
-                label="Alerts"
-            >
-                <n-switch v-model:value="featureSetObj.alertsEnabled" size="large">
-                    <template #checked-icon>
-                        <NIcon>
-                            <AlertOn24Regular/>
-                        </NIcon>
-
-                    </template>
-                    <template #unchecked-icon>
-                        <NIcon>
-                            <AlertOff24Regular/>
-                        </NIcon>
-                    </template>
-                </n-switch>
-
-            </n-form-item>
+            <!-- The per-product Alerts switch is intentionally not shown: alerts
+                 are not wired to anything yet. alertsEnabled stays in the
+                 emitted object (always false) so the update input is unchanged. -->
             <n-button type="success" @click="onSubmit">Submit</n-button>
             <n-button type="warning" @click="onReset">Reset</n-button>
         </n-form>
@@ -87,9 +70,7 @@ export default {
 <script lang="ts" setup>
 import { useStore } from 'vuex'
 import { ComputedRef, computed, ref } from 'vue'
-import { NButton, NForm, NFormItem, NInput, NSelect, NSwitch, NIcon } from 'naive-ui'
-import { AlertOff24Regular, AlertOn24Regular} from '@vicons/fluent'
-import constants from '../utils/constants'
+import { FormInst, FormRules, NButton, NForm, NFormItem, NInput, NSelect } from 'naive-ui'
 
 const props = defineProps<{
     orgProp: String,
@@ -101,22 +82,17 @@ const emit = defineEmits(['addedComponentBranch'])
 
 const store = useStore()
 const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
-const initialOrg = props.orgProp ? props.orgProp : myorg.value
-const org = ref(initialOrg)
-const orgWithExt: ComputedRef<any> = computed((): any => {
-    const orgWithExt = []
-    const storeOrgs = store.getters.allOrganizations
-    storeOrgs.forEach((so: any) => {
-        if (so.uuid === initialOrg) {
-            const orgObj = {
-                label: so.name,
-                value: so.uuid
-            }
-            orgWithExt.push(orgObj)
-        }
-    })
-    return orgWithExt
-})
+// Always the current org: a product can only be linked from the org the
+// instance belongs to.
+const org = ref(props.orgProp ? props.orgProp : myorg.value)
+const featureSetForm = ref<FormInst | null>(null)
+
+// Parent product and integration type are what the backend needs to create
+// the mapping; everything else on the form has a default.
+const rules: FormRules = {
+    product: { required: true, message: 'Parent product is required', trigger: ['blur', 'change'] },
+    type: { required: true, message: 'Integration type is required', trigger: ['blur', 'change'] }
+}
 
 const products: ComputedRef<any> = computed((): any => {
     const storeComponents = store.getters.productsOfOrg(org.value)
@@ -126,7 +102,7 @@ const products: ComputedRef<any> = computed((): any => {
             value: proj.uuid
         }
         return projObj
-    })
+    }).sort((a: any, b: any) => a.label.localeCompare(b.label))
 })
 
 const deploymentType: ComputedRef<any> = computed((): any => store.getters.instanceById(props.instanceUuid, -1))
@@ -159,14 +135,6 @@ const branches: ComputedRef<any> = computed((): any => {
     return branches
 })
 
-const onOrgChange = function () {
-    if (org.value !== constants.ExternalPublicComponentsOrg) {
-        store.dispatch('fetchProducts', org.value)
-    }
-    featureSetObj.value.product = ''
-    featureSetObj.value.featureSet = ''
-}
-
 const onComponentChange = function (componentId: string) {
     featureSetObj.value.featureSet = ''
     // Force a network refresh so the dropdown reflects feature sets created /
@@ -197,8 +165,22 @@ const onReset = function () {
 }
 
 const onSubmit = function () {
-    emit('addedComponentBranch', featureSetObj.value)
-    onReset()
+    // Editing an existing link (productUuid set) only exposes the feature
+    // set, so the product/type rules do not apply there.
+    if (props.productUuid) {
+        emit('addedComponentBranch', featureSetObj.value)
+        onReset()
+        return
+    }
+    // validate() also returns a promise that rejects with the same errors
+    // the callback receives; the callback is the handler, so swallow the
+    // rejection instead of surfacing an unhandled one.
+    featureSetForm.value?.validate((errors) => {
+        if (!errors) {
+            emit('addedComponentBranch', featureSetObj.value)
+            onReset()
+        }
+    }).catch(() => {})
 }
 
 if (!org.value) {

--- a/ui/src/components/AddComponentBranch.vue
+++ b/ui/src/components/AddComponentBranch.vue
@@ -87,10 +87,13 @@ const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
 const org = ref(props.orgProp ? props.orgProp : myorg.value)
 const featureSetForm = ref<FormInst | null>(null)
 
-// Parent product and integration type are what the backend needs to create
-// the mapping; everything else on the form has a default.
+// Product (to pick the feature set from), feature set and integration type
+// are required; everything else on the form has a default. The feature-set
+// item only registers once a product is chosen, so an empty product is
+// reported by its own rule first.
 const rules: FormRules = {
     product: { required: true, message: 'Parent product is required', trigger: ['blur', 'change'] },
+    featureSet: { required: true, message: 'Feature set is required', trigger: ['blur', 'change'] },
     type: { required: true, message: 'Integration type is required', trigger: ['blur', 'change'] }
 }
 

--- a/ui/src/components/CreateProperty.vue
+++ b/ui/src/components/CreateProperty.vue
@@ -53,10 +53,12 @@
                 <n-input v-else-if="props.instanceType === InstanceType.CLUSTER_INSTANCE" :disabled="true" :placeholder="props.reservedNs"></n-input>
                 <n-input v-else :disabled="true" placeholder="CLUSTER--WIDE"></n-input>
             </n-form-item>
-            <n-form-item v-if="props.instanceType !== InstanceType.CLUSTER" path="product" label="Product">
+            <n-form-item v-if="props.instanceType !== InstanceType.CLUSTER" path="product" :label="productLabel">
                 <n-select
                             v-model:value="property.product"
-                            :options="props.knownProducts" />
+                            filterable
+                            :options="productOptions"
+                            data-testid="create-property-product" />
             </n-form-item>
             <n-form-item path="value" label="Value" v-if="property.dataType === 'JSON' || property.dataType === 'YAML'">
                 <prism-editor class="editor" v-model="property.value" :highlight="highlighter" line-numbers></prism-editor>
@@ -77,7 +79,7 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { ref, ComputedRef, computed } from 'vue'
+import { ref, ComputedRef, computed, watch } from 'vue'
 import { useStore } from 'vuex'
 import { FormInst, NForm, NFormItem, NInput, NButton, NSelect, useNotification, NotificationType } from 'naive-ui'
 import { PrismEditor } from 'vue-prism-editor';
@@ -90,7 +92,9 @@ import constants from '@/utils/constants'
 
 const props = defineProps<{
     orgProp: String,
-    knownProducts: Array,
+    // The instance's product plans: { namespace, featureSetDetails.componentDetails{uuid,name} }.
+    // Products are offered per namespace from these.
+    productPlans: Array,
     knownNamespaces: Array,
     instProperties: Array,
     instanceType: String,
@@ -131,6 +135,33 @@ const property = ref({
     namespace: props.reservedNs,
     product: '',
     value: ''
+})
+
+// A property targets a product in a namespace, so once a namespace is picked
+// only products deployed there are offered. No namespace (cluster-wide) or a
+// non-standalone instance (single fixed namespace) offers every product.
+const namespaceScopesProducts: ComputedRef<boolean> = computed((): boolean =>
+    props.instanceType === InstanceType.STANDALONE_INSTANCE && !!property.value.namespace)
+const productOptions: ComputedRef<any[]> = computed((): any[] => {
+    const plans: any[] = (props.productPlans as any[]) || []
+    const byUuid: Record<string, any> = {}
+    plans.forEach((plan: any) => {
+        if (namespaceScopesProducts.value && plan.namespace !== property.value.namespace) return
+        const comp = plan.featureSetDetails && plan.featureSetDetails.componentDetails
+        if (comp && comp.uuid && !byUuid[comp.uuid]) byUuid[comp.uuid] = { label: comp.name, value: comp.uuid }
+    })
+    const opts = Object.values(byUuid).sort((a: any, b: any) => a.label.localeCompare(b.label))
+    opts.unshift({ label: '', value: '' })
+    return opts
+})
+const productLabel: ComputedRef<string> = computed((): string =>
+    namespaceScopesProducts.value ? `Product (deployed in ${property.value.namespace})` : 'Product')
+// Changing the namespace can make the chosen product unavailable; clear it
+// rather than submit a product/namespace pair the instance does not have.
+watch(productOptions, (opts) => {
+    if (property.value.product && !opts.some((o: any) => o.value === property.value.product)) {
+        property.value.product = ''
+    }
 })
 
 const properties: ComputedRef<any> = computed((): any => {
@@ -198,7 +229,7 @@ const onSubmit = async function () {
             }
             
         }
-    })
+    }).catch(() => {})
 }
 const notification = useNotification()
 

--- a/ui/src/components/CreateProperty.vue
+++ b/ui/src/components/CreateProperty.vue
@@ -47,9 +47,10 @@
             <n-form-item path="namespace" :label="nsLabel">
                 <n-select v-if="props.instanceType === InstanceType.STANDALONE_INSTANCE" 
                             v-model:value="property.namespace"
-                            :options="props.knownNamespaces"
+                            :options="namespaceOptions"
                             tag
-                            filterable />
+                            filterable
+                            data-testid="create-property-namespace" />
                 <n-input v-else-if="props.instanceType === InstanceType.CLUSTER_INSTANCE" :disabled="true" :placeholder="props.reservedNs"></n-input>
                 <n-input v-else :disabled="true" placeholder="CLUSTER--WIDE"></n-input>
             </n-form-item>
@@ -79,7 +80,7 @@ export default {
 }
 </script>
 <script lang="ts" setup>
-import { ref, ComputedRef, computed, watch } from 'vue'
+import { ref, ComputedRef, computed } from 'vue'
 import { useStore } from 'vuex'
 import { FormInst, NForm, NFormItem, NInput, NButton, NSelect, useNotification, NotificationType } from 'naive-ui'
 import { PrismEditor } from 'vue-prism-editor';
@@ -113,6 +114,8 @@ const nsLabel: ComputedRef<string> = computed((): any => {
         label = 'Namespace (defaults to cluster wide for cluster)'
     else if(props.instanceType === InstanceType.CLUSTER_INSTANCE)
         label = 'Namespace (reserved namespace for the instance will be used)'
+    else if(productScopesNamespaces.value)
+        label = `Namespace (where ${selectedProductName.value} is deployed)`
     return label
 })
 const orgs: ComputedRef<any> = computed((): any => {
@@ -137,32 +140,74 @@ const property = ref({
     value: ''
 })
 
-// A property targets a product in a namespace, so once a namespace is picked
-// only products deployed there are offered. No namespace (cluster-wide) or a
-// non-standalone instance (single fixed namespace) offers every product.
-const namespaceScopesProducts: ComputedRef<boolean> = computed((): boolean =>
-    props.instanceType === InstanceType.STANDALONE_INSTANCE && !!property.value.namespace)
+// A property targets a product in a namespace, and on a standalone instance
+// (the one type that spans namespaces) the two must be a pair the instance
+// actually deploys. The lists scope each other -- pick a namespace and only
+// products deployed there are offered; pick a product and only its
+// namespaces are offered -- and pairValidator rejects anything else (the
+// namespace select accepts typed values, so the lists alone are not enough).
+// No namespace (cluster-wide) or no product leaves the other side unscoped.
+const isStandalone: ComputedRef<boolean> = computed((): boolean =>
+    props.instanceType === InstanceType.STANDALONE_INSTANCE)
+const plans = (): any[] => (props.productPlans as any[]) || []
+const planProductUuid = (plan: any): string =>
+    (plan.featureSetDetails && plan.featureSetDetails.componentDetails && plan.featureSetDetails.componentDetails.uuid) || ''
+const planProductName = (plan: any): string =>
+    (plan.featureSetDetails && plan.featureSetDetails.componentDetails && plan.featureSetDetails.componentDetails.name) || ''
+const namespaceScopesProducts: ComputedRef<boolean> = computed((): boolean => isStandalone.value && !!property.value.namespace)
+const productScopesNamespaces: ComputedRef<boolean> = computed((): boolean => isStandalone.value && !!property.value.product)
+const selectedProductName: ComputedRef<string> = computed((): string => {
+    const plan = plans().find((pl: any) => planProductUuid(pl) === property.value.product)
+    return plan ? planProductName(plan) : ''
+})
 const productOptions: ComputedRef<any[]> = computed((): any[] => {
-    const plans: any[] = (props.productPlans as any[]) || []
     const byUuid: Record<string, any> = {}
-    plans.forEach((plan: any) => {
+    plans().forEach((plan: any) => {
         if (namespaceScopesProducts.value && plan.namespace !== property.value.namespace) return
-        const comp = plan.featureSetDetails && plan.featureSetDetails.componentDetails
-        if (comp && comp.uuid && !byUuid[comp.uuid]) byUuid[comp.uuid] = { label: comp.name, value: comp.uuid }
+        const uuid = planProductUuid(plan)
+        if (uuid && !byUuid[uuid]) byUuid[uuid] = { label: planProductName(plan), value: uuid }
     })
+    // Keep the current selection in the list even when the namespace no
+    // longer includes it, so it still renders by name (pairValidator flags
+    // it) instead of collapsing to a bare uuid.
+    if (property.value.product && !byUuid[property.value.product]) {
+        const plan = plans().find((pl: any) => planProductUuid(pl) === property.value.product)
+        if (plan) byUuid[property.value.product] = { label: planProductName(plan), value: property.value.product }
+    }
     const opts = Object.values(byUuid).sort((a: any, b: any) => a.label.localeCompare(b.label))
+    opts.unshift({ label: '', value: '' })
+    return opts
+})
+const namespaceOptions: ComputedRef<any[]> = computed((): any[] => {
+    if (!productScopesNamespaces.value) return (props.knownNamespaces as any[]) || []
+    const seen: Record<string, boolean> = {}
+    const opts: any[] = []
+    plans().forEach((plan: any) => {
+        if (planProductUuid(plan) !== property.value.product || !plan.namespace || seen[plan.namespace]) return
+        seen[plan.namespace] = true
+        opts.push({ label: plan.namespace, value: plan.namespace })
+    })
+    opts.sort((a: any, b: any) => a.label.localeCompare(b.label))
     opts.unshift({ label: '', value: '' })
     return opts
 })
 const productLabel: ComputedRef<string> = computed((): string =>
     namespaceScopesProducts.value ? `Product (deployed in ${property.value.namespace})` : 'Product')
-// Changing the namespace can make the chosen product unavailable; clear it
-// rather than submit a product/namespace pair the instance does not have.
-watch(productOptions, (opts) => {
-    if (property.value.product && !opts.some((o: any) => o.value === property.value.product)) {
-        property.value.product = ''
-    }
-})
+// The product/namespace pair must be one of the instance's product plans.
+// Both fields validate it so either one turning invalid is flagged at once;
+// the namespace side carries the full message (returning an Error is how
+// naive-ui carries one) and the product side a short one, so the same
+// sentence is not shown twice.
+const pairDeployed = (): boolean => {
+    if (!isStandalone.value || !property.value.product || !property.value.namespace) return true
+    return plans().some((plan: any) =>
+        planProductUuid(plan) === property.value.product && plan.namespace === property.value.namespace)
+}
+const pairValidator = (): boolean | Error => pairDeployed() ||
+    new Error(`${selectedProductName.value || 'This product'} is not deployed in namespace ${property.value.namespace}`)
+// Deliberately no auto-clearing when one side changes: a pair that is no
+// longer deployed is reported by pairValidator next to the field, which is
+// clearer than a selection silently disappearing.
 
 const properties: ComputedRef<any> = computed((): any => {
     const storeProps = store.getters.propertiesOfOrg(property.value.org)
@@ -200,7 +245,9 @@ const rules = {
     value: {
         required: true,
         message: 'Property value is required'
-    }
+    },
+    namespace: { validator: pairValidator, trigger: ['blur', 'change'] },
+    product: { validator: pairDeployed, message: 'Not deployed in the selected namespace', trigger: ['blur', 'change'] }
 }
 
 const onReset = function () {

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -20,15 +20,28 @@
             </div>
             <!-- Segmented sub-tab pill control — mirrors OrgIntegrations look-and-feel. -->
             <div class="subtab-bar">
-                <button class="subtab-pill" :class="{ active: activeTab === 'instance' }" @click="switchTab('instance')">
+                <button class="subtab-pill" :class="{ active: activeTab === 'instance' }" @click="switchTab('instance')" data-testid="instance-tab-instance">
                     <n-icon size="16" class="subtab-icon"><Server /></n-icon>
                     <span>{{ instanceWord }}</span>
                 </button>
-                <button class="subtab-pill" :class="{ active: activeTab === 'plan-history' }" @click="switchTab('plan-history')">
+                <button v-if="updatedInstance.instanceType !== InstanceType.CLUSTER" class="subtab-pill" :class="{ active: activeTab === 'target-releases' }" @click="switchTab('target-releases')" data-testid="instance-tab-target-releases">
+                    <n-icon size="16" class="subtab-icon"><Target /></n-icon>
+                    <span>Individual Target Releases</span>
+                </button>
+                <button v-if="updatedInstance.instanceType !== InstanceType.CLUSTER" class="subtab-pill" :class="{ active: activeTab === 'deployed-releases' }" @click="switchTab('deployed-releases')" data-testid="instance-tab-deployed-releases">
+                    <n-icon size="16" class="subtab-icon"><Rocket /></n-icon>
+                    <span>Deployed Component Releases</span>
+                </button>
+                <button class="subtab-pill" :class="{ active: activeTab === 'cd-failures' }" @click="switchTab('cd-failures')" data-testid="instance-tab-cd-failures">
+                    <n-icon size="16" class="subtab-icon"><AlertTriangle /></n-icon>
+                    <span>Deployment Failures</span>
+                    <span v-if="deploymentFailureCount > 0" class="subtab-count subtab-count-error" data-testid="instance-tab-cd-failures-count">{{ deploymentFailureCount }}</span>
+                </button>
+                <button class="subtab-pill" :class="{ active: activeTab === 'plan-history' }" @click="switchTab('plan-history')" data-testid="instance-tab-plan-history">
                     <n-icon size="16" class="subtab-icon"><History /></n-icon>
                     <span>Plan History</span>
                 </button>
-                <button class="subtab-pill" :class="{ active: activeTab === 'actual-history' }" @click="switchTab('actual-history')">
+                <button class="subtab-pill" :class="{ active: activeTab === 'actual-history' }" @click="switchTab('actual-history')" data-testid="instance-tab-actual-history">
                     <n-icon size="16" class="subtab-icon"><History /></n-icon>
                     <span>Actual History</span>
                 </button>
@@ -59,63 +72,6 @@
                 />
                 
                 
-                <div v-if="updatedInstance && updatedInstance.instanceType !== InstanceType.CLUSTER" class="instanceReleaseBlock individualTargetReleases">
-                    <div class="listHeaderText">Individual Target Releases:
-                        <n-dropdown v-if="updatedInstance.instanceType === InstanceType.STANDALONE_INSTANCE" title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
-                        <span>
-                                <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
-                                <Icon><CaretDownFilled/></Icon>
-                            </span>
-                        </n-dropdown>
-                        <n-icon v-if="isWritable" class="clickable" @click="showAddComponentTargetReleaseModal = true" title="Add Component Target Release" size="24"><CirclePlus /></n-icon>
-                    </div>
-                    <n-data-table :data="targetIndividualReleases" :columns="targetReleaseFeilds" />
-                    
-                </div>
-                <div v-if="updatedInstance && updatedInstance.instanceType != InstanceType.CLUSTER" class="instanceReleaseBlock actualReleasesOnInstance">
-                    <div class="listHeaderText">Deployed Component Releases:
-                        <n-dropdown v-if="!isChildInstance && updatedInstance.instanceType === InstanceType.STANDALONE_INSTANCE"  title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
-                        <span>
-                                <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
-                                <Icon><CaretDownFilled/></Icon>
-                            </span>
-                        </n-dropdown>
-                        <n-icon class="ml-1 clickable" @click="showAgentDataModal = true" title="Show Agent Data" size="20"><InfoCircle /></n-icon>
-                        <n-icon v-if="isWritable" class="ml-1 clickable" @click="clearAgentData" title="Clear Agent Data" size="20"><CircleX /></n-icon>
-                    </div>
-                    <n-data-table :data="deployedReleases" :columns="deployedReleaseFeilds"></n-data-table>
-                </div>
-                <div v-if="filteredDeploymentFailures.length" class="instanceReleaseBlock deploymentFailuresOnInstance">
-                    <div class="listHeaderText">
-                        Deployment Failures:
-                        <n-tooltip trigger="hover" placement="top" :style="{maxWidth: '460px'}">
-                            <template #trigger><n-icon class="ml-1 clickable" size="18"><InfoCircle /></n-icon></template>
-                            Failures reported by ReARM CD while reconciling this instance. A failure that repeats is shown once with its occurrence count — First Seen is when the current incident started, Last Seen is the most recent report. Rows disappear once the agent stops reporting the failure.
-                        </n-tooltip>
-                        <n-tag v-if="deploymentHealthChip" :type="deploymentHealthChip.type" size="small" round class="ml-1"
-                               :title="deploymentHealthChip.tip">
-                            {{ deploymentHealthChip.label }}
-                        </n-tag>
-                    </div>
-                    <n-data-table :data="filteredDeploymentFailures" :columns="deploymentFailureFields" />
-                </div>
-                <div v-if="updatedInstance && updatedInstance.instanceType != InstanceType.CLUSTER && filteredUnmatchedReleases.length"
-                     class="instanceReleaseBlock unmatchedImagesOnInstance">
-                    <div class="listHeaderText">
-                        Unmatched Deployed Images:
-                        <n-tooltip trigger="hover" placement="top" :style="{maxWidth: '420px'}">
-                            <template #trigger><n-icon class="ml-1 clickable" size="18"><InfoCircle /></n-icon></template>
-                            Images reported by the cluster watcher whose digest does not resolve to any known deliverable in this org. Typically third-party sidecars (redis, postgres, etc.) or pods missing build-time metadata.
-                        </n-tooltip>
-                        <n-dropdown v-if="!isChildInstance && updatedInstance.instanceType === InstanceType.STANDALONE_INSTANCE" title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
-                            <span>
-                                <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
-                                <Icon><CaretDownFilled/></Icon>
-                            </span>
-                        </n-dropdown>
-                    </div>
-                    <n-data-table :data="filteredUnmatchedReleases" :columns="unmatchedImageFields" />
-                </div>
                 <div v-if="updatedInstance" class="instancePropertiesBlock">
                     <div class="listHeaderText">{{ instanceWord }} Properties:
                         <n-icon v-if="isWritable" class="clickable" @click="showAddInstancePropertyModal = true" title="Add New Property Manually" size="24"><CirclePlus /></n-icon>
@@ -123,6 +79,74 @@
                     <n-data-table :data="updatedInstance.properties" :columns="instPropFeilds"></n-data-table>
                 </div>
                 </div>
+            </div>
+
+            <!-- ================= Individual Target Releases tab ================== -->
+            <div v-if="activeTab === 'target-releases' && updatedInstance && updatedInstance.instanceType !== InstanceType.CLUSTER" class="instanceReleaseBlock individualTargetReleases">
+                <div class="listHeaderText">Individual Target Releases:
+                    <n-dropdown v-if="showNamespaceFilter" title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
+                        <span>
+                            <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
+                            <Icon><CaretDownFilled/></Icon>
+                        </span>
+                    </n-dropdown>
+                    <n-icon v-if="isWritable" class="clickable" @click="showAddComponentTargetReleaseModal = true" title="Add Component Target Release" size="24"><CirclePlus /></n-icon>
+                </div>
+                <div v-if="targetDetailsLoading" class="historyLoading">Loading…</div>
+                <div v-else-if="targetDetailsFailed" class="historyEmpty">Could not load target release details. <a href="#" @click.prevent="retryReleaseDetails('targetReleases')">Retry</a></div>
+                <n-data-table v-else :data="targetIndividualReleases" :columns="targetReleaseFeilds" />
+            </div>
+
+            <!-- ================= Deployed Component Releases tab ================== -->
+            <div v-if="activeTab === 'deployed-releases' && updatedInstance && updatedInstance.instanceType !== InstanceType.CLUSTER">
+                <div class="instanceReleaseBlock actualReleasesOnInstance">
+                    <div class="listHeaderText">Deployed Component Releases:
+                        <n-dropdown v-if="showNamespaceFilter" title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
+                            <span>
+                                <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
+                                <Icon><CaretDownFilled/></Icon>
+                            </span>
+                        </n-dropdown>
+                        <n-icon class="ml-1 clickable" @click="showAgentDataModal = true" title="Show Agent Data" size="20"><InfoCircle /></n-icon>
+                        <n-icon v-if="isWritable" class="ml-1 clickable" @click="clearAgentData" title="Clear Agent Data" size="20"><CircleX /></n-icon>
+                    </div>
+                    <div v-if="deployedDetailsLoading" class="historyLoading">Loading…</div>
+                    <div v-else-if="deployedDetailsFailed" class="historyEmpty">Could not load deployed release details. <a href="#" @click.prevent="retryReleaseDetails('releases')">Retry</a></div>
+                    <n-data-table v-else :data="deployedReleases" :columns="deployedReleaseFeilds"></n-data-table>
+                </div>
+                <div v-if="filteredUnmatchedReleases.length" class="instanceReleaseBlock unmatchedImagesOnInstance">
+                    <div class="listHeaderText">
+                        Unmatched Deployed Images:
+                        <n-tooltip trigger="hover" placement="top" :style="{maxWidth: '420px'}">
+                            <template #trigger><n-icon class="ml-1 clickable" size="18"><InfoCircle /></n-icon></template>
+                            Images reported by the cluster watcher whose digest does not resolve to any known deliverable in this org. Typically third-party sidecars (redis, postgres, etc.) or pods missing build-time metadata.
+                        </n-tooltip>
+                    </div>
+                    <n-data-table :data="filteredUnmatchedReleases" :columns="unmatchedImageFields" />
+                </div>
+            </div>
+
+            <!-- ================= Deployment Failures (ReARM CD) tab ================== -->
+            <div v-if="activeTab === 'cd-failures'" class="instanceReleaseBlock deploymentFailuresOnInstance">
+                <div class="listHeaderText">
+                    Deployment Failures:
+                    <n-tooltip trigger="hover" placement="top" :style="{maxWidth: '460px'}">
+                        <template #trigger><n-icon class="ml-1 clickable" size="18"><InfoCircle /></n-icon></template>
+                        Failures reported by ReARM CD while reconciling this instance. A failure that repeats is shown once with its occurrence count — First Seen is when the current incident started, Last Seen is the most recent report. Rows disappear once the agent stops reporting the failure.
+                    </n-tooltip>
+                    <n-tag v-if="deploymentHealthChip" :type="deploymentHealthChip.type" size="small" round class="ml-1"
+                           :title="deploymentHealthChip.tip">
+                        {{ deploymentHealthChip.label }}
+                    </n-tag>
+                    <n-dropdown v-if="showNamespaceFilter" title="Select Namespace" trigger="hover" :options="namespacesForDropdown" @select="$key => {selectedNamespace = $key}">
+                        <span class="ml-1">
+                            <span>{{ selectedNamespace ? selectedNamespace : 'Filter By Namespace' }}</span>
+                            <Icon><CaretDownFilled/></Icon>
+                        </span>
+                    </n-dropdown>
+                </div>
+                <n-data-table v-if="filteredDeploymentFailures.length" :data="filteredDeploymentFailures" :columns="deploymentFailureFields" />
+                <div v-else class="historyEmpty">No open deployment failures reported by ReARM CD{{ selectedNamespace && selectedNamespace !== 'ALL' ? ' in namespace ' + selectedNamespace : '' }}.</div>
             </div>
 
             <!-- ================= Plan History tab ================== -->
@@ -459,7 +483,7 @@ import 'prismjs/components/prism-yaml';
 import 'prismjs/components/prism-json';
 import 'prismjs/themes/prism-tomorrow.css';
 import { AlertOff24Regular, AlertOn24Regular, Edit24Regular, Target20Regular, DismissCircle20Regular} from '@vicons/fluent'
-import { Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History, Bell } from '@vicons/tabler'
+import { Copy, LayoutColumns, Filter, Trash, Link as LinkIcon, Share as ShareIcon, ExternalLink, LockOpen, Download, Tool, Refresh, CirclePlus, TrendingUp, InfoCircle, CircleX, X, Check, Server, History, Bell, Target, Rocket, AlertTriangle } from '@vicons/tabler'
 import { Commit } from '@vicons/carbon'
 import constants from '@/utils/constants'
 import CreateInstance from '@/components/CreateInstance.vue'
@@ -521,8 +545,57 @@ function subscribeToDeploymentNotifications (): void {
 const envs: Ref<any[]> = ref([])
 
 // --- Tab state (URL-synced) ---
-type InstTab = 'instance' | 'plan-history' | 'actual-history'
-const activeTab = ref<InstTab>((route.query.instTab as InstTab) || 'instance')
+const INST_TABS = ['instance', 'target-releases', 'deployed-releases', 'cd-failures', 'plan-history', 'actual-history'] as const
+type InstTab = typeof INST_TABS[number]
+function isInstTab (t: unknown): t is InstTab {
+    return INST_TABS.includes(t as InstTab)
+}
+const activeTab = ref<InstTab>(isInstTab(route.query.instTab) ? route.query.instTab : 'instance')
+
+// The instance is fetched in two halves. The core document carries the
+// shallow deployed / target release rows (uuid, namespace, state -- what
+// updateInstance sends back and what the namespace filter and tab counts
+// need) but not DeployedRelease.releaseDetails, which the backend resolves
+// per row. Details are fetched only when the tab that renders them opens
+// (or when the product-match tooltip, which reads deployed versions, is
+// shown), and cached by release uuid for the life of the view so a core
+// refetch after a save does not pay for them again. Because the cache is
+// keyed by release uuid and merged onto whatever rows are current, a
+// response that arrives after the list changed can never resurrect a stale
+// list -- it only fills in details for rows that are still there.
+type ReleaseListPart = 'releases' | 'targetReleases'
+const RELEASE_LIST_PARTS: ReleaseListPart[] = ['releases', 'targetReleases']
+const releaseDetailCache = ref<Record<string, any>>({})
+const releaseDetailState: Record<ReleaseListPart, { loading: Ref<boolean>, failed: Ref<boolean> }> = {
+    releases: { loading: ref(false), failed: ref(false) },
+    targetReleases: { loading: ref(false), failed: ref(false) }
+}
+const releaseRows = (part: ReleaseListPart): any[] => (updatedInstance.value && updatedInstance.value[part]) || []
+// True when every row of the list has its details resolved (an empty list is
+// trivially loaded). Derived from the rows and the cache rather than stored,
+// so it cannot go stale when either changes.
+const releaseDetailsLoaded = (part: ReleaseListPart): boolean =>
+    releaseRows(part).every((r: any) => r.release in releaseDetailCache.value)
+const deployedDetailsLoaded = computed<boolean>(() => releaseDetailsLoaded('releases'))
+const targetDetailsLoaded = computed<boolean>(() => releaseDetailsLoaded('targetReleases'))
+const deployedDetailsLoading = releaseDetailState.releases.loading
+const targetDetailsLoading = releaseDetailState.targetReleases.loading
+const deployedDetailsFailed = releaseDetailState.releases.failed
+const targetDetailsFailed = releaseDetailState.targetReleases.failed
+
+const isCluster = computed<boolean>(() => updatedInstance.value && updatedInstance.value.instanceType === InstanceType.CLUSTER)
+// The two release tabs have neither a pill nor a panel on a CLUSTER, so a
+// URL that names one (a link copied from a standalone instance, or the child
+// drawer pushing its own tab onto the shared query) falls back to the
+// Instance tab instead of landing on a blank page and fetching for nothing.
+function tabAvailableHere (t: InstTab): InstTab {
+    return isCluster.value && (t === 'target-releases' || t === 'deployed-releases') ? 'instance' : t
+}
+// The namespace dropdown scopes the release, unmatched-image and failure
+// tables; it is only meaningful for a standalone instance, which is the one
+// type that can span namespaces.
+const showNamespaceFilter = computed<boolean>(() =>
+    updatedInstance.value && updatedInstance.value.instanceType === InstanceType.STANDALONE_INSTANCE)
 const planHistory: Ref<any[]> = ref([])
 const actualHistory: Ref<any[]> = ref([])
 const planHistoryLoading = ref(false)
@@ -613,6 +686,11 @@ const filteredDeploymentFailures: ComputedRef<any[]> = computed((): any[] => {
     return list.filter((f: any) => f.namespace === selectedNamespace.value)
 })
 
+// Unfiltered count for the tab pill -- the pill must reflect every open
+// failure regardless of the namespace filter, which only scopes the table.
+const deploymentFailureCount: ComputedRef<number> = computed((): number =>
+    ((updatedInstance.value && updatedInstance.value.deploymentFailures) || []).length)
+
 // Header chip. FAILING means the agent re-reported a failure recently;
 // DEGRADED means open failures exist but nothing recent — which is genuinely
 // ambiguous between "fixed" and "the agent stopped reporting", hence the
@@ -664,6 +742,16 @@ function buildMatchTooltipBody(row: any) {
         headerText = 'Not matching'
     }
     lines.push(h('div', { style: 'font-weight: 600; margin-bottom: 4px;' }, headerText))
+    if (!deployedDetailsLoaded.value) {
+        // Deployed release details are deferred; onMatchTooltipShow kicks off
+        // the fetch and this body re-renders once the versions are known.
+        // Don't draw the per-dependency rows yet: without actual versions
+        // every one would read as a red mismatch under a 'Matching' header.
+        lines.push(h('div', { style: 'font-style: italic; color: #888;' }, deployedDetailsFailed.value
+            ? 'Deployed release details could not be loaded. Open the Deployed Component Releases tab to retry.'
+            : 'Loading deployed releases...'))
+        return lines
+    }
 
     const deps = (row.featureSetDetails && row.featureSetDetails.dependencies) || []
     const targetParents = (row.targetReleaseDetails && row.targetReleaseDetails.parentReleases) || []
@@ -982,11 +1070,66 @@ const switchTab = async function (t: InstTab) {
     await lazyLoadTab(t)
 }
 
+// Attach cached details to the rows of one list. Rows whose release is not
+// in the cache are left as they are (the tables skip rows without details).
+function applyReleaseDetails (part: ReleaseListPart) {
+    releaseRows(part).forEach((r: any) => {
+        if (r.release in releaseDetailCache.value) r.releaseDetails = releaseDetailCache.value[r.release]
+    })
+}
+
+// Fetch details for whichever rows of the list are not cached yet, then merge
+// them in. One request in flight per list; `attempt` bounds the follow-up
+// fetch that runs when the list changed underneath the request (a row added
+// by a save while the request was pending), so a backend that never returns
+// a row cannot spin this.
+async function ensureReleaseDetails (part: ReleaseListPart, attempt = 0) {
+    const state = releaseDetailState[part]
+    if (releaseDetailsLoaded(part) || state.loading.value) return
+    state.loading.value = true
+    state.failed.value = false
+    try {
+        const rows = await store.dispatch('fetchInstanceReleaseDetails', { id: instanceUuid, part })
+        rows.forEach((r: any) => {
+            // null is a resolved answer too (release gone): cache it so the
+            // row counts as loaded rather than re-fetching forever.
+            releaseDetailCache.value[r.release] = r.releaseDetails || null
+        })
+        applyReleaseDetails(part)
+    } catch (err: any) {
+        state.failed.value = true
+        console.error(err)
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        state.loading.value = false
+    }
+    if (!state.failed.value && !releaseDetailsLoaded(part) && attempt < 2) {
+        await ensureReleaseDetails(part, attempt + 1)
+    }
+}
+
+function retryReleaseDetails (part: ReleaseListPart) {
+    releaseDetailState[part].failed.value = false
+    ensureReleaseDetails(part)
+}
+
+// The product-match tooltip lists actual deployed versions per dependency,
+// so opening it is the one place outside its tab that needs release details.
+// A failed fetch is not retried from here -- hovering must not spam error
+// toasts; the tab has an explicit Retry.
+function onMatchTooltipShow (show: boolean) {
+    if (show && !deployedDetailsFailed.value) ensureReleaseDetails('releases')
+}
+
 async function lazyLoadTab(t: InstTab) {
     if (t === 'plan-history' && !planHistoryLoaded.value) {
         await fetchPlanHistory()
     } else if (t === 'actual-history' && !actualHistoryLoaded.value) {
         await fetchActualHistory()
+    } else if (t === 'target-releases') {
+        await ensureReleaseDetails('targetReleases')
+    } else if (t === 'deployed-releases') {
+        await ensureReleaseDetails('releases')
     }
 }
 
@@ -995,7 +1138,7 @@ async function lazyLoadTab(t: InstTab) {
 // absent/invalid param means the default tab, matching the pre-fix
 // remount-initializer behavior.
 watch(() => route.query.instTab, async (t) => {
-    const next: InstTab = (t === 'instance' || t === 'plan-history' || t === 'actual-history') ? t : 'instance'
+    const next: InstTab = tabAvailableHere(isInstTab(t) ? t : 'instance')
     if (next !== activeTab.value) {
         activeTab.value = next
         await lazyLoadTab(next)
@@ -1038,7 +1181,7 @@ const handleEnvironmentChange = async function (newEnv: string) {
 const fetchInstance = async function() {
     if( instanceUuid === undefined || instanceUuid === null || instanceUuid === '')
         return
-    const instResp = await store.dispatch('fetchInstance', { id: instanceUuid })
+    const instResp = await store.dispatch('fetchInstance', { id: instanceUuid, core: true })
     const updatedInstancePrep = commonFunctions.deepCopy(instResp)
     // sort products
     if (updatedInstancePrep.productPlans && updatedInstancePrep.productPlans.length) {
@@ -1074,6 +1217,14 @@ const fetchInstance = async function() {
         }
     }
     updatedInstance.value = updatedInstancePrep
+    // The core document replaced both release lists with shallow rows; put
+    // the cached details back on the rows that are still there, then load
+    // whatever the open tab is missing. Not awaited: the view is rendered
+    // under Suspense on first mount, and a deep link to a heavy tab should
+    // paint the page with its inline loading state, not block on the fetch.
+    RELEASE_LIST_PARTS.forEach(applyReleaseDetails)
+    activeTab.value = tabAvailableHere(activeTab.value)
+    lazyLoadTab(activeTab.value)
 }
 
 const genProductRelease = async function () {
@@ -1177,12 +1328,13 @@ const toggleAlerts = async function (prl: any, value: boolean) {
 const save = async function () {
     try {
         await store.dispatch('updateInstance', updatedInstance.value)
-        await fetchInstance()
-        // Invalidate cached history so the next visit to a history tab re-fetches.
+        // Invalidate cached history before the refetch, so that if a history
+        // tab is the one open, fetchInstance -> lazyLoadTab reloads it.
         planHistoryLoaded.value = false
         actualHistoryLoaded.value = false
         planHistory.value = []
         actualHistory.value = []
+        await fetchInstance()
         notify('info', 'SAVED', 'Instance changes saved successfully!')
     } catch (errOnSave: any) {
         console.error(errOnSave)
@@ -1304,6 +1456,7 @@ const doExportCycloneDx = async function () {
 const onCreate = async function () {
     if( instanceUuid === undefined || instanceUuid === null || instanceUuid === '')
         return
+    releaseDetailCache.value = {}
     await fetchInstance()
 
     graphqlClient.query({
@@ -1313,14 +1466,8 @@ const onCreate = async function () {
         envs.value = envsResp.data.environmentTypes.map((e: any) => {return {label: e, key: e}})
     })
 
-    // History (Plan / Actual) is loaded lazily — only when the user clicks
-    // into the corresponding tab. If a tab is selected via URL on first
-    // mount, kick off the fetch now.
-    if (activeTab.value === 'plan-history') {
-        fetchPlanHistory()
-    } else if (activeTab.value === 'actual-history') {
-        fetchActualHistory()
-    }
+    // Tab content (history, release details) is loaded lazily by
+    // fetchInstance -> lazyLoadTab for whichever tab the URL selected.
     if(route.params.subinstuuid !== undefined && route.params.subinstuuid !== null && route.params.subinstuuid !== ''){
         selectedChildInstRowKey.value = [route.params.subinstuuid.toString()]
         showChildInstance.value = true
@@ -1439,7 +1586,8 @@ const matchedProductFields: any[] = [
                     trigger: 'hover',
                     placement: 'top',
                     width: 720,
-                    style: { maxWidth: '720px' }
+                    style: { maxWidth: '720px' },
+                    'onUpdate:show': onMatchTooltipShow
                 }, {
                     trigger: () => h(NIcon, {
                         size: 16,
@@ -1468,7 +1616,8 @@ const matchedProductFields: any[] = [
                     trigger: 'hover',
                     placement: 'top',
                     width: 720,
-                    style: { maxWidth: '720px' }
+                    style: { maxWidth: '720px' },
+                    'onUpdate:show': onMatchTooltipShow
                 }, {
                     trigger: () => h(NIcon, {
                         size: 16,
@@ -2117,6 +2266,15 @@ await onCreate()
     font-weight: 600;
 }
 .subtab-icon { display: inline-flex; }
+.subtab-count {
+    font-size: 11px; font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 999px;
+}
+.subtab-count-error {
+    background: #fde8e8; color: #b42318;
+    border: 1px solid #f5c2c2;
+}
 
 /* ---- History tab content ---- */
 .historyTab {

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -325,7 +325,7 @@
                                 class="addProperty"
                                 v-if="updatedInstance && updatedInstance.org"
                                 :orgProp="updatedInstance.org"
-                                :knownProducts="knownProducts"
+                                :productPlans="updatedInstance.productPlans"
                                 :knownNamespaces="knownNamespaces"
                                 :instProperties="updatedInstance.properties"
                                 :instanceType="updatedInstance.instanceType"
@@ -840,20 +840,6 @@ const namespacesForDropdown: ComputedRef<any[]> = computed((): any => {
         retNs = Array.from(namespaces).map(n => {return {key: n, label: n}})
     }
     return retNs
-})
-
-const knownProducts: ComputedRef<any[]> = computed((): any => {
-    let knownProducts = []
-    if (updatedInstance.value && updatedInstance.value.productPlans && updatedInstance.value.productPlans.length) {
-        knownProducts = updatedInstance.value.productPlans.map((p: any) => {
-            return {
-                label: p.featureSetDetails.componentDetails.name,
-                value: p.featureSetDetails.componentDetails.uuid
-            }
-        })
-    }
-    knownProducts.unshift({label:"", value:""})
-    return knownProducts
 })
 
 const knownNamespaces: ComputedRef<any[]> = computed((): any => {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -911,7 +911,7 @@ const storeObject : any = {
                 mutation: gql`
                     mutation updateInstance($inst: InstanceInput!) {
                         updateInstance(instance:$inst) {
-                            ${graphqlQueries.InstanceGqlData}
+                            ${graphqlQueries.InstanceCoreGqlData}
                         }
                     }`,
                 variables: {
@@ -1639,14 +1639,33 @@ const storeObject : any = {
             if (!instFetchProps.revision) instFetchProps.revision = -1
             const variables: any = { instanceUuid: instFetchProps.id, revision: instFetchProps.revision }
             if (instFetchProps.stateType) variables.stateType = instFetchProps.stateType
+            // core: skip DeployedRelease.releaseDetails on both release lists
+            // (the per-row release fan-out that dominates the query); the
+            // InstanceView tabs fetch those on demand via
+            // fetchInstanceReleaseDetails. Either shape is committed to the
+            // store under (uuid, revision); store readers of instanceById only
+            // use the shallow row fields, so the two shapes are interchangeable
+            // there. A reader that needs releaseDetails must fetch them itself.
             const response = await graphqlClient.query({
-                query: graphqlQueries.InstanceGql,
+                query: instFetchProps.core ? graphqlQueries.InstanceCoreGql : graphqlQueries.InstanceGql,
                 variables,
                 fetchPolicy: 'no-cache'
             })
             response.data.instance.revision = instFetchProps.revision
             context.commit('ADD_INSTANCE', response.data.instance)
             return response.data.instance
+        },
+        // params.part is the Instance field to resolve with releaseDetails:
+        // 'releases' (deployed) or 'targetReleases'. Returns
+        // { release, releaseDetails } pairs for that field only; the caller
+        // merges them onto the shallow rows it already holds.
+        async fetchInstanceReleaseDetails (context: any, params: { id: string, part: 'releases' | 'targetReleases' }) {
+            const response = await graphqlClient.query({
+                query: graphqlQueries.InstanceReleaseDetailsGql[params.part],
+                variables: { instanceUuid: params.id },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.instance ? (response.data.instance[params.part] || []) : []
         },
         async fetchInstances (context: any, id: string) {
             const response = await graphqlClient.query({

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -173,7 +173,37 @@ const CHILD_RELEASE_GQL_DATA = `
     }
 `
 
-const INSTANCE_GQL_DATA = `
+// Instance selection sets. The backend resolves DeployedRelease.releaseDetails,
+// InstanceProductMapPlan.*Details, deploymentFailures and deploymentHealth as
+// per-field resolvers, so the cost of an instance query is driven by what the
+// document asks for. The shallow deployed-release rows below are cheap (they
+// live on the instance record) and are what updateInstance sends back, so
+// every instance document keeps them; only releaseDetails -- one release
+// lookup plus its artifacts / source-code-entry / component fan-out per row --
+// is split out so InstanceView can defer it to the tab that renders it.
+const DEPLOYED_RELEASE_SHALLOW_GQL_DATA = `
+        timeSent
+        release
+        deliverable
+        namespace
+        properties
+        state
+        partOf
+        replicas {
+            id
+            state
+        }
+        isInError
+`
+const TARGET_RELEASE_SHALLOW_GQL_DATA = `
+        timeSent
+        release
+        deliverable
+        namespace
+        properties
+`
+// Everything on Instance before the two release lists ...
+const INSTANCE_HEAD_GQL_DATA = `
     uuid
     name
     instanceType
@@ -196,33 +226,10 @@ const INSTANCE_GQL_DATA = `
             defaultValue
         }
     }
-    releases {
-        timeSent
-        release
-        deliverable
-        namespace
-        properties
-        state
-        partOf
-        replicas {
-            id
-            state
-        }
-        isInError
-        releaseDetails {
-            ${MULTI_RELEASE_GQL_DATA}
-        }
-    }
-    targetReleases {
-        timeSent
-        release
-        deliverable
-        namespace
-        properties
-        releaseDetails {
-            ${MULTI_RELEASE_GQL_DATA}
-        }
-    }
+`
+// ... and everything after them. Both instance shapes below are composed
+// from these so the only difference between them is the release lists.
+const INSTANCE_TAIL_GQL_DATA = `
     unmatchedReleases {
         image
         digestRecords {
@@ -312,6 +319,36 @@ const INSTANCE_GQL_DATA = `
     status
     spawnType
 `
+// Slim shape: shallow release rows only. What InstanceView loads first.
+const INSTANCE_CORE_GQL_DATA = `
+    ${INSTANCE_HEAD_GQL_DATA}
+    releases {
+        ${DEPLOYED_RELEASE_SHALLOW_GQL_DATA}
+    }
+    targetReleases {
+        ${TARGET_RELEASE_SHALLOW_GQL_DATA}
+    }
+    ${INSTANCE_TAIL_GQL_DATA}
+`
+// Full shape: core plus resolved release details on both deployed-release
+// lists. Used where a single round trip must return everything (revision
+// comparison, legacy callers).
+const INSTANCE_GQL_DATA = `
+    ${INSTANCE_HEAD_GQL_DATA}
+    releases {
+        ${DEPLOYED_RELEASE_SHALLOW_GQL_DATA}
+        releaseDetails {
+            ${MULTI_RELEASE_GQL_DATA}
+        }
+    }
+    targetReleases {
+        ${TARGET_RELEASE_SHALLOW_GQL_DATA}
+        releaseDetails {
+            ${MULTI_RELEASE_GQL_DATA}
+        }
+    }
+    ${INSTANCE_TAIL_GQL_DATA}
+`
 
 const MULTI_INSTANCE_GQL_DATA = `
     uuid
@@ -372,6 +409,60 @@ const INSTANCE_GQL = gql`
 query FetchInstance($instanceUuid: ID!, $revision:Int, $stateType: InstanceStateType) {
     instance(instanceUuid: $instanceUuid, revision:$revision, stateType:$stateType) {
         ${INSTANCE_GQL_DATA}
+    }
+}`
+
+const INSTANCE_CORE_GQL = gql`
+query FetchInstanceCore($instanceUuid: ID!, $revision:Int, $stateType: InstanceStateType) {
+    instance(instanceUuid: $instanceUuid, revision:$revision, stateType:$stateType) {
+        ${INSTANCE_CORE_GQL_DATA}
+    }
+}`
+
+// Deferred halves of the instance view: release details for the deployed /
+// target release rows, keyed by the row's release uuid. Only the fields the
+// instance tables and the product-match tooltip read -- not the full release
+// fragment, whose artifact / ticket / metrics fan-out is the expensive part.
+// InstanceView merges these onto the shallow rows it already holds.
+const DEPLOYED_RELEASE_DETAILS_GQL_DATA = `
+            uuid
+            version
+            componentDetails {
+                uuid
+                name
+                type
+            }
+            sourceCodeEntryDetails {
+                uuid
+                commit
+                vcsRepository {
+                    uri
+                }
+            }
+`
+const INSTANCE_DEPLOYED_RELEASE_DETAILS_GQL = gql`
+query FetchInstanceDeployedReleaseDetails($instanceUuid: ID!) {
+    instance(instanceUuid: $instanceUuid, revision: -1) {
+        uuid
+        releases {
+            release
+            releaseDetails {
+                ${DEPLOYED_RELEASE_DETAILS_GQL_DATA}
+            }
+        }
+    }
+}`
+
+const INSTANCE_TARGET_RELEASE_DETAILS_GQL = gql`
+query FetchInstanceTargetReleaseDetails($instanceUuid: ID!) {
+    instance(instanceUuid: $instanceUuid, revision: -1) {
+        uuid
+        targetReleases {
+            release
+            releaseDetails {
+                ${DEPLOYED_RELEASE_DETAILS_GQL_DATA}
+            }
+        }
     }
 }`
 
@@ -1537,6 +1628,16 @@ export default {
     BranchGqlMutate: BRANCH_GQL_MUTATE,
     InstanceGql: INSTANCE_GQL,
     InstanceGqlData: INSTANCE_GQL_DATA,
+    InstanceCoreGql: INSTANCE_CORE_GQL,
+    InstanceCoreGqlData: INSTANCE_CORE_GQL_DATA,
+    DeployedReleaseShallowGqlData: DEPLOYED_RELEASE_SHALLOW_GQL_DATA,
+    TargetReleaseShallowGqlData: TARGET_RELEASE_SHALLOW_GQL_DATA,
+    // Keyed by the Instance field each document resolves, so callers can
+    // select the deferred half by field name (see store.fetchInstanceReleaseDetails).
+    InstanceReleaseDetailsGql: {
+        releases: INSTANCE_DEPLOYED_RELEASE_DETAILS_GQL,
+        targetReleases: INSTANCE_TARGET_RELEASE_DETAILS_GQL
+    },
     InstancesGql: INSTANCES_GQL,
     MultiReleaseGqlData: MULTI_RELEASE_GQL_DATA,
     BranchReleaseListGqlData: BRANCH_RELEASE_LIST_GQL_DATA,

--- a/ui/src/utils/instanceFragmentsSchemaDrift.spec.ts
+++ b/ui/src/utils/instanceFragmentsSchemaDrift.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, DocumentNode } from 'graphql'
+import graphqlQueries from './graphqlQueries'
+
+// The instance view is fetched in two halves: a core document without
+// DeployedRelease.releaseDetails, plus one deferred document per release list
+// that carries the details when its tab opens. All of them interpolate shared
+// selection sets at module load, so scripts/validate-graphql skips them as
+// dynamic. This spec is the guard that keeps each half valid on its own --
+// a wrong field in the core fragment would blank the whole instance page,
+// and a wrong field in a detail document would blank just that tab, which is
+// the harder one to notice.
+//
+// Checked against the CE schema only, same reasoning as
+// releaseFragmentsSchemaDrift.spec.ts: it ships in this repo, and the Pro
+// schema is a superset of it for the Instance type.
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+
+function asInstanceQuery (fragment: string) {
+    return parse(`query FragmentCheck($instanceUuid: ID!) {
+        instance(instanceUuid: $instanceUuid, revision: -1) {
+            ${fragment}
+        }
+    }`)
+}
+
+const INSTANCE_FRAGMENTS: Array<[string, string]> = [
+    ['InstanceCoreGqlData', graphqlQueries.InstanceCoreGqlData],
+    ['InstanceGqlData', graphqlQueries.InstanceGqlData]
+]
+
+const INSTANCE_DOCUMENTS: Array<[string, DocumentNode]> = [
+    ['InstanceCoreGql', graphqlQueries.InstanceCoreGql],
+    ['InstanceGql', graphqlQueries.InstanceGql],
+    ['InstanceReleaseDetailsGql.releases', graphqlQueries.InstanceReleaseDetailsGql.releases],
+    ['InstanceReleaseDetailsGql.targetReleases', graphqlQueries.InstanceReleaseDetailsGql.targetReleases]
+]
+
+describe('instance selection fragments vs the CE schema', () => {
+    it.each(INSTANCE_FRAGMENTS)('%s is valid against the CE schema', (_name, fragment) => {
+        expect(validate(ceSchema, asInstanceQuery(fragment)).map(e => e.message)).toEqual([])
+    })
+
+    it.each(INSTANCE_DOCUMENTS)('%s is valid against the CE schema', (_name, doc) => {
+        expect(validate(ceSchema, doc).map(e => e.message)).toEqual([])
+    })
+
+    it('the core document does not ask for releaseDetails -- that is the deferred half', () => {
+        const core = graphqlQueries.InstanceCoreGqlData as string
+        expect(core).not.toMatch(/releaseDetails\s*\{[\s\S]*?\bartifacts\b/)
+        // The product-plan target summary legitimately nests a small
+        // releaseDetails under parentReleases; the deferred halves are the
+        // DeployedRelease ones, which carry artifacts / sourceCodeEntryDetails.
+        expect(core).not.toMatch(/sourceCodeEntryDetails/)
+    })
+
+    it('the core document embeds the shared shallow row fragments', () => {
+        // updateInstance maps these row fields back into DeployedReleaseInput,
+        // so the core document must carry them; the fragments are shared
+        // constants, and this pins the core document to them.
+        const core = graphqlQueries.InstanceCoreGqlData as string
+        expect(core).toContain(graphqlQueries.DeployedReleaseShallowGqlData)
+        expect(core).toContain(graphqlQueries.TargetReleaseShallowGqlData)
+        for (const field of ['timeSent', 'release', 'namespace', 'properties']) {
+            expect(graphqlQueries.DeployedReleaseShallowGqlData).toMatch(new RegExp(`\\b${field}\\b`))
+            expect(graphqlQueries.TargetReleaseShallowGqlData).toMatch(new RegExp(`\\b${field}\\b`))
+        }
+    })
+
+    it('each deferred document selects the row key its details are merged by', () => {
+        // InstanceView caches details by the row's release uuid and merges
+        // them onto the shallow rows, so `release` must be selected next to
+        // `releaseDetails` on the list the document resolves. Walk the AST
+        // rather than grepping the source: `release` also appears elsewhere.
+        for (const [part, doc] of [['releases', graphqlQueries.InstanceReleaseDetailsGql.releases],
+            ['targetReleases', graphqlQueries.InstanceReleaseDetailsGql.targetReleases]] as const) {
+            const op = doc.definitions[0]
+            if (op.kind !== 'OperationDefinition') throw new Error('expected an operation')
+            const instanceField = op.selectionSet.selections.find((sel) => sel.kind === 'Field' && sel.name.value === 'instance')
+            if (!instanceField || instanceField.kind !== 'Field' || !instanceField.selectionSet) throw new Error('expected instance field')
+            const listField = instanceField.selectionSet.selections.find((sel) => sel.kind === 'Field' && sel.name.value === part)
+            if (!listField || listField.kind !== 'Field' || !listField.selectionSet) throw new Error(`expected ${part} field`)
+            const names = listField.selectionSet.selections.map((sel) => sel.kind === 'Field' ? sel.name.value : '')
+            expect(names).toContain('release')
+            expect(names).toContain('releaseDetails')
+        }
+    })
+})


### PR DESCRIPTION
## What

Restructures the instance page into tabs and defers the expensive part of the instance query to the tab that needs it. UI only.

**Tabs** (URL-synced via `instTab`, same segmented bar):
1. **Instance** -- product releases + properties (and the cluster-instances table on a CLUSTER)
2. **Individual Target Releases**
3. **Deployed Component Releases** -- Unmatched Deployed Images sits inside this tab (same watcher data)
4. **Deployment Failures** -- the ReARM CD failures table; the pill shows the open-failure count (always unfiltered, the namespace dropdown only scopes the table)
5. Plan History / Actual History -- unchanged

## Deferred loading

The backend resolves `DeployedRelease.releaseDetails`, `deploymentFailures` and `deploymentHealth` per field, so the query cost follows the selection set. The view now:

- loads a **core** document without `releaseDetails` on either release list (shallow rows only: uuid / namespace / state -- what `updateInstance` sends back and what the namespace filter and tab counts need);
- fetches a **slim per-release detail** document (uuid, version, component, commit -- not the full release fragment with artifacts / tickets / metrics) when the target or deployed tab opens, or when the product-match tooltip is shown;
- caches details by release uuid for the life of the view and merges them onto the shallow rows, so a save (which refetches the core document) does not refetch them, and a late response can never resurrect a stale list;
- `updateInstance` selects the core shape too. The full document is untouched for revision comparison and the create/spawn mutations.

Measured on psclaude (instance with 39 deployed releases, in-browser, same session): core query 16-26 ms / 3.4 KB vs. the previous full query 45-77 ms / 15 KB. Tab click then costs one slim detail query.

`deploymentFailures` stays in the core document because the pill count needs it (one indexed query).

## Also

- History tabs reload after a save made while one is open (loaded flags reset before the refetch).
- A cluster URL naming a release tab falls back to the Instance tab instead of a blank panel.
- One `showNamespaceFilter` computed shared by the three tabs (the old copies had drifted).
- Failed detail fetch shows a Retry link instead of an empty table; the tooltip does not retry on hover (no toast spam).
- New `instanceFragmentsSchemaDrift.spec.ts` guards the split documents against the CE schema (they interpolate shared fragments, so `validate:graphql` skips them).

## Judgement calls to confirm

- Unmatched Deployed Images lives inside the Deployed tab rather than its own tab.
- The product-match tooltip on the Instance tab triggers the deployed-detail fetch on first hover (shows "Loading deployed releases..." until it lands). Alternative was to keep deployed details eager, which would have kept the biggest cost on initial load.
- The Deployment Failures tab is always shown (previously the block was hidden when empty).

## Backend follow-ups (not in this PR)

- `deploymentHealth` re-runs the open-failures query that `deploymentFailures` already ran; a per-request loader would drop one query per instance load.
- `DeployedRelease.releaseDetails` resolves one release per row; a DataLoader over `releaseDetailsLoader` would batch it for every document, including the deferred ones.
- A `deploymentFailureCount` field would let the failures list itself be deferred to its tab.

## Validation

- `npm run validate:graphql` clean; new spec 9/9; `npm run build` clean. ESLint: 54 pre-existing indent errors on lines this diff does not touch, none new.
- Hot-swapped onto psclaude and probed with Playwright: initial load fires only `FetchInstanceCore`; target / deployed tabs fire their detail query once; failures tab fires nothing; re-clicking a tab does not refetch; hovering the match tooltip loads deployed details; a notes save round-trips and the open tab keeps its data.

## Second commit: form tidy-ups

**Add Integration Feature Set** modal:
- Parent Organization field removed (always the current org; it had one option and no effect).
- Parent Product is filterable by typing and sorted by name.
- Parent Product and Integration Type carry required marks and are validated on submit; Extra Configuration is labelled optional and clearable.
- The Alerts switch is not rendered (alerts are not wired to anything yet). `alertsEnabled` stays in the emitted object as `false`, so the update input is unchanged.

**Add Property** modal:
- Once a namespace is chosen on a standalone instance, the Product list only offers products deployed in that namespace (derived from the instance's product plans; the label says which namespace scopes it). A product that drops out of the list is cleared rather than submitted with a namespace it is not deployed in. The select is filterable.

Probed on psclaude: org and Alerts fields gone, two required marks render, an empty submit shows both messages, typing "Reliza C" narrows the product list to "Reliza CD", and picking namespace `reliza-cd` in Add Property scopes the products to "Reliza CD".

## Fourth commit: product/namespace pair validation on Add Property

On a standalone instance the two selects scope each other: pick a namespace and only products deployed there are offered; pick a product and only its namespaces are offered (the label says which). Because the namespace select also accepts typed values, a cross-field rule backs the lists: a product/namespace pair that is not one of the instance's product plans fails validation (message under Namespace, product field flagged) and blocks submit. The earlier auto-clear of the product on namespace change is gone, and the current product stays in the option list so it keeps rendering by name while flagged.

Probed on psclaude: pick "Reliza Harbor" first and the namespace list narrows to `reliza-harbor`; type `relizahub` and submit, and the form reports "Reliza Harbor is not deployed in namespace relizahub".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
