### PR TITLE
fix(ui): stop claiming CLE 1.0.0 conformance on the release export

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -480,7 +480,13 @@
                     </n-spin>
                 </n-form>
                 <n-form v-if="exportBomType === 'CLE'">
-                    <h3>Format: CLE 1.0.0 (JSON)</h3>
+                    <!-- Deliberately NOT labelled "CLE 1.0.0". That is a conformance claim on a
+                         file a customer may hand to a regulator, and we do not currently meet it:
+                         endOfSupport events carry no resolvable supportId (the spec makes it
+                         mandatory), event ids are recomputed per export rather than persisted, and
+                         there is no pagination. Restore the version claim only when those are
+                         fixed -- see ai-plans/fda-readiness-1-plan.md in rearm-core. -->
+                    <h3>Format: Common Lifecycle Enumeration (JSON)</h3>
                     <n-button type="success"
                         :disabled="bomExportPending"
                         @click.prevent="exportReleaseCle">


### PR DESCRIPTION
The CLE export dialog is labelled `Format: CLE 1.0.0 (JSON)`. That is a conformance assertion on a file a customer may hand to a regulator, and we do not meet it today.

Three reasons, all verified against `rearm-core`:

- **`supportId` is missing.** The CLE spec states it "MUST be included" on `endOfSupport` events. Ours ships unset whenever no support policy resolves -- and since `supportPolicyId` / `defaultSupportPolicyId` have no UI anywhere, that is the **universal default state for every org**, not an edge case.
- **Event ids are unstable.** They are recomputed from sort position on every export and assigned *by effective date*, which the spec forbids in those words, so the newest event gets the **lowest** id. A `withdrawn` event referencing one could not work.
- **No pagination.** The spec's only sanctioned way to emit a subset is `index` + `next`.

Relabelled to `Format: Common Lifecycle Enumeration (JSON)` -- which is true, since the document *is* a CLE document; we simply stop asserting the version's conformance bar. A comment in place records what must be fixed before the version claim returns.

**Why now:** this unblocks removing the ~924-line support-policy surface in `rearm-core`. That removal drops `supportId` from `endOfSupport` events entirely, which is only acceptable once we are no longer claiming conformance. Ordering is recorded in `ai-plans/fda-readiness-1-plan.md` section 6 (P1).

## Validation

- `npm run test`: **178 passed, 1 failed.** The failure is `routeInputSchemaDrift.spec.ts` (`notifyComponentOwner`) -- a notifications file this change does not touch, and a documented pre-existing failure. Nothing in CI runs this suite, so the count is stated here deliberately.
- `npm run build`: clean.
- Added lines contain no non-ASCII (the file has 70 pre-existing).

One-line template change plus a comment.