### PR TITLE
feat(ui): dashboard views -- Product Security and a new DevOps view with instance status

### DIFF
--- a/ui/src/components/AppHome.vue
+++ b/ui/src/components/AppHome.vue
@@ -1,20 +1,11 @@
 <template>
     <div class="home">
         <div class="dashboardBlock">
-            <!-- Dashboard views. Product Security is the page as it always was;
-                 DevOps swaps the security widgets for the instance status roll-up.
-                 URL-synced (?view=) and remembered per browser. -->
-            <div class="subtab-bar" data-testid="dashboard-view-bar">
-                <button class="subtab-pill" :class="{ active: dashView === 'security' }" @click="switchView('security')" data-testid="dashboard-view-security">
-                    <n-icon size="16" class="subtab-icon"><ShieldCheck /></n-icon>
-                    <span>Product Security</span>
-                </button>
-                <button class="subtab-pill" :class="{ active: dashView === 'devops' }" @click="switchView('devops')" data-testid="dashboard-view-devops">
-                    <n-icon size="16" class="subtab-icon"><Server /></n-icon>
-                    <span>DevOps</span>
-                </button>
-            </div>
-            <n-grid x-gap="24" cols="2">
+            <!-- Dashboard views. Security is the page as it always was; DevOps
+                 swaps the security widgets for the instance status roll-up. The
+                 view is chosen from the header (View dropdown) and lives in the
+                 store, so the component page follows the same choice. -->
+            <n-grid x-gap="24" cols="2" :data-view="dashView" data-testid="dashboard-grid">
                 <n-gi v-if="dashView === 'devops'" span="2">
                     <instance-status-widget
                         :org-uuid="myorg?.uuid || ''"
@@ -579,10 +570,10 @@ import GqlQueries from '../utils/graphqlQueries'
 import InstanceHistory from './InstanceHistory.vue'
 import { RouterLink } from 'vue-router'
 import { Commit } from '@vicons/carbon'
-import { AspectRatio, Box, Eye, QuestionMark, Refresh, Server, ShieldCheck } from '@vicons/tabler'
+import { AspectRatio, Box, Eye, QuestionMark, Refresh } from '@vicons/tabler'
 import { CaretDownFilled } from '@vicons/antd'
 import { Icon } from '@vicons/utils'
-import { useRouter, useRoute } from 'vue-router'
+import { useRouter } from 'vue-router'
 import Swal from 'sweetalert2'
 import commonFunctions from '@/utils/commonFunctions'
 import constants from '@/utils/constants'
@@ -594,11 +585,11 @@ import ComponentBranchesTable from './ComponentBranchesTable.vue'
 import VulnerabilityModal from './VulnerabilityModal.vue'
 import MostRecentReleasesWidget from './MostRecentReleasesWidget.vue'
 import InstanceStatusWidget from './InstanceStatusWidget.vue'
+import { DashboardView } from '@/utils/dashboardView'
 import { processMetricsData } from '@/utils/metrics'
 
 const store = useStore()
 const router = useRouter()
-const route = useRoute()
 const notification = useNotification()
 
 const notify = (type: NotificationType, title: string, content: string) => {
@@ -612,37 +603,9 @@ const notify = (type: NotificationType, title: string, content: string) => {
 
 const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
 
-// --- Dashboard view (Product Security | DevOps) ---
-// Resolution order: URL (?view=) so links are shareable, then the browser's
-// last choice, then Product Security so existing users see no change.
-const DASH_VIEWS = ['security', 'devops'] as const
-type DashView = typeof DASH_VIEWS[number]
-const DASH_VIEW_STORAGE_KEY = 'rearm_dashboard_view'
-function isDashView (v: unknown): v is DashView {
-    return DASH_VIEWS.includes(v as DashView)
-}
-function rememberedDashView (): DashView {
-    try {
-        const stored = window.localStorage.getItem(DASH_VIEW_STORAGE_KEY)
-        if (isDashView(stored)) return stored
-    } catch {
-        // storage unavailable (private mode / policy): fall through to default
-    }
-    return 'security'
-}
-const dashView = ref<DashView>(isDashView(route.query.view) ? route.query.view : rememberedDashView())
-async function switchView (v: DashView) {
-    if (v === dashView.value) return
-    dashView.value = v
-    try { window.localStorage.setItem(DASH_VIEW_STORAGE_KEY, v) } catch { /* see rememberedDashView */ }
-    await router.replace({ query: { ...route.query, view: v } })
-}
-// Back/forward or the Home nav link can land on a URL without ?view=; that
-// means "the remembered view", same as a fresh load.
-watch(() => route.query.view, (v) => {
-    const next: DashView = isDashView(v) ? v : rememberedDashView()
-    if (next !== dashView.value) dashView.value = next
-})
+// --- Dashboard view (Security | DevOps) --- chosen in the header, kept in
+// the store (browser memory over org default over security).
+const dashView: ComputedRef<DashboardView> = computed((): DashboardView => store.getters.myview)
 
 const installationType: ComputedRef<any> = computed((): any => store.getters.myuser.installationType)
 const myperspective: ComputedRef<string> = computed((): string => store.getters.myperspective)
@@ -1506,32 +1469,6 @@ function displayVulnerableComponentType () {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
-/* ---- view bar -- mirrors the segmented pills on the instance page ---- */
-.subtab-bar {
-    display: inline-flex;
-    gap: 4px;
-    background: #F3F5F4;
-    padding: 4px;
-    border-radius: 10px;
-    margin: 0 0 14px;
-}
-.subtab-pill {
-    display: inline-flex; align-items: center; gap: 8px;
-    padding: 6px 14px;
-    border: none; background: transparent;
-    border-radius: 7px;
-    font-size: 13px; font-weight: 500;
-    color: #5b6770; cursor: pointer;
-    transition: background .12s, color .12s;
-}
-.subtab-pill:hover { color: #2b3540; }
-.subtab-pill.active {
-    background: #FFFFFF;
-    color: #2b3540;
-    box-shadow: 0 1px 2px rgba(16,24,40,.04);
-    font-weight: 600;
-}
-.subtab-icon { display: inline-flex; }
 
 .charts {
     display: grid;

--- a/ui/src/components/AppHome.vue
+++ b/ui/src/components/AppHome.vue
@@ -1,8 +1,29 @@
 <template>
     <div class="home">
         <div class="dashboardBlock">
+            <!-- Dashboard views. Product Security is the page as it always was;
+                 DevOps swaps the security widgets for the instance status roll-up.
+                 URL-synced (?view=) and remembered per browser. -->
+            <div class="subtab-bar" data-testid="dashboard-view-bar">
+                <button class="subtab-pill" :class="{ active: dashView === 'security' }" @click="switchView('security')" data-testid="dashboard-view-security">
+                    <n-icon size="16" class="subtab-icon"><ShieldCheck /></n-icon>
+                    <span>Product Security</span>
+                </button>
+                <button class="subtab-pill" :class="{ active: dashView === 'devops' }" @click="switchView('devops')" data-testid="dashboard-view-devops">
+                    <n-icon size="16" class="subtab-icon"><Server /></n-icon>
+                    <span>DevOps</span>
+                </button>
+            </div>
             <n-grid x-gap="24" cols="2">
-                <n-gi>
+                <n-gi v-if="dashView === 'devops'" span="2">
+                    <instance-status-widget
+                        :org-uuid="myorg?.uuid || ''"
+                        :perspective-uuid="currentPerspectiveUuid"
+                        :perspective-name="currentPerspectiveName"
+                    />
+                </n-gi>
+                <n-gi v-if="dashView === 'devops'" span="2"><n-divider /></n-gi>
+                <n-gi v-if="dashView === 'security'">
                     <releases-per-day-chart
                         :type="releaseChartType"
                         :org-uuid="releaseChartProps.orgUuid"
@@ -10,7 +31,7 @@
                         :perspective-name="releaseChartProps.perspectiveName"
                     />
                 </n-gi>
-                <n-gi>
+                <n-gi v-if="dashView === 'security'">
                     <div>
                         <n-input-number style="display:inline-block; width:80px;" 
                             v-model:value="activeComponentsInput.maxComponents" />
@@ -36,8 +57,8 @@
                         :feature-set-label="featureSetLabel"
                     />
                 </n-gi>
-                <n-gi span="2"><n-divider /></n-gi>
-                <n-gi>
+                <n-gi v-if="dashView === 'security'" span="2"><n-divider /></n-gi>
+                <n-gi v-if="dashView === 'security'">
                     <findings-over-time-chart
                         :type="releaseChartType"
                         :org-uuid="myorg?.uuid"
@@ -474,8 +495,14 @@
                         />
                     </div>
                 </n-gi>
-                <n-gi span="2"><n-divider /></n-gi>
-                <n-gi span="1">
+                <n-gi v-if="dashView === 'devops'">
+                    <most-recent-releases-widget
+                        :org-uuid="myorg?.uuid || ''"
+                        :perspective-uuid="currentPerspectiveUuid"
+                    />
+                </n-gi>
+                <n-gi v-if="dashView === 'security'" span="2"><n-divider /></n-gi>
+                <n-gi v-if="dashView === 'security'" span="1">
                     <div>
                         <n-input-number style="display:inline-block; width:80px;" 
                             v-model:value="vulnerableComponentsInput.maxComponents" :min="1" />
@@ -512,7 +539,7 @@
                         <div v-else>No vulnerable {{ displayVulnerableComponentType().toLowerCase() }} found.</div>
                     </n-spin>
                 </n-gi>
-                <n-gi span="1">
+                <n-gi v-if="dashView === 'security'" span="1">
                     <most-recent-releases-widget
                         :org-uuid="myorg?.uuid || ''"
                         :perspective-uuid="currentPerspectiveUuid"
@@ -552,7 +579,7 @@ import GqlQueries from '../utils/graphqlQueries'
 import InstanceHistory from './InstanceHistory.vue'
 import { RouterLink } from 'vue-router'
 import { Commit } from '@vicons/carbon'
-import { AspectRatio, Box, Eye, QuestionMark, Refresh } from '@vicons/tabler'
+import { AspectRatio, Box, Eye, QuestionMark, Refresh, Server, ShieldCheck } from '@vicons/tabler'
 import { CaretDownFilled } from '@vicons/antd'
 import { Icon } from '@vicons/utils'
 import { useRouter, useRoute } from 'vue-router'
@@ -566,6 +593,7 @@ import ReleasesByCve from './ReleasesByCve.vue'
 import ComponentBranchesTable from './ComponentBranchesTable.vue'
 import VulnerabilityModal from './VulnerabilityModal.vue'
 import MostRecentReleasesWidget from './MostRecentReleasesWidget.vue'
+import InstanceStatusWidget from './InstanceStatusWidget.vue'
 import { processMetricsData } from '@/utils/metrics'
 
 const store = useStore()
@@ -583,6 +611,39 @@ const notify = (type: NotificationType, title: string, content: string) => {
 }
 
 const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
+
+// --- Dashboard view (Product Security | DevOps) ---
+// Resolution order: URL (?view=) so links are shareable, then the browser's
+// last choice, then Product Security so existing users see no change.
+const DASH_VIEWS = ['security', 'devops'] as const
+type DashView = typeof DASH_VIEWS[number]
+const DASH_VIEW_STORAGE_KEY = 'rearm_dashboard_view'
+function isDashView (v: unknown): v is DashView {
+    return DASH_VIEWS.includes(v as DashView)
+}
+function rememberedDashView (): DashView {
+    try {
+        const stored = window.localStorage.getItem(DASH_VIEW_STORAGE_KEY)
+        if (isDashView(stored)) return stored
+    } catch {
+        // storage unavailable (private mode / policy): fall through to default
+    }
+    return 'security'
+}
+const dashView = ref<DashView>(isDashView(route.query.view) ? route.query.view : rememberedDashView())
+async function switchView (v: DashView) {
+    if (v === dashView.value) return
+    dashView.value = v
+    try { window.localStorage.setItem(DASH_VIEW_STORAGE_KEY, v) } catch { /* see rememberedDashView */ }
+    await router.replace({ query: { ...route.query, view: v } })
+}
+// Back/forward or the Home nav link can land on a URL without ?view=; that
+// means "the remembered view", same as a fresh load.
+watch(() => route.query.view, (v) => {
+    const next: DashView = isDashView(v) ? v : rememberedDashView()
+    if (next !== dashView.value) dashView.value = next
+})
+
 const installationType: ComputedRef<any> = computed((): any => store.getters.myuser.installationType)
 const myperspective: ComputedRef<string> = computed((): string => store.getters.myperspective)
 
@@ -661,12 +722,12 @@ onMounted(() => {
     if (myorg.value) {
         initLoad()
     }
-    fetchMostVulnerableComponents()
+    fetchMostVulnerableIfShown()
 })
 watch(myorg, (currentValue, oldValue) => {
     activeComponentsInput.value.organization = myorg.value.uuid
     initLoad()
-    fetchMostVulnerableComponents()
+    fetchMostVulnerableIfShown()
 });
 
 
@@ -1300,7 +1361,25 @@ async function fetchMostVulnerableComponents () {
 }
 
 watch(() => [vulnerableComponentsInput.value.componentType, vulnerableComponentsInput.value.maxComponents, myperspective.value], () => {
-    fetchMostVulnerableComponents()
+    fetchMostVulnerableIfShown()
+})
+
+// Most Vulnerable is only rendered on the Product Security view, and unlike
+// the chart widgets it is fetched from this component rather than a child
+// that mounts with the view. Skip the fetch while DevOps is showing and
+// catch up when the user switches back, so the DevOps view does not pay for
+// a list it never renders.
+const mostVulnerableStale = ref(true)
+function fetchMostVulnerableIfShown () {
+    if (dashView.value === 'security') {
+        mostVulnerableStale.value = false
+        fetchMostVulnerableComponents()
+    } else {
+        mostVulnerableStale.value = true
+    }
+}
+watch(dashView, (v) => {
+    if (v === 'security' && mostVulnerableStale.value) fetchMostVulnerableIfShown()
 })
 
 const showVulnModalForComponent = ref(false)
@@ -1427,6 +1506,33 @@ function displayVulnerableComponentType () {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
+/* ---- view bar -- mirrors the segmented pills on the instance page ---- */
+.subtab-bar {
+    display: inline-flex;
+    gap: 4px;
+    background: #F3F5F4;
+    padding: 4px;
+    border-radius: 10px;
+    margin: 0 0 14px;
+}
+.subtab-pill {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 6px 14px;
+    border: none; background: transparent;
+    border-radius: 7px;
+    font-size: 13px; font-weight: 500;
+    color: #5b6770; cursor: pointer;
+    transition: background .12s, color .12s;
+}
+.subtab-pill:hover { color: #2b3540; }
+.subtab-pill.active {
+    background: #FFFFFF;
+    color: #2b3540;
+    box-shadow: 0 1px 2px rgba(16,24,40,.04);
+    font-weight: 600;
+}
+.subtab-icon { display: inline-flex; }
+
 .charts {
     display: grid;
 }

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1,7 +1,18 @@
 <template>
     <div class="componentOuterWrapper">
         <n-grid x-gap="8" cols="10">
-            <n-gi span="10">
+            <!-- DevOps view (header View dropdown) swaps the two charts for the
+                 "Deployed to" table; Security keeps the charts. -->
+            <n-gi v-if="myview === 'devops'" span="10">
+                <deployed-to-widget
+                    v-if="componentData?.uuid"
+                    :org-uuid="myorg?.uuid || ''"
+                    :component-uuid="componentData.uuid"
+                    :component-type="componentData.type"
+                    @open-release="openReleaseFromDeployedTo"
+                />
+            </n-gi>
+            <n-gi v-else span="10">
                 <n-grid x-gap="12" cols="2">
                     <n-gi>
                         <releases-per-day-chart
@@ -1088,6 +1099,8 @@ import ChangelogView from './ChangelogView.vue'
 import BranchView from './BranchView.vue'
 import MrktReleasesOfComponent from './MrktReleasesOfComponent.vue'
 import FindingsOverTimeChart from './FindingsOverTimeChart.vue'
+import DeployedToWidget from './DeployedToWidget.vue'
+import { DashboardView } from '@/utils/dashboardView'
 import FeatureSetParticipation from './FeatureSetParticipation.vue'
 import ReleasesPerDayChart from './ReleasesPerDayChart.vue'
 import Swal from 'sweetalert2'
@@ -1225,6 +1238,12 @@ async function copyToClipboard (text: string, label = 'uuid') {
 }
 
 const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
+const myview: ComputedRef<DashboardView> = computed((): DashboardView => store.getters.myview)
+
+// The Deployed-to table links versions to the release page.
+function openReleaseFromDeployedTo (releaseUuid: string) {
+    router.push({ name: 'ReleaseView', params: { uuid: releaseUuid } })
+}
 const orguuid : Ref<string> = ref('')
 if (route.params.orguuid) {
     orguuid.value = route.params.orguuid.toString()

--- a/ui/src/components/DeployedToWidget.vue
+++ b/ui/src/components/DeployedToWidget.vue
@@ -1,0 +1,109 @@
+<template>
+    <div class="deployedToWidget" data-testid="deployed-to-widget">
+        <div class="widgetHeader">
+            <h5 style="margin: 0;">Deployed to</h5>
+            <n-icon class="clickable" size="18" title="Refresh" @click="load"><Refresh /></n-icon>
+            <span v-if="rows.length" class="countNote">{{ rows.length }} {{ rows.length === 1 ? 'deployment' : 'deployments' }}</span>
+        </div>
+        <n-spin :show="loading">
+            <div v-if="!supported" class="emptyNote">This ReARM backend does not provide deployment data for the DevOps view yet.</div>
+            <n-data-table v-else-if="rows.length" :data="rows" :columns="columns" :row-key="rowKey" size="small" :max-height="360" data-testid="deployed-to-table" />
+            <div v-else-if="!loading" class="emptyNote">Not deployed on any instance.</div>
+        </n-spin>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'DeployedToWidget'
+}
+</script>
+<script lang="ts" setup>
+import { h, ref, watch, Ref } from 'vue'
+import { useStore } from 'vuex'
+import { RouterLink } from 'vue-router'
+import { DataTableColumns, NDataTable, NIcon, NSpin, useNotification, NotificationType } from 'naive-ui'
+import { Refresh } from '@vicons/tabler'
+import commonFunctions from '@/utils/commonFunctions'
+
+interface DeployedToRow {
+    instanceUuid: string
+    instanceDisplayName: string
+    namespace: string | null
+    environment: string | null
+    featureSetUuid: string | null
+    featureSetName: string | null
+    releaseUuid: string | null
+    version: string | null
+    matched: boolean
+}
+
+const props = defineProps<{
+    orgUuid: string
+    componentUuid: string
+    // 'COMPONENT' | 'PRODUCT' -- only affects the feature-set column title
+    componentType?: string
+}>()
+const emit = defineEmits<{ (e: 'openRelease', releaseUuid: string): void }>()
+
+const store = useStore()
+const notification = useNotification()
+const notify = (type: NotificationType, title: string, content: string) => {
+    notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
+}
+
+const loading = ref(false)
+const supported = ref(true)
+const rows: Ref<DeployedToRow[]> = ref([])
+
+async function load () {
+    if (!props.componentUuid) return
+    loading.value = true
+    try {
+        const result = await store.dispatch('fetchDeployedTo', props.componentUuid)
+        supported.value = result.supported
+        rows.value = result.rows
+    } catch (err: any) {
+        console.error(err)
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        loading.value = false
+    }
+}
+
+const rowKey = (row: DeployedToRow) => `${row.instanceUuid}|${row.namespace || ''}|${row.featureSetUuid || ''}|${row.releaseUuid || ''}`
+
+const columns: DataTableColumns<DeployedToRow> = [
+    {
+        key: 'instanceDisplayName',
+        title: 'Instance',
+        render: (row) => h(RouterLink, {
+            to: { name: 'Instance', params: { orguuid: props.orgUuid, instuuid: row.instanceUuid } }
+        }, { default: () => row.instanceDisplayName })
+    },
+    { key: 'namespace', title: 'Namespace', render: (row) => row.namespace || 'default' },
+    { key: 'environment', title: 'Environment', render: (row) => row.environment || '-' },
+    {
+        key: 'featureSetName',
+        title: props.componentType === 'PRODUCT' ? 'Feature Set' : 'Branch',
+        render: (row) => row.featureSetName || '-'
+    },
+    {
+        key: 'version',
+        title: 'Version',
+        render: (row) => row.matched && row.releaseUuid
+            ? h('a', { href: '#', onClick: (e: Event) => { e.preventDefault(); emit('openRelease', row.releaseUuid as string) } }, row.version || row.releaseUuid)
+            : h('span', { class: 'notMatched' }, 'Not Matched')
+    }
+]
+
+watch(() => props.componentUuid, () => load())
+load()
+</script>
+
+<style scoped lang="scss">
+.widgetHeader { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.countNote { color: #7a8590; font-size: 12px; }
+.emptyNote { padding: 12px 0; color: #7a8590; font-style: italic; }
+:deep(.notMatched) { color: #7a8590; }
+</style>

--- a/ui/src/components/InstanceStatusWidget.vue
+++ b/ui/src/components/InstanceStatusWidget.vue
@@ -1,0 +1,214 @@
+<template>
+    <div class="instanceStatusWidget" data-testid="instance-status-widget">
+        <div class="widgetHeader">
+            <h3 style="margin: 0;">Instance Status</h3>
+            <n-icon class="clickable" size="20" title="Refresh" @click="load"><Refresh /></n-icon>
+            <span v-if="props.perspectiveName" class="scopeNote">Perspective: {{ props.perspectiveName }}</span>
+        </div>
+        <div class="summaryStrip" data-testid="instance-status-summary">
+            <button class="statTile" :class="{ active: !filters.driftOnly && !filters.health }" @click="clearQuickFilters" title="All instances">
+                <span class="statValue">{{ summary.instances }}</span><span class="statLabel">instances</span>
+            </button>
+            <button class="statTile ok" disabled title="Instances whose products all match their targets">
+                <span class="statValue">{{ summary.matched }}</span><span class="statLabel">in sync</span>
+            </button>
+            <button class="statTile warn" :class="{ active: filters.driftOnly }" @click="toggleDriftOnly" title="Show only instances with drift or unmatched products">
+                <span class="statValue">{{ summary.drifted + summary.notMatched }}</span><span class="statLabel">drifted / unmatched</span>
+            </button>
+            <button class="statTile err" :class="{ active: filters.health === 'FAILING' }" @click="toggleHealth('FAILING')" title="Show only failing instances">
+                <span class="statValue">{{ summary.failing }}</span><span class="statLabel">failing</span>
+            </button>
+            <button class="statTile warn" :class="{ active: filters.health === 'DEGRADED' }" @click="toggleHealth('DEGRADED')" title="Show only degraded instances">
+                <span class="statValue">{{ summary.degraded }}</span><span class="statLabel">degraded</span>
+            </button>
+            <button class="statTile err" disabled>
+                <span class="statValue">{{ summary.openFailures }}</span><span class="statLabel">open CD failures</span>
+            </button>
+        </div>
+        <div class="filterRow">
+            <n-select v-model:value="filters.environment" :options="environmentOptions" clearable filterable placeholder="Environment" style="width: 180px;" data-testid="instance-status-env" />
+            <n-input v-model:value="filters.text" clearable placeholder="Filter by URI, namespace, product" style="width: 280px;" data-testid="instance-status-text" />
+            <span class="resultCount">{{ filteredRows.length }} of {{ rows.length }}</span>
+        </div>
+        <n-spin :show="loading">
+            <n-data-table :data="filteredRows" :columns="columns" :row-key="rowKey" size="small" :max-height="520" data-testid="instance-status-table" />
+            <div v-if="!loading && !rows.length" class="emptyNote">
+                {{ props.perspectiveName ? 'No instance deploys a product of this perspective.' : 'No instances in this organization.' }}
+            </div>
+        </n-spin>
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'InstanceStatusWidget'
+}
+</script>
+<script lang="ts" setup>
+import { computed, h, ref, watch, Ref, ComputedRef } from 'vue'
+import { useStore } from 'vuex'
+import { RouterLink } from 'vue-router'
+import { DataTableColumns, NDataTable, NIcon, NInput, NPopover, NSelect, NSpin, NTag, useNotification, NotificationType } from 'naive-ui'
+import { Refresh } from '@vicons/tabler'
+import commonFunctions from '@/utils/commonFunctions'
+import {
+    buildInstanceStatusRows, summarizeInstanceStatus, filterInstanceStatusRows, PLAN_TYPE_INTEGRATE,
+    InstanceStatusRow, InstanceStatusFilters, ProductStatusRow, DeploymentHealth, ProductSyncState, InstanceSyncState
+} from '@/utils/instanceStatusRollup'
+
+const props = defineProps<{
+    orgUuid: string
+    // undefined = whole org; otherwise only instances deploying a product of the perspective
+    perspectiveUuid?: string
+    perspectiveName?: string
+}>()
+
+const store = useStore()
+const notification = useNotification()
+const notify = (type: NotificationType, title: string, content: string) => {
+    notification[type]({ content, meta: title, duration: 3500, keepAliveOnHover: true })
+}
+
+const loading = ref(false)
+const rows: Ref<InstanceStatusRow[]> = ref([])
+const filters: Ref<InstanceStatusFilters> = ref({ environment: undefined, health: '', driftOnly: false, text: '' })
+
+async function load () {
+    if (!props.orgUuid) return
+    loading.value = true
+    // Same rule as MostRecentReleasesWidget: the store's 'default' sentinel
+    // means the whole org, not a perspective to look up.
+    const usePerspective = props.perspectiveUuid && props.perspectiveUuid !== 'default'
+    try {
+        const [instances, perspectiveComponents] = await Promise.all([
+            store.dispatch('fetchInstanceStatus', props.orgUuid),
+            usePerspective ? store.dispatch('fetchComponentsOfPerspective', props.perspectiveUuid) : Promise.resolve(null)
+        ])
+        const scope = perspectiveComponents ? new Set<string>(perspectiveComponents.map((c: any) => c.uuid)) : null
+        rows.value = buildInstanceStatusRows(instances, scope)
+    } catch (err: any) {
+        console.error(err)
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        loading.value = false
+    }
+}
+
+const summary = computed(() => summarizeInstanceStatus(rows.value))
+const filteredRows: ComputedRef<InstanceStatusRow[]> = computed(() => filterInstanceStatusRows(rows.value, filters.value))
+const environmentOptions = computed(() => {
+    const envs = new Set<string>()
+    rows.value.forEach(r => { if (r.environment) envs.add(r.environment) })
+    return Array.from(envs).sort().map(e => ({ label: e, value: e }))
+})
+
+function toggleDriftOnly () { filters.value.driftOnly = !filters.value.driftOnly }
+function toggleHealth (health: DeploymentHealth) { filters.value.health = filters.value.health === health ? '' : health }
+function clearQuickFilters () { filters.value.driftOnly = false; filters.value.health = '' }
+
+const rowKey = (row: InstanceStatusRow) => row.uuid
+
+const SYNC_TAG: Record<ProductSyncState | InstanceSyncState, { type: 'success' | 'warning' | 'error' | 'default', label: string }> = {
+    MATCHED: { type: 'success', label: 'in sync' },
+    DRIFT: { type: 'warning', label: 'drift' },
+    NOT_MATCHED: { type: 'error', label: 'not matched' },
+    NOT_APPLICABLE: { type: 'default', label: 'n/a' },
+    EMPTY: { type: 'default', label: 'no products' }
+}
+const HEALTH_TAG: Record<DeploymentHealth, { type: 'success' | 'warning' | 'error', label: string }> = {
+    HEALTHY: { type: 'success', label: 'healthy' },
+    DEGRADED: { type: 'warning', label: 'degraded' },
+    FAILING: { type: 'error', label: 'failing' }
+}
+
+// Hover detail: the old one-row-per-product view, shown on demand so the
+// widget itself stays one line per instance.
+function productDetailTable (products: ProductStatusRow[]) {
+    const cols: DataTableColumns<ProductStatusRow> = [
+        { key: 'namespace', title: 'Namespace', render: (p: ProductStatusRow) => p.namespace || 'default' },
+        { key: 'productName', title: 'Product' },
+        { key: 'featureSetName', title: 'Feature Set' },
+        { key: 'actualVersion', title: 'Actual', render: (p: ProductStatusRow) => p.actualVersion || '-' },
+        { key: 'targetVersion', title: 'Target', render: (p: ProductStatusRow) => p.planType === PLAN_TYPE_INTEGRATE ? 'n/a' : (p.targetVersion || 'not set') },
+        { key: 'sync', title: 'Match', render: (p: ProductStatusRow) => h(NTag, { size: 'small', round: true, type: SYNC_TAG[p.sync].type }, () => SYNC_TAG[p.sync].label) }
+    ]
+    return h(NDataTable, { data: products, columns: cols, size: 'small', bordered: false, style: 'min-width: 640px;' })
+}
+
+const columns: DataTableColumns<InstanceStatusRow> = [
+    {
+        key: 'displayName',
+        title: 'Instance',
+        render: (row: InstanceStatusRow) => h(RouterLink, {
+            to: { name: 'Instance', params: { orguuid: props.orgUuid, instuuid: row.uuid } }
+        }, { default: () => row.displayName })
+    },
+    { key: 'environment', title: 'Environment', render: (row: InstanceStatusRow) => row.environment || '-' },
+    {
+        key: 'namespaces',
+        title: 'Namespaces',
+        render: (row: InstanceStatusRow) => row.namespaces.length
+            ? h('span', { title: row.namespaces.join(', ') }, row.namespaces.length === 1 ? row.namespaces[0] : `${row.namespaces.length}`)
+            : '-'
+    },
+    {
+        key: 'products',
+        title: 'Products',
+        render: (row: InstanceStatusRow) => row.products.length
+            ? h(NPopover, { trigger: 'hover', placement: 'bottom-start', style: 'padding: 6px;' }, {
+                trigger: () => h('span', { class: 'productsCell', 'data-testid': 'instance-status-products' },
+                    `${row.products.length} ${row.products.length === 1 ? 'product' : 'products'}`),
+                default: () => productDetailTable(row.products)
+            })
+            : h('span', '-')
+    },
+    {
+        key: 'sync',
+        title: 'Sync',
+        render: (row: InstanceStatusRow) => {
+            const counted = row.matched + row.drifted + row.notMatched
+            const els: any[] = [h(NTag, { size: 'small', round: true, type: SYNC_TAG[row.sync].type }, () => SYNC_TAG[row.sync].label)]
+            if (counted) els.push(h('span', { class: 'syncCount' }, `${row.matched}/${counted}`))
+            return h('span', { class: 'syncCell' }, els)
+        }
+    },
+    {
+        key: 'health',
+        title: 'Health',
+        render: (row: InstanceStatusRow) => {
+            const els: any[] = [h(NTag, { size: 'small', round: true, type: HEALTH_TAG[row.health].type }, () => HEALTH_TAG[row.health].label)]
+            if (row.openFailures) els.push(h('span', { class: 'syncCount', title: 'open ReARM CD failures' }, `${row.openFailures} ${row.openFailures === 1 ? 'failure' : 'failures'}`))
+            if (row.releasesInError) els.push(h('span', { class: 'syncCount', title: 'deployed releases reported in error' }, `${row.releasesInError} in error`))
+            return h('span', { class: 'syncCell' }, els)
+        }
+    }
+]
+
+watch(() => [props.orgUuid, props.perspectiveUuid], () => load())
+load()
+</script>
+
+<style scoped lang="scss">
+.widgetHeader { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; }
+.scopeNote { color: #7a8590; font-size: 13px; }
+.summaryStrip { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
+.statTile {
+    display: inline-flex; flex-direction: column; align-items: flex-start;
+    min-width: 96px; padding: 6px 12px;
+    border: 1px solid #e3e8ec; border-radius: 8px; background: #fff;
+    cursor: pointer; text-align: left;
+    &:disabled { cursor: default; }
+    &.active { border-color: #2b3540; box-shadow: 0 0 0 1px #2b3540 inset; }
+    &.ok .statValue { color: #2da44e; }
+    &.warn .statValue { color: #9a6700; }
+    &.err .statValue { color: #cf222e; }
+}
+.statValue { font-size: 20px; font-weight: 600; line-height: 1.1; }
+.statLabel { font-size: 11px; color: #5b6770; }
+.filterRow { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; flex-wrap: wrap; }
+.resultCount { color: #7a8590; font-size: 12px; }
+.emptyNote { padding: 16px 0; color: #7a8590; font-style: italic; }
+:deep(.productsCell) { cursor: default; text-decoration: underline dotted; }
+:deep(.syncCell) { display: inline-flex; align-items: center; gap: 6px; }
+:deep(.syncCount) { font-size: 12px; color: #5b6770; }
+</style>

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1057,6 +1057,24 @@ Spec: https://www.cisa.gov/sites/default/files/2023-04/minimum-requirements-for-
                         </n-space>
                     </n-form>
                 </div>
+                <div class="adminSettingsBlock mt-4" data-testid="org-default-view-block">
+                    <h5>Default View</h5>
+                    <p class="text-muted">The view (Security or DevOps) users of this organization land on. A user's own choice in the header, remembered in their browser, overrides this.</p>
+                    <n-form>
+                        <n-form-item label="Default View">
+                            <n-select
+                                v-model:value="orgDefaultView"
+                                :options="defaultViewOptions"
+                                style="max-width: 240px;"
+                                data-testid="org-default-view-select" />
+                        </n-form-item>
+                        <n-space>
+                            <n-button type="primary" @click="saveOrgDefaultView" :loading="savingOrgDefaultView" data-testid="org-default-view-save">
+                                Save Default View
+                            </n-button>
+                        </n-space>
+                    </n-form>
+                </div>
             </n-tab-pane>
             <n-tab-pane name="audit" tab="Audit" v-if="isOrgAdmin">
                 <n-tabs type="segment" :value="auditSubTab" @update:value="handleAuditSubTabSwitch" size="medium" animated style="margin-bottom: 16px;">
@@ -1143,6 +1161,7 @@ import { Marked } from '@ts-stack/markdown'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import graphqlQueries from '../utils/graphqlQueries'
+import { DASHBOARD_VIEWS, DASHBOARD_VIEW_LABELS, DashboardView, dashboardViewToWire } from '@/utils/dashboardView'
 import constants from '../utils/constants'
 import { buildUserGroupUpdateInput } from '../utils/userGroupUpdateInput'
 import { resolveApprovalRoles } from '../utils/approvalRoles'
@@ -3380,7 +3399,44 @@ async function saveIgnoreViolation() {
     }
 }
 
+// Default view is a Pro-only org setting fetched by its own document (the
+// boot-time organizations query must keep working on a backend without it)
+// and saved by its own mutation call for the same reason.
+const orgDefaultView = ref<DashboardView>('security')
+const savingOrgDefaultView = ref(false)
+const defaultViewOptions = DASHBOARD_VIEWS.map((v) => ({ label: DASHBOARD_VIEW_LABELS[v], value: v }))
+async function loadOrgDefaultView() {
+    orgDefaultView.value = (await store.dispatch('fetchOrgDefaultView', orgResolved.value)) || 'security'
+}
+async function saveOrgDefaultView() {
+    savingOrgDefaultView.value = true
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateOrganizationDefaultView($orgUuid: ID!, $settings: SettingsInput!) {
+                    updateOrganizationSettings(orgUuid: $orgUuid, settings: $settings) {
+                        uuid
+                        settings {
+                            defaultView
+                        }
+                    }
+                }`,
+            variables: {
+                orgUuid: orgResolved.value,
+                settings: { defaultView: dashboardViewToWire(orgDefaultView.value) }
+            }
+        })
+        notify('success', 'Saved', `Default view set to ${DASHBOARD_VIEW_LABELS[orgDefaultView.value]}`)
+    } catch (err: any) {
+        console.error('Error saving default view:', err)
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        savingOrgDefaultView.value = false
+    }
+}
+
 async function loadOrgSettings() {
+    await loadOrgDefaultView()
     const s = myorg.value?.settings
     orgSettings.justificationMandatory = s?.justificationMandatory || false
     orgSettings.branchSuffixMode = (s?.branchSuffixMode && s.branchSuffixMode !== 'INHERIT') ? s.branchSuffixMode : 'APPEND'

--- a/ui/src/components/TopNavBar.vue
+++ b/ui/src/components/TopNavBar.vue
@@ -33,6 +33,15 @@
                 </span>
                 <span v-else><strong>Perspective: </strong><span style="font-size: 16px;">{{ currentPerspectiveName }}</span></span>
             </div>
+            <div class="horizontalNavElement horizontalNavElementView" data-testid="app-view-nav">
+                <span><strong>View: </strong></span>
+                <n-dropdown trigger="hover" :options="viewOptions" @select="setMyView">
+                    <span data-testid="app-view-dropdown">
+                        <span style="font-size: 16px;">{{ currentViewLabel }}</span>
+                        <Icon><CaretDownFilled/></Icon>
+                    </span>
+                </n-dropdown>
+            </div>
             <div class="horizontalNavIcons" v-if="myorg && !isPlayground" >
                 <span>
                     <router-link :to="{ name: 'profile'}"><n-icon class="clickable" title="Profile" size="20"><User /></n-icon></router-link>
@@ -60,6 +69,7 @@ export default {
 import { NDropdown, NIcon } from 'naive-ui'
 import { User, Settings, Logout } from '@vicons/tabler'
 import { useStore } from 'vuex'
+import { DASHBOARD_VIEWS, DASHBOARD_VIEW_LABELS, DashboardView, isDashboardView } from '@/utils/dashboardView'
 import { ComputedRef, computed, h, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { CaretDownFilled } from '@vicons/antd'
@@ -157,6 +167,15 @@ const setMyPerspective = function (perspectiveUuid: string) {
     store.dispatch('updateMyPerspective', perspectiveUuid)
 }
 
+// View (Security | DevOps): same shape as the perspective dropdown; the store
+// remembers the choice per browser.
+const myview: ComputedRef<DashboardView> = computed((): DashboardView => store.getters.myview)
+const viewOptions = DASHBOARD_VIEWS.map((v) => ({ label: DASHBOARD_VIEW_LABELS[v], key: v }))
+const currentViewLabel: ComputedRef<string> = computed((): string => DASHBOARD_VIEW_LABELS[myview.value] || DASHBOARD_VIEW_LABELS.security)
+const setMyView = function (view: string) {
+    if (isDashboardView(view)) store.dispatch('updateMyView', view)
+}
+
 // Auto-select first available perspective when user has only perspective-scoped access
 watch([hasOnlyPerspectiveAccess, perspectives, myorg, myperspective], () => {
     if (!hasOnlyPerspectiveAccess.value || perspectives.value.length === 0) return
@@ -210,7 +229,7 @@ body {
     border-bottom-width: thin;
     border-bottom-color: #dfe4e5;
     display: grid;
-    grid-template-columns: 0.1fr 0.5fr 0.35fr 0.35fr 145px;
+    grid-template-columns: 0.1fr 0.4fr 0.3fr 0.3fr 0.25fr 145px;
     a {
         font-weight: bold;
         color: rgb(25, 25, 25);

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -4,7 +4,12 @@ import gql from 'graphql-tag'
 import constants from './utils/constants'
 import graphqlClient from './utils/graphql'
 import graphqlQueries from './utils/graphqlQueries'
+import { DashboardView, isDashboardView, dashboardViewFromWire } from '@/utils/dashboardView'
+import { classifyGraphqlError } from '@/utils/graphqlDriftFallback'
 import VcsReposOfOrg from './components/VcsReposOfOrg.vue'
+
+// Browser memory of the view choice; sibling of relizaOrgUuid / relizaPerspectiveUuid.
+const VIEW_STORAGE_KEY = 'relizaView'
 
 const storeObject : any = {
     state () {
@@ -26,7 +31,11 @@ const storeObject : any = {
                 orgUuid: '',
                 appUuid: '00000000-0000-0000-0000-000000000000',
                 name: '',
-                perspectiveUuid: 'default'
+                perspectiveUuid: 'default',
+                // Dashboard / component-page view: 'security' | 'devops'. Resolved at
+                // boot from the browser's last choice, then the org default, then
+                // security. Header dropdown, like the perspective.
+                view: 'security'
             },
             perspectives: [],
             fetchUserStatus: null,
@@ -75,6 +84,9 @@ const storeObject : any = {
         },
         myperspective (state : any) {
             return state.iam.perspectiveUuid
+        },
+        myview (state : any) {
+            return state.iam.view
         },
         allPerspectives (state: any) {
             return state.perspectives.slice()
@@ -264,6 +276,9 @@ const storeObject : any = {
         },
         UPDATE_MY_PERSPECTIVE (state : any, uuid : string) {
             state.iam.perspectiveUuid = uuid
+        },
+        UPDATE_MY_VIEW (state : any, view : string) {
+            state.iam.view = view
         },
         SET_PERSPECTIVES (state: any, perspectives: any[]) {
             state.perspectives = perspectives
@@ -551,6 +566,10 @@ const storeObject : any = {
                     } else {
                         context.commit('UPDATE_MY_PERSPECTIVE', 'default')
                     }
+
+                    // Resolve the view: this browser's choice wins over the org
+                    // default, which wins over the built-in default.
+                    await context.dispatch('resolveMyView', myOrg)
                 } else {
                     console.error('Error fetching user organizations')
                 }
@@ -712,6 +731,7 @@ const storeObject : any = {
         updateMyOrg (context : any, orgUuid : string) {
             // set local browser storage
             window.localStorage.setItem('relizaOrgUuid', orgUuid)
+            await context.dispatch('resolveMyView', orgUuid)
             context.commit('UPDATE_MY_ORG', orgUuid)
             // Reset perspective to default when changing org
             context.dispatch('updateMyPerspective', 'default')
@@ -720,6 +740,56 @@ const storeObject : any = {
             // set local browser storage
             window.localStorage.setItem('relizaPerspectiveUuid', perspectiveUuid)
             context.commit('UPDATE_MY_PERSPECTIVE', perspectiveUuid)
+        },
+        // The org's default view lives in Pro org settings; a backend without the
+        // field (CE mirror lag) fails this single small document only, and the
+        // view falls back to the built-in default.
+        async fetchOrgDefaultView (context : any, orgUuid : string) {
+            try {
+                const response = await graphqlClient.query({
+                    query: graphqlQueries.OrgDefaultViewGql,
+                    variables: { orgUuid },
+                    fetchPolicy: 'no-cache'
+                })
+                return dashboardViewFromWire(response.data.organization?.settings?.defaultView)
+            } catch (err) {
+                console.error('Org default view unavailable, using built-in default', err)
+                return null
+            }
+        },
+        async resolveMyView (context : any, orgUuid : string) {
+            let stored: string | null = null
+            try { stored = window.localStorage.getItem(VIEW_STORAGE_KEY) } catch { /* storage unavailable */ }
+            let view: DashboardView = 'security'
+            if (isDashboardView(stored)) {
+                view = stored
+            } else if (orgUuid) {
+                view = (await context.dispatch('fetchOrgDefaultView', orgUuid)) || 'security'
+            }
+            context.commit('UPDATE_MY_VIEW', view)
+        },
+        async updateMyView (context : any, view : DashboardView) {
+            try { window.localStorage.setItem(VIEW_STORAGE_KEY, view) } catch { /* storage unavailable */ }
+            context.commit('UPDATE_MY_VIEW', view)
+        },
+        // Returns { rows, supported }: supported=false when the backend has no
+        // deployedTo query (CE mirror lag) so the page can say so instead of
+        // showing an empty table.
+        async fetchDeployedTo (context : any, componentUuid : string) {
+            try {
+                const response = await graphqlClient.query({
+                    query: graphqlQueries.DeployedToGql,
+                    variables: { componentUuid },
+                    fetchPolicy: 'no-cache'
+                })
+                return { rows: response.data.deployedTo || [], supported: true }
+            } catch (err: any) {
+                if (classifyGraphqlError(err) === 'validation') {
+                    console.error('deployedTo query not available on this backend', err)
+                    return { rows: [], supported: false }
+                }
+                throw err
+            }
         },
         async fetchPerspectives (context : any, orgUuid : string) {
             try {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -748,10 +748,10 @@ const storeObject : any = {
             try {
                 const response = await graphqlClient.query({
                     query: graphqlQueries.OrgDefaultViewGql,
-                    variables: { orgUuid },
                     fetchPolicy: 'no-cache'
                 })
-                return dashboardViewFromWire(response.data.organization?.settings?.defaultView)
+                const org = (response.data.organizations || []).find((o: any) => o.uuid === orgUuid)
+                return dashboardViewFromWire(org?.settings?.defaultView)
             } catch (err) {
                 console.error('Org default view unavailable, using built-in default', err)
                 return null

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -728,7 +728,7 @@ const storeObject : any = {
             context.commit('ADD_RELEASES', response.data.releases)
             return response.data.releases
         },
-        updateMyOrg (context : any, orgUuid : string) {
+        async updateMyOrg (context : any, orgUuid : string) {
             // set local browser storage
             window.localStorage.setItem('relizaOrgUuid', orgUuid)
             await context.dispatch('resolveMyView', orgUuid)

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1667,6 +1667,25 @@ const storeObject : any = {
             })
             return response.data.instance ? (response.data.instance[params.part] || []) : []
         },
+        // DevOps dashboard reads. Neither is committed to the store: the status
+        // rows are a widget-local roll-up, and the perspective's components are
+        // only needed to scope them.
+        async fetchInstanceStatus (context: any, orgUuid: string) {
+            const response = await graphqlClient.query({
+                query: graphqlQueries.InstanceStatusGql,
+                variables: { orgUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.instancesOfOrganization || []
+        },
+        async fetchComponentsOfPerspective (context: any, perspectiveUuid: string) {
+            const response = await graphqlClient.query({
+                query: graphqlQueries.ComponentsOfPerspectiveGql,
+                variables: { perspectiveUuid },
+                fetchPolicy: 'no-cache'
+            })
+            return response.data.componentsOfPerspective || []
+        },
         async fetchInstances (context: any, id: string) {
             const response = await graphqlClient.query({
                 query: graphqlQueries.InstancesGql,

--- a/ui/src/utils/dashboardView.ts
+++ b/ui/src/utils/dashboardView.ts
@@ -1,0 +1,25 @@
+// The two views the UI can show: Security (the classic page) and DevOps.
+// Kept as a tiny module so the store, the header dropdown, the dashboard and
+// the component page all agree on the values and on the wire form.
+
+export const DASHBOARD_VIEWS = ['security', 'devops'] as const
+export type DashboardView = typeof DASHBOARD_VIEWS[number]
+
+export function isDashboardView (v: unknown): v is DashboardView {
+    return DASHBOARD_VIEWS.includes(v as DashboardView)
+}
+
+export const DASHBOARD_VIEW_LABELS: Record<DashboardView, string> = {
+    security: 'Security',
+    devops: 'DevOps'
+}
+
+// GraphQL enum DashboardView on org settings uses upper-case names.
+export function dashboardViewToWire (v: DashboardView): string {
+    return v.toUpperCase()
+}
+export function dashboardViewFromWire (v: unknown): DashboardView | null {
+    if (typeof v !== 'string') return null
+    const lower = v.toLowerCase()
+    return isDashboardView(lower) ? lower : null
+}

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -525,10 +525,11 @@ query ComponentsOfPerspective($perspectiveUuid: ID!) {
 
 // Org default view (Pro org setting). Deliberately its own tiny document:
 // the boot-time organizations query must keep working on a backend that
-// predates the field.
+// predates the field. Uses the organizations list (the single-organization
+// query in the schema has no resolver and always returns null).
 const ORG_DEFAULT_VIEW_GQL = gql`
-query OrgDefaultView($orgUuid: ID!) {
-    organization(orgUuid: $orgUuid) {
+query OrgDefaultView {
+    organizations {
         uuid
         settings {
             defaultView

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -523,6 +523,36 @@ query ComponentsOfPerspective($perspectiveUuid: ID!) {
     }
 }`
 
+// Org default view (Pro org setting). Deliberately its own tiny document:
+// the boot-time organizations query must keep working on a backend that
+// predates the field.
+const ORG_DEFAULT_VIEW_GQL = gql`
+query OrgDefaultView($orgUuid: ID!) {
+    organization(orgUuid: $orgUuid) {
+        uuid
+        settings {
+            defaultView
+        }
+    }
+}`
+
+// DevOps view on the component / product page: where is this thing deployed.
+// Pro-only query; the page degrades to a note when the backend lacks it.
+const DEPLOYED_TO_GQL = gql`
+query DeployedTo($componentUuid: ID!) {
+    deployedTo(componentUuid: $componentUuid) {
+        instanceUuid
+        instanceDisplayName
+        namespace
+        environment
+        featureSetUuid
+        featureSetName
+        releaseUuid
+        version
+        matched
+    }
+}`
+
 const INSTANCES_GQL = gql`
 query FetchInstances($orgUuid: ID!) {
     instancesOfOrganization(orgUuid: $orgUuid) {
@@ -1697,6 +1727,8 @@ export default {
     },
     InstancesGql: INSTANCES_GQL,
     InstanceStatusGql: INSTANCE_STATUS_GQL,
+    OrgDefaultViewGql: ORG_DEFAULT_VIEW_GQL,
+    DeployedToGql: DEPLOYED_TO_GQL,
     ComponentsOfPerspectiveGql: COMPONENTS_OF_PERSPECTIVE_GQL,
     MultiReleaseGqlData: MULTI_RELEASE_GQL_DATA,
     BranchReleaseListGqlData: BRANCH_RELEASE_LIST_GQL_DATA,

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -466,6 +466,63 @@ query FetchInstanceTargetReleaseDetails($instanceUuid: ID!) {
     }
 }`
 
+// DevOps dashboard: one org-wide read for the instance status widget. Kept
+// separate from FetchInstances (the instances list) because deploymentHealth
+// and deploymentFailures resolve per instance on the backend, and the list
+// page has no use for them.
+const INSTANCE_STATUS_GQL = gql`
+query FetchInstanceStatus($orgUuid: ID!) {
+    instancesOfOrganization(orgUuid: $orgUuid) {
+        uuid
+        uri
+        name
+        displayName
+        instanceType
+        environment
+        releases {
+            namespace
+            isInError
+        }
+        productPlans {
+            featureSet
+            type
+            namespace
+            targetReleaseDetails {
+                version
+            }
+            featureSetDetails {
+                name
+                componentDetails {
+                    uuid
+                    name
+                }
+            }
+        }
+        productActuals {
+            featureSet
+            namespace
+            matchedRelease
+            matchedReleaseDetails {
+                version
+            }
+            notMatchingSince
+        }
+        deploymentHealth
+        deploymentFailures {
+            uuid
+        }
+    }
+}`
+
+const COMPONENTS_OF_PERSPECTIVE_GQL = gql`
+query ComponentsOfPerspective($perspectiveUuid: ID!) {
+    componentsOfPerspective(perspectiveUuid: $perspectiveUuid) {
+        uuid
+        name
+        type
+    }
+}`
+
 const INSTANCES_GQL = gql`
 query FetchInstances($orgUuid: ID!) {
     instancesOfOrganization(orgUuid: $orgUuid) {
@@ -1639,6 +1696,8 @@ export default {
         targetReleases: INSTANCE_TARGET_RELEASE_DETAILS_GQL
     },
     InstancesGql: INSTANCES_GQL,
+    InstanceStatusGql: INSTANCE_STATUS_GQL,
+    ComponentsOfPerspectiveGql: COMPONENTS_OF_PERSPECTIVE_GQL,
     MultiReleaseGqlData: MULTI_RELEASE_GQL_DATA,
     BranchReleaseListGqlData: BRANCH_RELEASE_LIST_GQL_DATA,
     ChildReleaseGqlData: CHILD_RELEASE_GQL_DATA,

--- a/ui/src/utils/instanceStatusRollup.spec.ts
+++ b/ui/src/utils/instanceStatusRollup.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { buildInstanceStatusRows, summarizeInstanceStatus, filterInstanceStatusRows } from './instanceStatusRollup'
+
+const plan = (featureSet: string, ns: string, product: string, name: string, target: string, type = 'FOLLOW') => ({
+    featureSet, namespace: ns, type, targetRelease: target ? `rel-${target}` : null,
+    targetReleaseDetails: target ? { version: target } : null,
+    featureSetDetails: { name: 'Base Feature Set', componentDetails: { uuid: product, name } }
+})
+const actual = (featureSet: string, ns: string, version: string | null, notMatchingSince: string | null = null) => ({
+    featureSet, namespace: ns, matchedRelease: version ? `rel-${version}` : null,
+    matchedReleaseDetails: version ? { version } : null, notMatchingSince
+})
+
+const instances = [
+    {
+        uuid: 'i1', uri: 'app.example.com', instanceType: 'STANDALONE_INSTANCE', environment: 'PRODUCTION',
+        deploymentHealth: 'FAILING', deploymentFailures: [{ uuid: 'f1' }, { uuid: 'f2' }],
+        releases: [{ isInError: true, namespace: 'hub' }, { isInError: false, namespace: 'cd' }],
+        productPlans: [plan('fs1', 'hub', 'p-hub', 'Hub', '1.2.0'), plan('fs2', 'cd', 'p-cd', 'CD', '2.0.0'), plan('fs3', 'harbor', 'p-harbor', 'Harbor', '0.3.5')],
+        productActuals: [actual('fs1', 'hub', '1.2.0'), actual('fs2', 'cd', '1.9.0', '2026-09-01T00:00:00Z'), actual('fs3', 'harbor', null)]
+    },
+    {
+        uuid: 'i2', uri: 'bot.example.com', displayName: 'bot (server name)', instanceType: 'STANDALONE_INSTANCE', environment: 'TEST',
+        deploymentHealth: 'HEALTHY', deploymentFailures: [], releases: [],
+        productPlans: [plan('fs4', 'bot', 'p-bot', 'Bot', '22.04.22')],
+        productActuals: [actual('fs4', 'bot', '22.04.22')]
+    },
+    {
+        uuid: 'c1', name: 'the-cluster', instanceType: 'CLUSTER', instances: ['i3'], productPlans: [], productActuals: []
+    },
+    {
+        uuid: 'i3', uri: 'child.example.com', instanceType: 'CLUSTER_INSTANCE', namespace: 'child', environment: 'TEST',
+        productPlans: [plan('fs5', 'child', 'p-bot', 'Bot', '', 'INTEGRATE'), plan('fs6', 'child', 'p-old', 'Old', '', 'UNINSTALL')],
+        productActuals: [actual('fs5', 'child', '22.04.13'), actual('fs6', 'child', null)]
+    }
+]
+
+describe('buildInstanceStatusRows', () => {
+    const rows = buildInstanceStatusRows(instances)
+
+    it('yields one row per deployable instance and skips CLUSTER containers', () => {
+        expect(rows.map(r => r.uuid).sort()).toEqual(['i1', 'i2', 'i3'])
+    })
+
+    it('rolls product plans up against actuals', () => {
+        const r = rows.find(x => x.uuid === 'i1')!
+        expect(r.products.map(p => [p.productName, p.sync, p.actualVersion, p.targetVersion])).toEqual([
+            ['CD', 'DRIFT', '1.9.0', '2.0.0'],
+            ['Harbor', 'NOT_MATCHED', '', '0.3.5'],
+            ['Hub', 'MATCHED', '1.2.0', '1.2.0']
+        ])
+        expect([r.matched, r.drifted, r.notMatched]).toEqual([1, 1, 1])
+        expect(r.sync).toBe('NOT_MATCHED')
+        expect(r.namespaces).toEqual(['cd', 'harbor', 'hub'])
+        expect(r.openFailures).toBe(2)
+        expect(r.releasesInError).toBe(1)
+        expect(r.health).toBe('FAILING')
+    })
+
+    it('treats UNINSTALL plans as not applicable and defaults health to HEALTHY', () => {
+        const r = rows.find(x => x.uuid === 'i3')!
+        expect(r.products.map(p => p.sync)).toEqual(['MATCHED', 'NOT_APPLICABLE'])
+        expect(r.sync).toBe('MATCHED')
+        expect(r.health).toBe('HEALTHY')
+        expect(r.openFailures).toBe(0)
+    })
+
+    it('orders worst first', () => {
+        expect(rows.map(r => r.uuid)).toEqual(['i1', 'i2', 'i3'])
+    })
+
+    it('prefers the server displayName and falls back to uri', () => {
+        expect(rows.find(r => r.uuid === 'i2')!.displayName).toBe('bot (server name)')
+        expect(rows.find(r => r.uuid === 'i1')!.displayName).toBe('app.example.com')
+    })
+
+    it('scopes to a perspective by product: keeps instances deploying at least one of its products', () => {
+        const scoped = buildInstanceStatusRows(instances, new Set(['p-bot']))
+        expect(scoped.map(r => r.uuid).sort()).toEqual(['i2', 'i3'])
+        expect(scoped.find(r => r.uuid === 'i3')!.products.map(p => p.productName)).toEqual(['Bot'])
+    })
+})
+
+describe('summarizeInstanceStatus / filterInstanceStatusRows', () => {
+    const rows = buildInstanceStatusRows(instances)
+
+    it('summarises the org', () => {
+        expect(summarizeInstanceStatus(rows)).toEqual({
+            instances: 3, matched: 2, drifted: 0, notMatched: 1, failing: 1, degraded: 0, openFailures: 2
+        })
+    })
+
+    it('filters by environment, health, drift and text', () => {
+        expect(filterInstanceStatusRows(rows, { environment: 'TEST' }).map(r => r.uuid)).toEqual(['i2', 'i3'])
+        expect(filterInstanceStatusRows(rows, { health: 'FAILING' }).map(r => r.uuid)).toEqual(['i1'])
+        expect(filterInstanceStatusRows(rows, { driftOnly: true }).map(r => r.uuid)).toEqual(['i1'])
+        expect(filterInstanceStatusRows(rows, { text: 'harbor' }).map(r => r.uuid)).toEqual(['i1'])
+        expect(filterInstanceStatusRows(rows, { text: 'Bot' }).map(r => r.uuid)).toEqual(['i2', 'i3'])
+    })
+})

--- a/ui/src/utils/instanceStatusRollup.ts
+++ b/ui/src/utils/instanceStatusRollup.ts
@@ -1,0 +1,177 @@
+import constants from '@/utils/constants'
+
+// Pure roll-up behind the DevOps dashboard's "Instance status" widget: one row
+// per instance, summarising its product plans against what is actually
+// deployed. Kept free of Vue / store so it is unit-testable and so the widget
+// stays a thin renderer.
+
+export type ProductSyncState = 'MATCHED' | 'DRIFT' | 'NOT_MATCHED' | 'NOT_APPLICABLE'
+export type InstanceSyncState = 'MATCHED' | 'DRIFT' | 'NOT_MATCHED' | 'EMPTY'
+export type DeploymentHealth = 'HEALTHY' | 'DEGRADED' | 'FAILING'
+
+export interface ProductStatusRow {
+    productUuid: string
+    productName: string
+    featureSetUuid: string
+    featureSetName: string
+    namespace: string
+    planType: string
+    targetVersion: string
+    actualVersion: string
+    sync: ProductSyncState
+    notMatchingSince: string | null
+}
+
+export interface InstanceStatusRow {
+    uuid: string
+    uri: string
+    displayName: string
+    instanceType: string
+    environment: string
+    namespaces: string[]
+    products: ProductStatusRow[]
+    matched: number
+    drifted: number
+    notMatched: number
+    sync: InstanceSyncState
+    health: DeploymentHealth
+    openFailures: number
+    releasesInError: number
+}
+
+export interface InstanceStatusSummary {
+    instances: number
+    matched: number
+    drifted: number
+    notMatched: number
+    failing: number
+    degraded: number
+    openFailures: number
+}
+
+export interface InstanceStatusFilters {
+    environment?: string
+    health?: DeploymentHealth | ''
+    driftOnly?: boolean
+    text?: string
+}
+
+const CLUSTER = constants.InstanceType.CLUSTER
+// Plan types the roll-up treats specially: UNINSTALL is being removed (its
+// actual state is not a sync signal); INTEGRATE has no target release.
+export const PLAN_TYPE_UNINSTALL = 'UNINSTALL'
+export const PLAN_TYPE_INTEGRATE = 'INTEGRATE'
+
+function planKey (featureSet: string, namespace: string): string {
+    return `${featureSet}|${namespace || ''}`
+}
+
+function productSync (plan: any, actual: any): ProductSyncState {
+    if (plan.type === PLAN_TYPE_UNINSTALL) return 'NOT_APPLICABLE'
+    if (!actual || !actual.matchedRelease) return 'NOT_MATCHED'
+    return actual.notMatchingSince ? 'DRIFT' : 'MATCHED'
+}
+
+function instanceSync (products: ProductStatusRow[]): InstanceSyncState {
+    const counted = products.filter(p => p.sync !== 'NOT_APPLICABLE')
+    if (!counted.length) return 'EMPTY'
+    if (counted.some(p => p.sync === 'NOT_MATCHED')) return 'NOT_MATCHED'
+    if (counted.some(p => p.sync === 'DRIFT')) return 'DRIFT'
+    return 'MATCHED'
+}
+
+// The backend's displayName is documented as non-empty for any persisted
+// instance; the fallbacks only matter for hand-built fixtures.
+function displayNameOf (inst: any): string {
+    return inst.displayName || inst.uri || inst.name || inst.uuid
+}
+
+/**
+ * Build one row per deployable instance. CLUSTER containers are skipped --
+ * their child instances are the rows that deploy things and are listed in
+ * the same org query. When `perspectiveProducts` is given, only instances
+ * that deploy at least one of those products are kept, and their product
+ * list is narrowed to those products.
+ */
+export function buildInstanceStatusRows (instances: any[], perspectiveProducts?: Set<string> | null): InstanceStatusRow[] {
+    const rows: InstanceStatusRow[] = []
+    ;(instances || []).forEach((inst: any) => {
+        if (!inst || inst.instanceType === CLUSTER) return
+        const actualsByKey: Record<string, any> = {}
+        ;(inst.productActuals || []).forEach((a: any) => { actualsByKey[planKey(a.featureSet, a.namespace)] = a })
+        const products: ProductStatusRow[] = []
+        ;(inst.productPlans || []).forEach((plan: any) => {
+            const comp = plan.featureSetDetails && plan.featureSetDetails.componentDetails
+            const productUuid = (comp && comp.uuid) || ''
+            if (perspectiveProducts && !perspectiveProducts.has(productUuid)) return
+            const actual = actualsByKey[planKey(plan.featureSet, plan.namespace)]
+            products.push({
+                productUuid,
+                productName: (comp && comp.name) || productUuid,
+                featureSetUuid: plan.featureSet,
+                featureSetName: (plan.featureSetDetails && plan.featureSetDetails.name) || '',
+                namespace: plan.namespace || '',
+                planType: plan.type || '',
+                targetVersion: (plan.targetReleaseDetails && plan.targetReleaseDetails.version) || '',
+                actualVersion: (actual && actual.matchedReleaseDetails && actual.matchedReleaseDetails.version) || '',
+                sync: productSync(plan, actual),
+                notMatchingSince: (actual && actual.notMatchingSince) || null
+            })
+        })
+        if (perspectiveProducts && !products.length) return
+        products.sort((a, b) => a.productName.localeCompare(b.productName) || a.namespace.localeCompare(b.namespace))
+        const namespaces = new Set<string>()
+        products.forEach(p => { if (p.namespace) namespaces.add(p.namespace) })
+        ;(inst.releases || []).forEach((r: any) => { if (r && r.namespace) namespaces.add(r.namespace) })
+        const health: DeploymentHealth = inst.deploymentHealth || 'HEALTHY'
+        rows.push({
+            uuid: inst.uuid,
+            uri: inst.uri || '',
+            displayName: displayNameOf(inst),
+            instanceType: inst.instanceType || '',
+            environment: inst.environment || '',
+            namespaces: Array.from(namespaces).sort(),
+            products,
+            matched: products.filter(p => p.sync === 'MATCHED').length,
+            drifted: products.filter(p => p.sync === 'DRIFT').length,
+            notMatched: products.filter(p => p.sync === 'NOT_MATCHED').length,
+            sync: instanceSync(products),
+            health,
+            openFailures: (inst.deploymentFailures || []).length,
+            releasesInError: (inst.releases || []).filter((r: any) => r && r.isInError).length
+        })
+    })
+    // Worst first: failing / not matched at the top, then by name.
+    const healthRank: Record<DeploymentHealth, number> = { FAILING: 0, DEGRADED: 1, HEALTHY: 2 }
+    const syncRank: Record<InstanceSyncState, number> = { NOT_MATCHED: 0, DRIFT: 1, MATCHED: 2, EMPTY: 3 }
+    rows.sort((a, b) => healthRank[a.health] - healthRank[b.health]
+        || syncRank[a.sync] - syncRank[b.sync]
+        || a.displayName.localeCompare(b.displayName))
+    return rows
+}
+
+export function summarizeInstanceStatus (rows: InstanceStatusRow[]): InstanceStatusSummary {
+    return {
+        instances: rows.length,
+        matched: rows.filter(r => r.sync === 'MATCHED').length,
+        drifted: rows.filter(r => r.sync === 'DRIFT').length,
+        notMatched: rows.filter(r => r.sync === 'NOT_MATCHED').length,
+        failing: rows.filter(r => r.health === 'FAILING').length,
+        degraded: rows.filter(r => r.health === 'DEGRADED').length,
+        openFailures: rows.reduce((n, r) => n + r.openFailures, 0)
+    }
+}
+
+export function filterInstanceStatusRows (rows: InstanceStatusRow[], filters: InstanceStatusFilters): InstanceStatusRow[] {
+    const text = (filters.text || '').trim().toLowerCase()
+    return rows.filter(r => {
+        if (filters.environment && r.environment !== filters.environment) return false
+        if (filters.health && r.health !== filters.health) return false
+        if (filters.driftOnly && r.sync !== 'DRIFT' && r.sync !== 'NOT_MATCHED') return false
+        if (text) {
+            const hay = [r.displayName, r.uri, r.environment, ...r.namespaces, ...r.products.map(p => p.productName)].join(' ').toLowerCase()
+            if (!hay.includes(text)) return false
+        }
+        return true
+    })
+}


### PR DESCRIPTION
## What

The home dashboard gets two views behind a segmented switcher:

- **Product Security** -- the page exactly as it was.
- **DevOps** -- a new single-row-per-instance **Instance Status** widget on top, with Search Releases and Most Recent Releases carried over.

View choice resolves from the URL (`?view=security|devops`), then the browser's last choice, then Product Security, so existing users see no change and links stay shareable.

## Instance Status widget

- One row per deployable instance (CLUSTER containers are skipped; their child instances are the rows): instance, environment, namespaces, product count, a sync verdict (in sync / drift / not matched, with matched-over-counted) and a health chip with open ReARM CD failures and deployed releases in error.
- The old one-row-per-product view (namespace, product, feature set, actual, target, match) is a hover detail on the product count, so the table stays one line per instance.
- Summary tiles double as quick filters (drifted / unmatched, failing, degraded); environment and free-text filters; worst-first ordering.
- Perspective scoping: with a perspective selected, only instances that deploy at least one product of that perspective are shown, and their product list is narrowed to those products (via `componentsOfPerspective`).
- Data comes from a dedicated org-wide instances document, so the instances list page does not pick up the per-instance health / failure resolvers. Roll-up logic is a pure helper (`instanceStatusRollup.ts`) with a vitest spec.

Most Vulnerable is fetched from the dashboard component rather than a child widget, so its fetch is now skipped while DevOps is showing and caught up on switching back. The chart widgets already mount per view.

## Not in this PR (phase 2, needs backend)

- Recent deployments feed across the org (org-level read over instance actual-history plus an index).
- Last-change column per instance.
- Org-level open-failures read so health / failure counts stop resolving per instance.

## Validation

- New spec 8/8; `validate:graphql` clean on both schemas; no new ESLint errors (AppHome has 22 pre-existing indent errors on untouched lines).
- Hot-swapped onto psclaude and probed with Playwright: landing on `?view=devops` issues only the instance-status and recent-releases queries; switching to Product Security fetches the security widgets; summary tile filters, hover detail, URL sync and the remembered view across a reload all behave; no page errors.

## Second commit: header View dropdown, org default view, Deployed-to on the component page

- The view is now a **View** dropdown in the header next to Organization / Perspective (labels **Security** | **DevOps**), held in the store so every page follows it. Resolution at boot: this browser's last choice, then the org's default view, then Security. The dashboard pill bar is gone.
- **Org Settings > Admin Settings > Default View**: org-wide default for users with no browser choice. Pro org setting, fetched and saved through their own small documents so a backend without the field only loses that one feature.
- **Component / product page in the DevOps view** replaces the two charts with a **Deployed to** table (instance, namespace, environment, branch or feature set, version or Not Matched), backed by the new `deployedTo` query; a backend without the query shows a note instead.

Backend half (org `Settings.defaultView`, `deployedTo` query): separate PR on the backend repo. No SQL migration involved. The org default is read through the `organizations` list (the single-organization query in the schema has no resolver). `deployedTo` is gated on component read plus org-level DEVOPS_READ.

Validated on psclaude with the backend branch deployed via feature set: header dropdown switches views on the dashboard and component page; the Deployed-to table lists a product's plans (feature set, Not Matched) and a component's deployed releases (branch, version) and is absent in the Security view; saving the org default to DevOps makes a fresh browser with no stored choice land on DevOps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
