### PR TITLE
Harden the device-risk maps to match the support-status ones (Layer 2 on the scaffolding commit)

### DIFF
--- a/ui/src/utils/supportStatusTag.spec.ts
+++ b/ui/src/utils/supportStatusTag.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest'
 import {
+    DEVICE_RISK_DETAIL,
     DEVICE_RISK_LABEL,
     SUPPORT_TAG,
     UNRECOGNISED_TAG,
@@ -68,6 +69,20 @@ describe('isDeviceRiskFlagged', () => {
     // not be made, which the column shows by simply having no marker, same as OK.
     it.each(['OK', 'UNKNOWN', null, undefined, ''])('does not flag %s', (risk) => {
         expect(isDeviceRiskFlagged(risk)).toBe(false)
+    })
+
+    // The same prototype hole supportTag guards against, one function away. Guarding one of
+    // the pair and not the other is how they drift; DEVICE_RISK_LABEL['toString'] would put
+    // Object.prototype.toString -- a Function -- on screen as a tag label.
+    it.each(['toString', 'constructor', 'hasOwnProperty'])(
+        'does not treat the inherited %s as a flagged verdict', (risk) => {
+            expect(isDeviceRiskFlagged(risk)).toBe(false)
+        })
+
+    // The label and detail maps are read together by the badge renderer. A verdict in one
+    // and not the other renders a populated tag over an empty tooltip.
+    it('label and detail maps agree on their keys', () => {
+        expect(Object.keys(DEVICE_RISK_LABEL).sort()).toEqual(Object.keys(DEVICE_RISK_DETAIL).sort())
     })
 
     // Removed from the backend enum when end-of-life was redefined as end of SALE. A label

--- a/ui/src/utils/supportStatusTag.ts
+++ b/ui/src/utils/supportStatusTag.ts
@@ -48,9 +48,8 @@ export function supportTag (status: unknown): { type: SupportTagType, label: str
             && Object.prototype.hasOwnProperty.call(SUPPORT_TAG, status)) {
         return SUPPORT_TAG[status as LiveSupportStatus]
     }
-    console.error(
-        `[fda] unrecognised SupportStatus from the server: ${JSON.stringify(status)}.`
-        + ` This UI build knows only ${Object.keys(SUPPORT_TAG).join(', ')}.`
+    console.error('unrecognised SupportStatus from the server:', status,
+        `- this UI build knows only ${Object.keys(SUPPORT_TAG).join(', ')}.`
         + ' Rendering it as "Unknown" would assert it was never assessed.')
     return UNRECOGNISED_TAG
 }
@@ -69,11 +68,18 @@ export function supportTag (status: unknown): { type: SupportTagType, label: str
  * reading (EOL means end of SALE). Deliberately absent -- a label for a verdict the server
  * cannot send is a dead branch that reads as coverage.
  */
-export const DEVICE_RISK_LABEL: Record<string, string> = {
+export type FlaggedDeviceRisk = 'EOS_BEFORE_DEVICE'
+
+export const DEVICE_RISK_LABEL: Record<FlaggedDeviceRisk, string> = {
     EOS_BEFORE_DEVICE: 'EOS before device'
 }
 
-export const DEVICE_RISK_DETAIL: Record<string, string> = {
+/**
+ * Keyed on the SAME union as the label map, so the compiler enforces what a comment used to
+ * assert. deviceRiskBadge reads both, and a verdict present in LABEL but missing from DETAIL
+ * would render an empty tooltip body under a populated tag.
+ */
+export const DEVICE_RISK_DETAIL: Record<FlaggedDeviceRisk, string> = {
     EOS_BEFORE_DEVICE: 'This component stops receiving support before this device\'s declared'
         + ' support window ends, so it goes unsupported while the device is still fielded.'
 }
@@ -83,6 +89,13 @@ export const DEVICE_RISK_DETAIL: Record<string, string> = {
  * verdicts, and a hand-maintained second copy fails silently -- a second flagged value would
  * render a tag while a summary counted zero and a filter hid the row.
  */
-export function isDeviceRiskFlagged (risk: unknown): boolean {
-    return typeof risk === 'string' && risk in DEVICE_RISK_LABEL
+export function isDeviceRiskFlagged (risk: unknown): risk is FlaggedDeviceRisk {
+    // hasOwnProperty, not `in`. `'toString' in DEVICE_RISK_LABEL` is true, and the caller
+    // renders DEVICE_RISK_LABEL[risk] as a tag label -- so `in` would put
+    // Object.prototype.toString, a Function, on screen. supportTag above already guards this
+    // way; guarding one of the two is how the pair drifts. Not reachable from a conformant
+    // server, since deviceSupportRisk is a GraphQL enum, which is why this is consistency and
+    // defence rather than a live defect.
+    return typeof risk === 'string'
+        && Object.prototype.hasOwnProperty.call(DEVICE_RISK_LABEL, risk)
 }


### PR DESCRIPTION
Findings from a one-off Layer 2 pass over `96d2e948` — the dev branch's only directly-committed commit, which would otherwise have been reviewed only inside a large final `dev → main` diff. Running it now means the dev branch can be treated as fully gated.

Two findings, both the same shape: `supportStatusTag.ts` argues "type against what the server can send", then doesn't — one function away from where it does.

**`isDeviceRiskFlagged` used a bare `in`.** `supportTag`, right above it, deliberately uses `Object.prototype.hasOwnProperty.call` and has a spec pinning that. `'toString' in DEVICE_RISK_LABEL` is `true`, and the caller renders `DEVICE_RISK_LABEL[risk]` as a tag label — so `in` would put `Object.prototype.toString`, a Function, on screen.

Being accurate about severity: **this is not reachable from a conformant server**, because `deviceSupportRisk` is a GraphQL enum. It's consistency and defence, not a live defect. It's worth fixing because guarding one of a pair and not the other is exactly how the two drift apart later.

**The device maps were `Record<string, string>`** while `SUPPORT_TAG` was already `Record<LiveSupportStatus, ...>`. Both are now keyed on a `FlaggedDeviceRisk` union, so the compiler enforces what a comment previously asserted: the label and detail maps are read together by the badge renderer, and a verdict in one but not the other renders a populated tag over an empty tooltip. `isDeviceRiskFlagged` is now a type predicate so callers narrow.

Also dropped the `[fda]` console prefix — no other `console.*` in `ui/src` uses one, and all six existing sites pass the offending value as a separate argument rather than stringifying it into the message.

## Not in scope, deliberately

- **Layer 2's F1** (`deviceSupportRisk` is CE-invalid and the query had lost its drift fallback) is real and **already fixed downstream** — that's what the CORE/FULL split and `sbomComponentsSchemaDrift.spec.ts` in #319 restore.
- **The Support column sorts on `supportStatus`**, which it doesn't display when `supportSource` is absent. Layer 2 flagged the inconsistency with sibling sorters; changing the sort key is a behaviour question for the attestation UI, not a conventions fix, so it belongs with the work that decides what that column shows.
- Layer 2 also noted this repo has **no precedent for pinning a UI union against a backend enum's members** — the six existing drift specs validate documents or coerce inputs, never enum values. So `LiveSupportStatus` can still drift silently on a rename. That's a gap the codebase shares rather than a deviation, and a value-level pin would be a new convention; worth considering given the regulatory surface, but not something to introduce in a hardening PR.

## Checks

- 3 new specs, **verified non-vacuous** by reverting the guard and confirming all three fail.
- `npm run test`: 206 tests, 205 pass. The one failure is `routeInputSchemaDrift.spec.ts`, pre-existing and identical on clean `origin/main`. (Count is lower than #319's because this branch is off the dev base and doesn't carry that PR's specs.)
- `npm run lint`: 273 problems, unchanged. `vite build` passes. Added lines ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)