### PR TITLE
FDA 7e UI (3/4): per-component attestation form

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -518,11 +518,15 @@
                     </n-alert>
 
                     <n-form-item label="Level of support">
-                        <n-select v-model:value="attestForm.form.levelOfSupport" clearable
+                        <!-- Not clearable: the mutation has no way to remove a recorded
+                             level, so an x here would be a gesture the system cannot
+                             perform -- it emptied the box, sent nothing, and reported
+                             success. -->
+                        <n-select v-model:value="attestForm.form.levelOfSupport"
                             :options="LEVEL_OPTIONS" placeholder="Not stated" />
                     </n-form-item>
                     <n-form-item label="Who the claim is about">
-                        <n-select v-model:value="attestForm.form.party" clearable
+                        <n-select v-model:value="attestForm.form.party"
                             :options="PARTY_OPTIONS" placeholder="Unknown" />
                     </n-form-item>
                     <n-form-item label="Justification (basis for the claim -- exported)">
@@ -581,11 +585,24 @@
                             records your basis alone -- no level, no dates -- which is a
                             complete disclosure of what you actually know.
                         </div>
+                        <!-- Only offered where it can honour that promise. A recorded level
+                             cannot be removed at all, and blanking a field here means
+                             "leave it alone", so on an attested row this would publish the
+                             old level against a basis written to mean the opposite. -->
+                        <n-alert v-if="!attestForm.canUseNothingPublished()" type="warning"
+                            :show-icon="false" style="font-size: 12px;">
+                            Not available here: this component already has a recorded level or
+                            dates, and those cannot be removed by this action. Change the
+                            level above, or use "Remove recorded values" for the dates.
+                        </n-alert>
                         <n-input-group>
                             <n-input v-model:value="attestNothingPublishedText"
+                                :disabled="!attestForm.canUseNothingPublished()"
                                 placeholder="e.g. supplier declined to state a support level" />
-                            <n-button :disabled="!attestNothingPublishedText.trim()"
-                                @click="applyNothingPublished">Use this</n-button>
+                            <n-button
+                                :disabled="!attestNothingPublishedText.trim()
+                                    || !attestForm.canUseNothingPublished()"
+                                @click="applyNothingPublished">Replace form with this</n-button>
                         </n-input-group>
                     </n-card>
 
@@ -611,7 +628,7 @@
                 </div>
                 <template #footer>
                     <n-space justify="end">
-                        <n-button size="small" @click="attestModalOpen = false">Cancel</n-button>
+                        <n-button size="small" @click="cancelAttest">Cancel</n-button>
                         <n-button size="small" type="primary"
                             :disabled="attestUnsupported || attestLoading || attestSaving
                                 || !attestForm.canSubmit()"
@@ -1463,6 +1480,7 @@ import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
 import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
 import { useAttestationForm } from '@/utils/useAttestationForm'
+import type { LevelOfSupport, SupportMilestoneType, SupportParty } from '@/utils/supportAttestationInput'
 import { loadSbomComponentSupportDetail } from '@/utils/sbomComponentSupportDetail'
 import { setSbomComponentSupport } from '@/utils/setSbomComponentSupport'
 import { useReleaseSupportCoverage } from '@/utils/useReleaseSupportCoverage'
@@ -3096,25 +3114,34 @@ const attestSaving: Ref<boolean> = ref(false)
 const attestUnsupported: Ref<boolean> = ref(false)
 const attestNothingPublishedText: Ref<string> = ref('')
 
-const LEVEL_OPTIONS = [
+const LEVEL_OPTIONS: Array<{ label: string, value: LevelOfSupport }> = [
     { label: 'Actively maintained', value: 'ACTIVELY_MAINTAINED' },
     { label: 'No longer maintained', value: 'NO_LONGER_MAINTAINED' },
     { label: 'Abandoned', value: 'ABANDONED' }
 ]
 // The party is an attribute OF the attestation -- who the claim is about, first party or
 // third -- so it belongs inside the form rather than beside it as its own control.
-const PARTY_OPTIONS = [
-    { label: 'First party (our own component)', value: 'MANUFACTURER' },
-    { label: 'Third party (someone else\'s project)', value: 'SUPPLIER' },
-    { label: 'Third party, via another channel', value: 'THIRD_PARTY' }
+// Typed against the union so a value the backend does not declare is a COMPILE error. The
+// first version of this array invented two, and they failed only at request time -- wearing
+// the costume of an out-of-date server.
+const PARTY_OPTIONS: Array<{ label: string, value: SupportParty }> = [
+    { label: 'First party (our own component)', value: 'FIRST_PARTY' },
+    { label: 'Third party (someone else\'s project)', value: 'THIRD_PARTY' }
 ]
-const MILESTONE_CLEAR_OPTIONS = [
+const MILESTONE_CLEAR_OPTIONS: Array<{ label: string, value: SupportMilestoneType }> = [
     { label: 'End of guaranteed support', value: 'END_OF_GUARANTEED_SUPPORT' },
     { label: 'End of support', value: 'END_OF_SUPPORT' },
     { label: 'End of life', value: 'END_OF_LIFE' }
 ]
 
+let attestGen = 0
+
 async function openAttestForm (row: any) {
+    // Generation guard. attestRow is set synchronously but the seed load is awaited, so
+    // cancelling and opening a different component can land A's attestation in a form whose
+    // row is B -- and the save then diffs A's baseline and writes the result to B's uuid.
+    // An attestation recorded against the wrong component is silent and near-undetectable.
+    const gen = ++attestGen
     attestRow.value = row
     attestUnsupported.value = false
     attestNothingPublishedText.value = ''
@@ -3124,17 +3151,26 @@ async function openAttestForm (row: any) {
         const res = await loadSbomComponentSupportDetail(
             graphqlClient as any, updatedRelease.value.uuid,
             row.component?.uuid || row.sbomComponentUuid)
+        if (gen !== attestGen) return
         if (res.kind === 'unsupported') {
             attestUnsupported.value = true
             return
         }
         attestForm.open(res.attestation)
     } catch (err: any) {
+        if (gen !== attestGen) return
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
         attestModalOpen.value = false
     } finally {
-        attestLoading.value = false
+        if (gen === attestGen) attestLoading.value = false
     }
+}
+
+/** Closing invalidates any in-flight seed, so a late response cannot reopen or reseed. */
+function cancelAttest () {
+    attestGen += 1
+    attestLoading.value = false
+    attestModalOpen.value = false
 }
 
 function applyNothingPublished () {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -3193,19 +3193,43 @@ async function saveAttestation () {
     if (attestSaving.value || !attestForm.canSubmit()) return
     attestSaving.value = true
     let saved = false
+    const done: Array<Record<string, unknown>> = []
+    let attestFailedTotal = 0
     try {
         // SERIALISED: the mutation takes one supportNotes argument, so notes for two
         // milestones in one call would land on both. One call per edited milestone, each
         // its own audit revision -- honest rather than clever. Sequential, not parallel:
         // they touch the same optimistic-locked row.
         const componentUuid = attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid
-        for (const vars of attestForm.variableSets(componentUuid)) {
-            await setSbomComponentSupportVars(graphqlClient as any, vars)
+        const sets = attestForm.variableSets(componentUuid)
+        attestFailedTotal = sets.length
+        try {
+            for (const vars of sets) {
+                await setSbomComponentSupportVars(graphqlClient as any, vars)
+                done.push(vars)
+            }
+            attestModalOpen.value = false
+        } finally {
+            // PARTIAL SUCCESS IS REAL on a serialised save, and reporting it as a plain
+            // failure is worse than useless: the operator resubmits, and the milestone that
+            // already landed is written a second time -- re-stamping its lastAssessed for an
+            // assessment that happened once. Fold what landed into the baseline so a retry
+            // sends only the remainder.
+            if (done.length) attestForm.markSaved(done)
         }
-        attestModalOpen.value = false
         saved = true
     } catch (err: any) {
-        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+        if (done.length) {
+            notify('warning', `Saved ${done.length} of ${attestFailedTotal} changes`,
+                'The rest could not be saved: '
+                + commonFunctions.parseGraphQLError(err.message)
+                + ' What already saved has been kept; pressing Save again sends only the'
+                + ' remainder.')
+            // Still refresh: part of the record moved, so the list and gauge are stale.
+            saved = true
+        } else {
+            notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+        }
     } finally {
         attestSaving.value = false
     }

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -496,6 +496,131 @@
                 </n-form>
             </n-modal>
             <n-modal
+                v-model:show="attestModalOpen"
+                preset="card"
+                style="width: 640px;"
+                title="Record support attestation">
+                <div v-if="attestLoading"><n-spin size="small" /> Loading current attestation...</div>
+                <!-- A server that cannot store a full attestation gets a refusal, not a
+                     narrower form. Writing what it CAN take would drop the level and the
+                     justification while reporting success. -->
+                <n-alert v-else-if="attestUnsupported" type="error" :show-icon="true">
+                    This server cannot store a full support attestation: it accepts only the
+                    milestone dates and internal notes, so the level of support and the
+                    justification would be silently dropped. Nothing was written.
+                </n-alert>
+                <div v-else>
+                    <n-alert v-if="attestForm.isUnRetract()" type="warning" :show-icon="true"
+                        style="margin-bottom: 12px;">
+                        This attestation was withdrawn. Saving re-asserts it, so a reason is
+                        required -- the audit row is the only record that the withdrawal was
+                        reversed.
+                    </n-alert>
+
+                    <n-form-item label="Level of support">
+                        <n-select v-model:value="attestForm.form.levelOfSupport" clearable
+                            :options="LEVEL_OPTIONS" placeholder="Not stated" />
+                    </n-form-item>
+                    <n-form-item label="Who the claim is about">
+                        <n-select v-model:value="attestForm.form.party" clearable
+                            :options="PARTY_OPTIONS" placeholder="Unknown" />
+                    </n-form-item>
+                    <n-form-item label="Justification (basis for the claim -- exported)">
+                        <n-input v-model:value="attestForm.form.justification" type="textarea"
+                            :rows="3"
+                            placeholder="What you checked and what you found." />
+                    </n-form-item>
+
+                    <n-form-item label="End of guaranteed support">
+                        <n-input v-model:value="attestForm.form.endOfGuaranteedSupportDate"
+                            placeholder="YYYY-MM-DD" />
+                    </n-form-item>
+                    <n-form-item label="End of support">
+                        <n-input v-model:value="attestForm.form.endOfSupportDate"
+                            placeholder="YYYY-MM-DD" />
+                    </n-form-item>
+                    <n-form-item label="End of life (end of sale)">
+                        <n-input v-model:value="attestForm.form.endOfLifeDate"
+                            placeholder="YYYY-MM-DD" />
+                    </n-form-item>
+                    <n-form-item label="Internal notes (never exported)">
+                        <n-input v-model:value="attestForm.form.supportNotes" type="textarea"
+                            :rows="2" />
+                    </n-form-item>
+
+                    <!-- Confirm-or-revise. The stored basis was written for the dates that
+                         were there at the time; moving one leaves it vouching for a claim it
+                         was never about. -->
+                    <n-alert v-if="attestForm.needsJustificationDecision()" type="warning"
+                        :show-icon="true" style="margin-bottom: 12px;">
+                        A date changed. Does the recorded basis still hold?
+                        <n-button size="tiny" style="margin-left: 8px;"
+                            @click="attestForm.confirmJustification()">
+                            It still holds
+                        </n-button>
+                        <span style="margin-left: 8px; font-size: 12px;">
+                            or edit the justification above to revise it.
+                        </span>
+                    </n-alert>
+
+                    <n-form-item v-if="attestForm.isUnRetract()
+                        || attestForm.form.clearJustification
+                        || attestForm.form.clearMilestones.length"
+                        label="Reason for this edit (audit only, never exported)">
+                        <n-input v-model:value="attestForm.form.reason"
+                            placeholder="Why this change is being made." />
+                    </n-form-item>
+
+                    <!-- SEPARATE REGION, and deliberately far from the clear controls below.
+                         This RECORDS a basis and nothing else; clearing REMOVES one. They
+                         look alike in the data and are opposites in meaning. -->
+                    <n-card size="small" title="Assessed, nothing published"
+                        style="margin-top: 16px;">
+                        <div style="font-size: 12px; margin-bottom: 8px;">
+                            Use when you asked and the supplier would not state a level. This
+                            records your basis alone -- no level, no dates -- which is a
+                            complete disclosure of what you actually know.
+                        </div>
+                        <n-input-group>
+                            <n-input v-model:value="attestNothingPublishedText"
+                                placeholder="e.g. supplier declined to state a support level" />
+                            <n-button :disabled="!attestNothingPublishedText.trim()"
+                                @click="applyNothingPublished">Use this</n-button>
+                        </n-input-group>
+                    </n-card>
+
+                    <n-card size="small" title="Remove recorded values"
+                        style="margin-top: 24px;">
+                        <div style="font-size: 12px; margin-bottom: 8px;">
+                            Removing is destructive and needs a reason above.
+                        </div>
+                        <n-checkbox v-model:checked="attestForm.form.clearJustification">
+                            Clear the justification
+                        </n-checkbox>
+                        <n-form-item label="Clear dates" style="margin-top: 8px;">
+                            <n-select v-model:value="attestForm.form.clearMilestones"
+                                multiple clearable :options="MILESTONE_CLEAR_OPTIONS"
+                                placeholder="None" />
+                        </n-form-item>
+                    </n-card>
+
+                    <n-alert v-for="e in attestForm.errors()" :key="e" type="error"
+                        :show-icon="false" style="margin-top: 10px; font-size: 12px;">
+                        {{ e }}
+                    </n-alert>
+                </div>
+                <template #footer>
+                    <n-space justify="end">
+                        <n-button size="small" @click="attestModalOpen = false">Cancel</n-button>
+                        <n-button size="small" type="primary"
+                            :disabled="attestUnsupported || attestLoading || attestSaving
+                                || !attestForm.canSubmit()"
+                            :loading="attestSaving"
+                            @click="saveAttestation">Save</n-button>
+                    </n-space>
+                </template>
+            </n-modal>
+            <n-modal
                 v-model:show="showDownloadArtifactModal"
                 title='Download Artifact'
                 preset="dialog"
@@ -1337,6 +1462,9 @@ import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
 import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
+import { useAttestationForm } from '@/utils/useAttestationForm'
+import { loadSbomComponentSupportDetail } from '@/utils/sbomComponentSupportDetail'
+import { setSbomComponentSupport } from '@/utils/setSbomComponentSupport'
 import { useReleaseSupportCoverage } from '@/utils/useReleaseSupportCoverage'
 import { useSbomComponentsPaging } from '@/utils/useSbomComponentsPaging'
 import type { SupportAttestationFilter } from '@/utils/sbomComponentsQuery'
@@ -1347,7 +1475,7 @@ import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regu
 import { UpCircleOutlined } from '@vicons/antd'
 import type { SelectOption } from 'naive-ui'
 import { DEVICE_RISK_DETAIL, DEVICE_RISK_LABEL, isDeviceRiskFlagged, supportTag } from '@/utils/supportStatusTag'
-import { NAlert, NBadge, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
+import { NAlert, NBadge, NCheckbox, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
 import Swal from 'sweetalert2'
 import { ComputedRef, Ref, computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
 import type { Component } from 'vue'
@@ -2956,6 +3084,85 @@ async function loadSbomComponents (forceRefresh: boolean = false) {
     await loadSbomCoverage()
 }
 
+// Per-component attestation form (FDA-Readiness-1 PR5.3).
+//
+// The rules about when a save is allowed live in useAttestationForm, outside this file, so
+// they can be tested; what follows is opening, saving and refreshing.
+const attestForm = useAttestationForm()
+const attestModalOpen: Ref<boolean> = ref(false)
+const attestRow: Ref<any> = ref(null)
+const attestLoading: Ref<boolean> = ref(false)
+const attestSaving: Ref<boolean> = ref(false)
+const attestUnsupported: Ref<boolean> = ref(false)
+const attestNothingPublishedText: Ref<string> = ref('')
+
+const LEVEL_OPTIONS = [
+    { label: 'Actively maintained', value: 'ACTIVELY_MAINTAINED' },
+    { label: 'No longer maintained', value: 'NO_LONGER_MAINTAINED' },
+    { label: 'Abandoned', value: 'ABANDONED' }
+]
+// The party is an attribute OF the attestation -- who the claim is about, first party or
+// third -- so it belongs inside the form rather than beside it as its own control.
+const PARTY_OPTIONS = [
+    { label: 'First party (our own component)', value: 'MANUFACTURER' },
+    { label: 'Third party (someone else\'s project)', value: 'SUPPLIER' },
+    { label: 'Third party, via another channel', value: 'THIRD_PARTY' }
+]
+const MILESTONE_CLEAR_OPTIONS = [
+    { label: 'End of guaranteed support', value: 'END_OF_GUARANTEED_SUPPORT' },
+    { label: 'End of support', value: 'END_OF_SUPPORT' },
+    { label: 'End of life', value: 'END_OF_LIFE' }
+]
+
+async function openAttestForm (row: any) {
+    attestRow.value = row
+    attestUnsupported.value = false
+    attestNothingPublishedText.value = ''
+    attestModalOpen.value = true
+    attestLoading.value = true
+    try {
+        const res = await loadSbomComponentSupportDetail(
+            graphqlClient as any, row.component?.uuid || row.sbomComponentUuid)
+        if (res.kind === 'unsupported') {
+            attestUnsupported.value = true
+            return
+        }
+        attestForm.open(res.attestation)
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+        attestModalOpen.value = false
+    } finally {
+        attestLoading.value = false
+    }
+}
+
+function applyNothingPublished () {
+    attestForm.assessedNothingPublished(attestNothingPublishedText.value)
+    attestNothingPublishedText.value = ''
+}
+
+async function saveAttestation () {
+    // Guarded here as well as by the disabled button: a double-click on OK is the classic
+    // way a modal fires twice, and the second write would bump the audit revision again.
+    if (attestSaving.value || !attestForm.canSubmit()) return
+    attestSaving.value = true
+    try {
+        await setSbomComponentSupport(graphqlClient as any,
+            attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid,
+            attestForm.form)
+        attestModalOpen.value = false
+        notify('success', 'Saved', 'Support attestation recorded.')
+        // forceRefresh, because the gauge only re-reads with the list -- and an attestation
+        // is exactly the thing that moves the number above the table. Without this the write
+        // succeeds and the gauge stays stale, which reads to an operator as a failure.
+        await loadSbomComponents(true)
+    } catch (err: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
+    } finally {
+        attestSaving.value = false
+    }
+}
+
 // Release-scoped support-disclosure gauge (FDA-Readiness-1).
 //
 // Sourced from sbomComponentSupportCoverage(orgUuid, releaseUuid) and NOTHING ELSE. In
@@ -3175,6 +3382,13 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
         title: 'Actions',
         render: (row: any) => {
             const els: any[] = [h(NButton, { size: 'small', onClick: () => openSbomComponentGraph(row) }, () => 'View graph')]
+            // Root components are the release's own coordinate, never a third-party
+            // dependency to disclose -- the server skips them and the gauge excludes them,
+            // so offering the action would be offering a no-op.
+            if (isWritable.value && !row.component?.isRoot) {
+                els.push(h(NButton, { size: 'small', type: 'primary', ghost: true,
+                    onClick: () => openAttestForm(row) }, () => 'Attest'))
+            }
             return h('div', { style: 'display: flex; gap: 6px;' }, els)
         }
     }

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -3151,7 +3151,7 @@ async function saveAttestation () {
     try {
         await setSbomComponentSupport(graphqlClient as any,
             attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid,
-            attestForm.form)
+            attestForm)
         attestModalOpen.value = false
         saved = true
     } catch (err: any) {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -535,21 +535,22 @@
                             placeholder="What you checked and what you found." />
                     </n-form-item>
 
-                    <n-form-item label="End of guaranteed support">
-                        <n-input v-model:value="attestForm.form.endOfGuaranteedSupportDate"
-                            placeholder="YYYY-MM-DD" />
-                    </n-form-item>
-                    <n-form-item label="End of support">
-                        <n-input v-model:value="attestForm.form.endOfSupportDate"
-                            placeholder="YYYY-MM-DD" />
-                    </n-form-item>
-                    <n-form-item label="End of life (end of sale)">
-                        <n-input v-model:value="attestForm.form.endOfLifeDate"
-                            placeholder="YYYY-MM-DD" />
-                    </n-form-item>
-                    <n-form-item label="Internal notes (never exported)">
-                        <n-input v-model:value="attestForm.form.supportNotes" type="textarea"
-                            :rows="2" />
+                    <!-- Notes live WITH their date, because that is where the server stores
+                         them: supportNotes is written onto the milestones being staged, and
+                         a milestone's notes are the evidence for that date. A single
+                         component-level box was a lie about the storage model -- a
+                         notes-only edit went nowhere, and notes saved with one date landed
+                         on that milestone alone. -->
+                    <n-form-item v-for="m in MILESTONE_FIELDS" :key="m.type" :label="m.label">
+                        <n-space vertical style="width: 100%;">
+                            <n-date-picker
+                                v-model:formatted-value="attestForm.form[m.field]"
+                                value-format="yyyy-MM-dd" type="date" clearable
+                                style="width: 100%;" :placeholder="'YYYY-MM-DD'" />
+                            <n-input v-model:value="attestForm.form.milestoneNotes[m.type]"
+                                type="textarea" :rows="2"
+                                :placeholder="'What you checked for this date (internal, never exported)'" />
+                        </n-space>
                     </n-form-item>
 
                     <!-- Confirm-or-revise. The stored basis was written for the dates that
@@ -1482,7 +1483,7 @@ import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
 import { useAttestationForm } from '@/utils/useAttestationForm'
 import type { LevelOfSupport, SupportMilestoneType, SupportParty } from '@/utils/supportAttestationInput'
 import { loadSbomComponentSupportDetail } from '@/utils/sbomComponentSupportDetail'
-import { setSbomComponentSupport } from '@/utils/setSbomComponentSupport'
+import { setSbomComponentSupportVars } from '@/utils/setSbomComponentSupport'
 import { useReleaseSupportCoverage } from '@/utils/useReleaseSupportCoverage'
 import { useSbomComponentsPaging } from '@/utils/useSbomComponentsPaging'
 import type { SupportAttestationFilter } from '@/utils/sbomComponentsQuery'
@@ -3128,6 +3129,14 @@ const PARTY_OPTIONS: Array<{ label: string, value: SupportParty }> = [
     { label: 'First party (our own component)', value: 'FIRST_PARTY' },
     { label: 'Third party (someone else\'s project)', value: 'THIRD_PARTY' }
 ]
+// One row per milestone: its date and the notes that justify it.
+const MILESTONE_FIELDS: Array<{ type: SupportMilestoneType, field: string, label: string }> = [
+    { type: 'END_OF_GUARANTEED_SUPPORT', field: 'endOfGuaranteedSupportDate',
+        label: 'End of guaranteed support' },
+    { type: 'END_OF_SUPPORT', field: 'endOfSupportDate', label: 'End of support' },
+    { type: 'END_OF_LIFE', field: 'endOfLifeDate', label: 'End of life (end of sale)' }
+]
+
 const MILESTONE_CLEAR_OPTIONS: Array<{ label: string, value: SupportMilestoneType }> = [
     { label: 'End of guaranteed support', value: 'END_OF_GUARANTEED_SUPPORT' },
     { label: 'End of support', value: 'END_OF_SUPPORT' },
@@ -3185,9 +3194,14 @@ async function saveAttestation () {
     attestSaving.value = true
     let saved = false
     try {
-        await setSbomComponentSupport(graphqlClient as any,
-            attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid,
-            attestForm)
+        // SERIALISED: the mutation takes one supportNotes argument, so notes for two
+        // milestones in one call would land on both. One call per edited milestone, each
+        // its own audit revision -- honest rather than clever. Sequential, not parallel:
+        // they touch the same optimistic-locked row.
+        const componentUuid = attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid
+        for (const vars of attestForm.variableSets(componentUuid)) {
+            await setSbomComponentSupportVars(graphqlClient as any, vars)
+        }
         attestModalOpen.value = false
         saved = true
     } catch (err: any) {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -3122,7 +3122,8 @@ async function openAttestForm (row: any) {
     attestLoading.value = true
     try {
         const res = await loadSbomComponentSupportDetail(
-            graphqlClient as any, row.component?.uuid || row.sbomComponentUuid)
+            graphqlClient as any, updatedRelease.value.uuid,
+            row.component?.uuid || row.sbomComponentUuid)
         if (res.kind === 'unsupported') {
             attestUnsupported.value = true
             return
@@ -3146,20 +3147,36 @@ async function saveAttestation () {
     // way a modal fires twice, and the second write would bump the audit revision again.
     if (attestSaving.value || !attestForm.canSubmit()) return
     attestSaving.value = true
+    let saved = false
     try {
         await setSbomComponentSupport(graphqlClient as any,
             attestRow.value.component?.uuid || attestRow.value.sbomComponentUuid,
             attestForm.form)
         attestModalOpen.value = false
-        notify('success', 'Saved', 'Support attestation recorded.')
-        // forceRefresh, because the gauge only re-reads with the list -- and an attestation
-        // is exactly the thing that moves the number above the table. Without this the write
-        // succeeds and the gauge stays stale, which reads to an operator as a failure.
-        await loadSbomComponents(true)
+        saved = true
     } catch (err: any) {
         notify('error', 'Error', commonFunctions.parseGraphQLError(err.message))
     } finally {
         attestSaving.value = false
+    }
+    if (!saved) return
+    // Refreshed OUTSIDE the write's try, and reported separately.
+    //
+    // forceRefresh, because the gauge only re-reads with the list and an attestation is
+    // exactly what moves the number above the table -- without it the write succeeds and the
+    // gauge stays stale, which reads as a failure.
+    //
+    // But a refresh failure is NOT a write failure. Inside the same try it would produce
+    // "Saved" followed by "Error" for a write that landed perfectly, leaving the operator
+    // unable to tell whether to redo it -- which is the exact ambiguity this screen exists to
+    // remove. Say which half failed.
+    try {
+        await loadSbomComponents(true)
+        notify('success', 'Saved', 'Support attestation recorded.')
+    } catch (err: any) {
+        notify('warning', 'Saved, but not refreshed',
+            'The attestation was recorded. The component list could not be reloaded, so the'
+            + ' coverage figure above may be out of date until you refresh.')
     }
 }
 

--- a/ui/src/components/releaseViewAttestWiring.spec.ts
+++ b/ui/src/components/releaseViewAttestWiring.spec.ts
@@ -20,6 +20,22 @@ const code = source
     .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
     .join('\n')
 
+/**
+ * The whole body of a top-level function, rather than a fixed number of characters.
+ *
+ * The first version sliced 1400 chars from the declaration, and two assertions started
+ * failing the moment saveAttestation grew -- reporting missing wiring that was present a few
+ * lines further down. A guard that fails as the code it guards gets longer is a guard that
+ * will be deleted.
+ */
+function functionBody (name: string): string {
+    const start = code.indexOf(`async function ${name} (`)
+    if (start < 0) return ''
+    const rest = code.slice(start + 1)
+    const next = rest.search(/\n(async )?function /)
+    return next < 0 ? rest : rest.slice(0, next)
+}
+
 describe('the attestation form is wired into ReleaseView', () => {
     it.each([
         ['useAttestationForm', '@/utils/useAttestationForm'],
@@ -52,8 +68,7 @@ describe('the attestation form is wired into ReleaseView', () => {
      * while the number above the table stayed stale, which reads to an operator as a failure.
      */
     it('refreshes the list AND gauge after a successful save', () => {
-        const save = code.slice(code.indexOf('async function saveAttestation'))
-            .slice(0, 1400)
+        const save = functionBody('saveAttestation')
         expect(save, 'saveAttestation must force a reload so the gauge re-reads')
             .toMatch(/loadSbomComponents\s*\(\s*true\s*\)/)
     })
@@ -70,15 +85,24 @@ describe('the attestation form is wired into ReleaseView', () => {
 
     // One supportNotes argument per call means two milestones must be serialised.
     it('serialises the writes rather than issuing one', () => {
-        const save = code.slice(code.indexOf('async function saveAttestation')).slice(0, 1600)
-        expect(save).toMatch(/for\s*\(\s*const\s+vars\s+of\s+attestForm\.variableSets/)
+        expect(functionBody('saveAttestation'))
+            .toMatch(/for\s*\(\s*const\s+vars\s+of\s+sets/)
     })
 
     // A double-click on OK is the classic way a modal writes twice; under an audit trail
     // that shows up as two revisions for one intended edit.
     it('guards the save against a double submit', () => {
-        const save = code.slice(code.indexOf('async function saveAttestation')).slice(0, 400)
-        expect(save).toMatch(/attestSaving\.value/)
+        expect(functionBody('saveAttestation')).toMatch(/attestSaving\.value/)
+    })
+
+    /**
+     * A serialised save can land call 1 and fail call 2. Reporting that as a plain failure
+     * makes the operator resubmit both, re-stamping the milestone that already landed.
+     */
+    it('folds completed writes into the baseline on a partial failure', () => {
+        const save = functionBody('saveAttestation')
+        expect(save, 'a partial save must not leave landed writes pending')
+            .toMatch(/markSaved\s*\(\s*done\s*\)/)
     })
 
     // Root components are never attested: the server skips them and the gauge excludes them.

--- a/ui/src/components/releaseViewAttestWiring.spec.ts
+++ b/ui/src/components/releaseViewAttestWiring.spec.ts
@@ -24,7 +24,7 @@ describe('the attestation form is wired into ReleaseView', () => {
     it.each([
         ['useAttestationForm', '@/utils/useAttestationForm'],
         ['loadSbomComponentSupportDetail', '@/utils/sbomComponentSupportDetail'],
-        ['setSbomComponentSupport', '@/utils/setSbomComponentSupport']
+        ['setSbomComponentSupportVars', '@/utils/setSbomComponentSupport']
     ])('imports %s from %s', (symbol, module) => {
         expect(source, `${symbol} is used but not imported -- the build will not catch this`)
             .toMatch(new RegExp(
@@ -56,6 +56,22 @@ describe('the attestation form is wired into ReleaseView', () => {
             .slice(0, 1400)
         expect(save, 'saveAttestation must force a reload so the gauge re-reads')
             .toMatch(/loadSbomComponents\s*\(\s*true\s*\)/)
+    })
+
+    /**
+     * Notes must be rendered per milestone, not as one component-level box. The server
+     * stores them against the staged milestone, so a single box discarded a notes-only edit
+     * and mislabelled notes saved alongside one date.
+     */
+    it('renders notes per milestone rather than one component-level box', () => {
+        expect(code).toContain('milestoneNotes[m.type]')
+        expect(code).not.toContain('form.supportNotes')
+    })
+
+    // One supportNotes argument per call means two milestones must be serialised.
+    it('serialises the writes rather than issuing one', () => {
+        const save = code.slice(code.indexOf('async function saveAttestation')).slice(0, 1600)
+        expect(save).toMatch(/for\s*\(\s*const\s+vars\s+of\s+attestForm\.variableSets/)
     })
 
     // A double-click on OK is the classic way a modal writes twice; under an audit trail

--- a/ui/src/components/releaseViewAttestWiring.spec.ts
+++ b/ui/src/components/releaseViewAttestWiring.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * Import and call-site assertions for the attestation form, comment-aware.
+ *
+ * Same rationale as the coverage wiring spec: this repo has no vue-tsc, so an undefined
+ * identifier in <script setup> is a runtime ReferenceError that `vite build` and the whole
+ * vitest suite will happily pass -- which is exactly how the coverage gauge shipped a blank
+ * tab. Behaviour lives in useAttestationForm.spec.ts; this covers the seam.
+ *
+ * Honest about the limit: this catches "removed or commented out", not "made conditional".
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .join('\n')
+
+describe('the attestation form is wired into ReleaseView', () => {
+    it.each([
+        ['useAttestationForm', '@/utils/useAttestationForm'],
+        ['loadSbomComponentSupportDetail', '@/utils/sbomComponentSupportDetail'],
+        ['setSbomComponentSupport', '@/utils/setSbomComponentSupport']
+    ])('imports %s from %s', (symbol, module) => {
+        expect(source, `${symbol} is used but not imported -- the build will not catch this`)
+            .toMatch(new RegExp(
+                `import\\s+(type\\s+)?\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
+    })
+
+    /**
+     * "Used" means invoked OR bound as a template handler. Vue binds handlers by name --
+     * `@click="saveAttestation"` with no parentheses -- so a call-site regex alone reports
+     * a correctly-wired handler as dead. The first version of this test did exactly that
+     * and failed on two working handlers.
+     */
+    it.each(['openAttestForm', 'saveAttestation', 'applyNothingPublished'])(
+        'references %s in live code, not only declaring it', (fn) => {
+            const invoked = code.match(new RegExp(`(?<!function\\s{1,10})\\b${fn}\\s*\\(`, 'g')) || []
+            const bound = code.match(new RegExp(`="\\s*${fn}\\s*"`, 'g')) || []
+            expect(invoked.length + bound.length,
+                `${fn} is neither called nor bound to a handler -- it is dead`)
+                .toBeGreaterThan(0)
+        })
+
+    /**
+     * The write must refresh the gauge. The gauge only re-reads with the list, and an
+     * attestation is precisely what moves it -- so a save that skipped this would succeed
+     * while the number above the table stayed stale, which reads to an operator as a failure.
+     */
+    it('refreshes the list AND gauge after a successful save', () => {
+        const save = code.slice(code.indexOf('async function saveAttestation'))
+            .slice(0, 1400)
+        expect(save, 'saveAttestation must force a reload so the gauge re-reads')
+            .toMatch(/loadSbomComponents\s*\(\s*true\s*\)/)
+    })
+
+    // A double-click on OK is the classic way a modal writes twice; under an audit trail
+    // that shows up as two revisions for one intended edit.
+    it('guards the save against a double submit', () => {
+        const save = code.slice(code.indexOf('async function saveAttestation')).slice(0, 400)
+        expect(save).toMatch(/attestSaving\.value/)
+    })
+
+    // Root components are never attested: the server skips them and the gauge excludes them.
+    it('does not offer the action on root components', () => {
+        expect(code).toMatch(/isRoot[\s\S]{0,200}openAttestForm|openAttestForm[\s\S]{0,200}isRoot/)
+    })
+})

--- a/ui/src/utils/attestationVariablesCoercion.spec.ts
+++ b/ui/src/utils/attestationVariablesCoercion.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, coerceInputValue, GraphQLError, type GraphQLSchema } from 'graphql'
+import { attestationVariables, emptyAttestationForm } from './supportAttestationInput'
+
+/**
+ * Coerces the built variables against the REAL schema's argument types.
+ *
+ * Document validation -- which the other drift specs do -- checks structure. It cannot see an
+ * enum VALUE passed as a variable, which is how two invented SupportParty members
+ * (MANUFACTURER, SUPPLIER, borrowed from unrelated enums) reached the browser. They failed at
+ * coercion, which is a validation error, which isSchemaDriftError reports as drift -- so the
+ * operator was told to upgrade a backend that was perfectly capable.
+ *
+ * routeInputSchemaDrift.spec.ts already establishes coerceInputValue as the tool for this in
+ * this repo. This applies it to the attestation write.
+ */
+const PRO = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const schema: GraphQLSchema | null = existsSync(PRO) ? buildSchema(readFileSync(PRO, 'utf8')) : null
+
+function argType (name: string) {
+    const field = schema!.getMutationType()!.getFields()['setSbomComponentSupport']
+    const arg = field.args.find(a => a.name === name)
+    if (!arg) throw new Error(`setSbomComponentSupport has no argument ${name}`)
+    return arg.type
+}
+
+function coerce (name: string, value: unknown): string[] {
+    const errors: string[] = []
+    coerceInputValue(value, argType(name), (_p, _v, err: GraphQLError) => errors.push(err.message))
+    return errors
+}
+
+describe.runIf(schema)('attestation variables coerce against the real mutation', () => {
+    it('every argument the builder emits exists on the mutation', () => {
+        const form = emptyAttestationForm()
+        form.levelOfSupport = 'ACTIVELY_MAINTAINED'
+        form.party = 'FIRST_PARTY'
+        form.justification = 'basis'
+        form.supportNotes = 'note'
+        form.reason = 'why'
+        form.endOfSupportDate = '2030-01-01'
+        form.clearMilestones = ['END_OF_LIFE']
+        form.state = 'ATTESTED'
+        const vars = attestationVariables('c-1', form)
+        for (const key of Object.keys(vars)) {
+            expect(() => argType(key), `${key} is not an argument of setSbomComponentSupport`)
+                .not.toThrow()
+        }
+    })
+
+    // The assertion that would have caught the invented party values before the browser did.
+    it.each(['FIRST_PARTY', 'THIRD_PARTY'])('supportParty %s is accepted', (value) => {
+        expect(coerce('supportParty', value)).toEqual([])
+    })
+
+    it.each(['MANUFACTURER', 'SUPPLIER'])('rejects %s, which is not a SupportParty', (value) => {
+        expect(coerce('supportParty', value).length).toBeGreaterThan(0)
+    })
+
+    it.each(['ACTIVELY_MAINTAINED', 'NO_LONGER_MAINTAINED', 'ABANDONED'])(
+        'levelOfSupport %s is accepted', (v) => expect(coerce('levelOfSupport', v)).toEqual([]))
+
+    it.each(['END_OF_GUARANTEED_SUPPORT', 'END_OF_SUPPORT', 'END_OF_LIFE'])(
+        'clearMilestones accepts %s', (v) => expect(coerce('clearMilestones', [v])).toEqual([]))
+
+    it('state ATTESTED is accepted', () => expect(coerce('state', 'ATTESTED')).toEqual([]))
+})

--- a/ui/src/utils/sbomComponentSupportDetail.spec.ts
+++ b/ui/src/utils/sbomComponentSupportDetail.spec.ts
@@ -4,9 +4,9 @@ import { loadSbomComponentSupportDetail } from './sbomComponentSupportDetail'
 describe('loadSbomComponentSupportDetail', () => {
     it('returns the stored attestation', async () => {
         const query = vi.fn().mockResolvedValue({
-            data: { sbomComponent: { uuid: 'c-1', attestationState: 'ATTESTED', justification: 'x' } }
+            data: { getReleaseSbomComponentGraph: { component: { uuid: 'c-1', attestationState: 'ATTESTED', justification: 'x' } } }
         })
-        const r = await loadSbomComponentSupportDetail({ query } as any, 'c-1')
+        const r = await loadSbomComponentSupportDetail({ query } as any, 'rel-1', 'c-1')
         expect(r).toEqual({ kind: 'ok', attestation: { uuid: 'c-1', attestationState: 'ATTESTED', justification: 'x' } })
     })
 
@@ -14,8 +14,8 @@ describe('loadSbomComponentSupportDetail', () => {
     // another's attestation, because an omitted field means "keep" under PATCH semantics --
     // so a cached form would re-send values that had already changed underneath it.
     it('always hits the network', async () => {
-        const query = vi.fn().mockResolvedValue({ data: { sbomComponent: null } })
-        await loadSbomComponentSupportDetail({ query } as any, 'c-1')
+        const query = vi.fn().mockResolvedValue({ data: { getReleaseSbomComponentGraph: null } })
+        await loadSbomComponentSupportDetail({ query } as any, 'rel-1', 'c-1')
         expect(query.mock.calls[0][0].fetchPolicy).toBe('network-only')
     })
 
@@ -27,17 +27,17 @@ describe('loadSbomComponentSupportDetail', () => {
     it('reports drift as unsupported, distinctly from an unattested component', async () => {
         const drift = vi.fn().mockRejectedValue(
             new Error('Cannot query field "attestationState" on type "SbomComponent"'))
-        expect(await loadSbomComponentSupportDetail({ query: drift } as any, 'c-1'))
+        expect(await loadSbomComponentSupportDetail({ query: drift } as any, 'rel-1', 'c-1'))
             .toEqual({ kind: 'unsupported' })
 
-        const empty = vi.fn().mockResolvedValue({ data: { sbomComponent: null } })
-        expect(await loadSbomComponentSupportDetail({ query: empty } as any, 'c-1'))
+        const empty = vi.fn().mockResolvedValue({ data: { getReleaseSbomComponentGraph: null } })
+        expect(await loadSbomComponentSupportDetail({ query: empty } as any, 'rel-1', 'c-1'))
             .toEqual({ kind: 'ok', attestation: null })
     })
 
     it('propagates real errors rather than reporting them as unsupported', async () => {
         const query = vi.fn().mockRejectedValue(new Error('Not authorized'))
-        await expect(loadSbomComponentSupportDetail({ query } as any, 'c-1'))
+        await expect(loadSbomComponentSupportDetail({ query } as any, 'rel-1', 'c-1'))
             .rejects.toThrow('Not authorized')
     })
 })

--- a/ui/src/utils/sbomComponentSupportDetail.spec.ts
+++ b/ui/src/utils/sbomComponentSupportDetail.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { loadSbomComponentSupportDetail } from './sbomComponentSupportDetail'
+
+describe('loadSbomComponentSupportDetail', () => {
+    it('returns the stored attestation', async () => {
+        const query = vi.fn().mockResolvedValue({
+            data: { sbomComponent: { uuid: 'c-1', attestationState: 'ATTESTED', justification: 'x' } }
+        })
+        const r = await loadSbomComponentSupportDetail({ query } as any, 'c-1')
+        expect(r).toEqual({ kind: 'ok', attestation: { uuid: 'c-1', attestationState: 'ATTESTED', justification: 'x' } })
+    })
+
+    // The form seeds from this. Editing a stale copy is how one operator silently overwrites
+    // another's attestation, because an omitted field means "keep" under PATCH semantics --
+    // so a cached form would re-send values that had already changed underneath it.
+    it('always hits the network', async () => {
+        const query = vi.fn().mockResolvedValue({ data: { sbomComponent: null } })
+        await loadSbomComponentSupportDetail({ query } as any, 'c-1')
+        expect(query.mock.calls[0][0].fetchPolicy).toBe('network-only')
+    })
+
+    /**
+     * "This server cannot answer" and "no attestation yet" look identical if both are null,
+     * and they must not: the first has to refuse the form, the second has to open an empty
+     * one. Hence a tagged result rather than a nullable attestation.
+     */
+    it('reports drift as unsupported, distinctly from an unattested component', async () => {
+        const drift = vi.fn().mockRejectedValue(
+            new Error('Cannot query field "attestationState" on type "SbomComponent"'))
+        expect(await loadSbomComponentSupportDetail({ query: drift } as any, 'c-1'))
+            .toEqual({ kind: 'unsupported' })
+
+        const empty = vi.fn().mockResolvedValue({ data: { sbomComponent: null } })
+        expect(await loadSbomComponentSupportDetail({ query: empty } as any, 'c-1'))
+            .toEqual({ kind: 'ok', attestation: null })
+    })
+
+    it('propagates real errors rather than reporting them as unsupported', async () => {
+        const query = vi.fn().mockRejectedValue(new Error('Not authorized'))
+        await expect(loadSbomComponentSupportDetail({ query } as any, 'c-1'))
+            .rejects.toThrow('Not authorized')
+    })
+})

--- a/ui/src/utils/sbomComponentSupportDetail.ts
+++ b/ui/src/utils/sbomComponentSupportDetail.ts
@@ -1,0 +1,61 @@
+// The stored attestation for one component, loaded when the attest form opens.
+
+import gql from 'graphql-tag'
+import { isSchemaDriftError } from './graphqlDriftFallback'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import type { ExistingAttestation } from './useAttestationForm'
+
+/**
+ * Deliberately NOT folded into the component-list query.
+ *
+ * Four of these fields -- attestationState, attestedLevelOfSupport, supportParty,
+ * endOfGuaranteedSupportDate -- do not exist on the CE mirror. Adding them to the list
+ * would make the list itself CE-invalid and defeat the CORE fallback that keeps the SBOM
+ * tab working there. They are only needed when the form opens, so they load then.
+ *
+ * The form is Pro-only as a whole in any case: the write refuses on a CE server because the
+ * mutation there cannot store a level or a justification. So a drift here and a drift on the
+ * write mean the same thing to the operator, and carry the same message.
+ */
+export const SBOM_COMPONENT_SUPPORT_DETAIL = gql`
+    query sbomComponentSupportDetail($uuid: ID!) {
+        sbomComponent(uuid: $uuid) {
+            uuid
+            attestationState
+            attestedLevelOfSupport
+            justification
+            supportParty
+            endOfGuaranteedSupportDate
+            endOfSupportDate
+            endOfLifeDate
+            supportNotes
+        }
+    }`
+
+/** Distinguishes "this server cannot answer" from "no attestation yet", which look alike. */
+export type SupportDetailResult =
+    | { kind: 'ok', attestation: ExistingAttestation | null }
+    | { kind: 'unsupported' }
+
+export async function loadSbomComponentSupportDetail (
+    client: DriftFallbackClient,
+    uuid: string
+): Promise<SupportDetailResult> {
+    try {
+        const resp = await client.query({
+            query: SBOM_COMPONENT_SUPPORT_DETAIL,
+            variables: { uuid },
+            // Never cached: the form seeds from this, and editing a stale copy is how one
+            // operator silently overwrites another's attestation under PATCH semantics.
+            fetchPolicy: 'network-only'
+        })
+        const c = (resp.data as any)?.sbomComponent
+        if (!c) return { kind: 'ok', attestation: null }
+        // A component with no attestation at all still returns a row, with every support
+        // field null. Seed from it either way -- the form handles both.
+        return { kind: 'ok', attestation: c as ExistingAttestation }
+    } catch (err: any) {
+        if (isSchemaDriftError(err)) return { kind: 'unsupported' }
+        throw err
+    }
+}

--- a/ui/src/utils/sbomComponentSupportDetail.ts
+++ b/ui/src/utils/sbomComponentSupportDetail.ts
@@ -13,22 +13,35 @@ import type { ExistingAttestation } from './useAttestationForm'
  * would make the list itself CE-invalid and defeat the CORE fallback that keeps the SBOM
  * tab working there. They are only needed when the form opens, so they load then.
  *
+ * Read through getReleaseSbomComponentGraph, which is the only single-component read this
+ * schema offers -- there is no root sbomComponent(uuid:) query. An earlier revision invented
+ * one, and the cost was instructive: an unknown field is a GraphQL validation error, which
+ * isSchemaDriftError classifies as drift, so a typo in MY query rendered as "this server is
+ * too old to store attestations". A bug that disguises itself as someone else's outdated
+ * backend. The schema-drift spec beside this file validates the document against Pro for
+ * exactly that reason.
+ *
  * The form is Pro-only as a whole in any case: the write refuses on a CE server because the
  * mutation there cannot store a level or a justification. So a drift here and a drift on the
  * write mean the same thing to the operator, and carry the same message.
  */
 export const SBOM_COMPONENT_SUPPORT_DETAIL = gql`
-    query sbomComponentSupportDetail($uuid: ID!) {
-        sbomComponent(uuid: $uuid) {
-            uuid
-            attestationState
-            attestedLevelOfSupport
-            justification
-            supportParty
-            endOfGuaranteedSupportDate
-            endOfSupportDate
-            endOfLifeDate
-            supportNotes
+    query sbomComponentSupportDetail($releaseUuid: ID!, $sbomComponentUuid: ID!) {
+        getReleaseSbomComponentGraph(
+            releaseUuid: $releaseUuid
+            sbomComponentUuid: $sbomComponentUuid
+        ) {
+            component {
+                uuid
+                attestationState
+                attestedLevelOfSupport
+                justification
+                supportParty
+                endOfGuaranteedSupportDate
+                endOfSupportDate
+                endOfLifeDate
+                supportNotes
+            }
         }
     }`
 
@@ -39,17 +52,18 @@ export type SupportDetailResult =
 
 export async function loadSbomComponentSupportDetail (
     client: DriftFallbackClient,
-    uuid: string
+    releaseUuid: string,
+    sbomComponentUuid: string
 ): Promise<SupportDetailResult> {
     try {
         const resp = await client.query({
             query: SBOM_COMPONENT_SUPPORT_DETAIL,
-            variables: { uuid },
+            variables: { releaseUuid, sbomComponentUuid },
             // Never cached: the form seeds from this, and editing a stale copy is how one
             // operator silently overwrites another's attestation under PATCH semantics.
             fetchPolicy: 'network-only'
         })
-        const c = (resp.data as any)?.sbomComponent
+        const c = (resp.data as any)?.getReleaseSbomComponentGraph?.component
         if (!c) return { kind: 'ok', attestation: null }
         // A component with no attestation at all still returns a row, with every support
         // field null. Seed from it either way -- the form handles both.

--- a/ui/src/utils/sbomComponentSupportDetail.ts
+++ b/ui/src/utils/sbomComponentSupportDetail.ts
@@ -40,7 +40,11 @@ export const SBOM_COMPONENT_SUPPORT_DETAIL = gql`
                 endOfGuaranteedSupportDate
                 endOfSupportDate
                 endOfLifeDate
-                supportNotes
+                supportMilestones {
+                    milestoneType
+                    date
+                    notes
+                }
             }
         }
     }`

--- a/ui/src/utils/sbomComponentSupportDetailSchemaDrift.spec.ts
+++ b/ui/src/utils/sbomComponentSupportDetailSchemaDrift.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
+import { SBOM_COMPONENT_SUPPORT_DETAIL } from './sbomComponentSupportDetail'
+
+/**
+ * Validates the attestation-detail query against Pro, and this spec exists because its
+ * absence cost a browser round trip.
+ *
+ * The query originally selected a root `sbomComponent(uuid:)` field that does not exist in
+ * this schema at all -- I invented it. An unknown field is a GraphQL VALIDATION error, and
+ * isSchemaDriftError treats validation errors as drift, so the form refused with "this
+ * server cannot store a full support attestation" against a Pro backend that could store one
+ * perfectly well. A bug in my own query, wearing the costume of somebody else's outdated
+ * server, and no unit test could see it because they all mock the client.
+ *
+ * Any query written against a schema needs one of these. Validation is the only thing that
+ * distinguishes "the server is old" from "I typed it wrong".
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const loadSchema = (p: string): GraphQLSchema | null =>
+    existsSync(p) ? buildSchema(readFileSync(p, 'utf8')) : null
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+const errors = (s: GraphQLSchema) =>
+    validate(s, parse(SBOM_COMPONENT_SUPPORT_DETAIL.loc!.source.body)).map(e => e.message)
+
+describe('attestation detail query vs the schemas', () => {
+    // The assertion that would have caught the invented query name before the browser did.
+    it.runIf(proSchema)('is valid on Pro -- every field and argument exists', () => {
+        expect(errors(proSchema as GraphQLSchema)).toEqual([])
+    })
+
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    /**
+     * Pro-only, which is correct and is why the form refuses on CE rather than opening a
+     * narrower one: a server that cannot report the stored level or party also cannot store
+     * them. Fails by design when the CE sync lands.
+     */
+    it.runIf(ceSchema)('is Pro-only, matching the write it precedes', () => {
+        const errs = errors(ceSchema as GraphQLSchema)
+        expect(errs.length,
+            'the detail query now validates on CE -- re-check whether the form should still'
+            + ' refuse there, since the write may also have become possible')
+            .toBeGreaterThan(0)
+        expect(errs.join(' ')).toContain('attestationState')
+    })
+})

--- a/ui/src/utils/setSbomComponentSupport.ts
+++ b/ui/src/utils/setSbomComponentSupport.ts
@@ -1,0 +1,93 @@
+// The per-component attestation write.
+
+import gql from 'graphql-tag'
+import { isSchemaDriftError } from './graphqlDriftFallback'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import { attestationVariables } from './supportAttestationInput'
+import type { AttestationForm } from './supportAttestationInput'
+
+/**
+ * The full Pro mutation. Twelve arguments; the CE mirror currently declares four.
+ *
+ * THERE IS NO FALLBACK, and this is the opposite of the rule used for reads. A read that
+ * degrades shows less; a WRITE that degrades stores less while reporting success. Falling
+ * back to the CE signature would silently drop levelOfSupport and justification -- the two
+ * fields section V.A.4(b) actually asks for -- and the operator would have no way to tell
+ * from the UI that their attestation had been hollowed out. Refuse instead, and say what
+ * would have been lost.
+ */
+export const SET_SBOM_COMPONENT_SUPPORT = gql`
+    mutation setSbomComponentSupport(
+        $sbomComponentUuid: ID!
+        $levelOfSupport: LevelOfSupport
+        $justification: String
+        $supportParty: SupportParty
+        $endOfGuaranteedSupportDate: String
+        $endOfSupportDate: String
+        $endOfLifeDate: String
+        $supportNotes: String
+        $clearMilestones: [SupportMilestoneType!]
+        $reason: String
+    ) {
+        setSbomComponentSupport(
+            sbomComponentUuid: $sbomComponentUuid
+            levelOfSupport: $levelOfSupport
+            justification: $justification
+            supportParty: $supportParty
+            endOfGuaranteedSupportDate: $endOfGuaranteedSupportDate
+            endOfSupportDate: $endOfSupportDate
+            endOfLifeDate: $endOfLifeDate
+            supportNotes: $supportNotes
+            clearMilestones: $clearMilestones
+            reason: $reason
+        ) {
+            uuid
+            supportStatus
+            supportSource
+            endOfSupportDate
+            attestedLevelOfSupport
+            justification
+        }
+    }`
+
+/**
+ * Names what a narrower server cannot store, rather than saying "unsupported".
+ *
+ * An operator told "this server does not support that" has no idea whether to retry, work
+ * around it, or escalate. An operator told the level of support and the justification would
+ * not be saved knows immediately that the thing they came to record is the thing that
+ * cannot be recorded.
+ */
+export const DRIFT_REFUSAL =
+    'This server cannot store a full support attestation: it accepts only the milestone'
+    + ' dates and internal notes, so the level of support and the justification would be'
+    + ' silently dropped. Nothing was written. Upgrade the backend before attesting.'
+
+export interface AttestationResult {
+    uuid: string
+    supportStatus: string | null
+    supportSource: string | null
+    endOfSupportDate: string | null
+    attestedLevelOfSupport: string | null
+    justification: string | null
+}
+
+/**
+ * Write one component's attestation. Throws on refusal or failure; never partially writes.
+ */
+export async function setSbomComponentSupport (
+    client: DriftFallbackClient,
+    sbomComponentUuid: string,
+    form: AttestationForm
+): Promise<AttestationResult> {
+    try {
+        const resp = await (client as any).mutate({
+            mutation: SET_SBOM_COMPONENT_SUPPORT,
+            variables: attestationVariables(sbomComponentUuid, form)
+        })
+        return (resp.data as any)?.setSbomComponentSupport
+    } catch (err: any) {
+        if (isSchemaDriftError(err)) throw new Error(DRIFT_REFUSAL)
+        throw err
+    }
+}

--- a/ui/src/utils/setSbomComponentSupport.ts
+++ b/ui/src/utils/setSbomComponentSupport.ts
@@ -3,7 +3,12 @@
 import gql from 'graphql-tag'
 import { isSchemaDriftError } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
-interface VariableSource { variables: (uuid: string) => Record<string, unknown> }
+
+/** DriftFallbackClient declares only query; the write needs mutate. */
+export interface MutationClient extends DriftFallbackClient {
+    mutate (opts: { mutation: unknown, variables: Record<string, unknown> }): Promise<{ data?: any }>
+}
+
 
 /**
  * The full Pro mutation. Twelve arguments; the CE mirror currently declares four.
@@ -77,15 +82,21 @@ export interface AttestationResult {
 /**
  * Write one component's attestation. Throws on refusal or failure; never partially writes.
  */
-export async function setSbomComponentSupport (
-    client: DriftFallbackClient,
-    sbomComponentUuid: string,
-    form: VariableSource
+/**
+ * One write, given ready-made variables.
+ *
+ * Takes variables rather than a form because a single save may need SEVERAL writes: the
+ * mutation carries one supportNotes argument, so notes for two milestones must be
+ * serialised or they cross-contaminate. The caller owns that sequencing.
+ */
+export async function setSbomComponentSupportVars (
+    client: MutationClient,
+    variables: Record<string, unknown>
 ): Promise<AttestationResult> {
     try {
-        const resp = await (client as any).mutate({
+        const resp = await client.mutate({
             mutation: SET_SBOM_COMPONENT_SUPPORT,
-            variables: form.variables(sbomComponentUuid)
+            variables
         })
         return (resp.data as any)?.setSbomComponentSupport
     } catch (err: any) {

--- a/ui/src/utils/setSbomComponentSupport.ts
+++ b/ui/src/utils/setSbomComponentSupport.ts
@@ -3,8 +3,7 @@
 import gql from 'graphql-tag'
 import { isSchemaDriftError } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
-import { attestationVariables } from './supportAttestationInput'
-import type { AttestationForm } from './supportAttestationInput'
+interface VariableSource { variables: (uuid: string) => Record<string, unknown> }
 
 /**
  * The full Pro mutation. Twelve arguments; the CE mirror currently declares four.
@@ -81,12 +80,12 @@ export interface AttestationResult {
 export async function setSbomComponentSupport (
     client: DriftFallbackClient,
     sbomComponentUuid: string,
-    form: AttestationForm
+    form: VariableSource
 ): Promise<AttestationResult> {
     try {
         const resp = await (client as any).mutate({
             mutation: SET_SBOM_COMPONENT_SUPPORT,
-            variables: attestationVariables(sbomComponentUuid, form)
+            variables: form.variables(sbomComponentUuid)
         })
         return (resp.data as any)?.setSbomComponentSupport
     } catch (err: any) {

--- a/ui/src/utils/setSbomComponentSupport.ts
+++ b/ui/src/utils/setSbomComponentSupport.ts
@@ -27,6 +27,7 @@ export const SET_SBOM_COMPONENT_SUPPORT = gql`
         $endOfLifeDate: String
         $supportNotes: String
         $clearMilestones: [SupportMilestoneType!]
+        $state: SupportState
         $reason: String
     ) {
         setSbomComponentSupport(
@@ -39,6 +40,7 @@ export const SET_SBOM_COMPONENT_SUPPORT = gql`
             endOfLifeDate: $endOfLifeDate
             supportNotes: $supportNotes
             clearMilestones: $clearMilestones
+            state: $state
             reason: $reason
         ) {
             uuid
@@ -47,6 +49,7 @@ export const SET_SBOM_COMPONENT_SUPPORT = gql`
             endOfSupportDate
             attestedLevelOfSupport
             justification
+            attestationState
         }
     }`
 

--- a/ui/src/utils/setSbomComponentSupportSchemaDrift.spec.ts
+++ b/ui/src/utils/setSbomComponentSupportSchemaDrift.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
+import { SET_SBOM_COMPONENT_SUPPORT, DRIFT_REFUSAL } from './setSbomComponentSupport'
+
+/**
+ * The attestation WRITE against both schemas.
+ *
+ * This matters more than the read drift specs. A read that a server cannot serve shows less
+ * information; a write it cannot serve, if silently narrowed, stores less while reporting
+ * success. The CE mirror's setSbomComponentSupport takes four arguments to Pro's twelve --
+ * a copy-src.sh snapshot that the CE schema sync resolves -- so until then a CE backend
+ * would accept a write with the level of support and the justification simply absent.
+ *
+ * Hence no fallback and an explicit refusal, and hence this spec asserting the CE gap by
+ * name. When the sync lands this test FAILS BY DESIGN, and whoever lands it should delete
+ * the refusal path along with it.
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+const loadSchema = (p: string): GraphQLSchema | null =>
+    existsSync(p) ? buildSchema(readFileSync(p, 'utf8')) : null
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+const errors = (s: GraphQLSchema) =>
+    validate(s, parse(SET_SBOM_COMPONENT_SUPPORT.loc!.source.body)).map(e => e.message)
+
+describe('the attestation write vs the schemas', () => {
+    it.runIf(proSchema)('is valid on Pro', () => {
+        expect(errors(proSchema as GraphQLSchema)).toEqual([])
+    })
+
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    it.runIf(ceSchema)('is Pro-only, which is why the write refuses instead of degrading', () => {
+        const errs = errors(ceSchema as GraphQLSchema)
+        expect(errs.length,
+            'the attestation mutation now validates on CE -- the schema sync has landed, so'
+            + ' remove the refuse-on-drift path in setSbomComponentSupport.ts and delete'
+            + ' this test').toBeGreaterThan(0)
+    })
+
+    /**
+     * Names the specific arguments, not just "it fails". If CE gained levelOfSupport but not
+     * justification, an all-or-nothing refusal would still be right but the REASON would
+     * have changed, and a bare count would not notice.
+     */
+    it.runIf(ceSchema)('is missing exactly the fields the refusal names', () => {
+        const joined = errors(ceSchema as GraphQLSchema).join(' ')
+        expect(joined).toContain('levelOfSupport')
+        expect(joined).toContain('justification')
+    })
+
+    // The message has to name what would be lost. "Unsupported server" tells an operator
+    // nothing about whether to retry, work around it, or escalate.
+    it('the refusal names the fields at stake and says nothing was written', () => {
+        expect(DRIFT_REFUSAL).toContain('level of support')
+        expect(DRIFT_REFUSAL).toContain('justification')
+        expect(DRIFT_REFUSAL).toContain('Nothing was written')
+    })
+})

--- a/ui/src/utils/supportAttestationInput.spec.ts
+++ b/ui/src/utils/supportAttestationInput.spec.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import {
+    attestationVariables,
+    validateAttestation,
+    type AttestationForm
+} from './supportAttestationInput'
+
+/** A form where nothing has been touched. */
+const pristine = (): AttestationForm => ({
+    levelOfSupport: null,
+    justification: '',
+    party: null,
+    endOfGuaranteedSupportDate: null,
+    endOfSupportDate: null,
+    endOfLifeDate: null,
+    supportNotes: '',
+    reason: '',
+    clearMilestones: [],
+    clearJustification: false
+})
+
+describe('clearing is explicit, never accidental', () => {
+    /**
+     * An empty string is not "nothing to say" on this mutation -- it is the CLEAR signal.
+     * The server reads a supplied-but-blank justification as an instruction to null the
+     * stored basis (`request.justification() != null ? blankToNull(...) : existing`), and
+     * its own error text offers it as such: "or an empty one to clear the previous basis".
+     *
+     * So the form must never emit '' by accident. Only an explicit clear does.
+     */
+    it('emits an empty justification ONLY for an explicit clear', () => {
+        const f = pristine()
+        expect('justification' in attestationVariables('c-1', f)).toBe(false)
+        f.clearJustification = true
+        f.reason = 'basis belonged to the previous claim'
+        expect(attestationVariables('c-1', f).justification).toBe('')
+    })
+
+    /**
+     * The case with NO SERVER BACKSTOP. The negative levels are protected -- a blank
+     * justification on NO_LONGER_MAINTAINED or ABANDONED is rejected on the stored result.
+     * ACTIVELY_MAINTAINED does not require a basis, so a blank justification is accepted and
+     * SILENTLY CLEARS whatever basis was recorded before. Nothing server-side catches it;
+     * the form is the only guard.
+     */
+    it('does not clear the basis when setting ACTIVELY_MAINTAINED with an untouched justification', () => {
+        const f = pristine()
+        f.levelOfSupport = 'ACTIVELY_MAINTAINED'
+        const v = attestationVariables('c-1', f)
+        expect(v.levelOfSupport).toBe('ACTIVELY_MAINTAINED')
+        expect('justification' in v,
+            'sending justification:"" here would silently wipe the previous basis, and'
+            + ' ACTIVELY_MAINTAINED is the one level the server does not backstop')
+            .toBe(false)
+    })
+
+    // Clearing carries a reason because the audit row is the only trace it happened. This
+    // mirrors the server guard rather than duplicating its judgement.
+    it('refuses a clear with no reason', () => {
+        const f = pristine()
+        f.clearJustification = true
+        expect(validateAttestation(f)).toContain(
+            'Clearing the justification needs a reason: the audit row is the only record that it happened.')
+    })
+
+    it('refuses a milestone clear with no reason', () => {
+        const f = pristine()
+        f.clearMilestones = ['END_OF_SUPPORT']
+        expect(validateAttestation(f).length).toBeGreaterThan(0)
+    })
+
+    // Mirrors the server's stored-result invariant so the operator finds out before the
+    // round trip, not after a rejected write.
+    it.each(['NO_LONGER_MAINTAINED', 'ABANDONED'] as const)(
+        'refuses %s without a justification', (level) => {
+            const f = pristine()
+            f.levelOfSupport = level
+            expect(validateAttestation(f).some(e => e.includes('justification'))).toBe(true)
+        })
+
+    it('accepts a negative level once a justification is given', () => {
+        const f = pristine()
+        f.levelOfSupport = 'ABANDONED'
+        f.justification = 'upstream archived the repository in 2024'
+        expect(validateAttestation(f)).toEqual([])
+    })
+
+    it('accepts ACTIVELY_MAINTAINED with no justification', () => {
+        const f = pristine()
+        f.levelOfSupport = 'ACTIVELY_MAINTAINED'
+        expect(validateAttestation(f)).toEqual([])
+    })
+})
+
+describe('attestationVariables: PATCH semantics', () => {
+    /**
+     * THE contract. The backend treats an absent argument as "leave this alone" and a
+     * supplied one as "set it". So a form that always sends every field would overwrite
+     * another person's recorded level of support with null every time someone edited a date.
+     * Untouched must mean OMITTED, not empty.
+     */
+    it('omits every untouched field rather than sending null or empty', () => {
+        const v = attestationVariables('c-1', pristine())
+        expect(Object.keys(v)).toEqual(['sbomComponentUuid'])
+    })
+
+    it('sends only the field that changed', () => {
+        const f = pristine()
+        f.endOfSupportDate = '2030-01-01'
+        const v = attestationVariables('c-1', f)
+        expect(v).toEqual({ sbomComponentUuid: 'c-1', endOfSupportDate: '2030-01-01' })
+    })
+
+    // Blank strings are the trap: an untouched text input is '' , not null, and '' is a
+    // value the server would happily store, wiping a justification someone else wrote.
+    it.each(['justification', 'supportNotes', 'reason'] as const)(
+        'treats a blank %s as untouched, not as a value', (field) => {
+            const f = pristine()
+            ;(f as any)[field] = '   '
+            expect(Object.keys(attestationVariables('c-1', f))).toEqual(['sbomComponentUuid'])
+        })
+
+    it('trims text it does send', () => {
+        const f = pristine()
+        f.justification = '  supplier confirmed  '
+        expect(attestationVariables('c-1', f).justification).toBe('supplier confirmed')
+    })
+
+    /**
+     * Clearing is an explicit act and must survive the omit-empties rule: an empty
+     * clearMilestones array means "clear nothing", but a populated one is a real instruction
+     * that happens to be about absence.
+     */
+    it('omits an empty clearMilestones but sends a populated one', () => {
+        const f = pristine()
+        expect('clearMilestones' in attestationVariables('c-1', f)).toBe(false)
+        f.clearMilestones = ['END_OF_SUPPORT']
+        expect(attestationVariables('c-1', f).clearMilestones).toEqual(['END_OF_SUPPORT'])
+    })
+
+    // "Assessed, nothing published": the operator asked the supplier and got no answer. A
+    // justification alone IS a complete attestation -- it is the case the storage shape
+    // exists for, and the fresh-row guard on the server accepts exactly this.
+    it('accepts a justification with no level and no dates', () => {
+        const f = pristine()
+        f.justification = 'supplier declined to state a support level'
+        expect(attestationVariables('c-1', f)).toEqual({
+            sbomComponentUuid: 'c-1',
+            justification: 'supplier declined to state a support level'
+        })
+    })
+
+    it('sends level and party when chosen', () => {
+        const f = pristine()
+        f.levelOfSupport = 'NO_LONGER_MAINTAINED'
+        f.party = 'SUPPLIER'
+        f.justification = 'upstream archived the repository'
+        const v = attestationVariables('c-1', f)
+        expect(v.levelOfSupport).toBe('NO_LONGER_MAINTAINED')
+        expect(v.supportParty).toBe('SUPPLIER')
+    })
+
+    // The wire name differs from the form field name; a rename on either side would
+    // silently stop sending it, and the server would treat it as untouched.
+    it('maps party to the supportParty argument the schema declares', () => {
+        const f = pristine()
+        f.party = 'MANUFACTURER'
+        const v = attestationVariables('c-1', f)
+        expect('supportParty' in v).toBe(true)
+        expect('party' in v).toBe(false)
+    })
+})

--- a/ui/src/utils/supportAttestationInput.ts
+++ b/ui/src/utils/supportAttestationInput.ts
@@ -68,28 +68,58 @@ export function emptyAttestationForm (): AttestationForm {
  * A populated clearMilestones survives that rule deliberately: clearing is an explicit
  * instruction that happens to be about absence.
  */
+export const MILESTONE_FIELD_TO_TYPE: Record<string, SupportMilestoneType> = {
+    endOfGuaranteedSupportDate: 'END_OF_GUARANTEED_SUPPORT',
+    endOfSupportDate: 'END_OF_SUPPORT',
+    endOfLifeDate: 'END_OF_LIFE'
+}
+
+/**
+ * @param baseline the stored attestation the form was seeded from. When supplied, fields
+ *        EQUAL to it are omitted.
+ *
+ *        This is not an optimisation. A seeded form holds the stored dates, so without a
+ *        diff every save re-sends them -- which re-stamps each milestone's lastAssessed and
+ *        asserts a fresh assessment that never happened, quietly ageing the record forward.
+ *        It also makes clearing impossible: sending endOfSupportDate while asking to clear
+ *        END_OF_SUPPORT is rejected outright as "cannot set and clear the same milestone in
+ *        one call".
+ */
 export function attestationVariables (
     sbomComponentUuid: string,
-    form: AttestationForm
+    form: AttestationForm,
+    baseline?: Partial<Record<string, unknown>> | null
 ): Record<string, unknown> {
     const vars: Record<string, unknown> = { sbomComponentUuid }
     const text = (v: string) => (v && v.trim() ? v.trim() : undefined)
+    const unchanged = (field: string, value: unknown): boolean =>
+        !!baseline && (baseline[field] ?? null) === (value ?? null)
 
-    if (form.levelOfSupport) vars.levelOfSupport = form.levelOfSupport
+    if (form.levelOfSupport && !unchanged('attestedLevelOfSupport', form.levelOfSupport)) {
+        vars.levelOfSupport = form.levelOfSupport
+    }
     // The wire name is supportParty, not party. Pinned by a spec: a rename on either side
     // would stop sending it and the server would read that as "leave the party alone".
-    if (form.party) vars.supportParty = form.party
+    if (form.party && !unchanged('supportParty', form.party)) vars.supportParty = form.party
     // Order matters: an explicit clear wins over typed text, so a user who types and then
     // clicks Clear gets the clear they asked for rather than the text they abandoned.
     if (form.clearJustification) vars.justification = ''
-    else if (text(form.justification)) vars.justification = text(form.justification)
-    if (text(form.supportNotes)) vars.supportNotes = text(form.supportNotes)
-    if (text(form.reason)) vars.reason = text(form.reason)
-    if (form.endOfGuaranteedSupportDate) {
-        vars.endOfGuaranteedSupportDate = form.endOfGuaranteedSupportDate
+    else if (text(form.justification) && !unchanged('justification', text(form.justification))) {
+        vars.justification = text(form.justification)
     }
-    if (form.endOfSupportDate) vars.endOfSupportDate = form.endOfSupportDate
-    if (form.endOfLifeDate) vars.endOfLifeDate = form.endOfLifeDate
+    if (text(form.supportNotes) && !unchanged('supportNotes', text(form.supportNotes))) {
+        vars.supportNotes = text(form.supportNotes)
+    }
+    if (text(form.reason)) vars.reason = text(form.reason)
+    for (const field of Object.keys(MILESTONE_FIELD_TO_TYPE)) {
+        const value = (form as any)[field] as string | null
+        if (!value) continue
+        // Never set a milestone this save is also clearing: the server refuses the pair, and
+        // a seeded form holds the stored date, so a clear would otherwise always collide.
+        if (form.clearMilestones.includes(MILESTONE_FIELD_TO_TYPE[field])) continue
+        if (unchanged(field, value)) continue
+        vars[field] = value
+    }
     if (form.clearMilestones.length) vars.clearMilestones = form.clearMilestones
     if (form.state) vars.state = form.state
     return vars

--- a/ui/src/utils/supportAttestationInput.ts
+++ b/ui/src/utils/supportAttestationInput.ts
@@ -1,0 +1,131 @@
+// Form state -> setSbomComponentSupport variables, honouring the mutation's PATCH contract.
+
+import type { SupportAttestationFilter } from './sbomComponentsQuery'
+
+export type LevelOfSupport = 'ACTIVELY_MAINTAINED' | 'NO_LONGER_MAINTAINED' | 'ABANDONED'
+export type SupportParty = 'MANUFACTURER' | 'SUPPLIER' | 'THIRD_PARTY'
+export type SupportMilestoneType =
+    'END_OF_GUARANTEED_SUPPORT' | 'END_OF_SUPPORT' | 'END_OF_LIFE'
+
+export interface AttestationForm {
+    levelOfSupport: LevelOfSupport | null
+    justification: string
+    party: SupportParty | null
+    endOfGuaranteedSupportDate: string | null
+    endOfSupportDate: string | null
+    endOfLifeDate: string | null
+    supportNotes: string
+    reason: string
+    clearMilestones: SupportMilestoneType[]
+    /**
+     * Explicit "remove the recorded basis" action, NOT an empty text box.
+     *
+     * On this mutation an empty string is the clear signal, not an absence: the server reads
+     * a supplied-but-blank justification as an instruction to null the stored basis, and
+     * says so in its own error text. Deriving the clear from `justification === ''` would
+     * make every untouched form a clear.
+     */
+    clearJustification: boolean
+}
+
+export function emptyAttestationForm (): AttestationForm {
+    return {
+        levelOfSupport: null,
+        justification: '',
+        party: null,
+        endOfGuaranteedSupportDate: null,
+        endOfSupportDate: null,
+        endOfLifeDate: null,
+        supportNotes: '',
+        reason: '',
+        clearMilestones: [],
+        clearJustification: false
+    }
+}
+
+/**
+ * The mutation variables for a form, with untouched fields OMITTED.
+ *
+ * setSbomComponentSupport is a PATCH: an absent argument means "leave this alone", a
+ * supplied one means "set it". So a form that posted every field on every save would
+ * overwrite a level of support somebody else recorded with null each time a colleague
+ * edited a date -- silently, because the write would succeed.
+ *
+ * The trap is blank strings rather than nulls: an untouched text input holds '', not null,
+ * and '' is a value the server will happily store over an existing justification. Anything
+ * blank or whitespace-only is therefore treated as untouched.
+ *
+ * A populated clearMilestones survives that rule deliberately: clearing is an explicit
+ * instruction that happens to be about absence.
+ */
+export function attestationVariables (
+    sbomComponentUuid: string,
+    form: AttestationForm
+): Record<string, unknown> {
+    const vars: Record<string, unknown> = { sbomComponentUuid }
+    const text = (v: string) => (v && v.trim() ? v.trim() : undefined)
+
+    if (form.levelOfSupport) vars.levelOfSupport = form.levelOfSupport
+    // The wire name is supportParty, not party. Pinned by a spec: a rename on either side
+    // would stop sending it and the server would read that as "leave the party alone".
+    if (form.party) vars.supportParty = form.party
+    // Order matters: an explicit clear wins over typed text, so a user who types and then
+    // clicks Clear gets the clear they asked for rather than the text they abandoned.
+    if (form.clearJustification) vars.justification = ''
+    else if (text(form.justification)) vars.justification = text(form.justification)
+    if (text(form.supportNotes)) vars.supportNotes = text(form.supportNotes)
+    if (text(form.reason)) vars.reason = text(form.reason)
+    if (form.endOfGuaranteedSupportDate) {
+        vars.endOfGuaranteedSupportDate = form.endOfGuaranteedSupportDate
+    }
+    if (form.endOfSupportDate) vars.endOfSupportDate = form.endOfSupportDate
+    if (form.endOfLifeDate) vars.endOfLifeDate = form.endOfLifeDate
+    if (form.clearMilestones.length) vars.clearMilestones = form.clearMilestones
+    return vars
+}
+
+/**
+ * Problems to show BEFORE the round trip, phrased as the operator's problem.
+ *
+ * These mirror server-side guards rather than replacing them -- the server is still the
+ * authority and will reject the same things. The point is that a form which lets you press
+ * Save and then reports a validation failure has wasted the attempt and, on a slow link,
+ * left you unsure whether anything was written.
+ *
+ * The ACTIVELY_MAINTAINED case is the exception: there is no server guard, because that
+ * level does not require a basis. The form is the only thing standing between an operator
+ * and a silently wiped justification, which is why the variables builder omits rather than
+ * blanks.
+ */
+export function validateAttestation (form: AttestationForm): string[] {
+    const errors: string[] = []
+    const hasReason = !!(form.reason && form.reason.trim())
+    if (form.clearJustification && !hasReason) {
+        errors.push('Clearing the justification needs a reason: the audit row is the only'
+            + ' record that it happened.')
+    }
+    if (form.clearMilestones.length && !hasReason) {
+        errors.push('Clearing a date needs a reason: the audit row is the only record that it'
+            + ' happened.')
+    }
+    const negative = form.levelOfSupport === 'NO_LONGER_MAINTAINED'
+        || form.levelOfSupport === 'ABANDONED'
+    if (negative && !form.justification.trim() && !form.clearJustification) {
+        errors.push(`A level of ${form.levelOfSupport} is a negative claim about someone`
+            + " else's project, so it needs a justification recording its basis.")
+    }
+    if (negative && form.clearJustification) {
+        errors.push(`You cannot clear the justification while setting ${form.levelOfSupport}:`
+            + ' that would leave an unsupported negative claim.')
+    }
+    return errors
+}
+
+/** Nothing to send beyond the id -- the caller should not fire a mutation at all. */
+export function isEmptyAttestation (form: AttestationForm): boolean {
+    return Object.keys(attestationVariables('x', form)).length === 1
+}
+
+// Re-exported so the form and the list agree on the filter type without a second import
+// path; keeps the attestation module the single place the form imports from.
+export type { SupportAttestationFilter }

--- a/ui/src/utils/supportAttestationInput.ts
+++ b/ui/src/utils/supportAttestationInput.ts
@@ -26,6 +26,15 @@ export interface AttestationForm {
      * make every untouched form a clear.
      */
     clearJustification: boolean
+    /**
+     * Set to ATTESTED only when re-asserting a WITHDRAWN attestation; null otherwise.
+     *
+     * Omitting it means PRESERVE, so a form that never sent it saved the justification and
+     * the reason onto a still-withdrawn row -- the audit trail looked immaculate and the
+     * component stayed withdrawn and uncounted. The bulk path already forces ATTESTED for
+     * exactly this reason; the single-component form has to as well.
+     */
+    state: 'ATTESTED' | null
 }
 
 export function emptyAttestationForm (): AttestationForm {
@@ -39,7 +48,8 @@ export function emptyAttestationForm (): AttestationForm {
         supportNotes: '',
         reason: '',
         clearMilestones: [],
-        clearJustification: false
+        clearJustification: false,
+        state: null
     }
 }
 
@@ -81,6 +91,7 @@ export function attestationVariables (
     if (form.endOfSupportDate) vars.endOfSupportDate = form.endOfSupportDate
     if (form.endOfLifeDate) vars.endOfLifeDate = form.endOfLifeDate
     if (form.clearMilestones.length) vars.clearMilestones = form.clearMilestones
+    if (form.state) vars.state = form.state
     return vars
 }
 

--- a/ui/src/utils/supportAttestationInput.ts
+++ b/ui/src/utils/supportAttestationInput.ts
@@ -24,7 +24,16 @@ export interface AttestationForm {
     endOfGuaranteedSupportDate: string | null
     endOfSupportDate: string | null
     endOfLifeDate: string | null
-    supportNotes: string
+    /**
+     * Notes PER MILESTONE, keyed by type -- not one component-level box.
+     *
+     * That follows the storage model rather than fighting it: the server writes
+     * supportNotes onto the milestones it is staging, and SupportMilestoneFact.notes is
+     * documented as "the text that justified [the date]... often the only evidence of what
+     * the assessor checked". The flat supportNotes field is just the END_OF_SUPPORT
+     * milestone's notes, left over from the pre-milestone column.
+     */
+    milestoneNotes: Record<SupportMilestoneType, string>
     reason: string
     clearMilestones: SupportMilestoneType[]
     /**
@@ -55,7 +64,11 @@ export function emptyAttestationForm (): AttestationForm {
         endOfGuaranteedSupportDate: null,
         endOfSupportDate: null,
         endOfLifeDate: null,
-        supportNotes: '',
+        milestoneNotes: {
+            END_OF_GUARANTEED_SUPPORT: '',
+            END_OF_SUPPORT: '',
+            END_OF_LIFE: ''
+        },
         reason: '',
         clearMilestones: [],
         clearJustification: false,
@@ -117,9 +130,6 @@ export function attestationVariables (
     else if (text(form.justification) && !unchanged('justification', text(form.justification))) {
         vars.justification = text(form.justification)
     }
-    if (text(form.supportNotes) && !unchanged('supportNotes', text(form.supportNotes))) {
-        vars.supportNotes = text(form.supportNotes)
-    }
     if (text(form.reason)) vars.reason = text(form.reason)
     for (const field of Object.keys(MILESTONE_FIELD_TO_TYPE)) {
         const value = (form as any)[field] as string | null
@@ -175,6 +185,13 @@ export function validateAttestation (form: AttestationForm): string[] {
 /** Nothing to send beyond the id -- the caller should not fire a mutation at all. */
 export function isEmptyAttestation (form: AttestationForm): boolean {
     return Object.keys(attestationVariables('x', form)).length === 1
+}
+
+/** The mutation argument that carries each milestone's date. */
+export const MILESTONE_TYPE_TO_FIELD: Record<SupportMilestoneType, string> = {
+    END_OF_GUARANTEED_SUPPORT: 'endOfGuaranteedSupportDate',
+    END_OF_SUPPORT: 'endOfSupportDate',
+    END_OF_LIFE: 'endOfLifeDate'
 }
 
 // Re-exported so the form and the list agree on the filter type without a second import

--- a/ui/src/utils/supportAttestationInput.ts
+++ b/ui/src/utils/supportAttestationInput.ts
@@ -3,7 +3,17 @@
 import type { SupportAttestationFilter } from './sbomComponentsQuery'
 
 export type LevelOfSupport = 'ACTIVELY_MAINTAINED' | 'NO_LONGER_MAINTAINED' | 'ABANDONED'
-export type SupportParty = 'MANUFACTURER' | 'SUPPLIER' | 'THIRD_PARTY'
+/**
+ * EXACTLY the members of the backend SupportParty enum.
+ *
+ * An earlier revision invented MANUFACTURER and SUPPLIER -- values borrowed from two
+ * unrelated enums -- so two of the three options an operator could pick were rejected at
+ * variable coercion. That is a GraphQL VALIDATION error, which isSchemaDriftError classifies
+ * as drift, so picking "First party" against a fully capable Pro backend produced "This
+ * server cannot store a full support attestation. Upgrade the backend before attesting."
+ * The same disguise the detail query wore, on the write path where it is harder to notice.
+ */
+export type SupportParty = 'FIRST_PARTY' | 'THIRD_PARTY'
 export type SupportMilestoneType =
     'END_OF_GUARANTEED_SUPPORT' | 'END_OF_SUPPORT' | 'END_OF_LIFE'
 

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -108,6 +108,38 @@ describe('un-retracting a withdrawn attestation', () => {
         expect(f.canSubmit()).toBe(true)
     })
 
+    /**
+     * The defect a browser probe caught that every other check missed: the audit row was
+     * correct, the reason landed, the toast said saved -- and the component stayed
+     * WITHDRAWN, because state is preserved when omitted.
+     */
+    it('sends state ATTESTED, or the re-assertion does not happen', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'supplier confirmed the original window'
+        expect(attestationVariables('c-1', f.form).state).toBe('ATTESTED')
+    })
+
+    /**
+     * The most likely un-retract of all: the original claim was right and the withdrawal was
+     * the mistake, so nothing needs editing. The form refused this until the pending state
+     * change was counted as a change.
+     */
+    it('allows a pure un-retract with a reason and no other edit', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'the withdrawal was filed against the wrong component'
+        expect(f.dirty()).toBe(true)
+        expect(f.canSubmit()).toBe(true)
+    })
+
+    it('does not touch state on an ordinary edit', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.supportNotes = 'note'
+        expect('state' in attestationVariables('c-1', f.form)).toBe(false)
+    })
+
     it('does not demand a reason for an ordinary edit', () => {
         const f = useAttestationForm()
         f.open(existing())

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+import { useAttestationForm } from './useAttestationForm'
+import { attestationVariables } from './supportAttestationInput'
+
+const existing = (over: Record<string, unknown> = {}) => ({
+    attestationState: 'ATTESTED',
+    attestedLevelOfSupport: 'ACTIVELY_MAINTAINED',
+    justification: 'checked the upstream release feed in March',
+    supportParty: 'SUPPLIER',
+    endOfGuaranteedSupportDate: null,
+    endOfSupportDate: '2030-01-01',
+    endOfLifeDate: null,
+    supportNotes: '',
+    ...over
+})
+
+describe('seeding', () => {
+    it('opens with the stored attestation, so a save is a no-op until something changes', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        expect(f.form.levelOfSupport).toBe('ACTIVELY_MAINTAINED')
+        expect(f.form.party).toBe('SUPPLIER')
+        expect(f.form.endOfSupportDate).toBe('2030-01-01')
+        expect(f.dirty()).toBe(false)
+    })
+
+    it('opens empty for a component with no attestation', () => {
+        const f = useAttestationForm()
+        f.open(null)
+        expect(f.form.levelOfSupport).toBeNull()
+        expect(f.form.justification).toBe('')
+        expect(f.isUnRetract()).toBe(false)
+    })
+})
+
+describe('justification confirm-or-revise on a milestone change', () => {
+    /**
+     * The basis was written for the dates that were there when it was written. Changing a
+     * date without revisiting it leaves a justification silently vouching for a claim it was
+     * never about -- which is the substantiation record quietly going stale.
+     */
+    it('blocks a date change while an existing basis is neither confirmed nor revised', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = '2032-06-01'
+        expect(f.needsJustificationDecision()).toBe(true)
+        expect(f.canSubmit()).toBe(false)
+    })
+
+    it('is satisfied by confirming the existing basis still holds', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = '2032-06-01'
+        f.confirmJustification()
+        expect(f.needsJustificationDecision()).toBe(false)
+        expect(f.canSubmit()).toBe(true)
+    })
+
+    it('is satisfied by revising the basis instead', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = '2032-06-01'
+        f.form.justification = 'supplier published a new support window in September'
+        expect(f.needsJustificationDecision()).toBe(false)
+    })
+
+    // No stored basis means nothing to go stale.
+    it('does not ask when there was no basis to begin with', () => {
+        const f = useAttestationForm()
+        f.open(existing({ justification: null }))
+        f.form.endOfSupportDate = '2032-06-01'
+        expect(f.needsJustificationDecision()).toBe(false)
+    })
+
+    // Editing only the internal notes is not a claim change.
+    it('does not ask when no milestone moved', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.supportNotes = 'chased the supplier again'
+        expect(f.needsJustificationDecision()).toBe(false)
+    })
+
+    // Confirming means "still true for the NEW dates" -- it must not survive a further edit.
+    it('re-asks if a date changes again after confirmation', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = '2032-06-01'
+        f.confirmJustification()
+        f.form.endOfLifeDate = '2035-01-01'
+        expect(f.needsJustificationDecision()).toBe(true)
+    })
+})
+
+describe('un-retracting a withdrawn attestation', () => {
+    /**
+     * Re-asserting a withdrawn claim is a reversal, and the audit row is the only record it
+     * happened. Same argument the bulk path already enforces server-side.
+     */
+    it('requires a reason', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        expect(f.isUnRetract()).toBe(true)
+        f.form.endOfSupportDate = '2031-01-01'
+        f.confirmJustification()
+        expect(f.canSubmit()).toBe(false)
+        expect(f.errors().some(e => e.includes('reason'))).toBe(true)
+        f.form.reason = 'supplier confirmed the original window in writing'
+        expect(f.canSubmit()).toBe(true)
+    })
+
+    it('does not demand a reason for an ordinary edit', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.supportNotes = 'note'
+        expect(f.errors()).toEqual([])
+    })
+})
+
+describe('"assessed, nothing published"', () => {
+    /**
+     * The most complete attestation available when a supplier will not state a level. It
+     * submits a justification ALONE -- no level, no dates, no party -- which is exactly the
+     * justification-only path the server's fresh-row guard accepts.
+     *
+     * It is the near-opposite of clearing, which removes a basis. Keeping them apart in the
+     * UI matters; keeping them apart in the data is what this asserts.
+     */
+    it('submits a justification and nothing else', () => {
+        const f = useAttestationForm()
+        f.open(null)
+        f.assessedNothingPublished('supplier declined to state a support level')
+        const v = attestationVariables('c-1', f.form)
+        expect(v).toEqual({
+            sbomComponentUuid: 'c-1',
+            justification: 'supplier declined to state a support level'
+        })
+    })
+
+    it('discards a level and dates already typed, rather than half-applying them', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.assessedNothingPublished('supplier declined to state a support level')
+        expect(f.form.levelOfSupport).toBeNull()
+        expect(f.form.endOfSupportDate).toBeNull()
+        expect(f.form.party).toBeNull()
+    })
+
+    it('is not a clear', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.assessedNothingPublished('supplier declined to state a support level')
+        expect(f.form.clearJustification).toBe(false)
+        expect(attestationVariables('c-1', f.form).justification).not.toBe('')
+    })
+})
+
+describe('submission gating', () => {
+    it('refuses a save that would send nothing', () => {
+        const f = useAttestationForm()
+        f.open(null)
+        expect(f.canSubmit()).toBe(false)
+    })
+
+    it('surfaces the server-mirrored guards', () => {
+        const f = useAttestationForm()
+        f.open(null)
+        f.form.levelOfSupport = 'ABANDONED'
+        expect(f.canSubmit()).toBe(false)
+        f.form.justification = 'upstream archived the repository'
+        expect(f.canSubmit()).toBe(true)
+    })
+})

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -91,6 +91,52 @@ describe('justification confirm-or-revise on a milestone change', () => {
     })
 })
 
+describe('variables are diffed against what was seeded', () => {
+    /**
+     * A seeded form holds the stored dates. Re-sending them re-stamps each milestone's
+     * lastAssessed, asserting a fresh assessment nobody made -- the record quietly ageing
+     * itself forward. Only what actually changed goes on the wire.
+     */
+    it('sends nothing but the id when nothing changed', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        expect(Object.keys(f.variables('c-1'))).toEqual(['sbomComponentUuid'])
+    })
+
+    it('sends only the field that moved', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfLifeDate = '2035-01-01'
+        f.confirmJustification()
+        expect(f.variables('c-1')).toEqual({
+            sbomComponentUuid: 'c-1', endOfLifeDate: '2035-01-01'
+        })
+    })
+
+    /**
+     * The failure the browser probe hit: the seeded date and a clear of the same milestone
+     * went out together, and the server refused the pair outright -- "cannot set and clear
+     * the same milestone in one call". A clear could therefore never succeed from a seeded
+     * form.
+     */
+    it('never sets a milestone it is also clearing', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.clearMilestones = ['END_OF_SUPPORT']
+        f.form.reason = 'the date belonged to the superseded claim'
+        const v = f.variables('c-1')
+        expect('endOfSupportDate' in v).toBe(false)
+        expect(v.clearMilestones).toEqual(['END_OF_SUPPORT'])
+    })
+
+    it('still sends an unchanged level when re-asserting, since state travels with it', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'withdrawal was filed in error'
+        expect(f.variables('c-1').state).toBe('ATTESTED')
+    })
+})
+
 describe('un-retracting a withdrawn attestation', () => {
     /**
      * Re-asserting a withdrawn claim is a reversal, and the audit row is the only record it

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -189,7 +189,9 @@ describe('un-retracting a withdrawn attestation', () => {
     it('does not demand a reason for an ordinary edit', () => {
         const f = useAttestationForm()
         f.open(existing())
-        f.form.supportNotes = 'note'
+        // Deliberately NOT a notes-only edit: notes are stored per-milestone, so that is
+        // blocked on its own. Revising the basis is the ordinary no-reason-needed change.
+        f.form.justification = 'rechecked the upstream release feed in September'
         expect(f.errors()).toEqual([])
     })
 })
@@ -229,6 +231,137 @@ describe('"assessed, nothing published"', () => {
         f.assessedNothingPublished('supplier declined to state a support level')
         expect(f.form.clearJustification).toBe(false)
         expect(attestationVariables('c-1', f.form).justification).not.toBe('')
+    })
+})
+
+describe('a save that would send nothing is refused', () => {
+    /**
+     * The failure this replaced: emptying a seeded box enabled Save, the baseline diff then
+     * omitted the emptied field, and the mutation went out as the component id alone --
+     * behind a green "Saved. Support attestation recorded." A success message for a write
+     * that changed nothing is worse than an error on a form meant to produce a defensible
+     * record.
+     */
+    it.each(['justification', 'supportNotes'] as const)(
+        'refuses a save after emptying the seeded %s', (field) => {
+            const f = useAttestationForm()
+            f.open(existing())
+            ;(f.form as any)[field] = ''
+            expect(f.sendsAnything()).toBe(false)
+            expect(f.canSubmit()).toBe(false)
+        })
+
+    it('refuses a save after blanking a seeded date', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = null
+        expect(f.canSubmit()).toBe(false)
+    })
+
+    it('still allows a save that genuinely changes something', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.justification = 'rechecked the upstream release feed in September'
+        expect(f.canSubmit()).toBe(true)
+    })
+})
+
+describe('"assessed, nothing published" does not cancel a pending un-retract', () => {
+    /**
+     * It resets the form, and state carries the PENDING UN-RETRACT set at open(). Dropping
+     * it left the row withdrawn and uncounted behind a success toast -- the same defect this
+     * feature shipped once already, reached by a different route.
+     */
+    it('keeps state ATTESTED and the reason', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'withdrawal was filed against the wrong component'
+        f.assessedNothingPublished('supplier declined to state a support level')
+        expect(f.form.state).toBe('ATTESTED')
+        expect(f.form.reason).toBe('withdrawal was filed against the wrong component')
+        expect(f.variables('c-1').state).toBe('ATTESTED')
+        expect(f.canSubmit()).toBe(true)
+    })
+})
+
+describe('contradictions and affordance honesty', () => {
+    // Clearing a date that is already stored is the ordinary case, not a contradiction.
+    it('allows clearing a seeded milestone', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.clearMilestones = ['END_OF_SUPPORT']
+        f.form.reason = 'the date belonged to the superseded claim'
+        expect(f.errors()).toEqual([])
+        expect(f.canSubmit()).toBe(true)
+    })
+
+    /**
+     * Typing a replacement date while also ticking its clear is a contradiction the server
+     * refuses outright. The builder silently preferred the clear, so the operator's new date
+     * evaporated with no warning.
+     */
+    it('refuses setting and clearing the same milestone', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfSupportDate = '2032-06-01'
+        f.confirmJustification()
+        f.form.clearMilestones = ['END_OF_SUPPORT']
+        f.form.reason = 'r'
+        expect(f.errors().some(e => e.includes('setting and clearing'))).toBe(true)
+        expect(f.canSubmit()).toBe(false)
+    })
+
+    /**
+     * The card promises "no level, no dates". Under PATCH, blanking those omits them, and
+     * omit means preserve -- so on a row carrying a level it would leave that level
+     * published against a justification written to mean the opposite. There is no way to
+     * unset a level at all, so the card is only offered where it can tell the truth.
+     */
+    it('is unavailable when the row already carries a level or dates', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        expect(f.canUseNothingPublished()).toBe(false)
+    })
+
+    it('is available on a fresh row and on a justification-only row', () => {
+        const fresh = useAttestationForm()
+        fresh.open(null)
+        expect(fresh.canUseNothingPublished()).toBe(true)
+        const basisOnly = useAttestationForm()
+        basisOnly.open(existing({
+            attestedLevelOfSupport: null, endOfSupportDate: null,
+            endOfGuaranteedSupportDate: null, endOfLifeDate: null
+        }))
+        expect(basisOnly.canUseNothingPublished()).toBe(true)
+    })
+})
+
+describe('internal notes are per-milestone server-side', () => {
+    /**
+     * The server reads supportNotes only inside its staged-milestone loop, and SupportData
+     * has no record-level notes field. A notes-only save therefore reported success and
+     * stored nothing -- and the backend's own comment calls that text "often the only
+     * evidence of what the assessor checked".
+     *
+     * Blocked rather than silently dropped. Whether notes should become record-level or the
+     * form should present them per-milestone is a design decision, not something to paper
+     * over here.
+     */
+    it('refuses a notes-only edit instead of discarding it', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.supportNotes = 'called the vendor again on 3 Sep'
+        expect(f.canSubmit()).toBe(false)
+        expect(f.errors().some(e => e.includes('stored against a date'))).toBe(true)
+    })
+
+    it('allows notes alongside a date change, which is where they land', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.supportNotes = 'vendor confirmed by email'
+        f.form.endOfSupportDate = '2032-01-01'
+        f.confirmJustification()
+        expect(f.errors()).toEqual([])
     })
 })
 

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -10,7 +10,9 @@ const existing = (over: Record<string, unknown> = {}) => ({
     endOfGuaranteedSupportDate: null,
     endOfSupportDate: '2030-01-01',
     endOfLifeDate: null,
-    supportNotes: '',
+    supportMilestones: [
+        { milestoneType: 'END_OF_SUPPORT', date: '2030-01-01', notes: 'vendor advisory of 3 March' }
+    ],
     ...over
 })
 
@@ -76,7 +78,7 @@ describe('justification confirm-or-revise on a milestone change', () => {
     it('does not ask when no milestone moved', () => {
         const f = useAttestationForm()
         f.open(existing())
-        f.form.supportNotes = 'chased the supplier again'
+        f.form.justification = 'rechecked the upstream feed'
         expect(f.needsJustificationDecision()).toBe(false)
     })
 
@@ -182,7 +184,7 @@ describe('un-retracting a withdrawn attestation', () => {
     it('does not touch state on an ordinary edit', () => {
         const f = useAttestationForm()
         f.open(existing())
-        f.form.supportNotes = 'note'
+        f.form.justification = 'rechecked the upstream feed'
         expect('state' in attestationVariables('c-1', f.form)).toBe(false)
     })
 
@@ -242,14 +244,13 @@ describe('a save that would send nothing is refused', () => {
      * that changed nothing is worse than an error on a form meant to produce a defensible
      * record.
      */
-    it.each(['justification', 'supportNotes'] as const)(
-        'refuses a save after emptying the seeded %s', (field) => {
-            const f = useAttestationForm()
-            f.open(existing())
-            ;(f.form as any)[field] = ''
-            expect(f.sendsAnything()).toBe(false)
-            expect(f.canSubmit()).toBe(false)
-        })
+    it('refuses a save after emptying the seeded justification', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.justification = ''
+        expect(f.sendsAnything()).toBe(false)
+        expect(f.canSubmit()).toBe(false)
+    })
 
     it('refuses a save after blanking a seeded date', () => {
         const f = useAttestationForm()
@@ -336,32 +337,90 @@ describe('contradictions and affordance honesty', () => {
     })
 })
 
-describe('internal notes are per-milestone server-side', () => {
+describe('notes are per milestone', () => {
     /**
-     * The server reads supportNotes only inside its staged-milestone loop, and SupportData
-     * has no record-level notes field. A notes-only save therefore reported success and
-     * stored nothing -- and the backend's own comment calls that text "often the only
-     * evidence of what the assessor checked".
-     *
-     * Blocked rather than silently dropped. Whether notes should become record-level or the
-     * form should present them per-milestone is a design decision, not something to paper
-     * over here.
+     * The server reads supportNotes only inside its staged-milestone loop and writes it onto
+     * the milestones being staged; SupportMilestoneFact.notes is documented as "the text
+     * that justified [the date]... often the only evidence of what the assessor checked".
+     * The flat supportNotes field is just the END_OF_SUPPORT milestone's notes under another
+     * name. So the form follows the model instead of fighting it.
      */
-    it('refuses a notes-only edit instead of discarding it', () => {
+    it('seeds each milestone note from its own milestone', () => {
         const f = useAttestationForm()
         f.open(existing())
-        f.form.supportNotes = 'called the vendor again on 3 Sep'
-        expect(f.canSubmit()).toBe(false)
-        expect(f.errors().some(e => e.includes('stored against a date'))).toBe(true)
+        expect(f.form.milestoneNotes.END_OF_SUPPORT).toBe('vendor advisory of 3 March')
+        expect(f.form.milestoneNotes.END_OF_LIFE).toBe('')
     })
 
-    it('allows notes alongside a date change, which is where they land', () => {
+    /**
+     * A notes-only edit sends that milestone's OWN date alongside the text, unchanged,
+     * because the server writes notes only onto milestones it is staging. That re-stamps
+     * the milestone's lastAssessed, and that is correct rather than a breach of the diff
+     * rule: revising what you checked IS a re-assessment of that milestone. The rule stays
+     * "never send a date the operator did not touch" -- editing its notes counts as
+     * touching it.
+     */
+    it('sends the milestone date with its notes, and nothing else', () => {
         const f = useAttestationForm()
         f.open(existing())
-        f.form.supportNotes = 'vendor confirmed by email'
-        f.form.endOfSupportDate = '2032-01-01'
+        f.form.milestoneNotes.END_OF_SUPPORT = 'vendor reconfirmed by email on 3 Sep'
+        expect(f.variableSets('c-1')).toEqual([{
+            sbomComponentUuid: 'c-1',
+            endOfSupportDate: '2030-01-01',
+            supportNotes: 'vendor reconfirmed by email on 3 Sep'
+        }])
+    })
+
+    /**
+     * One supportNotes argument per call, so two milestones' notes in a single call would
+     * land on both and cross-contaminate the evidence for each date. Serialised instead:
+     * one call per edited milestone, each its own audit revision.
+     */
+    it('serialises rather than cross-contaminating two milestones', () => {
+        const f = useAttestationForm()
+        f.open(existing({
+            supportMilestones: [
+                { milestoneType: 'END_OF_SUPPORT', date: '2030-01-01', notes: 'a' },
+                { milestoneType: 'END_OF_LIFE', date: '2031-01-01', notes: 'b' }
+            ],
+            endOfLifeDate: '2031-01-01'
+        }))
+        f.form.milestoneNotes.END_OF_SUPPORT = 'a2'
+        f.form.milestoneNotes.END_OF_LIFE = 'b2'
+        const sets = f.variableSets('c-1')
+        expect(sets.length).toBe(2)
+        expect(sets.map(x => x.supportNotes)).toEqual(['a2', 'b2'])
+        expect(sets[0].endOfSupportDate).toBe('2030-01-01')
+        expect(sets[1].endOfLifeDate).toBe('2031-01-01')
+        expect('supportNotes' in sets[0] && 'endOfLifeDate' in sets[0]).toBe(false)
+    })
+
+    // The server has nowhere to put a note for a milestone that does not exist.
+    it('refuses notes on a milestone with no date', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.milestoneNotes.END_OF_LIFE = 'orphan note'
+        expect(f.canSubmit()).toBe(false)
+        expect(f.errors().some(e => e.includes('set the date first'))).toBe(true)
+    })
+
+    it('accepts notes on a milestone whose date is set in the same save', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.endOfLifeDate = '2035-01-01'
+        f.form.milestoneNotes.END_OF_LIFE = 'supplier end-of-sale notice'
         f.confirmJustification()
         expect(f.errors()).toEqual([])
+    })
+
+    it('carries the reason onto every write so each audit revision explains itself', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'withdrawal was filed in error'
+        f.form.milestoneNotes.END_OF_SUPPORT = 'reconfirmed'
+        const sets = f.variableSets('c-1')
+        expect(sets.length).toBeGreaterThan(1)
+        for (const set of sets) expect(set.reason).toBe('withdrawal was filed in error')
     })
 })
 

--- a/ui/src/utils/useAttestationForm.spec.ts
+++ b/ui/src/utils/useAttestationForm.spec.ts
@@ -424,6 +424,58 @@ describe('notes are per milestone', () => {
     })
 })
 
+describe('a partial save leaves only the remainder pending', () => {
+    /**
+     * Writes are serialised, so call 1 of 2 can land and call 2 throw. Reporting that as a
+     * plain failure makes the operator resubmit BOTH, and the milestone that already landed
+     * gets written again -- re-stamping its lastAssessed for an assessment that happened
+     * once, so the record claims two re-assessments where there was one.
+     */
+    it('drops the completed write and keeps the failed one pending', () => {
+        const f = useAttestationForm()
+        f.open(existing({
+            supportMilestones: [
+                { milestoneType: 'END_OF_SUPPORT', date: '2030-01-01', notes: 'a' },
+                { milestoneType: 'END_OF_LIFE', date: '2031-01-01', notes: 'b' }
+            ],
+            endOfLifeDate: '2031-01-01'
+        }))
+        f.form.milestoneNotes.END_OF_SUPPORT = 'a2'
+        f.form.milestoneNotes.END_OF_LIFE = 'b2'
+        const sets = f.variableSets('c-1')
+        expect(sets.length).toBe(2)
+
+        // First landed, second threw.
+        f.markSaved([sets[0]])
+
+        const remaining = f.variableSets('c-1')
+        expect(remaining.length).toBe(1)
+        expect(remaining[0].supportNotes).toBe('b2')
+        expect(remaining[0].endOfLifeDate).toBe('2031-01-01')
+    })
+
+    it('reports nothing pending once every write has landed', () => {
+        const f = useAttestationForm()
+        f.open(existing())
+        f.form.milestoneNotes.END_OF_SUPPORT = 'reconfirmed'
+        const sets = f.variableSets('c-1')
+        f.markSaved(sets)
+        expect(f.variableSets('c-1')).toEqual([])
+        expect(f.canSubmit()).toBe(false)
+    })
+
+    // A landed un-retract must not be re-sent either.
+    it('clears the pending un-retract once it has landed', () => {
+        const f = useAttestationForm()
+        f.open(existing({ attestationState: 'WITHDRAWN' }))
+        f.form.reason = 'withdrawal was filed in error'
+        const sets = f.variableSets('c-1')
+        f.markSaved(sets)
+        expect(f.form.state).toBeNull()
+        expect(f.variableSets('c-1')).toEqual([])
+    })
+})
+
 describe('submission gating', () => {
     it('refuses a save that would send nothing', () => {
         const f = useAttestationForm()

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -154,6 +154,54 @@ export function useAttestationForm () {
         form.milestoneNotes = notes
     }
 
+    /**
+     * Fold completed writes into the baseline, so they stop counting as pending edits.
+     *
+     * Needed because a save can be PARTIAL: the writes are serialised, so call 1 of 2 can
+     * land and call 2 throw. Without this the form still shows both edits as outstanding,
+     * the operator resubmits, and milestone 1 is written a second time -- re-stamping its
+     * lastAssessed for an assessment that happened once. The record would then claim two
+     * re-assessments where there was one.
+     */
+    function markSaved (sets: Array<Record<string, unknown>>): void {
+        const seeded = (seededRef.value ?? {}) as any
+        for (const set of sets) {
+            for (const [type, field] of Object.entries(MILESTONE_TYPE_TO_FIELD)) {
+                if (set[field] !== undefined && set.supportNotes !== undefined) {
+                    const list = (seeded.supportMilestones ?? []).slice()
+                    const at = list.findIndex((m: any) => m.milestoneType === type)
+                    const row = { milestoneType: type, date: set[field] as string,
+                        notes: set.supportNotes as string }
+                    if (at >= 0) list[at] = { ...list[at], ...row }
+                    else list.push(row)
+                    seeded.supportMilestones = list
+                }
+            }
+            if (set.levelOfSupport !== undefined) seeded.attestedLevelOfSupport = set.levelOfSupport
+            if (set.supportParty !== undefined) seeded.supportParty = set.supportParty
+            if (set.justification !== undefined) seeded.justification = set.justification
+            for (const field of Object.values(MILESTONE_TYPE_TO_FIELD)) {
+                if (set[field] !== undefined && set.supportNotes === undefined) {
+                    seeded[field] = set[field]
+                }
+            }
+            if (set.state !== undefined) seeded.attestationState = set.state
+        }
+        seededRef.value = { ...seeded }
+        // Re-seed ONLY the milestones that landed. Re-seeding all of them would overwrite a
+        // still-pending edit on another milestone with its stored value -- silently
+        // discarding the very change the operator is about to retry.
+        for (const set of sets) {
+            for (const [type, field] of Object.entries(MILESTONE_TYPE_TO_FIELD)) {
+                if (set[field] !== undefined && set.supportNotes !== undefined
+                        && type in form.milestoneNotes) {
+                    (form.milestoneNotes as any)[type] = set.supportNotes as string
+                }
+            }
+        }
+        if ((seededRef.value as any).attestationState !== 'WITHDRAWN') form.state = null
+    }
+
     function errors (): string[] {
         const out = validateAttestation(form)
         if (isUnRetract() && !form.reason.trim()) {
@@ -252,7 +300,11 @@ export function useAttestationForm () {
     function variableSets (sbomComponentUuid: string): Array<Record<string, unknown>> {
         const sets: Array<Record<string, unknown>> = []
         const base = variables(sbomComponentUuid)
-        if (Object.keys(base).length > 1) sets.push(base)
+        // A reason on its own is not a change. It annotates one, so a base set carrying
+        // nothing but the id and a reason would write an audit revision explaining an edit
+        // that never happened.
+        const substantive = Object.keys(base).filter(k => k !== 'sbomComponentUuid' && k !== 'reason')
+        if (substantive.length > 0) sets.push(base)
         const reason = form.reason.trim()
         for (const type of editedMilestoneNotes()) {
             const field = MILESTONE_TYPE_TO_FIELD[type as keyof typeof MILESTONE_TYPE_TO_FIELD]
@@ -277,6 +329,7 @@ export function useAttestationForm () {
         sendsAnything,
         variableSets,
         editedMilestoneNotes,
+        markSaved,
         canUseNothingPublished,
         open,
         isUnRetract,

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -3,6 +3,7 @@ import {
     emptyAttestationForm,
     validateAttestation,
     isEmptyAttestation,
+    attestationVariables,
     type AttestationForm,
     type LevelOfSupport,
     type SupportParty
@@ -138,8 +139,14 @@ export function useAttestationForm () {
         return dirty() && errors().length === 0 && !isEmptyAttestation(form)
     }
 
+    /** Variables for this save, diffed against what the form was seeded with. */
+    function variables (sbomComponentUuid: string): Record<string, unknown> {
+        return attestationVariables(sbomComponentUuid, form, seeded as any)
+    }
+
     return {
         form,
+        variables,
         open,
         isUnRetract,
         milestoneChanged,

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -53,6 +53,10 @@ export function useAttestationForm () {
         form.endOfSupportDate = existing.endOfSupportDate ?? null
         form.endOfLifeDate = existing.endOfLifeDate ?? null
         form.supportNotes = existing.supportNotes ?? ''
+        // Re-asserting is the POINT of opening a withdrawn attestation, and it does not
+        // happen by itself: state is preserved when omitted, so saving without this leaves
+        // the row withdrawn and still uncounted while every other field updates.
+        form.state = existing.attestationState === 'WITHDRAWN' ? 'ATTESTED' : null
     }
 
     /** Re-asserting a withdrawn claim is a reversal; the audit row is its only trace. */
@@ -118,6 +122,11 @@ export function useAttestationForm () {
 
     function dirty (): boolean {
         if (!seeded) return !isEmptyAttestation(form)
+        // Re-asserting a withdrawn attestation IS the change, even when no field differs.
+        // Without this the form refuses a pure un-retract -- reason supplied, nothing else
+        // edited -- which is the most likely un-retract there is: the original claim was
+        // right and the withdrawal was the mistake.
+        if (form.state === 'ATTESTED') return true
         return milestoneChanged() || justificationRevised()
             || (form.levelOfSupport ?? null) !== (seeded.attestedLevelOfSupport ?? null)
             || (form.party ?? null) !== (seeded.supportParty ?? null)

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -1,9 +1,10 @@
-import { reactive } from 'vue'
+import { reactive, ref, type Ref } from 'vue'
 import {
     emptyAttestationForm,
     validateAttestation,
     isEmptyAttestation,
     attestationVariables,
+    MILESTONE_FIELD_TO_TYPE,
     type AttestationForm,
     type LevelOfSupport,
     type SupportParty
@@ -35,8 +36,14 @@ const MILESTONE_FIELDS = [
  */
 export function useAttestationForm () {
     const form = reactive(emptyAttestationForm()) as AttestationForm
-    let seeded: ExistingAttestation | null = null
-    let confirmedForDates = ''
+    // REFS, not plain closure variables. needsJustificationDecision() reads both, and the
+    // template reads it through errors()/canSubmit(); with plain `let`, clicking "It still
+    // holds" mutated nothing Vue tracks, so the warning stayed on screen and Save stayed
+    // disabled until the operator happened to touch another field. The two sibling
+    // composables on this track keep every value a consumer reads in a ref for this reason,
+    // and use plain `let` only for things nothing renders.
+    const seededRef: Ref<ExistingAttestation | null> = ref(null)
+    const confirmedForDates = ref('')
 
     function snapshotDates (): string {
         return MILESTONE_FIELDS.map(f => form[f] ?? '').join('|')
@@ -44,8 +51,8 @@ export function useAttestationForm () {
 
     function open (existing: ExistingAttestation | null): void {
         Object.assign(form, emptyAttestationForm())
-        seeded = existing
-        confirmedForDates = ''
+        seededRef.value = existing
+        confirmedForDates.value = ''
         if (!existing) return
         form.levelOfSupport = existing.attestedLevelOfSupport ?? null
         form.justification = existing.justification ?? ''
@@ -62,16 +69,16 @@ export function useAttestationForm () {
 
     /** Re-asserting a withdrawn claim is a reversal; the audit row is its only trace. */
     function isUnRetract (): boolean {
-        return seeded?.attestationState === 'WITHDRAWN'
+        return seededRef.value?.attestationState === 'WITHDRAWN'
     }
 
     function milestoneChanged (): boolean {
-        if (!seeded) return MILESTONE_FIELDS.some(f => !!form[f])
-        return MILESTONE_FIELDS.some(f => (form[f] ?? null) !== (seeded?.[f] ?? null))
+        if (!seededRef.value) return MILESTONE_FIELDS.some(f => !!form[f])
+        return MILESTONE_FIELDS.some(f => (form[f] ?? null) !== (seededRef.value?.[f] ?? null))
     }
 
     function justificationRevised (): boolean {
-        return (form.justification ?? '').trim() !== (seeded?.justification ?? '').trim()
+        return (form.justification ?? '').trim() !== (seededRef.value?.justification ?? '').trim()
     }
 
     /**
@@ -83,14 +90,15 @@ export function useAttestationForm () {
      * true" is a statement about a specific claim, not a permanent dismissal.
      */
     function needsJustificationDecision (): boolean {
-        if (!seeded?.justification || !seeded.justification.trim()) return false
+        const basis = seededRef.value?.justification
+        if (!basis || !basis.trim()) return false
         if (!milestoneChanged()) return false
         if (justificationRevised()) return false
-        return confirmedForDates !== snapshotDates()
+        return confirmedForDates.value !== snapshotDates()
     }
 
     function confirmJustification (): void {
-        confirmedForDates = snapshotDates()
+        confirmedForDates.value = snapshotDates()
     }
 
     /**
@@ -101,11 +109,38 @@ export function useAttestationForm () {
      * Resets the rest rather than layering on top, so a half-typed level cannot ride along
      * into a submission that is meant to say only "we asked, and this is what we found".
      */
+    /**
+     * True when the card can honour its own promise.
+     *
+     * It says "your basis alone -- no level, no dates". Under PATCH, blanking those in the
+     * form OMITS them, and omit means PRESERVE -- so on a row that already carries a level,
+     * the card would leave that level published against a justification written to mean the
+     * opposite. There is no way to unset a level at all: the mutation has no argument for it.
+     * So the card is offered only where it can tell the truth.
+     */
+    function canUseNothingPublished (): boolean {
+        const seeded = seededRef.value
+        if (!seeded) return true
+        return !seeded.attestedLevelOfSupport
+            && !seeded.endOfGuaranteedSupportDate
+            && !seeded.endOfSupportDate
+            && !seeded.endOfLifeDate
+    }
+
     function assessedNothingPublished (justification: string): void {
+        // state and reason survive the reset. state carries a PENDING UN-RETRACT, which is
+        // set at open() precisely because omitting it means preserve -- dropping it here made
+        // this card silently cancel the re-assertion, leaving the row withdrawn and
+        // uncounted behind a success toast. That is the same defect this feature already
+        // shipped once. reason survives because the guards that demand one still apply.
         const notes = form.supportNotes
+        const state = form.state
+        const reason = form.reason
         Object.assign(form, emptyAttestationForm())
         form.justification = justification
         form.supportNotes = notes
+        form.state = state
+        form.reason = reason
     }
 
     function errors (): string[] {
@@ -113,6 +148,29 @@ export function useAttestationForm () {
         if (isUnRetract() && !form.reason.trim()) {
             out.push('This attestation was withdrawn. Re-asserting it needs a reason: the'
                 + ' audit row is the only record that the withdrawal was reversed.')
+        }
+        // Set-and-clear is only a contradiction when the operator has staged a NEW value.
+        // A seeded date sitting in the box alongside a clear is the ordinary case -- that is
+        // what clearing a recorded date looks like -- and the variables builder drops it.
+        for (const [field, type] of Object.entries(MILESTONE_FIELD_TO_TYPE)) {
+            const staged = (form as any)[field] as string | null
+            const stored = (seededRef.value as any)?.[field] ?? null
+            if (form.clearMilestones.includes(type) && staged && staged !== stored) {
+                out.push(`You are both setting and clearing ${type.replace(/_/g, ' ').toLowerCase()}.`
+                    + ' Pick one: clear it, or enter the new date.')
+            }
+        }
+        // supportNotes is stored PER MILESTONE, not per component: the server reads it only
+        // inside the staged-milestone loop, and SupportData has no record-level notes field.
+        // So a notes-only edit is silently discarded, and notes saved alongside one date land
+        // on THAT milestone. Blocked rather than silently dropped, pending a decision on
+        // whether notes should become record-level (backend) or per-milestone (UI).
+        const notesChanged = (form.supportNotes ?? '').trim()
+            !== ((seededRef.value?.supportNotes ?? '') as string).trim()
+        if (notesChanged && !milestoneChanged() && form.clearMilestones.length === 0) {
+            out.push('Internal notes are stored against a date, not against the component, so'
+                + ' a notes-only change cannot be saved. Edit a date as well, or record the'
+                + ' text in the justification if it belongs in the disclosure.')
         }
         if (needsJustificationDecision()) {
             out.push('A date changed. Confirm the recorded basis still holds, or revise it --'
@@ -122,6 +180,7 @@ export function useAttestationForm () {
     }
 
     function dirty (): boolean {
+        const seeded = seededRef.value
         if (!seeded) return !isEmptyAttestation(form)
         // Re-asserting a withdrawn attestation IS the change, even when no field differs.
         // Without this the form refuses a pure un-retract -- reason supplied, nothing else
@@ -135,18 +194,34 @@ export function useAttestationForm () {
             || form.clearJustification || form.clearMilestones.length > 0
     }
 
+    /**
+     * Gated on what this save would actually SEND, diffed against the seed.
+     *
+     * It used to use isEmptyAttestation, which builds variables with NO baseline and so
+     * answers "does the form contain any text" -- true for any seeded row. Emptying a box
+     * therefore enabled Save, the diff then omitted the emptied field, and the mutation went
+     * out as the component id alone: a green "Saved. Support attestation recorded." for a
+     * write that changed nothing. On a form whose purpose is a defensible record, a success
+     * message for a no-op is worse than an error.
+     */
+    function sendsAnything (): boolean {
+        return Object.keys(variables('x')).length > 1
+    }
+
     function canSubmit (): boolean {
-        return dirty() && errors().length === 0 && !isEmptyAttestation(form)
+        return dirty() && errors().length === 0 && sendsAnything()
     }
 
     /** Variables for this save, diffed against what the form was seeded with. */
     function variables (sbomComponentUuid: string): Record<string, unknown> {
-        return attestationVariables(sbomComponentUuid, form, seeded as any)
+        return attestationVariables(sbomComponentUuid, form, seededRef.value as any)
     }
 
     return {
         form,
         variables,
+        sendsAnything,
+        canUseNothingPublished,
         open,
         isUnRetract,
         milestoneChanged,

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -1,0 +1,144 @@
+import { reactive } from 'vue'
+import {
+    emptyAttestationForm,
+    validateAttestation,
+    isEmptyAttestation,
+    type AttestationForm,
+    type LevelOfSupport,
+    type SupportParty
+} from './supportAttestationInput'
+
+/** The stored attestation a component already carries, as the list/detail query returns it. */
+export interface ExistingAttestation {
+    attestationState?: string | null
+    attestedLevelOfSupport?: LevelOfSupport | null
+    justification?: string | null
+    supportParty?: SupportParty | null
+    endOfGuaranteedSupportDate?: string | null
+    endOfSupportDate?: string | null
+    endOfLifeDate?: string | null
+    supportNotes?: string | null
+}
+
+const MILESTONE_FIELDS = [
+    'endOfGuaranteedSupportDate', 'endOfSupportDate', 'endOfLifeDate'
+] as const
+
+/**
+ * The attestation form's state machine, outside the SFC so it can be tested.
+ *
+ * Everything here is a rule about WHEN a save is allowed, and those rules are the substance
+ * of the form -- the markup is just inputs. Keeping them in the component would put them
+ * beyond reach of a test, which on this feature has already meant shipping a screen that
+ * rendered nothing.
+ */
+export function useAttestationForm () {
+    const form = reactive(emptyAttestationForm()) as AttestationForm
+    let seeded: ExistingAttestation | null = null
+    let confirmedForDates = ''
+
+    function snapshotDates (): string {
+        return MILESTONE_FIELDS.map(f => form[f] ?? '').join('|')
+    }
+
+    function open (existing: ExistingAttestation | null): void {
+        Object.assign(form, emptyAttestationForm())
+        seeded = existing
+        confirmedForDates = ''
+        if (!existing) return
+        form.levelOfSupport = existing.attestedLevelOfSupport ?? null
+        form.justification = existing.justification ?? ''
+        form.party = existing.supportParty ?? null
+        form.endOfGuaranteedSupportDate = existing.endOfGuaranteedSupportDate ?? null
+        form.endOfSupportDate = existing.endOfSupportDate ?? null
+        form.endOfLifeDate = existing.endOfLifeDate ?? null
+        form.supportNotes = existing.supportNotes ?? ''
+    }
+
+    /** Re-asserting a withdrawn claim is a reversal; the audit row is its only trace. */
+    function isUnRetract (): boolean {
+        return seeded?.attestationState === 'WITHDRAWN'
+    }
+
+    function milestoneChanged (): boolean {
+        if (!seeded) return MILESTONE_FIELDS.some(f => !!form[f])
+        return MILESTONE_FIELDS.some(f => (form[f] ?? null) !== (seeded?.[f] ?? null))
+    }
+
+    function justificationRevised (): boolean {
+        return (form.justification ?? '').trim() !== (seeded?.justification ?? '').trim()
+    }
+
+    /**
+     * A stored basis was written for the dates that were there at the time. Move a date and
+     * it silently vouches for a claim it was never about -- the substantiation record going
+     * stale without anyone deciding it should.
+     *
+     * Confirming is scoped to the dates confirmed FOR, so a further edit re-asks: "still
+     * true" is a statement about a specific claim, not a permanent dismissal.
+     */
+    function needsJustificationDecision (): boolean {
+        if (!seeded?.justification || !seeded.justification.trim()) return false
+        if (!milestoneChanged()) return false
+        if (justificationRevised()) return false
+        return confirmedForDates !== snapshotDates()
+    }
+
+    function confirmJustification (): void {
+        confirmedForDates = snapshotDates()
+    }
+
+    /**
+     * "Assessed, nothing published": a justification ALONE, which is a complete attestation
+     * when a supplier will not state a level, and exactly the path the server's fresh-row
+     * guard accepts.
+     *
+     * Resets the rest rather than layering on top, so a half-typed level cannot ride along
+     * into a submission that is meant to say only "we asked, and this is what we found".
+     */
+    function assessedNothingPublished (justification: string): void {
+        const notes = form.supportNotes
+        Object.assign(form, emptyAttestationForm())
+        form.justification = justification
+        form.supportNotes = notes
+    }
+
+    function errors (): string[] {
+        const out = validateAttestation(form)
+        if (isUnRetract() && !form.reason.trim()) {
+            out.push('This attestation was withdrawn. Re-asserting it needs a reason: the'
+                + ' audit row is the only record that the withdrawal was reversed.')
+        }
+        if (needsJustificationDecision()) {
+            out.push('A date changed. Confirm the recorded basis still holds, or revise it --'
+                + ' it was written for the previous dates.')
+        }
+        return out
+    }
+
+    function dirty (): boolean {
+        if (!seeded) return !isEmptyAttestation(form)
+        return milestoneChanged() || justificationRevised()
+            || (form.levelOfSupport ?? null) !== (seeded.attestedLevelOfSupport ?? null)
+            || (form.party ?? null) !== (seeded.supportParty ?? null)
+            || (form.supportNotes ?? '').trim() !== (seeded.supportNotes ?? '').trim()
+            || form.clearJustification || form.clearMilestones.length > 0
+    }
+
+    function canSubmit (): boolean {
+        return dirty() && errors().length === 0 && !isEmptyAttestation(form)
+    }
+
+    return {
+        form,
+        open,
+        isUnRetract,
+        milestoneChanged,
+        needsJustificationDecision,
+        confirmJustification,
+        assessedNothingPublished,
+        errors,
+        dirty,
+        canSubmit
+    }
+}

--- a/ui/src/utils/useAttestationForm.ts
+++ b/ui/src/utils/useAttestationForm.ts
@@ -5,6 +5,7 @@ import {
     isEmptyAttestation,
     attestationVariables,
     MILESTONE_FIELD_TO_TYPE,
+    MILESTONE_TYPE_TO_FIELD,
     type AttestationForm,
     type LevelOfSupport,
     type SupportParty
@@ -20,6 +21,7 @@ export interface ExistingAttestation {
     endOfSupportDate?: string | null
     endOfLifeDate?: string | null
     supportNotes?: string | null
+    supportMilestones?: Array<{ milestoneType: string, date?: string | null, notes?: string | null }>
 }
 
 const MILESTONE_FIELDS = [
@@ -60,7 +62,13 @@ export function useAttestationForm () {
         form.endOfGuaranteedSupportDate = existing.endOfGuaranteedSupportDate ?? null
         form.endOfSupportDate = existing.endOfSupportDate ?? null
         form.endOfLifeDate = existing.endOfLifeDate ?? null
-        form.supportNotes = existing.supportNotes ?? ''
+        // Seeded from each milestone's OWN notes, not from the flat supportNotes field --
+        // that field is only the END_OF_SUPPORT milestone's notes under another name.
+        for (const m of existing.supportMilestones ?? []) {
+            if (m.milestoneType in form.milestoneNotes) {
+                (form.milestoneNotes as any)[m.milestoneType] = m.notes ?? ''
+            }
+        }
         // Re-asserting is the POINT of opening a withdrawn attestation, and it does not
         // happen by itself: state is preserved when omitted, so saving without this leaves
         // the row withdrawn and still uncounted while every other field updates.
@@ -133,14 +141,17 @@ export function useAttestationForm () {
         // this card silently cancel the re-assertion, leaving the row withdrawn and
         // uncounted behind a success toast. That is the same defect this feature already
         // shipped once. reason survives because the guards that demand one still apply.
-        const notes = form.supportNotes
         const state = form.state
         const reason = form.reason
+        const notes = { ...form.milestoneNotes }
         Object.assign(form, emptyAttestationForm())
         form.justification = justification
-        form.supportNotes = notes
         form.state = state
         form.reason = reason
+        // Milestone notes are restored, not blanked. Blanking them reads as an EDIT to each
+        // milestone's notes -- against dates this same reset just cleared -- so the form
+        // demanded a date for a note the operator never touched.
+        form.milestoneNotes = notes
     }
 
     function errors (): string[] {
@@ -160,17 +171,12 @@ export function useAttestationForm () {
                     + ' Pick one: clear it, or enter the new date.')
             }
         }
-        // supportNotes is stored PER MILESTONE, not per component: the server reads it only
-        // inside the staged-milestone loop, and SupportData has no record-level notes field.
-        // So a notes-only edit is silently discarded, and notes saved alongside one date land
-        // on THAT milestone. Blocked rather than silently dropped, pending a decision on
-        // whether notes should become record-level (backend) or per-milestone (UI).
-        const notesChanged = (form.supportNotes ?? '').trim()
-            !== ((seededRef.value?.supportNotes ?? '') as string).trim()
-        if (notesChanged && !milestoneChanged() && form.clearMilestones.length === 0) {
-            out.push('Internal notes are stored against a date, not against the component, so'
-                + ' a notes-only change cannot be saved. Edit a date as well, or record the'
-                + ' text in the justification if it belongs in the disclosure.')
+        for (const type of editedMilestoneNotes()) {
+            const field = MILESTONE_TYPE_TO_FIELD[type as keyof typeof MILESTONE_TYPE_TO_FIELD]
+            if (!(form as any)[field]) {
+                out.push(`Notes for ${type.replace(/_/g, ' ').toLowerCase()} need a date --`
+                    + ' the note is stored against the date, so set the date first.')
+            }
         }
         if (needsJustificationDecision()) {
             out.push('A date changed. Confirm the recorded basis still holds, or revise it --'
@@ -190,7 +196,7 @@ export function useAttestationForm () {
         return milestoneChanged() || justificationRevised()
             || (form.levelOfSupport ?? null) !== (seeded.attestedLevelOfSupport ?? null)
             || (form.party ?? null) !== (seeded.supportParty ?? null)
-            || (form.supportNotes ?? '').trim() !== (seeded.supportNotes ?? '').trim()
+            || editedMilestoneNotes().length > 0
             || form.clearJustification || form.clearMilestones.length > 0
     }
 
@@ -205,11 +211,23 @@ export function useAttestationForm () {
      * message for a no-op is worse than an error.
      */
     function sendsAnything (): boolean {
-        return Object.keys(variables('x')).length > 1
+        return variableSets('x').length > 0
     }
 
     function canSubmit (): boolean {
         return dirty() && errors().length === 0 && sendsAnything()
+    }
+
+    function storedNote (type: string): string {
+        const m = (seededRef.value?.supportMilestones ?? [])
+            .find(x => x.milestoneType === type)
+        return (m?.notes ?? '').trim()
+    }
+
+    /** Milestone types whose notes the operator has edited. */
+    function editedMilestoneNotes (): string[] {
+        return Object.keys(form.milestoneNotes)
+            .filter(t => (form.milestoneNotes as any)[t].trim() !== storedNote(t))
     }
 
     /** Variables for this save, diffed against what the form was seeded with. */
@@ -217,10 +235,48 @@ export function useAttestationForm () {
         return attestationVariables(sbomComponentUuid, form, seededRef.value as any)
     }
 
+    /**
+     * Every write this save needs, in order.
+     *
+     * SERIALISED because the mutation takes ONE supportNotes argument: notes for two
+     * milestones in a single call would land on both, cross-contaminating the evidence for
+     * each date. One call per edited milestone instead, each its own audit revision, which
+     * is the honest shape rather than a clever one.
+     *
+     * A notes write carries that milestone's own date UNCHANGED, because the server only
+     * writes notes onto milestones it is staging. That re-stamps the milestone's
+     * lastAssessed, which is correct: revising what you checked is a re-assessment of that
+     * milestone. The diff rule is "never send a date the operator did not touch" -- editing
+     * its notes counts as touching it.
+     */
+    function variableSets (sbomComponentUuid: string): Array<Record<string, unknown>> {
+        const sets: Array<Record<string, unknown>> = []
+        const base = variables(sbomComponentUuid)
+        if (Object.keys(base).length > 1) sets.push(base)
+        const reason = form.reason.trim()
+        for (const type of editedMilestoneNotes()) {
+            const field = MILESTONE_TYPE_TO_FIELD[type as keyof typeof MILESTONE_TYPE_TO_FIELD]
+            const date = (form as any)[field]
+            if (!date) continue
+            const set: Record<string, unknown> = {
+                sbomComponentUuid,
+                [field]: date,
+                supportNotes: (form.milestoneNotes as any)[type].trim()
+            }
+            // Carried onto every write so each audit revision explains itself rather than
+            // leaving the follow-up rows unexplained.
+            if (reason) set.reason = reason
+            sets.push(set)
+        }
+        return sets
+    }
+
     return {
         form,
         variables,
         sendsAnything,
+        variableSets,
+        editedMilestoneNotes,
         canUseNothingPublished,
         open,
         isUnRetract,


### PR DESCRIPTION
Third of four, and **the first write surface in this track** — which is why it got a four-lens panel rather than the usual two layers.

## What it does

A per-component attestation form: level of support, party, justification (exported), per-milestone dates with their own notes, and an audit reason. Plus an "assessed, nothing published" affordance for the case a supplier won't state a level, and an explicit clear for recorded values.

## The rules that make it correct

The mutation is a **PATCH**: an omitted argument means *leave alone*, and a supplied empty string is the **clear signal** — the server reads a blank justification as an instruction to null the stored basis. So:

- Untouched means **omitted**, never blank. Variables are diffed against what the form was seeded with, so a save with no edits sends only the component id.
- Clearing is an explicit action, never derived from an empty box, and requires a reason.
- `ACTIVELY_MAINTAINED` is the one level with **no server backstop** — the stored-result invariant only fires for levels that require a basis — so a blank justification there would silently wipe the previous one. The form is the only guard, and it has its own spec.
- **A write never degrades.** The CE mirror declares four arguments to Pro's twelve, so a fallback would drop the level and the justification while reporting success. It refuses instead, naming what would be lost.
- **Notes are per milestone**, following the storage model: `SupportMilestoneFact.notes` is the evidence for *that date*. Writes are serialised — one call per edited milestone — because a single `supportNotes` argument would cross-contaminate two milestones.

## What review found

**Four probe rounds against the running stack found four defects that the build, 360 tests and the success toast all passed.** Every one needed the server assertion:

| Defect | Why nothing else caught it |
|---|---|
| The un-retract **didn't un-retract** — `state` omitted means preserve | Audit row was immaculate: right revision, right reason |
| A **pure un-retract was refused** — `dirty()` compared fields, none differed | The most likely un-retract of all |
| The detail query named a **field that doesn't exist** | Unknown field is a *validation* error → reported as "server too old" |
| A seeded form **re-sent unchanged dates**, colliding with clears and re-stamping `lastAssessed` | Clearing a milestone could never have worked |

**The panel then found five more**, and the two added lenses found the worst:

- **Two of three party options were not members of the enum.** The schema declares `SupportParty { FIRST_PARTY, THIRD_PARTY }`; the form sent `MANUFACTURER`/`SUPPLIER`. Coercion failure is a validation error, so picking "First party" against a capable backend produced *"Upgrade the backend before attesting."* There's now a `coerceInputValue` guard — document validation checks structure and can never see an enum value passed as a variable.
- **"It still holds" updated nothing.** `confirmedForDates` was a plain closure variable read through `canSubmit()`, so the click mutated nothing Vue tracks. The centrepiece flow was inert, and no unit test could see it because they call confirm and read errors in the same tick.
- **Three paths ended in "Saved" having written nothing or the wrong thing** — including "assessed, nothing published" on an `ABANDONED` row, which would have left a public accusation about a third party's project standing against a justification written to mean the opposite.

Also fixed: a generation guard on the seed load (cancel-then-open-another could seed from component A and write to B), and set-and-clear of the same milestone is now an error rather than a silent preference for the clear.

## Verified on the running stack

Both images hot-swapped; every claim below is a SQL read or a network-layer count, not a toast:

- attestation write → `revision` +1 exactly, justification stored, no duplicate revisions;
- gauge **0 of 3 → 1 of 3** with no reload;
- un-retract → `state=ATTESTED`, audit row carries the reason;
- clear → justification null, `milestones {}`, audit reason present;
- negative-level guard → **zero write requests**, refused client-side;
- `FIRST_PARTY` stored where the previous build refused it as an outdated server;
- notes-only edit → one write, note on `END_OF_SUPPORT`, date untouched, `lastAssessed` advanced.

## Checks

`npm run test`: **362 tests, 361 pass**. The one failure is `routeInputSchemaDrift.spec.ts`, pre-existing and identical on `origin/main` — stated explicitly because **nothing in CI runs vitest**. Lint unchanged at 273. Build clean. ASCII clean.

## Requesting `/ultrareview`

I'd like this one run before merge. It's the first write surface, it produces a regulatory record that is exported and customer-visible, and the pattern across four probe rounds and a four-lens panel is that **every defect here was semantic rather than syntactic** — a correct-looking write that recorded the wrong thing. That's the class a heavier multi-agent review is best placed to find, and I can't launch it myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)