### PR TITLE
feat(config): wire SBOM_RECONCILE_DRAIN_BATCH through application.yaml, helm chart and compose

### DIFF
--- a/backend/application.yaml
+++ b/backend/application.yaml
@@ -159,6 +159,10 @@ relizaprops:
   # deliveries dispatched per 5s tick.
   notificationOutboxBatch: ${NOTIFICATION_OUTBOX_BATCH:50}
   notificationDeliveryBatch: ${NOTIFICATION_DELIVERY_BATCH:50}
+  # SBOM reconciles processed per 5s tick (same shared scheduler). Bounds the
+  # work one drain claims while holding the advisory lock; raise for burst
+  # ingestion (e.g. mass SBOM re-reconciles) rather than shortening the tick.
+  sbomReconcileDrainBatch: ${SBOM_RECONCILE_DRAIN_BATCH:50}
   # Resumable finding-change v3 backfill drain (shared scheduler): kill switch and
   # max branches drained per 60s tick.
   findingChangeV3BackfillDrainEnabled: ${FINDING_CHANGE_V3_BACKFILL_DRAIN_ENABLED:true}

--- a/backend/src/main/java/io/reliza/service/SchedulingService.java
+++ b/backend/src/main/java/io/reliza/service/SchedulingService.java
@@ -618,15 +618,22 @@ public class SchedulingService {
     FindingChangeEventBackfillService findingChangeEventBackfillService;
 
     /**
+     * Number of pending SBOM reconciles processed per tick. Bounds the work
+     * one drain claims while holding the advisory lock; raise for burst
+     * ingestion (see the 20k-release note in the reconcile drain) rather
+     * than shortening the tick. Configurable via
+     * {@code relizaprops.sbomReconcileDrainBatch} / {@code SBOM_RECONCILE_DRAIN_BATCH}.
+     */
+    @Value("${relizaprops.sbomReconcileDrainBatch:50}")
+    private int sbomReconcileDrainBatch;
+
+    /**
      * Number of outbox events drained per tick. Tuned: enough to make
      * progress on realistic per-org volumes without holding the advisory
      * lock unnecessarily long. Configurable via
      * {@code relizaprops.notificationOutboxBatch} for operator tuning
      * without a redeploy.
      */
-    @Value("${relizaprops.sbomReconcileDrainBatch:50}")
-    private int sbomReconcileDrainBatch;
-
     @Value("${relizaprops.notificationOutboxBatch:50}")
     private int notificationOutboxBatch;
 

--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -21,6 +21,8 @@ services:
      # service's 8083.
      - RELIZAPROP_OCIARTIFACTS_SERVICE_HOST=http://oci-artifact-service:8083
      - MAX_UPLOAD_SIZE=50MB
+     # SBOM reconciles processed per scheduler tick; raise for burst ingestion
+     - SBOM_RECONCILE_DRAIN_BATCH=50
     depends_on:
      - rearm-postgresql
      - keycloak

--- a/deploy/helm/rearm-helm/templates/backend-deployment.yaml
+++ b/deploy/helm/rearm-helm/templates/backend-deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: {{ .Values.projectHost }}
             - name: MAX_UPLOAD_SIZE
               value: {{ .Values.max_upload_size_in_MB }}MB
+            - name: SBOM_RECONCILE_DRAIN_BATCH
+              value: {{ .Values.sbom_reconcile_drain_batch | quote }}
               # aws account below is used for secret storage if enabled
             - name: RELIZAPROP_INSTALLATION_SECRET
               valueFrom:

--- a/deploy/helm/rearm-helm/values.yaml
+++ b/deploy/helm/rearm-helm/values.yaml
@@ -47,6 +47,11 @@ projectProtocol: http
 projectHost: rearm.localhost
 useDefaultSecrets: true
 max_upload_size_in_MB: 50
+# SBOM reconciles processed per scheduler tick (relizaprops.sbomReconcileDrainBatch).
+# Raise for burst ingestion: a 20k-release burst test cleared backlog at ~245/min
+# at 250 (11G heap) vs ~66/min at the default 50. Size to expected peak
+# releases/min and available heap.
+sbom_reconcile_drain_batch: 50
 backend:
   logFormatType: "plain"
   enableDtrackCleanupScheduler: false


### PR DESCRIPTION
CE counterpart of the Pro change (merged there first): makes `SBOM_RECONCILE_DRAIN_BATCH` a real env var. `relizaprops.sbomReconcileDrainBatch` has been read by `SchedulingService` (default 50) since the reconcile drain landed, but `application.yaml` never mapped an env var for it — the name cited in the load-test writeup only worked via Spring relaxed binding (`RELIZAPROPS_SBOMRECONCILEDRAINBATCH`). The notification batch tunables were already mapped on this repo; this closes the remaining gap.

## Changes
- **backend/application.yaml**: map `SBOM_RECONCILE_DRAIN_BATCH` (default 50) next to the notification drain mappings.
- **rearm-helm**: new `sbom_reconcile_drain_batch` value (default 50) passed as `SBOM_RECONCILE_DRAIN_BATCH` next to `MAX_UPLOAD_SIZE`; values comment carries the measured burst-test numbers (~245/min backlog clearance at 250 with 11G heap vs ~66/min at 50).
- **docker-compose**: same env with the default, next to `MAX_UPLOAD_SIZE` (compose is a first-class CE deploy path, hence included here unlike the Pro PR).
- **SchedulingService**: fixed a misattached javadoc — the comment describing the *outbox* batch was sitting on the `sbomReconcileDrainBatch` field; each field now has its own doc.

## Verification
- Backend compiles (JDK 25 / Maven 3.9.11).
- Chart verified by the install-then-upgrade discipline on the sandbox cluster: installed `main` chart into a scratch namespace, upgraded to this branch, upgraded again — helm status `deployed` each time; the first upgrade rolled only the backend deployment (expected for an env addition) and the pod env showed `SBOM_RECONCILE_DRAIN_BATCH=50`; the second upgrade changed no workload generations.
- `docker compose config` renders the new env correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)