### PR TITLE
FDA 7e UI (1/4): server-side attestation filter and keyset paging

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -917,10 +917,10 @@
                                 v-if="sbomViewMode === 'list'"
                                 v-model:value="sbomSearchQueryInput"
                                 @update:value="onSbomSearchInput"
-                                @clear="onSbomSearchInput"
                                 placeholder="Search by canonical purl"
                                 clearable
                                 size="small"
+                                :disabled="sbomDegraded"
                                 style="width: 320px;"
                             />
                             <n-select
@@ -929,6 +929,7 @@
                                 @update:value="onSbomFilterChange"
                                 size="small"
                                 style="width: 260px;"
+                                :disabled="sbomDegraded"
                                 :options="sbomAttestationFilterOptions"
                             />
                             <n-radio-group v-model:value="sbomViewMode" size="small" @update:value="handleSbomViewModeChange">
@@ -964,14 +965,20 @@
                             <n-spin size="medium" />
                             <p>Loading SBOM components...</p>
                         </div>
-                        <div v-else-if="sbomComponentsLoaded && sbomComponents.length === 0">
+                        <!-- Scoped to the LIST view. A filtered-empty result used to sit
+                             ahead of the tree branch in this chain and swallow it, and the
+                             search and filter controls are list-only, so the operator was
+                             left staring at "no components match" with nothing on screen
+                             able to clear the filter. -->
+                        <div v-else-if="sbomComponentsLoaded && sbomComponents.length === 0
+                            && sbomViewMode === 'list'">
                             <!-- "the filter matched nothing" and "the release has no
                                  components" are different facts, and the second one is a
                                  claim about the SBOM. Saying it while a filter is active
                                  would report an empty inventory for a release that has one. -->
-                            <p v-if="sbomAttestationFilter !== 'ALL' || sbomSearchQueryInput">
+                            <p v-if="sbomFilterIsActive">
                                 No components match this filter.
-                                <template v-if="sbomAttestationFilter === 'UNATTESTED'">
+                                <template v-if="sbomAppliedFilter === 'UNATTESTED'">
                                     Every component in this release has a support disclosure.
                                 </template>
                             </p>
@@ -986,8 +993,12 @@
                             <n-space align="center" style="margin-top: 8px;">
                                 <span style="font-size: 12px; color: #999;">
                                     Showing {{ sbomComponents.length }} of {{ sbomFilteredTotal }}
-                                    <template v-if="sbomAttestationFilter !== 'ALL' || sbomSearchQueryInput">matching</template>
+                                    <template v-if="sbomFilterIsActive">matching</template>
                                     <template v-else>components</template>
+                                    <template v-if="sbomDegraded">
+                                        &mdash; this server cannot filter or page SBOM
+                                        components, so the whole release is shown unfiltered.
+                                    </template>
                                 </span>
                                 <n-button
                                     v-if="sbomHasMore"
@@ -1308,7 +1319,7 @@ import graphqlClient from '../utils/graphql'
 import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
-import { loadSbomComponentsPage, loadSbomComponentsForRelease } from '@/utils/sbomComponentsQuery'
+import { useSbomComponentsPaging } from '@/utils/useSbomComponentsPaging'
 import type { SupportAttestationFilter } from '@/utils/sbomComponentsQuery'
 import { GlobeAdd24Regular, Info24Regular, Edit24Regular } from '@vicons/fluent'
 import { Bell, Check, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh, X } from '@vicons/tabler'
@@ -1591,6 +1602,9 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+    // Cancels the search debounce and fences in-flight responses, so a trailing keystroke
+    // cannot fire a query, or notify an error toast, against a component that is gone.
+    sbomPaging.dispose()
     stopStatusPolling()
 })
 
@@ -2092,8 +2106,11 @@ async function goToRelease (uuid: string) {
     // so without this the next release renders the previous one's components. That was
     // merely stale before; now the device-risk summary would state "N outlived by this
     // device" about a device whose SBOM we are not showing.
-    sbomComponentsLoaded.value = false
-    sbomComponents.value = []
+    // reset() clears items, total, cursor, hasMore and loaded together, and bumps the
+    // request fence so a response for the PREVIOUS release cannot land here. Clearing them
+    // piecemeal is how the tab label kept showing the old release's count over an empty
+    // pane, and how a trailing debounce could re-mark the list loaded with A's rows.
+    sbomPaging.reset()
     sbomGraphLoaded.value = false
     sbomGraphByUuid.value = {}
     sbomGraphDirty.value = true
@@ -2827,9 +2844,7 @@ async function reconcileSbomFromTab () {
 // Release SBOM Components tab — list view query (cheap: no dependencies/dependedOnBy).
 // The detail modal (ReleaseSbomComponentGraph) loads the deeper graph on demand;
 // both queries hit Apollo cache-first so the tree view and the modal share results.
-const sbomComponents: Ref<any[]> = ref([])
-const sbomComponentsLoading: Ref<boolean> = ref(false)
-const sbomComponentsLoaded: Ref<boolean> = ref(false)
+// sbomComponents / loading / loaded now come from useSbomComponentsPaging below.
 const sbomGraphLoading: Ref<boolean> = ref(false)
 const sbomGraphLoaded: Ref<boolean> = ref(false)
 const sbomGraphByUuid: Ref<Record<string, any>> = ref({})
@@ -2843,109 +2858,74 @@ const sbomGraphDirty: Ref<boolean> = ref(false)
 // The search used to be a client-side computed over the whole loaded release, and the
 // support filter did not exist here at all. Both moved to the server, and the search move
 // is a consequence of the filter move rather than an optimisation: ATTESTED/UNATTESTED are
-// evaluated with the SAME predicate the coverage gauge counts with, so a client-side filter
-// over a partially-loaded release could disagree with the gauge sitting above it -- the
-// in-step failure this feature has hit repeatedly. One filter, evaluated once, server-side.
+// evaluated with the SAME predicate the release-scoped coverage gauge counts with, so a
+// client-side filter over a partially-loaded release could disagree with that number. One
+// filter, evaluated once, server-side. (The gauge itself lands in the next step of this
+// series; the constraint is on the filter regardless of what is rendered beside it today.)
 //
 // Note the search semantics changed with the move: the server matches the CANONICAL PURL
 // only, where the old client filter also matched name/version/group/type. The purl contains
 // group, name and version for every ecosystem we ingest, so this is narrower in form rather
 // than in practice; the placeholder says so.
-const sbomSearchQueryInput: Ref<string> = ref('')
-const sbomAttestationFilter: Ref<SupportAttestationFilter> = ref('ALL')
+//
+// The state and the loaders live in useSbomComponentsPaging, not here. Review found three
+// ordering bugs in the inline version -- a load-more landing after a filter change, two
+// searches resolving out of order, and a trailing debounce firing after navigation, which
+// left release B showing release A's components permanently. All three need a request fence,
+// and a fence is only trustworthy if every assignment goes through it, which is not
+// reviewable spread through a 6,000-line component. See useSbomComponentsPaging.spec.ts.
+const sbomPaging = useSbomComponentsPaging({
+    client: graphqlClient as any,
+    releaseUuid: () => updatedRelease.value?.uuid,
+    onError: (msg: string) => notify('error', 'Error', commonFunctions.parseGraphQLError(msg)),
+    // Only a genuine data reload should invalidate the dependency-graph cache. A filter or
+    // search change alters the QUERY, not the rows, and forcing a full graph re-fetch on
+    // every settled keystroke was the previous behaviour.
+    onDataReplaced: () => { if (sbomForceRefreshPending) { invalidateSbomGraph(); sbomForceRefreshPending = false } }
+})
+const sbomComponents = sbomPaging.items
+const sbomComponentsLoading = sbomPaging.loading
+const sbomComponentsLoaded = sbomPaging.loaded
+const sbomFilteredTotal = sbomPaging.totalCount
+const sbomHasMore = sbomPaging.hasMore
+const sbomPageLoading = sbomPaging.loadingMore
+const sbomSearchQueryInput = sbomPaging.searchInput
+const sbomAttestationFilter = sbomPaging.filter
+const sbomAppliedFilter = sbomPaging.appliedFilter
+const sbomAppliedSearch = sbomPaging.appliedSearch
+const sbomDegraded = sbomPaging.degraded
+
+// Labels key off the APPLIED filter, never the control: during the debounce and any
+// in-flight request they differ, and "3 matching" over unfiltered rows is a claim about the
+// data that is not true yet.
+const sbomFilterIsActive: ComputedRef<boolean> = computed(
+    (): boolean => sbomAppliedFilter.value !== 'ALL' || !!sbomAppliedSearch.value)
+
 // Labels say what the filter MEANS for disclosure, not just the enum name: "Not disclosed"
 // is the operator's word for UNATTESTED, and it is the same population the coverage gauge
-// counts as missing.
-const sbomAttestationFilterOptions = [
+// counts as missing. Typed against the union so a typo cannot ship an option the server
+// rejects -- the adjacent SUPPORT_TAG map learned that lesson already.
+const sbomAttestationFilterOptions: Array<{ label: string, value: SupportAttestationFilter }> = [
     { label: 'All components', value: 'ALL' },
     { label: 'Support disclosed', value: 'ATTESTED' },
     { label: 'Not disclosed', value: 'UNATTESTED' }
 ]
-// Components matching the CURRENT FILTER across all pages -- not the release's size, and
-// not the coverage denominator. Under UNATTESTED it falls as rows are attested, by design.
-const sbomFilteredTotal: Ref<number> = ref(0)
-const sbomCursor: Ref<string | null> = ref(null)
-const sbomHasMore: Ref<boolean> = ref(false)
-const sbomPageLoading: Ref<boolean> = ref(false)
-const SBOM_PAGE_SIZE = 50
 
-let sbomSearchDebounce: ReturnType<typeof setTimeout> | null = null
+let sbomForceRefreshPending = false
 
-/** Re-request from the start. Any filter change invalidates the cursor. */
-function reloadSbomComponentsFromStart () {
-    sbomCursor.value = null
-    loadSbomComponents(true)
+function invalidateSbomGraph () {
+    sbomGraphLoaded.value = false
+    sbomGraphByUuid.value = {}
+    sbomGraphDirty.value = true
 }
 
-function onSbomFilterChange () {
-    reloadSbomComponentsFromStart()
-}
-
-function onSbomSearchInput () {
-    // Debounced: every keystroke is a network round trip otherwise, and the server is doing
-    // an ILIKE over the release's component set.
-    if (sbomSearchDebounce) clearTimeout(sbomSearchDebounce)
-    sbomSearchDebounce = setTimeout(() => { reloadSbomComponentsFromStart() }, 300)
-}
+function onSbomFilterChange () { sbomPaging.onFilterChange() }
+function onSbomSearchInput () { sbomPaging.onSearchInput() }
+function loadMoreSbomComponents () { sbomPaging.loadMore() }
 
 async function loadSbomComponents (forceRefresh: boolean = false) {
-    if (!updatedRelease.value?.uuid) return
-    if (sbomComponentsLoaded.value && !forceRefresh) return
-    sbomComponentsLoading.value = true
-    try {
-        const page = await loadSbomComponentsPage(graphqlClient as any, updatedRelease.value.uuid, {
-            attestation: sbomAttestationFilter.value,
-            search: sbomSearchQueryInput.value,
-            limit: SBOM_PAGE_SIZE
-        })
-        sbomComponents.value = page.items
-        sbomFilteredTotal.value = page.totalCount
-        sbomCursor.value = page.endCursor
-        sbomHasMore.value = page.hasMore
-        sbomComponentsLoaded.value = true
-        // Refresh invalidates the deeper graph too -- rows may have changed.
-        if (forceRefresh) {
-            sbomGraphLoaded.value = false
-            sbomGraphByUuid.value = {}
-            sbomGraphDirty.value = true
-        }
-    } catch (err: any) {
-        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
-    } finally {
-        sbomComponentsLoading.value = false
-    }
-}
-
-/**
- * Append the next page.
- *
- * APPEND, not replace, and no page numbers: the cursor is forward-only, so there is no
- * backward cursor to build a numbered pager on. Offering page numbers over a forward-only
- * cursor would mean re-walking from the start on every jump and pretending otherwise.
- *
- * A rejected cursor surfaces as an error rather than restarting from the beginning. That is
- * the server contract and it matters here: a silent restart would append the first page
- * again and again while the operator scrolled, with no sign anything was wrong.
- */
-async function loadMoreSbomComponents () {
-    if (!updatedRelease.value?.uuid || !sbomHasMore.value || sbomPageLoading.value) return
-    sbomPageLoading.value = true
-    try {
-        const page = await loadSbomComponentsPage(graphqlClient as any, updatedRelease.value.uuid, {
-            attestation: sbomAttestationFilter.value,
-            search: sbomSearchQueryInput.value,
-            limit: SBOM_PAGE_SIZE,
-            after: sbomCursor.value
-        })
-        sbomComponents.value = sbomComponents.value.concat(page.items)
-        sbomFilteredTotal.value = page.totalCount
-        sbomCursor.value = page.endCursor
-        sbomHasMore.value = page.hasMore
-    } catch (err: any) {
-        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
-    } finally {
-        sbomPageLoading.value = false
-    }
+    if (forceRefresh) sbomForceRefreshPending = true
+    await sbomPaging.load(forceRefresh)
 }
 
 async function ensureSbomGraphLoaded (forceRefresh: boolean = false) {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -910,16 +910,26 @@
                 </n-tab-pane>
                 <n-tab-pane name="bomComponents" tab="BOM Components">
                     <n-tabs type="line" v-model:value="bomSubTab" @update:value="handleBomSubTabSwitch" animated>
-                        <n-tab-pane name="sbomSub" :tab="`SBOM Components${sbomComponents.length ? ' · ' + sbomComponents.length : ''}`">
+                        <n-tab-pane name="sbomSub" :tab="`SBOM Components${sbomFilteredTotal ? ' \u00b7 ' + sbomFilteredTotal : ''}`">
                     <div class="container">
                         <n-space style="margin-bottom: 8px;" align="center">
                             <n-input
                                 v-if="sbomViewMode === 'list'"
                                 v-model:value="sbomSearchQueryInput"
-                                placeholder="Search SBOM components (name, version, group, type, purl)"
+                                @update:value="onSbomSearchInput"
+                                @clear="onSbomSearchInput"
+                                placeholder="Search by canonical purl"
                                 clearable
                                 size="small"
-                                style="width: 420px;"
+                                style="width: 320px;"
+                            />
+                            <n-select
+                                v-if="sbomViewMode === 'list'"
+                                v-model:value="sbomAttestationFilter"
+                                @update:value="onSbomFilterChange"
+                                size="small"
+                                style="width: 260px;"
+                                :options="sbomAttestationFilterOptions"
                             />
                             <n-radio-group v-model:value="sbomViewMode" size="small" @update:value="handleSbomViewModeChange">
                                 <n-radio-button value="list" label="List" />
@@ -955,15 +965,39 @@
                             <p>Loading SBOM components...</p>
                         </div>
                         <div v-else-if="sbomComponentsLoaded && sbomComponents.length === 0">
-                            <p>No SBOM components recorded for this release.</p>
+                            <!-- "the filter matched nothing" and "the release has no
+                                 components" are different facts, and the second one is a
+                                 claim about the SBOM. Saying it while a filter is active
+                                 would report an empty inventory for a release that has one. -->
+                            <p v-if="sbomAttestationFilter !== 'ALL' || sbomSearchQueryInput">
+                                No components match this filter.
+                                <template v-if="sbomAttestationFilter === 'UNATTESTED'">
+                                    Every component in this release has a support disclosure.
+                                </template>
+                            </p>
+                            <p v-else>No SBOM components recorded for this release.</p>
                         </div>
                         <div v-else-if="sbomComponentsLoaded && sbomViewMode === 'list'">
                             <n-data-table
-                                :data="filteredSbomComponents"
+                                :data="sbomComponents"
                                 :columns="sbomComponentsTableFields"
                                 :row-key="(row: any) => row.uuid"
-                                :pagination="{ pageSize: 15 }"
                             />
+                            <n-space align="center" style="margin-top: 8px;">
+                                <span style="font-size: 12px; color: #999;">
+                                    Showing {{ sbomComponents.length }} of {{ sbomFilteredTotal }}
+                                    <template v-if="sbomAttestationFilter !== 'ALL' || sbomSearchQueryInput">matching</template>
+                                    <template v-else>components</template>
+                                </span>
+                                <n-button
+                                    v-if="sbomHasMore"
+                                    size="small"
+                                    @click="loadMoreSbomComponents"
+                                    :loading="sbomPageLoading"
+                                    :disabled="sbomPageLoading">
+                                    Load more
+                                </n-button>
+                            </n-space>
                         </div>
                         <div v-else-if="sbomComponentsLoaded && sbomViewMode === 'tree'">
                             <div v-if="sbomGraphLoading && !sbomGraphLoaded">
@@ -1274,7 +1308,8 @@ import graphqlClient from '../utils/graphql'
 import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
-import { loadSbomComponentsForRelease } from '@/utils/sbomComponentsQuery'
+import { loadSbomComponentsPage, loadSbomComponentsForRelease } from '@/utils/sbomComponentsQuery'
+import type { SupportAttestationFilter } from '@/utils/sbomComponentsQuery'
 import { GlobeAdd24Regular, Info24Regular, Edit24Regular } from '@vicons/fluent'
 import { Bell, Check, CirclePlus, ClipboardCheck, Copy, Download, Edit, Eye, GitCompare, Link, Tag, Trash, Refresh, X } from '@vicons/tabler'
 import { Icon } from '@vicons/utils'
@@ -2803,29 +2838,72 @@ const sbomGraphByUuid: Ref<Record<string, any>> = ref({})
 // after reconcile changes.
 const sbomGraphDirty: Ref<boolean> = ref(false)
 
-// Client-side filter for the list view. Matches against any of name, version,
-// group, type, or canonical purl (case-insensitive substring).
+// Server-side filter and paging for the list view.
+//
+// The search used to be a client-side computed over the whole loaded release, and the
+// support filter did not exist here at all. Both moved to the server, and the search move
+// is a consequence of the filter move rather than an optimisation: ATTESTED/UNATTESTED are
+// evaluated with the SAME predicate the coverage gauge counts with, so a client-side filter
+// over a partially-loaded release could disagree with the gauge sitting above it -- the
+// in-step failure this feature has hit repeatedly. One filter, evaluated once, server-side.
+//
+// Note the search semantics changed with the move: the server matches the CANONICAL PURL
+// only, where the old client filter also matched name/version/group/type. The purl contains
+// group, name and version for every ecosystem we ingest, so this is narrower in form rather
+// than in practice; the placeholder says so.
 const sbomSearchQueryInput: Ref<string> = ref('')
-const filteredSbomComponents: ComputedRef<any[]> = computed((): any[] => {
-    const q = (sbomSearchQueryInput.value || '').trim().toLowerCase()
-    return sbomComponents.value.filter((row: any) => {
-        const c = row.component || {}
-        if (q) {
-            const haystack = [c.name, c.version, c.group, c.type, c.canonicalPurl].filter(Boolean).join(' ').toLowerCase()
-            if (!haystack.includes(q)) return false
-        }
-        return true
-    })
-})
+const sbomAttestationFilter: Ref<SupportAttestationFilter> = ref('ALL')
+// Labels say what the filter MEANS for disclosure, not just the enum name: "Not disclosed"
+// is the operator's word for UNATTESTED, and it is the same population the coverage gauge
+// counts as missing.
+const sbomAttestationFilterOptions = [
+    { label: 'All components', value: 'ALL' },
+    { label: 'Support disclosed', value: 'ATTESTED' },
+    { label: 'Not disclosed', value: 'UNATTESTED' }
+]
+// Components matching the CURRENT FILTER across all pages -- not the release's size, and
+// not the coverage denominator. Under UNATTESTED it falls as rows are attested, by design.
+const sbomFilteredTotal: Ref<number> = ref(0)
+const sbomCursor: Ref<string | null> = ref(null)
+const sbomHasMore: Ref<boolean> = ref(false)
+const sbomPageLoading: Ref<boolean> = ref(false)
+const SBOM_PAGE_SIZE = 50
+
+let sbomSearchDebounce: ReturnType<typeof setTimeout> | null = null
+
+/** Re-request from the start. Any filter change invalidates the cursor. */
+function reloadSbomComponentsFromStart () {
+    sbomCursor.value = null
+    loadSbomComponents(true)
+}
+
+function onSbomFilterChange () {
+    reloadSbomComponentsFromStart()
+}
+
+function onSbomSearchInput () {
+    // Debounced: every keystroke is a network round trip otherwise, and the server is doing
+    // an ILIKE over the release's component set.
+    if (sbomSearchDebounce) clearTimeout(sbomSearchDebounce)
+    sbomSearchDebounce = setTimeout(() => { reloadSbomComponentsFromStart() }, 300)
+}
 
 async function loadSbomComponents (forceRefresh: boolean = false) {
     if (!updatedRelease.value?.uuid) return
     if (sbomComponentsLoaded.value && !forceRefresh) return
     sbomComponentsLoading.value = true
     try {
-        sbomComponents.value = await loadSbomComponentsForRelease(graphqlClient as any, updatedRelease.value.uuid)
+        const page = await loadSbomComponentsPage(graphqlClient as any, updatedRelease.value.uuid, {
+            attestation: sbomAttestationFilter.value,
+            search: sbomSearchQueryInput.value,
+            limit: SBOM_PAGE_SIZE
+        })
+        sbomComponents.value = page.items
+        sbomFilteredTotal.value = page.totalCount
+        sbomCursor.value = page.endCursor
+        sbomHasMore.value = page.hasMore
         sbomComponentsLoaded.value = true
-        // Refresh invalidates the deeper graph too — rows may have changed.
+        // Refresh invalidates the deeper graph too -- rows may have changed.
         if (forceRefresh) {
             sbomGraphLoaded.value = false
             sbomGraphByUuid.value = {}
@@ -2835,6 +2913,38 @@ async function loadSbomComponents (forceRefresh: boolean = false) {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     } finally {
         sbomComponentsLoading.value = false
+    }
+}
+
+/**
+ * Append the next page.
+ *
+ * APPEND, not replace, and no page numbers: the cursor is forward-only, so there is no
+ * backward cursor to build a numbered pager on. Offering page numbers over a forward-only
+ * cursor would mean re-walking from the start on every jump and pretending otherwise.
+ *
+ * A rejected cursor surfaces as an error rather than restarting from the beginning. That is
+ * the server contract and it matters here: a silent restart would append the first page
+ * again and again while the operator scrolled, with no sign anything was wrong.
+ */
+async function loadMoreSbomComponents () {
+    if (!updatedRelease.value?.uuid || !sbomHasMore.value || sbomPageLoading.value) return
+    sbomPageLoading.value = true
+    try {
+        const page = await loadSbomComponentsPage(graphqlClient as any, updatedRelease.value.uuid, {
+            attestation: sbomAttestationFilter.value,
+            search: sbomSearchQueryInput.value,
+            limit: SBOM_PAGE_SIZE,
+            after: sbomCursor.value
+        })
+        sbomComponents.value = sbomComponents.value.concat(page.items)
+        sbomFilteredTotal.value = page.totalCount
+        sbomCursor.value = page.endCursor
+        sbomHasMore.value = page.hasMore
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        sbomPageLoading.value = false
     }
 }
 

--- a/ui/src/utils/sbomComponentsQuery.spec.ts
+++ b/ui/src/utils/sbomComponentsQuery.spec.ts
@@ -47,7 +47,8 @@ describe('loadSbomComponentsPage', () => {
             items: [{ uuid: 'a' }], totalCount: 312, endCursor: 'c-1', hasMore: true
         })
         expect(await loadSbomComponentsPage(client, 'rel-1')).toEqual({
-            items: [{ uuid: 'a' }], totalCount: 312, endCursor: 'c-1', hasMore: true
+            items: [{ uuid: 'a' }], totalCount: 312, endCursor: 'c-1', hasMore: true,
+            degraded: false
         })
     })
 
@@ -63,8 +64,31 @@ describe('loadSbomComponentsPage', () => {
     it('degrades to an empty page when the field is absent', async () => {
         const query = vi.fn().mockResolvedValue({ data: {} })
         expect(await loadSbomComponentsPage({ query } as any, 'rel-1')).toEqual({
-            items: [], totalCount: 0, endCursor: null, hasMore: false
+            items: [], totalCount: 0, endCursor: null, hasMore: false, degraded: false
         })
+    })
+
+    // The CE mirror lacks the paged query until the schema sync lands, and this UI ships in
+    // the CE repo. Without the fallback the SBOM tab renders a toolbar over nothing there.
+    it('falls back to the unpaged query when the server does not know the paged one', async () => {
+        const query = vi.fn()
+            .mockRejectedValueOnce(new Error('Cannot query field "getReleaseSbomComponentsPage" on type "Query"'))
+            .mockResolvedValueOnce({ data: { getReleaseSbomComponents: [{ uuid: 'a' }, { uuid: 'b' }] } })
+        const res = await loadSbomComponentsPage({ query } as any, 'rel-1', { attestation: 'UNATTESTED' })
+        expect(res.degraded).toBe(true)
+        expect(res.items.length).toBe(2)
+        // The fallback returned everything: there is no next page to walk to.
+        expect(res.hasMore).toBe(false)
+        expect(res.endCursor).toBeNull()
+    })
+
+    // A rejected cursor is NOT schema drift. Retrying it as a full unfiltered reload would
+    // turn a broken walk into a silently different result set.
+    it('does not treat a rejected cursor as drift', async () => {
+        const query = vi.fn().mockRejectedValue(new Error('unknown pagination cursor: abc'))
+        await expect(loadSbomComponentsPage({ query } as any, 'rel-1', { after: 'abc' }))
+            .rejects.toThrow('unknown pagination cursor')
+        expect(query).toHaveBeenCalledOnce()
     })
 
     // A rejected cursor is a server error and must reach the caller. Swallowing it and

--- a/ui/src/utils/sbomComponentsQuery.spec.ts
+++ b/ui/src/utils/sbomComponentsQuery.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadSbomComponentsPage } from './sbomComponentsQuery'
+
+function clientReturning (page: any) {
+    const query = vi.fn().mockResolvedValue({ data: { getReleaseSbomComponentsPage: page } })
+    return { client: { query } as any, query }
+}
+
+describe('loadSbomComponentsPage', () => {
+    it('defaults to the whole release, unsearched, one page', async () => {
+        const { client, query } = clientReturning({ items: [], totalCount: 0, endCursor: null, hasMore: false })
+        await loadSbomComponentsPage(client, 'rel-1')
+        expect(query.mock.calls[0][0].variables).toEqual({
+            releaseUuid: 'rel-1', attestation: 'ALL', search: null, limit: 50, after: null
+        })
+    })
+
+    // Never cache this. The bulk-attest walk re-reads the SAME filter after writing to it,
+    // and a cached page would hand back rows that have just been attested -- re-attesting
+    // them, or reporting them as still missing.
+    it('always hits the network', async () => {
+        const { client, query } = clientReturning({ items: [], totalCount: 0, endCursor: null, hasMore: false })
+        await loadSbomComponentsPage(client, 'rel-1')
+        expect(query.mock.calls[0][0].fetchPolicy).toBe('network-only')
+    })
+
+    it('passes the filter, the trimmed search and the cursor through', async () => {
+        const { client, query } = clientReturning({ items: [], totalCount: 0, endCursor: null, hasMore: false })
+        await loadSbomComponentsPage(client, 'rel-1', {
+            attestation: 'UNATTESTED', search: '  log4j  ', limit: 10, after: 'cursor-9'
+        })
+        expect(query.mock.calls[0][0].variables).toEqual({
+            releaseUuid: 'rel-1', attestation: 'UNATTESTED', search: 'log4j', limit: 10, after: 'cursor-9'
+        })
+    })
+
+    // An empty or whitespace search is NO search, not a search for "". The server would
+    // match every row either way, but sending it makes an unfiltered request look filtered.
+    it.each(['', '   '])('sends null rather than a blank search (%s)', async (search) => {
+        const { client, query } = clientReturning({ items: [], totalCount: 0, endCursor: null, hasMore: false })
+        await loadSbomComponentsPage(client, 'rel-1', { search })
+        expect(query.mock.calls[0][0].variables.search).toBeNull()
+    })
+
+    it('surfaces the page fields', async () => {
+        const { client } = clientReturning({
+            items: [{ uuid: 'a' }], totalCount: 312, endCursor: 'c-1', hasMore: true
+        })
+        expect(await loadSbomComponentsPage(client, 'rel-1')).toEqual({
+            items: [{ uuid: 'a' }], totalCount: 312, endCursor: 'c-1', hasMore: true
+        })
+    })
+
+    // hasMore is the server's over-fetch answer. Deriving it from totalCount would be wrong
+    // under UNATTESTED, where the population shrinks as the caller attests.
+    it('does not infer hasMore from totalCount', async () => {
+        const { client } = clientReturning({
+            items: [{ uuid: 'a' }], totalCount: 999, endCursor: 'c-1', hasMore: false
+        })
+        expect((await loadSbomComponentsPage(client, 'rel-1')).hasMore).toBe(false)
+    })
+
+    it('degrades to an empty page when the field is absent', async () => {
+        const query = vi.fn().mockResolvedValue({ data: {} })
+        expect(await loadSbomComponentsPage({ query } as any, 'rel-1')).toEqual({
+            items: [], totalCount: 0, endCursor: null, hasMore: false
+        })
+    })
+
+    // A rejected cursor is a server error and must reach the caller. Swallowing it and
+    // returning an empty page would make a cursor walk look finished when it had failed.
+    it('propagates a rejected cursor rather than returning an empty page', async () => {
+        const query = vi.fn().mockRejectedValue(new Error('unknown pagination cursor: abc'))
+        await expect(loadSbomComponentsPage({ query } as any, 'rel-1', { after: 'abc' }))
+            .rejects.toThrow('unknown pagination cursor')
+    })
+})

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -1,20 +1,30 @@
 // Release SBOM-components query.
 
 import gql from 'graphql-tag'
+import { isSchemaDriftError, loadWithSchemaDriftFallback } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
 
 /**
  * Which slice of a release's non-root components to load.
  *
  * Mirrors the backend SupportAttestationFilter enum. ATTESTED and UNATTESTED are evaluated
- * server-side with the SAME predicate the coverage gauge counts with, which is the point:
- * the gauge says how many components are undisclosed and this filter is how the operator
- * selects exactly those. A client-side filter over a loaded page could not agree with a
- * gauge computed over the whole release.
+ * server-side with the SAME predicate the release-scoped coverage gauge counts with, which
+ * is the point: the gauge says how many components are undisclosed and this filter is how
+ * the operator selects exactly those. A client-side filter over a loaded page could not
+ * agree with a gauge computed over the whole release.
  */
 export type SupportAttestationFilter = 'ALL' | 'ATTESTED' | 'UNATTESTED'
 
-export const SBOM_COMPONENT_FIELDS = `
+/**
+ * Everything the CE mirror schema can serve today.
+ *
+ * The CORE/FULL split is back, for exactly the reason it existed before #311 removed it as
+ * "no longer needed": deviceSupportRisk is Pro-only until the CE schema sync lands, and this
+ * component ships IN the CE repo. Verified rather than assumed -- supportStatus,
+ * supportSource and endOfSupportDate DO exist on CE's SbomComponent; deviceSupportRisk is
+ * the single field that does not.
+ */
+export const SBOM_COMPONENT_CORE_FIELDS = `
             uuid
             sbomComponentUuid
             component {
@@ -28,12 +38,20 @@ export const SBOM_COMPONENT_FIELDS = `
                 supportStatus
                 supportSource
                 endOfSupportDate
-                deviceSupportRisk
             }
             artifactParticipations {
                 artifact
                 exactPurls
             }`
+
+/**
+ * CORE plus the Pro-only device verdict. A caller served CORE must treat an absent
+ * deviceSupportRisk as "not checked", never as "not at risk" -- isDeviceRiskFlagged already
+ * does, since undefined is not a flagged value.
+ */
+export const SBOM_COMPONENT_FIELDS = SBOM_COMPONENT_CORE_FIELDS.replace(
+    '                endOfSupportDate\n',
+    '                endOfSupportDate\n                deviceSupportRisk\n')
 
 /**
  * Paged, filtered load. Deliberately NOT selecting dependencies / dependedOnBy / ancestors:
@@ -65,10 +83,17 @@ export const SBOM_COMPONENTS_PAGE_QUERY = gql`
         }
     }`
 
-/** The unpaged query, still used where the whole release is genuinely needed. */
+/** The unpaged query, and the first fallback target when the paged one is unknown. */
 export const SBOM_COMPONENTS_QUERY = gql`
     query getReleaseSbomComponentsList($releaseUuid: ID!) {
         getReleaseSbomComponents(releaseUuid: $releaseUuid) {${SBOM_COMPONENT_FIELDS}
+        }
+    }`
+
+/** The last fallback: no Pro-only fields, so a CE backend can serve it. */
+export const SBOM_COMPONENTS_QUERY_CORE = gql`
+    query getReleaseSbomComponentsListCore($releaseUuid: ID!) {
+        getReleaseSbomComponents(releaseUuid: $releaseUuid) {${SBOM_COMPONENT_CORE_FIELDS}
         }
     }`
 
@@ -82,6 +107,18 @@ export interface SbomComponentsPage {
     totalCount: number
     endCursor: string | null
     hasMore: boolean
+    /**
+     * True when the server did not understand the paged query and the whole release was
+     * loaded instead. The CE mirror schema lags Pro -- getReleaseSbomComponentsPage and
+     * SupportAttestationFilter do not exist there until the schema sync lands -- and this
+     * component ships IN the CE repo, so without the fallback a CE install would render the
+     * SBOM Components tab as a toolbar over nothing.
+     *
+     * Callers must treat a degraded page as UNFILTERED: the server applied no attestation
+     * filter and no search, so presenting it under a filter label would be a lie about which
+     * components these are.
+     */
+    degraded: boolean
 }
 
 /**
@@ -108,26 +145,53 @@ export async function loadSbomComponentsPage (
         after?: string | null
     } = {}
 ): Promise<SbomComponentsPage> {
-    const resp = await client.query({
-        query: SBOM_COMPONENTS_PAGE_QUERY,
-        variables: {
-            releaseUuid,
-            attestation: opts.attestation || 'ALL',
-            // Empty string is not a search. Sending one would ask the server to match a
-            // literal empty substring, which is every row -- harmless but it makes the
-            // request look like a filtered one in logs and in the cache key.
-            search: opts.search && opts.search.trim() ? opts.search.trim() : null,
-            limit: opts.limit || 50,
-            after: opts.after || null
-        },
-        fetchPolicy: 'network-only'
-    })
-    const page = (resp.data as any)?.getReleaseSbomComponentsPage
-    return {
-        items: page?.items || [],
-        totalCount: page?.totalCount || 0,
-        endCursor: page?.endCursor || null,
-        hasMore: !!page?.hasMore
+    try {
+        const resp = await client.query({
+            query: SBOM_COMPONENTS_PAGE_QUERY,
+            variables: {
+                releaseUuid,
+                attestation: opts.attestation || 'ALL',
+                // Empty string is not a search. Sending one would ask the server to match a
+                // literal empty substring, which is every row -- harmless but it makes the
+                // request look like a filtered one in logs and in the cache key.
+                search: opts.search && opts.search.trim() ? opts.search.trim() : null,
+                limit: opts.limit || 50,
+                after: opts.after || null
+            },
+            fetchPolicy: 'network-only'
+        })
+        const page = (resp.data as any)?.getReleaseSbomComponentsPage
+        return {
+            items: page?.items || [],
+            totalCount: page?.totalCount || 0,
+            endCursor: page?.endCursor || null,
+            hasMore: !!page?.hasMore,
+            degraded: false
+        }
+    } catch (err: any) {
+        // Only a schema-drift-shaped failure warrants the narrower retry. Transport, auth
+        // and server errors surface unchanged -- including a rejected cursor, which must
+        // reach the caller rather than silently becoming a full unfiltered reload.
+        if (!isSchemaDriftError(err)) throw err
+        // Two lag windows, so two steps, via the house helper: a Pro backend predating the
+        // paged query still has deviceSupportRisk and should keep it; a CE backend has
+        // neither and drops to CORE. Falling straight to CORE would throw away the device
+        // verdict on the first of those for no reason.
+        const res = await loadWithSchemaDriftFallback(client, {
+            fullQuery: SBOM_COMPONENTS_QUERY,
+            coreQuery: SBOM_COMPONENTS_QUERY_CORE,
+            variables: { releaseUuid },
+            extractPath: (d: any) => d?.getReleaseSbomComponents || []
+        })
+        const all = res.data as any[]
+        return {
+            items: all,
+            totalCount: all.length,
+            endCursor: null,
+            // No cursor and nothing further to fetch: the fallback returned everything.
+            hasMore: false,
+            degraded: true
+        }
     }
 }
 

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -24,10 +24,8 @@ export type SupportAttestationFilter = 'ALL' | 'ATTESTED' | 'UNATTESTED'
  * supportSource and endOfSupportDate DO exist on CE's SbomComponent; deviceSupportRisk is
  * the single field that does not.
  */
-export const SBOM_COMPONENT_CORE_FIELDS = `
-            uuid
-            sbomComponentUuid
-            component {
+/** The component sub-selection CE can serve. */
+const COMPONENT_CORE_SELECTION = `
                 uuid
                 canonicalPurl
                 type
@@ -37,21 +35,36 @@ export const SBOM_COMPONENT_CORE_FIELDS = `
                 isRoot
                 supportStatus
                 supportSource
-                endOfSupportDate
+                endOfSupportDate`
+
+/**
+ * CORE plus the Pro-only device verdict, by APPENDING rather than by text-substituting into
+ * CORE. An earlier revision derived FULL with a .replace() keyed on an exact indentation
+ * match, which is a silent failure waiting to happen: reformat the selection and the replace
+ * no-ops, FULL becomes identical to CORE, deviceSupportRisk vanishes from every query, and
+ * nothing fails -- the field simply stops being requested and the device-risk column goes
+ * quietly blank. Appending cannot fail that way. The spec also asserts FULL !== CORE.
+ *
+ * A caller served CORE must treat an absent deviceSupportRisk as "not checked", never as
+ * "not at risk" -- isDeviceRiskFlagged already does, since undefined is not a flagged value.
+ */
+const COMPONENT_FULL_SELECTION = COMPONENT_CORE_SELECTION + `
+                deviceSupportRisk`
+
+function releaseComponentFields (componentSelection: string): string {
+    return `
+            uuid
+            sbomComponentUuid
+            component {${componentSelection}
             }
             artifactParticipations {
                 artifact
                 exactPurls
             }`
+}
 
-/**
- * CORE plus the Pro-only device verdict. A caller served CORE must treat an absent
- * deviceSupportRisk as "not checked", never as "not at risk" -- isDeviceRiskFlagged already
- * does, since undefined is not a flagged value.
- */
-export const SBOM_COMPONENT_FIELDS = SBOM_COMPONENT_CORE_FIELDS.replace(
-    '                endOfSupportDate\n',
-    '                endOfSupportDate\n                deviceSupportRisk\n')
+export const SBOM_COMPONENT_CORE_FIELDS = releaseComponentFields(COMPONENT_CORE_SELECTION)
+export const SBOM_COMPONENT_FIELDS = releaseComponentFields(COMPONENT_FULL_SELECTION)
 
 /**
  * Paged, filtered load. Deliberately NOT selecting dependencies / dependedOnBy / ancestors:

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -3,9 +3,18 @@
 import gql from 'graphql-tag'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
 
-export const SBOM_COMPONENTS_QUERY = gql`
-    query getReleaseSbomComponentsList($releaseUuid: ID!) {
-        getReleaseSbomComponents(releaseUuid: $releaseUuid) {
+/**
+ * Which slice of a release's non-root components to load.
+ *
+ * Mirrors the backend SupportAttestationFilter enum. ATTESTED and UNATTESTED are evaluated
+ * server-side with the SAME predicate the coverage gauge counts with, which is the point:
+ * the gauge says how many components are undisclosed and this filter is how the operator
+ * selects exactly those. A client-side filter over a loaded page could not agree with a
+ * gauge computed over the whole release.
+ */
+export type SupportAttestationFilter = 'ALL' | 'ATTESTED' | 'UNATTESTED'
+
+export const SBOM_COMPONENT_FIELDS = `
             uuid
             sbomComponentUuid
             component {
@@ -24,12 +33,106 @@ export const SBOM_COMPONENTS_QUERY = gql`
             artifactParticipations {
                 artifact
                 exactPurls
+            }`
+
+/**
+ * Paged, filtered load. Deliberately NOT selecting dependencies / dependedOnBy / ancestors:
+ * on the paged query the server hydrates only the page, so those three report edges WITHIN
+ * the page rather than within the release -- wrong data presented as complete. The graph
+ * view uses the unpaged query for that.
+ */
+export const SBOM_COMPONENTS_PAGE_QUERY = gql`
+    query getReleaseSbomComponentsPage(
+        $releaseUuid: ID!
+        $attestation: SupportAttestationFilter
+        $search: String
+        $limit: Int
+        $after: ID
+    ) {
+        getReleaseSbomComponentsPage(
+            releaseUuid: $releaseUuid
+            attestation: $attestation
+            search: $search
+            limit: $limit
+            after: $after
+        ) {
+            items {${SBOM_COMPONENT_FIELDS}
             }
+            totalCount
+            limit
+            endCursor
+            hasMore
         }
     }`
 
+/** The unpaged query, still used where the whole release is genuinely needed. */
+export const SBOM_COMPONENTS_QUERY = gql`
+    query getReleaseSbomComponentsList($releaseUuid: ID!) {
+        getReleaseSbomComponents(releaseUuid: $releaseUuid) {${SBOM_COMPONENT_FIELDS}
+        }
+    }`
+
+export interface SbomComponentsPage {
+    items: any[]
+    /**
+     * Components matching the filter across all pages. Under UNATTESTED this is a moving
+     * target BY DESIGN -- it is the size of the remaining work, so it falls as rows are
+     * attested. Never derive "is there another page" from it; use hasMore.
+     */
+    totalCount: number
+    endCursor: string | null
+    hasMore: boolean
+}
+
 /**
- * Load a release's SBOM components. Always hits the network -- callers
+ * Load one page of a release's components.
+ *
+ * KEYSET, not offset: `after` is the uuid of the last item seen. UNATTESTED is a predicate
+ * over mutable state, so attesting a page removes those rows -- an offset would index into a
+ * set that had shifted underneath it and silently skip exactly as many components as were
+ * just written. Pass `endCursor` from the previous page; omit for the first.
+ *
+ * An unrecognised cursor is an error from the server, never a silent restart. Callers
+ * walking the cursor should surface that rather than looping from the beginning.
+ *
+ * Always hits the network -- callers (e.g. the post-reconcile refresh, and any walk that
+ * writes as it goes) rely on this never serving a stale Apollo-cached response.
+ */
+export async function loadSbomComponentsPage (
+    client: DriftFallbackClient,
+    releaseUuid: string,
+    opts: {
+        attestation?: SupportAttestationFilter,
+        search?: string,
+        limit?: number,
+        after?: string | null
+    } = {}
+): Promise<SbomComponentsPage> {
+    const resp = await client.query({
+        query: SBOM_COMPONENTS_PAGE_QUERY,
+        variables: {
+            releaseUuid,
+            attestation: opts.attestation || 'ALL',
+            // Empty string is not a search. Sending one would ask the server to match a
+            // literal empty substring, which is every row -- harmless but it makes the
+            // request look like a filtered one in logs and in the cache key.
+            search: opts.search && opts.search.trim() ? opts.search.trim() : null,
+            limit: opts.limit || 50,
+            after: opts.after || null
+        },
+        fetchPolicy: 'network-only'
+    })
+    const page = (resp.data as any)?.getReleaseSbomComponentsPage
+    return {
+        items: page?.items || [],
+        totalCount: page?.totalCount || 0,
+        endCursor: page?.endCursor || null,
+        hasMore: !!page?.hasMore
+    }
+}
+
+/**
+ * Load a release's SBOM components, unpaged. Always hits the network -- callers
  * (e.g. the post-reconcile refresh) rely on this never serving a stale
  * Apollo-cached response.
  */

--- a/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
+import { SBOM_COMPONENTS_PAGE_QUERY, SBOM_COMPONENTS_QUERY, SBOM_COMPONENTS_QUERY_CORE } from './sbomComponentsQuery'
+
+/**
+ * These documents interpolate a shared selection set (`${SBOM_COMPONENT_FIELDS}`), and
+ * scripts/validate-graphql.mjs deliberately SKIPS any gql body containing `${`. That is the
+ * house split -- static documents are covered by the script, dynamic ones by a spec like
+ * this -- but it means the script stopped covering BOTH SBOM documents the moment the
+ * shared fields were extracted, including the unpaged one it had been checking. Nothing
+ * announced that. This file is the replacement coverage.
+ *
+ * Same skip/fail convention as the sibling drift specs: the CE mirror ships in this repo so
+ * its checks are unconditional; the Pro schema lives in a sibling checkout that CE-only CI
+ * does not have, so those are skipped rather than failed when absent.
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+const errorsAgainst = (schema: GraphQLSchema, doc: any) =>
+    validate(schema, parse(doc.loc.source.body)).map(e => e.message)
+
+describe('SBOM component documents parse at all', () => {
+    // The interpolation is textual. A missing brace or a stray field would previously have
+    // been caught by validate-graphql.mjs; now it is caught here.
+    it.each([
+        ['paged', SBOM_COMPONENTS_PAGE_QUERY],
+        ['unpaged full', SBOM_COMPONENTS_QUERY],
+        ['unpaged core', SBOM_COMPONENTS_QUERY_CORE]
+    ])('%s document is syntactically valid after interpolation', (_name, doc) => {
+        expect(() => parse((doc as any).loc.source.body)).not.toThrow()
+    })
+})
+
+describe('against the Pro schema (skipped when the sibling checkout is absent)', () => {
+    it.runIf(proSchema)('the paged query is valid on Pro', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, SBOM_COMPONENTS_PAGE_QUERY)).toEqual([])
+    })
+
+    it.runIf(proSchema)('the unpaged full query is valid on Pro', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, SBOM_COMPONENTS_QUERY)).toEqual([])
+    })
+
+    it.runIf(proSchema)('the core query is valid on Pro too, so the last fallback always lands', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, SBOM_COMPONENTS_QUERY_CORE)).toEqual([])
+    })
+})
+
+describe('against the CE mirror schema (always runs)', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    /**
+     * The unpaged query is the CE FALLBACK TARGET. If it ever stops validating on CE, the
+     * fallback in loadSbomComponentsPage has nowhere to land and a CE install renders the
+     * SBOM Components tab as a toolbar over nothing. This is the load-bearing assertion in
+     * the file.
+     */
+    it('the CORE fallback query is valid on CE', () => {
+        expect(errorsAgainst(ceSchema as GraphQLSchema, SBOM_COMPONENTS_QUERY_CORE)).toEqual([])
+    })
+
+    /**
+     * The FULL unpaged query is Pro-only, and only by deviceSupportRisk. This is the
+     * assertion that would have caught the real bug in the first cut of this change: the
+     * drift fallback pointed at the full query, which a CE backend cannot serve either, so
+     * the "fallback" would have failed exactly where it was needed. Naming the single
+     * offending field keeps the CORE/FULL split honest -- if the list grows, the split has
+     * to be re-examined rather than silently widened.
+     */
+    it('the full query is CE-invalid on deviceSupportRisk alone', () => {
+        const errs = errorsAgainst(ceSchema as GraphQLSchema, SBOM_COMPONENTS_QUERY)
+        expect(errs).toEqual(['Cannot query field "deviceSupportRisk" on type "SbomComponent".'])
+    })
+
+    /**
+     * The paged query is Pro-only until the CE schema sync lands, and that is EXPECTED, not
+     * a failure -- syncing early is the one-way door on this track. Asserted rather than
+     * ignored so the day it becomes valid is visible: when this flips, the runtime fallback
+     * is dead code and should go with it.
+     */
+    it('the paged query is Pro-only for now, which is why the fallback exists', () => {
+        const errs = errorsAgainst(ceSchema as GraphQLSchema, SBOM_COMPONENTS_PAGE_QUERY)
+        expect(errs.length,
+            'the paged query now validates on CE -- the schema sync has landed, so remove the'
+            + ' drift fallback in loadSbomComponentsPage and delete this test').toBeGreaterThan(0)
+        expect(errs.join(' ')).toContain('getReleaseSbomComponentsPage')
+    })
+})

--- a/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentsSchemaDrift.spec.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
-import { SBOM_COMPONENTS_PAGE_QUERY, SBOM_COMPONENTS_QUERY, SBOM_COMPONENTS_QUERY_CORE } from './sbomComponentsQuery'
+import {
+    SBOM_COMPONENTS_PAGE_QUERY,
+    SBOM_COMPONENTS_QUERY,
+    SBOM_COMPONENTS_QUERY_CORE,
+    SBOM_COMPONENT_CORE_FIELDS,
+    SBOM_COMPONENT_FIELDS
+} from './sbomComponentsQuery'
 
 /**
  * These documents interpolate a shared selection set (`${SBOM_COMPONENT_FIELDS}`), and
@@ -29,6 +35,22 @@ const proSchema = loadSchema(PRO_SCHEMA_PATH)
 
 const errorsAgainst = (schema: GraphQLSchema, doc: any) =>
     validate(schema, parse(doc.loc.source.body)).map(e => e.message)
+
+describe('the CORE/FULL split is a real split', () => {
+    /**
+     * If FULL ever collapses into CORE, deviceSupportRisk stops being requested by EVERY
+     * query and the device-risk column goes quietly blank -- no error, no failing document,
+     * just a disclosure that silently stops being made. FULL is built by appending so this
+     * cannot happen by reformatting, and asserted here so it cannot happen by editing.
+     */
+    it('FULL is not CORE, and differs by exactly deviceSupportRisk', () => {
+        expect(SBOM_COMPONENT_FIELDS).not.toBe(SBOM_COMPONENT_CORE_FIELDS)
+        expect(SBOM_COMPONENT_FIELDS).toContain('deviceSupportRisk')
+        expect(SBOM_COMPONENT_CORE_FIELDS).not.toContain('deviceSupportRisk')
+        expect(SBOM_COMPONENT_FIELDS.replace(/\s*deviceSupportRisk\n/, '\n'))
+            .toBe(SBOM_COMPONENT_CORE_FIELDS)
+    })
+})
 
 describe('SBOM component documents parse at all', () => {
     // The interpolation is textual. A missing brace or a stray field would previously have

--- a/ui/src/utils/useSbomComponentsPaging.spec.ts
+++ b/ui/src/utils/useSbomComponentsPaging.spec.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { useSbomComponentsPaging } from './useSbomComponentsPaging'
+
+/** A client whose responses are resolved by the test, so ordering is explicit. */
+function deferredClient () {
+    const pending: Array<{ vars: any, resolve: (v: any) => void, reject: (e: any) => void }> = []
+    const query = vi.fn((opts: any) => new Promise((resolve, reject) => {
+        pending.push({ vars: opts.variables, resolve, reject })
+    }))
+    return { client: { query } as any, pending, query }
+}
+
+function page (items: any[], totalCount: number, endCursor: string | null, hasMore: boolean) {
+    return { data: { getReleaseSbomComponentsPage: { items, totalCount, endCursor, hasMore } } }
+}
+const row = (id: string) => ({ uuid: id, sbomComponentUuid: id })
+
+describe('useSbomComponentsPaging request fencing', () => {
+    // THE bug this composable exists for. A load-more issued under ALL must not append its
+    // rows to a list that has since been replaced by an UNATTESTED load -- and must not
+    // overwrite the cursor, which would make the next page resume from a position in the
+    // other ordering: rows skipped, rows repeated, under a filter label describing neither.
+    it('discards a load-more that lands after the filter changed', async () => {
+        const { client, pending } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+
+        p.load()
+        pending[0].resolve(page([row('a1'), row('a2')], 99, 'ca2', true))
+        await Promise.resolve(); await Promise.resolve()
+        expect(p.items.value.map((r: any) => r.uuid)).toEqual(['a1', 'a2'])
+
+        const more = p.loadMore()            // issued under ALL
+        p.filter.value = 'UNATTESTED'
+        p.onFilterChange()                   // replaces the list
+        pending[2].resolve(page([row('u1')], 5, 'cu1', false))
+        await Promise.resolve(); await Promise.resolve()
+        pending[1].resolve(page([row('a3')], 99, 'ca3', true))   // the stale one, last
+        await more
+        await Promise.resolve()
+
+        expect(p.items.value.map((r: any) => r.uuid)).toEqual(['u1'])
+        expect(p.totalCount.value).toBe(5)
+        expect(p.hasMore.value).toBe(false)
+        expect(p.appliedFilter.value).toBe('UNATTESTED')
+    })
+
+    it('keeps the last-ISSUED search when two resolve out of order', async () => {
+        const { client, pending } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn(), debounceMs: 0 })
+        vi.useFakeTimers()
+
+        p.searchInput.value = 'log4j'
+        p.onSearchInput(); vi.advanceTimersByTime(1)
+        p.searchInput.value = 'jackson'
+        p.onSearchInput(); vi.advanceTimersByTime(1)
+        vi.useRealTimers()
+
+        // The FIRST request resolves last.
+        pending[1].resolve(page([row('jackson-1')], 1, null, false))
+        await Promise.resolve(); await Promise.resolve()
+        pending[0].resolve(page([row('log4j-1')], 1, null, false))
+        await Promise.resolve(); await Promise.resolve()
+
+        expect(p.items.value.map((r: any) => r.uuid)).toEqual(['jackson-1'])
+        expect(p.appliedSearch.value).toBe('jackson')
+    })
+
+    // Release B showing release A's components, persistently, because the stale load set
+    // loaded=true and every later load then early-returned.
+    it('discards a response for a release the user has navigated away from', async () => {
+        const { client, pending } = deferredClient()
+        let current = 'rel-A'
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => current, onError: vi.fn() })
+
+        p.load()
+        current = 'rel-B'
+        p.reset()
+        pending[0].resolve(page([row('from-A')], 7, null, false))
+        await Promise.resolve(); await Promise.resolve()
+
+        expect(p.items.value).toEqual([])
+        expect(p.loaded.value).toBe(false)
+        expect(p.totalCount.value).toBe(0)
+    })
+
+    it('reset clears every piece of paging state, not just the rows', async () => {
+        const { client, pending } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+        p.load()
+        pending[0].resolve(page([row('a1')], 312, 'c1', true))
+        await Promise.resolve(); await Promise.resolve()
+        expect(p.totalCount.value).toBe(312)
+
+        p.reset()
+        expect(p.items.value).toEqual([])
+        expect(p.totalCount.value).toBe(0)
+        expect(p.hasMore.value).toBe(false)
+        expect(p.loaded.value).toBe(false)
+        expect(p.degraded.value).toBe(false)
+    })
+})
+
+describe('useSbomComponentsPaging debounce lifecycle', () => {
+    beforeEach(() => { vi.useFakeTimers() })
+    afterEach(() => { vi.useRealTimers() })
+
+    it('never fires a trailing search after dispose', () => {
+        const { client, query } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+        p.searchInput.value = 'log4j'
+        p.onSearchInput()
+        p.dispose()
+        vi.advanceTimersByTime(1000)
+        expect(query).not.toHaveBeenCalled()
+    })
+
+    it('never fires a trailing search after the release changed', () => {
+        const { client, query } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-A', onError: vi.fn() })
+        p.searchInput.value = 'log4j'
+        p.onSearchInput()
+        p.reset()
+        vi.advanceTimersByTime(1000)
+        expect(query).not.toHaveBeenCalled()
+    })
+
+    it('collapses a burst of keystrokes into one request', () => {
+        const { client, query } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+        for (const q of ['l', 'lo', 'log', 'log4', 'log4j']) {
+            p.searchInput.value = q
+            p.onSearchInput()
+            vi.advanceTimersByTime(50)
+        }
+        vi.advanceTimersByTime(300)
+        expect(query).toHaveBeenCalledOnce()
+        expect(query.mock.calls[0][0].variables.search).toBe('log4j')
+    })
+})
+
+describe('useSbomComponentsPaging failure and degraded handling', () => {
+    // Leaving the previous filter's rows on screen under the new filter's label reads as a
+    // successful, differently-filtered result. It is not one.
+    it('clears the list when a filter change fails rather than relabelling old rows', async () => {
+        const { client, pending } = deferredClient()
+        const onError = vi.fn()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError })
+        p.load()
+        pending[0].resolve(page([row('a1'), row('a2')], 2, null, false))
+        await Promise.resolve(); await Promise.resolve()
+
+        p.filter.value = 'UNATTESTED'
+        p.onFilterChange()
+        pending[1].reject(new Error('boom'))
+        await Promise.resolve(); await Promise.resolve(); await Promise.resolve()
+
+        expect(p.items.value).toEqual([])
+        expect(p.failed.value).toBe(true)
+        expect(onError).toHaveBeenCalledOnce()
+    })
+
+    // A CE fallback returns the WHOLE release unfiltered. Reporting the requested filter as
+    // applied would label rows the server never filtered.
+    it('reports a degraded page as unfiltered whatever was asked for', async () => {
+        const query = vi.fn()
+            .mockRejectedValueOnce(new Error('Cannot query field "getReleaseSbomComponentsPage" on type "Query"'))
+            .mockResolvedValueOnce({ data: { getReleaseSbomComponents: [row('x'), row('y')] } })
+        const p = useSbomComponentsPaging({
+            client: { query } as any, releaseUuid: () => 'rel-1', onError: vi.fn()
+        })
+        p.filter.value = 'UNATTESTED'
+        p.searchInput.value = 'log4j'
+        await p.load(true)
+
+        expect(p.degraded.value).toBe(true)
+        expect(p.items.value.length).toBe(2)
+        expect(p.appliedFilter.value).toBe('ALL')
+        expect(p.appliedSearch.value).toBe('')
+        expect(p.hasMore.value).toBe(false)
+    })
+
+    it('does not send after: null when hasMore is true but the cursor is missing', async () => {
+        const { client, pending, query } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+        p.load()
+        pending[0].resolve(page([row('a1')], 9, null, true))
+        await Promise.resolve(); await Promise.resolve()
+        expect(p.hasMore.value).toBe(true)
+
+        await p.loadMore()
+        expect(query).toHaveBeenCalledOnce()
+    })
+
+    it('leaves the cursor intact when load-more fails, so a retry resumes', async () => {
+        const { client, pending } = deferredClient()
+        const p = useSbomComponentsPaging({ client, releaseUuid: () => 'rel-1', onError: vi.fn() })
+        p.load()
+        pending[0].resolve(page([row('a1')], 9, 'c1', true))
+        await Promise.resolve(); await Promise.resolve()
+
+        const more = p.loadMore()
+        pending[1].reject(new Error('network'))
+        await more
+        expect(p.hasMore.value).toBe(true)
+
+        // Not awaited: the deferred client never resolves this one, and the assertion is
+        // about what was REQUESTED, not what came back.
+        p.loadMore()
+        await Promise.resolve()
+        expect(pending[2].vars.after).toBe('c1')
+    })
+})

--- a/ui/src/utils/useSbomComponentsPaging.ts
+++ b/ui/src/utils/useSbomComponentsPaging.ts
@@ -1,0 +1,221 @@
+import { ref, type Ref } from 'vue'
+import { loadSbomComponentsPage } from './sbomComponentsQuery'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import type { SupportAttestationFilter } from './sbomComponentsQuery'
+
+/**
+ * Paging + filtering state for a release's SBOM component list.
+ *
+ * Extracted from ReleaseView.vue rather than left inline for two reasons, both found in
+ * review. First, none of it was testable inside a 6,000-line SFC, and the bugs here are
+ * ordering bugs that only a test can hold down. Second, the fix for those bugs is a request
+ * fence, and a fence is only trustworthy if EVERY assignment goes through it -- which is
+ * much easier to see, and to review, in eighty lines than scattered through a component.
+ *
+ * The fence: every request captures a sequence number and the release it was issued for,
+ * and writes nothing back unless both still match on return. Three real failures need it:
+ *
+ *  - A "Load more" in flight when the filter changes. The late response would otherwise
+ *    concat ALL rows onto an UNATTESTED list and overwrite the cursor, so the next page
+ *    would resume from a position in the other ordering -- skipping rows and re-appending
+ *    others under a filter label that does not describe them.
+ *  - Two debounced searches resolving out of order, leaving the list and cursor from a
+ *    stale query while the input shows the new one.
+ *  - A trailing debounce firing after the user navigated to another release. The old
+ *    release's components would load and mark the list loaded, so every later load
+ *    early-returned and release B kept showing release A's SBOM.
+ */
+export interface SbomComponentsPaging {
+    items: Ref<any[]>
+    totalCount: Ref<number>
+    hasMore: Ref<boolean>
+    loading: Ref<boolean>
+    loadingMore: Ref<boolean>
+    loaded: Ref<boolean>
+    failed: Ref<boolean>
+    degraded: Ref<boolean>
+    filter: Ref<SupportAttestationFilter>
+    searchInput: Ref<string>
+    /**
+     * The filter and search the CURRENTLY DISPLAYED rows were fetched with, as opposed to
+     * what the controls show. They differ during the debounce and during any in-flight
+     * request, and labels must key off these: saying "3 matching" next to unfiltered rows,
+     * or "no components match" while the applied search is still empty, states something
+     * about the data that is not true yet.
+     */
+    appliedFilter: Ref<SupportAttestationFilter>
+    appliedSearch: Ref<string>
+    load: (force?: boolean) => Promise<void>
+    loadMore: () => Promise<void>
+    onFilterChange: () => void
+    onSearchInput: () => void
+    reset: () => void
+    dispose: () => void
+}
+
+export interface SbomComponentsPagingDeps {
+    client: DriftFallbackClient
+    /** Read at issue time AND re-read on return; a change discards the response. */
+    releaseUuid: () => string | undefined
+    onError: (message: string) => void
+    /** Invoked only when a load actually replaces the list, so callers can drop caches. */
+    onDataReplaced?: () => void
+    pageSize?: number
+    debounceMs?: number
+}
+
+export function useSbomComponentsPaging (deps: SbomComponentsPagingDeps): SbomComponentsPaging {
+    const pageSize = deps.pageSize ?? 50
+    const debounceMs = deps.debounceMs ?? 300
+
+    const items: Ref<any[]> = ref([])
+    const totalCount = ref(0)
+    const hasMore = ref(false)
+    const loading = ref(false)
+    const loadingMore = ref(false)
+    const loaded = ref(false)
+    const failed = ref(false)
+    const degraded = ref(false)
+    const filter: Ref<SupportAttestationFilter> = ref('ALL')
+    const searchInput = ref('')
+    const appliedFilter: Ref<SupportAttestationFilter> = ref('ALL')
+    const appliedSearch = ref('')
+
+    let cursor: string | null = null
+    let seq = 0
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+    /** Invalidates every in-flight request. Returns the token for the new one. */
+    function nextSeq (): number {
+        seq += 1
+        return seq
+    }
+
+    function stale (mySeq: number, myRelease: string | undefined): boolean {
+        return mySeq !== seq || myRelease !== deps.releaseUuid()
+    }
+
+    async function load (force: boolean = false): Promise<void> {
+        const releaseUuid = deps.releaseUuid()
+        if (!releaseUuid) return
+        if (loaded.value && !force) return
+        const mySeq = nextSeq()
+        cursor = null
+        loading.value = true
+        const reqFilter = filter.value
+        const reqSearch = searchInput.value
+        try {
+            const page = await loadSbomComponentsPage(deps.client, releaseUuid, {
+                attestation: reqFilter, search: reqSearch, limit: pageSize
+            })
+            if (stale(mySeq, releaseUuid)) return
+            items.value = page.items
+            totalCount.value = page.totalCount
+            cursor = page.endCursor
+            hasMore.value = page.hasMore
+            degraded.value = page.degraded
+            // A degraded page is the WHOLE release, unfiltered. Reporting the requested
+            // filter as applied would label rows the server never filtered.
+            appliedFilter.value = page.degraded ? 'ALL' : reqFilter
+            appliedSearch.value = page.degraded ? '' : reqSearch
+            loaded.value = true
+            failed.value = false
+            if (deps.onDataReplaced) deps.onDataReplaced()
+        } catch (err: any) {
+            if (stale(mySeq, releaseUuid)) return
+            // Clear rather than leave the previous filter's rows on screen under the new
+            // filter's label -- that reads as a successful, differently-filtered result.
+            items.value = []
+            totalCount.value = 0
+            hasMore.value = false
+            cursor = null
+            failed.value = true
+            loaded.value = true
+            appliedFilter.value = reqFilter
+            appliedSearch.value = reqSearch
+            deps.onError(err?.message || String(err))
+        } finally {
+            if (!stale(mySeq, releaseUuid)) loading.value = false
+        }
+    }
+
+    async function loadMore (): Promise<void> {
+        const releaseUuid = deps.releaseUuid()
+        // A null cursor with hasMore true would send after: null and append page one again,
+        // forever. Guard on the cursor, not just on hasMore.
+        if (!releaseUuid || !hasMore.value || !cursor || loadingMore.value || loading.value) return
+        const mySeq = nextSeq()
+        const after = cursor
+        loadingMore.value = true
+        try {
+            const page = await loadSbomComponentsPage(deps.client, releaseUuid, {
+                attestation: appliedFilter.value, search: appliedSearch.value,
+                limit: pageSize, after
+            })
+            if (stale(mySeq, releaseUuid)) return
+            items.value = items.value.concat(page.items)
+            totalCount.value = page.totalCount
+            cursor = page.endCursor
+            hasMore.value = page.hasMore
+        } catch (err: any) {
+            if (stale(mySeq, releaseUuid)) return
+            // Cursor and hasMore deliberately untouched: the button stays and a retry
+            // resumes from the correct position rather than stranding the walk.
+            deps.onError(err?.message || String(err))
+        } finally {
+            if (!stale(mySeq, releaseUuid)) loadingMore.value = false
+        }
+    }
+
+    function reloadFromStart (): void {
+        loaded.value = false
+        load(true)
+    }
+
+    function onFilterChange (): void {
+        cancelDebounce()
+        reloadFromStart()
+    }
+
+    function onSearchInput (): void {
+        cancelDebounce()
+        debounceTimer = setTimeout(() => { debounceTimer = null; reloadFromStart() }, debounceMs)
+    }
+
+    function cancelDebounce (): void {
+        if (debounceTimer) {
+            clearTimeout(debounceTimer)
+            debounceTimer = null
+        }
+    }
+
+    /** Release changed. Everything about the old release is now wrong, including in flight. */
+    function reset (): void {
+        cancelDebounce()
+        nextSeq()
+        items.value = []
+        totalCount.value = 0
+        hasMore.value = false
+        cursor = null
+        loading.value = false
+        loadingMore.value = false
+        loaded.value = false
+        failed.value = false
+        degraded.value = false
+        appliedFilter.value = filter.value
+        appliedSearch.value = searchInput.value
+    }
+
+    function dispose (): void {
+        cancelDebounce()
+        // Bump the fence so anything already awaiting discards its result instead of
+        // writing to refs on a component that is gone.
+        nextSeq()
+    }
+
+    return {
+        items, totalCount, hasMore, loading, loadingMore, loaded, failed, degraded,
+        filter, searchInput, appliedFilter, appliedSearch,
+        load, loadMore, onFilterChange, onSearchInput, reset, dispose
+    }
+}


### PR DESCRIPTION
First of four PRs for the 7e attestation UI, into the long-lived dev branch. Pairs with `rearm-saas#484`.

Re-opened from #318, which I had wrongly targeted `fda-readiness-1-dev → main`. That would have put the FDA UI into CE `main` ahead of the schema sync, and — because the head was a long-lived branch — every later commit would have silently grown the PR, the trap `rearm-saas#481` taught us. The `fda-readiness-1-dev → main` PR gets opened only after PR 6. The display-scaffolding restore (`96d2e948`) stays on the dev branch as its base; this PR is the 5.1 work only.

## What's here

Replaces the SBOM component list's client-side search with a server-side `attestation` filter (ALL / ATTESTED / UNATTESTED) and keyset paging on the cursor API.

The filter move is the point; the search move is a consequence. ATTESTED/UNATTESTED are evaluated server-side with the **same predicate the release-scoped coverage gauge counts with**, so the list and the number cannot disagree — an in-step failure this feature has hit repeatedly. Once the filter is server-side the search has to be too, or the two compose wrongly.

Keyset, so **"Load more" rather than page numbers**: the cursor is forward-only, so there is no backward cursor to build a numbered pager on, and offering one would mean re-walking from the start on every jump while pretending otherwise.

## Review: both layers, 13 findings

The two that mattered were things this change *broke*:

**The CE fallback was aimed at a query CE cannot serve.** This UI ships in the CE repo and the CE mirror has neither the paged query nor the filter enum, so a CE install rendered the tab as a toolbar over nothing. Writing the test for the fallback showed the fallback was *itself* CE-invalid, on exactly one field: `deviceSupportRisk`. So the CORE/FULL split is back — for precisely the reason it existed before #311 removed it as "no longer needed". Chain is paged → unpaged FULL → unpaged CORE. A degraded page reports as **unfiltered** whatever was asked for, and the filter controls disable, because the server applied no filter and labelling those rows otherwise would misdescribe them.

**I silently dropped both documents out of the `validate:graphql` gate.** The script skips any `gql` body containing `${...}`; extracting the shared selection set made both dynamic. Measured, not assumed: `origin/main` had 1 document and 0 skipped; my first commit had 2 and skipped both — including the one the gate had been checking. That *is* the house split, but the companion spec has to exist. `sbomComponentsSchemaDrift.spec.ts` is it, and it asserts the Pro-only documents are **invalid on CE with the message named** — so when PR 6 lands the sync, that test fails by design and tells whoever lands it to delete the fallback. **That failure is the intended signal, not a break.**

**Three ordering bugs** needed a request fence, so the paging state moved into `useSbomComponentsPaging`:
- a Load-more in flight when the filter changed appended ALL rows onto an UNATTESTED list *and overwrote the cursor*, so the next page resumed from a position in the other ordering — rows skipped, rows repeated, under a label describing neither;
- two debounced searches resolving out of order left the list and cursor from the stale query;
- a trailing debounce after navigation loaded release A's components and set `loaded=true`, so every later load early-returned and **release B kept showing A's SBOM indefinitely**.

Each is now a test that fails without the fence. Steps 5.2–5.4 must route new loads through the composable rather than adding a second loader — the fence only works if every assignment goes through it.

Also fixed: release-change resets the whole paging state (the tab label had kept the previous release's count over an empty pane); `onUnmounted` disposal; a failed filter change clears rather than relabelling old rows; the filtered empty state no longer swallows the tree view (where nothing on screen could clear the filter, since the controls are list-only); labels key off the *applied* filter; `loadMore` guards on the cursor not just `hasMore`; filter changes no longer nuke the dependency-graph cache; the options array is typed against the union.

Last review round caught that `SBOM_COMPONENT_FIELDS` was derived from CORE by a `.replace()` on an exact indentation match — a reformat would have no-op'd it, collapsed FULL into CORE, and dropped `deviceSupportRisk` from every query with nothing failing. Now composed by appending, plus an assertion that FULL ≠ CORE. Verified non-vacuous by collapsing it and confirming two tests fail.

## Validated against the running backend

Hot-swapped `rearm-core` built from `fda-readiness-1-dev@7303cb29` into the sandbox and probed with seeded data:

- release-scoped gauge total **7 == page `ALL` total 7**, root excluded from both;
- `ATTESTED` 2 + `UNATTESTED` 5 == `ALL` 7, and `gauge.attested == ATTESTED`;
- cursor walk at limit 3 returned `totalCount` 7 on **every** page, visiting 7 items / 7 distinct;
- **walking `UNATTESTED` while attesting each page** visited all 5 remaining exactly once and closed the gauge to 7/7 — the walk offset pagination could not do;
- `search: "lib%"` → 0 while `"lib0"` → 7, confirming `ESCAPE '!'` literal handling in a real deployment.

## Checks

- `npm run test`: **235 tests, 234 pass**. The one failure is `routeInputSchemaDrift.spec.ts`, pre-existing and identical on clean `origin/main`. Stated explicitly because **nothing in CI runs vitest** — this count is a manual gate.
- `npm run lint`: 273 problems with *and* without this diff.
- `npm run validate:graphql`: 3 Pro failures, identical on `origin/main`, none in these files.
- `vite build` passes. Added lines ASCII-clean (detector validated against a planted em-dash). This repo has no `vue-tsc`, so the build is the type gate rather than a full SFC typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)