### PR TITLE
FDA-Readiness-1 PR 5.4/4: bulk support attestation over the current filter

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -501,6 +501,7 @@
                 style="width: 720px;"
                 :mask-closable="!bulk.submitting.value"
                 :closable="!bulk.submitting.value"
+                :close-on-esc="!bulk.submitting.value"
                 title="Attest every component matching this filter">
                 <!-- COMPOSE -->
                 <div v-if="bulkStage === 'compose'">
@@ -510,7 +511,11 @@
                         withdrawing each component individually, and a withdrawn claim stays
                         on the record.
                     </n-alert>
-                    <n-form label-placement="top">
+                    <!-- Frozen during the walk: the collect is awaited over many round
+                         trips while this stage stays mounted, so an edit made after the
+                         click would be written by a confirmation the operator already
+                         approved against different values. -->
+                    <n-form label-placement="top" :disabled="bulk.collecting.value">
                         <n-form-item label="Level of support">
                             <n-select v-model:value="bulkForm.levelOfSupport"
                                 :options="LEVEL_OPTIONS" placeholder="Not stated" />
@@ -555,9 +560,9 @@
                             components will be attested.
                         </div>
                         <div style="font-size: 12px; margin-top: 6px;">
-                            Filter <strong>{{ sbomAppliedFilter }}</strong><span
-                                v-if="sbomAppliedSearch">, search
-                                <strong>"{{ sbomAppliedSearch }}"</strong></span>.
+                            Filter <strong>{{ bulkAppliedLabel }}</strong><span
+                                v-if="bulkCollected.search">, search
+                                <strong>"{{ bulkCollected.search }}"</strong></span>.
                             There is no bulk undo.
                         </div>
                     </n-alert>
@@ -573,14 +578,18 @@
                     <n-alert type="default" :show-icon="false" style="font-size: 12px;">
                         Writing: level
                         <strong>{{ bulkForm.levelOfSupport || 'not stated' }}</strong>;
-                        justification <strong>"{{ bulkForm.justification || '(none)' }}"</strong>
+                        justification <strong>"{{ bulkForm.justification || '(none)' }}"</strong>;
+                        claim is about
+                        <strong>{{ partyLabel(bulkForm.party) }}</strong>
                         <span v-if="bulkForm.endOfSupportDate">; end of support
                             <strong>{{ bulkForm.endOfSupportDate }}</strong></span>.
+                        <div style="margin-top: 4px;">
+                            Audit reason (not exported):
+                            <strong>"{{ bulkForm.reason }}"</strong>
+                        </div>
                     </n-alert>
                     <div v-if="bulk.submitting.value" style="margin-top: 12px;">
-                        <n-progress type="line"
-                            :percentage="Math.round(100 * bulk.progress.value
-                                / Math.max(bulkCollected.ids.length, 1))" />
+                        <n-progress type="line" :percentage="bulkPercent" />
                         <div style="font-size: 12px;">
                             {{ bulk.progress.value }} of {{ bulkCollected.ids.length }} sent.
                             Everything already sent has been written and cannot be recalled.
@@ -590,7 +599,9 @@
 
                 <!-- DONE: grouped by what the operator must DO about it -->
                 <div v-else-if="bulkStage === 'done' && bulkResult">
-                    <n-alert :type="bulkResult.failed ? 'warning' : 'success'" :show-icon="true">
+                    <n-alert
+                        :type="bulkResult.failed || bulkResult.aborted ? 'warning' : 'success'"
+                        :show-icon="true">
                         {{ bulkResult.applied }} attested.
                         <span v-if="bulkResult.skippedRoot">
                             {{ bulkResult.skippedRoot }} skipped as the release's own
@@ -614,8 +625,19 @@
                     </n-alert>
                     <n-alert v-if="bulkResult.error" type="error" :show-icon="true"
                         style="margin-top: 8px; font-size: 12px;">
-                        {{ bulkResult.error }} Re-running the same sweep is safe and completes
-                        the remainder.
+                        {{ bulkResult.error }}
+                        <span v-if="bulkResult.retryable">Re-running the same sweep is safe
+                            and completes the remainder.</span>
+                    </n-alert>
+                    <!-- The counters stopped summing: the server returned an outcome this
+                         build does not know. Reported, because the alternative is "0
+                         attested" over components that were in fact written. -->
+                    <n-alert v-if="bulkResult.unknownOutcomes" type="warning" :show-icon="true"
+                        style="margin-top: 8px; font-size: 12px;">
+                        Some components came back with a result this version cannot
+                        interpret ({{ bulkResult.unknownOutcomes }} of them), so they are
+                        counted in none of the totals above. Check those components before
+                        relying on this sweep.
                     </n-alert>
                     <div v-if="bulkResult.failed" style="margin-top: 10px;">
                         <div style="font-size: 12px; font-weight: 600;">Failures</div>
@@ -638,9 +660,10 @@
                             :loading="bulk.collecting.value"
                             @click="collectBulkTargets">Review selection</n-button>
                         <n-button v-if="bulkStage === 'confirm' && !bulk.submitting.value"
-                            size="small" @click="bulkStage = 'compose'">Back</n-button>
+                            size="small" @click="bulkBackToCompose">Back</n-button>
                         <n-button v-if="bulkStage === 'confirm'" size="small" type="error"
-                            :disabled="bulk.submitting.value || !bulkCollected.ids.length"
+                            :disabled="bulk.submitting.value || !bulkCollected.ids.length
+                                || bulkErrors.length > 0"
                             :loading="bulk.submitting.value"
                             @click="runBulkAttest">
                             Attest {{ bulkCollected.ids.length }} components
@@ -1250,6 +1273,7 @@
                                 v-if="sbomViewMode === 'list' && isWritable
                                     && sbomAppliedFilter === 'UNATTESTED'"
                                 size="small" type="primary" ghost
+                                :disabled="sbomDegraded"
                                 @click="openBulkAttest">
                                 Attest all shown
                             </n-button>
@@ -1642,7 +1666,8 @@ import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
 import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
-import { useBulkAttest, validateBulkInput } from '@/utils/useBulkAttest'
+import { useBulkAttest, validateBulkInput, emptyBulkForm } from '@/utils/useBulkAttest'
+import type { BulkAttestInput, BulkCollectResult, BulkOutcome } from '@/utils/useBulkAttest'
 import { useAttestationForm } from '@/utils/useAttestationForm'
 import type { LevelOfSupport, SupportMilestoneType, SupportParty } from '@/utils/supportAttestationInput'
 import { loadSbomComponentSupportDetail } from '@/utils/sbomComponentSupportDetail'
@@ -1930,11 +1955,26 @@ onMounted(async () => {
     loadingBar.finish()
 })
 
+/**
+ * A bulk sweep writes a regulatory claim across thousands of components in batches, with no
+ * bulk undo and no way to abort a batch already sent. Leaving mid-sweep discards the outcome
+ * report -- which components failed, whether a colleague raced the walk -- for writes that
+ * have already landed. The browser only allows a generic prompt here; that is enough.
+ */
+function warnOnLeaveDuringSweep (e: BeforeUnloadEvent) {
+    if (!bulk.submitting.value) return
+    e.preventDefault()
+    e.returnValue = ''
+}
+
+onMounted(() => window.addEventListener('beforeunload', warnOnLeaveDuringSweep))
+
 onUnmounted(() => {
     // Cancels the search debounce and fences in-flight responses, so a trailing keystroke
     // cannot fire a query, or notify an error toast, against a component that is gone.
     sbomPaging.dispose()
     stopStatusPolling()
+    window.removeEventListener('beforeunload', warnOnLeaveDuringSweep)
 })
 
 const pullRequest: ComputedRef<any> = computed((): any => {
@@ -3274,17 +3314,26 @@ async function loadSbomComponents (forceRefresh: boolean = false) {
 const bulk = useBulkAttest()
 const bulkModalOpen: Ref<boolean> = ref(false)
 const bulkStage: Ref<'compose' | 'confirm' | 'done'> = ref('compose')
-const bulkForm = reactive({
-    levelOfSupport: null as LevelOfSupport | null,
-    party: null as SupportParty | null,
-    justification: '',
-    endOfSupportDate: null as string | null,
-    reason: ''
-})
-const bulkCollected: Ref<{ ids: string[], backlogTotal: number,
-    sample: Array<{ uuid: string, name: string, version: string }> }> =
-    ref({ ids: [], backlogTotal: 0, sample: [] })
-const bulkResult: Ref<any> = ref(null)
+const bulkForm: BulkAttestInput = reactive(emptyBulkForm())
+/**
+ * A collected selection carries the filter and search it was walked under. Kept WITH the
+ * ids rather than read live at confirm and submit time: the search debounce can reassign
+ * the applied filter behind the open modal, and a degraded page resets it to ALL. Reading
+ * it live would let the confirmation describe one set while writing another, and would
+ * evaluate the concurrent-write check against a filter the walk never used.
+ */
+interface BulkSelection extends Omit<BulkCollectResult, 'refused'> {
+    filter: SupportAttestationFilter
+    search: string
+}
+
+const emptyBulkSelection = (): BulkSelection =>
+    ({ ids: [], backlogTotal: 0, sample: [], filter: 'UNATTESTED', search: '' })
+
+const bulkCollected: Ref<BulkSelection> = ref(emptyBulkSelection())
+const bulkResult: Ref<BulkOutcome | null> = ref(null)
+const bulkAppliedLabel: ComputedRef<string> = computed(
+    (): string => filterLabel(bulkCollected.value.filter))
 const bulkAssessedAt: Ref<string> = ref('')
 
 /** Failures grouped by message: 800 identical validation errors are one line, not 800. */
@@ -3298,16 +3347,43 @@ const bulkFailureGroups: ComputedRef<Record<string, number>> = computed(() => {
     return out
 })
 
+const bulkPercent: ComputedRef<number> = computed((): number =>
+    Math.round(100 * bulk.progress.value / Math.max(bulkCollected.value.ids.length, 1)))
+
+/** The operator's word for a filter value, never the raw wire enum. */
+function filterLabel (value: string): string {
+    return sbomAttestationFilterOptions.find(o => o.value === value)?.label ?? value
+}
+
+/** Same for the party, which the confirmation must show: it is exported on the BOM. */
+function partyLabel (value: SupportParty | null): string {
+    if (!value) return 'not stated'
+    return PARTY_OPTIONS.find(o => o.value === value)?.label ?? value
+}
+
 const bulkErrors: ComputedRef<string[]> = computed(
-    (): string[] => validateBulkInput({ ...bulkForm, assessedAt: bulkAssessedAt.value }))
+    (): string[] => validateBulkInput(bulkForm))
+
+function bulkBackToCompose () { bulkStage.value = 'compose' }
 
 function openBulkAttest () {
+    // Invalidates any walk still running from a previous open.
+    bulkGen += 1
+    // A refusal from the previous open ("7412 components, more than the 5000 a browser
+    // sweep will attempt") lives on the composable, not here, and is cleared only inside
+    // collect/submit -- so without this the operator narrows their filter and is met by a
+    // fresh empty form still carrying the old refusal.
+    bulk.error.value = null
+    // "Stop after this batch" tells the operator re-running is safe and completes the
+    // remainder, but the only way back in is through here. Wiping the form would make them
+    // retype level, party, justification, date and reason from memory, so the second half
+    // of one sweep could carry a different justification than the first. Keep it after a
+    // deliberate stop; clear it otherwise.
+    const resuming = bulkResult.value?.stoppedEarly === true
     bulkStage.value = 'compose'
     bulkResult.value = null
-    bulkCollected.value = { ids: [], backlogTotal: 0, sample: [] }
-    Object.assign(bulkForm, {
-        levelOfSupport: null, party: null, justification: '', endOfSupportDate: null, reason: ''
-    })
+    bulkCollected.value = emptyBulkSelection()
+    if (!resuming) Object.assign(bulkForm, emptyBulkForm())
     bulkModalOpen.value = true
 }
 
@@ -3318,24 +3394,54 @@ function openBulkAttest () {
  * those differ, and sweeping what the box says rather than what the list shows is exactly
  * how an operator attests the wrong set.
  */
+let bulkGen = 0
+
 async function collectBulkTargets () {
     if (!updatedRelease.value?.uuid) return
+    // Generation guard, same as attestGen below and for the same reason -- which I had
+    // already fixed once in this file and did not carry across. The walk is awaited and the
+    // modal stays closable while it runs, so closing and reopening lets a late collect land
+    // on the reopened form: it jumps to confirm holding the PREVIOUS search's ids while the
+    // screen renders the CURRENT filter beside them. A confirmation describing a different
+    // set than it will write is the one failure this stage exists to prevent.
+    const gen = ++bulkGen
     const res = await bulk.collect(graphqlClient as any, updatedRelease.value.uuid,
         sbomAppliedFilter.value, sbomAppliedSearch.value)
+    if (gen !== bulkGen) return
     if (res.refused) return
-    bulkCollected.value = { ids: res.ids, backlogTotal: res.backlogTotal, sample: res.sample }
+    // Pinned alongside the ids: the confirmation must describe -- and the write must use --
+    // the filter the walk actually ran under, not whatever the list is showing by the time
+    // the operator reads it.
+    bulkCollected.value = {
+        ids: res.ids, backlogTotal: res.backlogTotal, sample: res.sample,
+        filter: sbomAppliedFilter.value, search: sbomAppliedSearch.value
+    }
     bulkStage.value = 'confirm'
 }
 
 async function runBulkAttest () {
+    // Re-checked at the moment of the write, not only at the moment of the click that led
+    // here. The compose stage stays mounted through the walk, so the values validated
+    // before "Review selection" are not necessarily the values about to be sent -- and
+    // reason is a UI-only requirement the server will not enforce for us.
+    if (bulkErrors.value.length) { bulkStage.value = 'compose'; return }
     // One instant for the whole sweep, captured HERE -- at the moment the operator confirms,
     // not per write. The sweep is one act of assessment.
     bulkAssessedAt.value = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
     bulkResult.value = await bulk.submit(graphqlClient as any, bulkCollected.value.ids,
-        { ...bulkForm, assessedAt: bulkAssessedAt.value }, sbomAppliedFilter.value)
+        { ...bulkForm, assessedAt: bulkAssessedAt.value }, bulkCollected.value.filter)
     bulkStage.value = 'done'
-    // The gauge and the list both moved.
-    await loadSbomComponents(true)
+    // The gauge and the list both moved. Reported separately from the write, same as the
+    // per-component path below: a stale list after 800 successful attestations is not a
+    // failed sweep, and a bare red "Error" over "800 attested." leaves the operator unable
+    // to tell which half went wrong.
+    try {
+        await loadSbomComponents(true)
+    } catch (err: any) {
+        notify('warning', 'Attested, but the list did not refresh',
+            'The attestations were written. The list and coverage above may be stale until'
+            + ' you reload: ' + commonFunctions.parseGraphQLError(err.message))
+    }
 }
 
 // Per-component attestation form (FDA-Readiness-1 PR5.3).

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -496,6 +496,161 @@
                 </n-form>
             </n-modal>
             <n-modal
+                v-model:show="bulkModalOpen"
+                preset="card"
+                style="width: 720px;"
+                :mask-closable="!bulk.submitting.value"
+                :closable="!bulk.submitting.value"
+                title="Attest every component matching this filter">
+                <!-- COMPOSE -->
+                <div v-if="bulkStage === 'compose'">
+                    <n-alert type="warning" :show-icon="true" style="margin-bottom: 12px;">
+                        This writes the same attestation to every component matching the
+                        current filter. There is no bulk undo: correcting it means
+                        withdrawing each component individually, and a withdrawn claim stays
+                        on the record.
+                    </n-alert>
+                    <n-form label-placement="top">
+                        <n-form-item label="Level of support">
+                            <n-select v-model:value="bulkForm.levelOfSupport"
+                                :options="LEVEL_OPTIONS" placeholder="Not stated" />
+                        </n-form-item>
+                        <n-form-item label="Who the claim is about">
+                            <n-select v-model:value="bulkForm.party"
+                                :options="PARTY_OPTIONS" placeholder="Unknown" />
+                        </n-form-item>
+                        <n-form-item label="Justification (exported, customer-visible)">
+                            <n-input v-model:value="bulkForm.justification" type="textarea"
+                                :rows="3"
+                                placeholder="Must be true of EVERY component in the selection." />
+                        </n-form-item>
+                        <n-form-item label="End of support (optional)">
+                            <n-date-picker v-model:formatted-value="bulkForm.endOfSupportDate"
+                                value-format="yyyy-MM-dd" type="date" clearable
+                                style="width: 100%;" />
+                        </n-form-item>
+                        <n-alert v-if="bulkForm.endOfSupportDate" type="warning"
+                            :show-icon="false" style="font-size: 12px; margin-bottom: 12px;">
+                            This one date will be published as a manufacturer-stated
+                            end-of-support fact for every component in the selection, and it
+                            drives each component's derived support status and device-risk
+                            verdict. Only set it if it is true of all of them.
+                        </n-alert>
+                        <n-form-item label="Reason for this sweep (audit only, never exported)">
+                            <n-input v-model:value="bulkForm.reason"
+                                placeholder="Why this batch is being written." />
+                        </n-form-item>
+                    </n-form>
+                    <n-alert v-for="e in bulkErrors" :key="e" type="error" :show-icon="false"
+                        style="margin-top: 8px; font-size: 12px;">{{ e }}</n-alert>
+                    <n-alert v-if="bulk.error.value" type="error" :show-icon="true"
+                        style="margin-top: 8px;">{{ bulk.error.value }}</n-alert>
+                </div>
+
+                <!-- CONFIRM: the count alone cannot catch a filter that silently reset -->
+                <div v-else-if="bulkStage === 'confirm'">
+                    <n-alert type="warning" :show-icon="true" style="margin-bottom: 12px;">
+                        <div style="font-size: 14px; font-weight: 600;">
+                            {{ bulkCollected.ids.length }} of {{ bulkCollected.backlogTotal }}
+                            components will be attested.
+                        </div>
+                        <div style="font-size: 12px; margin-top: 6px;">
+                            Filter <strong>{{ sbomAppliedFilter }}</strong><span
+                                v-if="sbomAppliedSearch">, search
+                                <strong>"{{ sbomAppliedSearch }}"</strong></span>.
+                            There is no bulk undo.
+                        </div>
+                    </n-alert>
+                    <div style="font-size: 12px; margin-bottom: 6px;">Including:</div>
+                    <ul style="font-size: 12px; margin: 0 0 12px 18px;">
+                        <li v-for="c in bulkCollected.sample" :key="c.uuid">
+                            {{ c.name }} {{ c.version }}
+                        </li>
+                        <li v-if="bulkCollected.ids.length > bulkCollected.sample.length">
+                            and {{ bulkCollected.ids.length - bulkCollected.sample.length }} more
+                        </li>
+                    </ul>
+                    <n-alert type="default" :show-icon="false" style="font-size: 12px;">
+                        Writing: level
+                        <strong>{{ bulkForm.levelOfSupport || 'not stated' }}</strong>;
+                        justification <strong>"{{ bulkForm.justification || '(none)' }}"</strong>
+                        <span v-if="bulkForm.endOfSupportDate">; end of support
+                            <strong>{{ bulkForm.endOfSupportDate }}</strong></span>.
+                    </n-alert>
+                    <div v-if="bulk.submitting.value" style="margin-top: 12px;">
+                        <n-progress type="line"
+                            :percentage="Math.round(100 * bulk.progress.value
+                                / Math.max(bulkCollected.ids.length, 1))" />
+                        <div style="font-size: 12px;">
+                            {{ bulk.progress.value }} of {{ bulkCollected.ids.length }} sent.
+                            Everything already sent has been written and cannot be recalled.
+                        </div>
+                    </div>
+                </div>
+
+                <!-- DONE: grouped by what the operator must DO about it -->
+                <div v-else-if="bulkStage === 'done' && bulkResult">
+                    <n-alert :type="bulkResult.failed ? 'warning' : 'success'" :show-icon="true">
+                        {{ bulkResult.applied }} attested.
+                        <span v-if="bulkResult.skippedRoot">
+                            {{ bulkResult.skippedRoot }} skipped as the release's own
+                            component.</span>
+                        <span v-if="bulkResult.failed"> {{ bulkResult.failed }} failed.</span>
+                    </n-alert>
+                    <!-- Not hidden: on a fresh UNATTESTED walk this should be zero, so a
+                         non-zero count means a colleague attested one of these between the
+                         walk and the write. -->
+                    <n-alert v-if="bulkResult.concurrentWriteDetected" type="warning"
+                        :show-icon="true" style="margin-top: 8px; font-size: 12px;">
+                        {{ bulkResult.skippedAttested }} were skipped because they had already
+                        been attested. They were undisclosed when this sweep started, so
+                        somebody else recorded them while it ran. Their attestations were left
+                        untouched.
+                    </n-alert>
+                    <n-alert v-if="bulkResult.stoppedEarly" type="warning" :show-icon="true"
+                        style="margin-top: 8px; font-size: 12px;">
+                        Stopped after the batch in flight. Re-running the same sweep is safe:
+                        components already attested are skipped, not rewritten.
+                    </n-alert>
+                    <n-alert v-if="bulkResult.error" type="error" :show-icon="true"
+                        style="margin-top: 8px; font-size: 12px;">
+                        {{ bulkResult.error }} Re-running the same sweep is safe and completes
+                        the remainder.
+                    </n-alert>
+                    <div v-if="bulkResult.failed" style="margin-top: 10px;">
+                        <div style="font-size: 12px; font-weight: 600;">Failures</div>
+                        <ul style="font-size: 12px; margin: 4px 0 0 18px;">
+                            <li v-for="(count, message) in bulkFailureGroups" :key="message">
+                                {{ message }} &times; {{ count }}
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+
+                <template #footer>
+                    <n-space justify="end">
+                        <n-button size="small" :disabled="bulk.submitting.value"
+                            @click="bulkModalOpen = false">
+                            {{ bulkStage === 'done' ? 'Close' : 'Cancel' }}
+                        </n-button>
+                        <n-button v-if="bulkStage === 'compose'" size="small" type="primary"
+                            :disabled="bulkErrors.length > 0 || bulk.collecting.value"
+                            :loading="bulk.collecting.value"
+                            @click="collectBulkTargets">Review selection</n-button>
+                        <n-button v-if="bulkStage === 'confirm' && !bulk.submitting.value"
+                            size="small" @click="bulkStage = 'compose'">Back</n-button>
+                        <n-button v-if="bulkStage === 'confirm'" size="small" type="error"
+                            :disabled="bulk.submitting.value || !bulkCollected.ids.length"
+                            :loading="bulk.submitting.value"
+                            @click="runBulkAttest">
+                            Attest {{ bulkCollected.ids.length }} components
+                        </n-button>
+                        <n-button v-if="bulkStage === 'confirm' && bulk.submitting.value"
+                            size="small" @click="bulk.requestCancel()">Stop after this batch</n-button>
+                    </n-space>
+                </template>
+            </n-modal>
+            <n-modal
                 v-model:show="attestModalOpen"
                 preset="card"
                 style="width: 640px;"
@@ -1091,6 +1246,13 @@
                                 :disabled="sbomDegraded"
                                 :options="sbomAttestationFilterOptions"
                             />
+                            <n-button
+                                v-if="sbomViewMode === 'list' && isWritable
+                                    && sbomAppliedFilter === 'UNATTESTED'"
+                                size="small" type="primary" ghost
+                                @click="openBulkAttest">
+                                Attest all shown
+                            </n-button>
                             <n-radio-group v-model:value="sbomViewMode" size="small" @update:value="handleSbomViewModeChange">
                                 <n-radio-button value="list" label="List" />
                                 <n-radio-button value="tree" label="Tree" />
@@ -1480,6 +1642,7 @@ import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
 import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
+import { useBulkAttest, validateBulkInput } from '@/utils/useBulkAttest'
 import { useAttestationForm } from '@/utils/useAttestationForm'
 import type { LevelOfSupport, SupportMilestoneType, SupportParty } from '@/utils/supportAttestationInput'
 import { loadSbomComponentSupportDetail } from '@/utils/sbomComponentSupportDetail'
@@ -1494,9 +1657,9 @@ import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regu
 import { UpCircleOutlined } from '@vicons/antd'
 import type { SelectOption } from 'naive-ui'
 import { DEVICE_RISK_DETAIL, DEVICE_RISK_LABEL, isDeviceRiskFlagged, supportTag } from '@/utils/supportStatusTag'
-import { NAlert, NBadge, NCheckbox, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
+import { NAlert, NBadge, NProgress, NCheckbox, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
 import Swal from 'sweetalert2'
-import { ComputedRef, Ref, computed, h, onMounted, onUnmounted, ref, watch } from 'vue'
+import { ComputedRef, Ref, computed, h, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import type { Component } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { useStore } from 'vuex'
@@ -3101,6 +3264,78 @@ async function loadSbomComponents (forceRefresh: boolean = false) {
     // the rows on screen without moving the number above them. Wiring it to those would make
     // the gauge flicker on every keystroke while reporting the same value.
     await loadSbomCoverage()
+}
+
+// Bulk attestation over the current filter (FDA-Readiness-1 PR5.4).
+//
+// The walk and the writes live in useBulkAttest; this is selection, confirmation and
+// reporting. The confirmation is the load-bearing part: a sweep writes a regulatory claim
+// across up to five thousand components on one click, and there is no bulk undo.
+const bulk = useBulkAttest()
+const bulkModalOpen: Ref<boolean> = ref(false)
+const bulkStage: Ref<'compose' | 'confirm' | 'done'> = ref('compose')
+const bulkForm = reactive({
+    levelOfSupport: null as LevelOfSupport | null,
+    party: null as SupportParty | null,
+    justification: '',
+    endOfSupportDate: null as string | null,
+    reason: ''
+})
+const bulkCollected: Ref<{ ids: string[], backlogTotal: number,
+    sample: Array<{ uuid: string, name: string, version: string }> }> =
+    ref({ ids: [], backlogTotal: 0, sample: [] })
+const bulkResult: Ref<any> = ref(null)
+const bulkAssessedAt: Ref<string> = ref('')
+
+/** Failures grouped by message: 800 identical validation errors are one line, not 800. */
+const bulkFailureGroups: ComputedRef<Record<string, number>> = computed(() => {
+    const out: Record<string, number> = {}
+    for (const r of bulkResult.value?.results ?? []) {
+        if (r.outcome !== 'FAILED') continue
+        const key = r.message || 'no reason given'
+        out[key] = (out[key] ?? 0) + 1
+    }
+    return out
+})
+
+const bulkErrors: ComputedRef<string[]> = computed(
+    (): string[] => validateBulkInput({ ...bulkForm, assessedAt: bulkAssessedAt.value }))
+
+function openBulkAttest () {
+    bulkStage.value = 'compose'
+    bulkResult.value = null
+    bulkCollected.value = { ids: [], backlogTotal: 0, sample: [] }
+    Object.assign(bulkForm, {
+        levelOfSupport: null, party: null, justification: '', endOfSupportDate: null, reason: ''
+    })
+    bulkModalOpen.value = true
+}
+
+/**
+ * Walk the CURRENTLY APPLIED filter and collect ids. Writes nothing.
+ *
+ * Uses the applied filter and search, never the live inputs: during the search debounce
+ * those differ, and sweeping what the box says rather than what the list shows is exactly
+ * how an operator attests the wrong set.
+ */
+async function collectBulkTargets () {
+    if (!updatedRelease.value?.uuid) return
+    const res = await bulk.collect(graphqlClient as any, updatedRelease.value.uuid,
+        sbomAppliedFilter.value, sbomAppliedSearch.value)
+    if (res.refused) return
+    bulkCollected.value = { ids: res.ids, backlogTotal: res.backlogTotal, sample: res.sample }
+    bulkStage.value = 'confirm'
+}
+
+async function runBulkAttest () {
+    // One instant for the whole sweep, captured HERE -- at the moment the operator confirms,
+    // not per write. The sweep is one act of assessment.
+    bulkAssessedAt.value = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+    bulkResult.value = await bulk.submit(graphqlClient as any, bulkCollected.value.ids,
+        { ...bulkForm, assessedAt: bulkAssessedAt.value }, sbomAppliedFilter.value)
+    bulkStage.value = 'done'
+    // The gauge and the list both moved.
+    await loadSbomComponents(true)
 }
 
 // Per-component attestation form (FDA-Readiness-1 PR5.3).

--- a/ui/src/components/releaseViewBulkWiring.spec.ts
+++ b/ui/src/components/releaseViewBulkWiring.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * Import and wiring assertions for the bulk sweep, comment-aware.
+ *
+ * Same reason as its siblings: no vue-tsc, so an undefined identifier in <script setup> is a
+ * runtime error the build ignores. Behaviour lives in useBulkAttest.spec.ts; this covers the
+ * seam, and specifically the two things a sweep must not get wrong.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
+    .join('\n')
+
+function functionBody (name: string): string {
+    const start = code.indexOf(`async function ${name} (`)
+    if (start < 0) return ''
+    const rest = code.slice(start + 1)
+    const next = rest.search(/\n(async )?function /)
+    return next < 0 ? rest : rest.slice(0, next)
+}
+
+describe('the bulk sweep is wired into ReleaseView', () => {
+    it.each([
+        ['useBulkAttest', '@/utils/useBulkAttest'],
+        ['validateBulkInput', '@/utils/useBulkAttest']
+    ])('imports %s from %s', (symbol, module) => {
+        expect(source).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
+    })
+
+    it.each(['openBulkAttest', 'collectBulkTargets', 'runBulkAttest'])(
+        'references %s in live code', (fn) => {
+            const invoked = code.match(new RegExp(`(?<!function\\s{1,10})\\b${fn}\\s*\\(`, 'g')) || []
+            const bound = code.match(new RegExp(`="\\s*${fn}\\s*"`, 'g')) || []
+            expect(invoked.length + bound.length, `${fn} is dead`).toBeGreaterThan(0)
+        })
+
+    /**
+     * THE one that matters. The sweep must walk the filter the LIST is showing, not the
+     * live input boxes -- during the search debounce those differ, and sweeping what the box
+     * says rather than what the operator can see is how the wrong set gets attested.
+     */
+    it('collects using the APPLIED filter and search, never the live inputs', () => {
+        const body = functionBody('collectBulkTargets')
+        expect(body).toContain('sbomAppliedFilter')
+        expect(body).toContain('sbomAppliedSearch')
+        expect(body, 'the live search input must not drive the sweep')
+            .not.toContain('sbomSearchQueryInput')
+    })
+
+    /** One instant for the sweep, captured at confirmation rather than per write. */
+    it('captures a single assessedAt before submitting', () => {
+        const body = functionBody('runBulkAttest')
+        expect(body).toMatch(/bulkAssessedAt\.value\s*=/)
+        expect(body).toMatch(/assessedAt:\s*bulkAssessedAt\.value/)
+    })
+
+    /** The sweep moves the gauge; without this it reads as a failure. */
+    it('refreshes the list and gauge after the sweep', () => {
+        expect(functionBody('runBulkAttest')).toMatch(/loadSbomComponents\s*\(\s*true\s*\)/)
+    })
+
+    // A count alone cannot catch a filter that silently reset to All.
+    it.each(['sbomAppliedFilter', 'sbomAppliedSearch', 'bulkCollected.sample', 'backlogTotal'])(
+        'the confirmation shows %s', (token) => expect(source).toContain(token))
+
+    it('surfaces SKIPPED_ATTESTED rather than hiding it', () => {
+        expect(source).toContain('concurrentWriteDetected')
+    })
+})

--- a/ui/src/components/releaseViewBulkWiring.spec.ts
+++ b/ui/src/components/releaseViewBulkWiring.spec.ts
@@ -17,9 +17,14 @@ const code = source
     .map(l => l.replace(/(^|[^:])\/\/.*$/, '$1'))
     .join('\n')
 
+/**
+ * Throws rather than returning '' on a miss. The first version matched only `async
+ * function`, so every assertion about the one plain function here passed against an empty
+ * string -- a spec that reads as protection and checks nothing. A rename must fail loudly.
+ */
 function functionBody (name: string): string {
-    const start = code.indexOf(`async function ${name} (`)
-    if (start < 0) return ''
+    const start = code.search(new RegExp(`\\n(async )?function ${name} \\(`))
+    if (start < 0) throw new Error(`no function ${name} in ReleaseView.vue`)
     const rest = code.slice(start + 1)
     const next = rest.search(/\n(async )?function /)
     return next < 0 ? rest : rest.slice(0, next)
@@ -69,6 +74,127 @@ describe('the bulk sweep is wired into ReleaseView', () => {
     // A count alone cannot catch a filter that silently reset to All.
     it.each(['sbomAppliedFilter', 'sbomAppliedSearch', 'bulkCollected.sample', 'backlogTotal'])(
         'the confirmation shows %s', (token) => expect(source).toContain(token))
+
+    /**
+     * The walk is awaited while the modal stays closable, so a late collect can land on a
+     * reopened form -- jumping to confirm with the previous search's ids while the screen
+     * shows the current filter. The per-component modal in this same file already carries
+     * this guard; it was not carried across.
+     */
+    it('fences the collect against a reopened modal', () => {
+        expect(functionBody('collectBulkTargets')).toMatch(/gen\s*!==\s*bulkGen/)
+    })
+
+    /**
+     * The confirmation must quote the filter the WALK used, in the operator's words --
+     * "Not disclosed", not the wire value UNATTESTED. Read live instead, it can move
+     * between collect and confirm: the search debounce reassigns the applied filter behind
+     * the open modal, and a degraded page resets it to ALL.
+     */
+    it('pins the walked filter and search onto the selection itself', () => {
+        const collect = functionBody('collectBulkTargets')
+        expect(collect).toMatch(/filter:\s*sbomAppliedFilter\.value/)
+        expect(collect).toMatch(/search:\s*sbomAppliedSearch\.value/)
+        expect(source).toContain('bulkAppliedLabel')
+        const confirm = source.slice(source.indexOf('components will be attested'), 600
+            + source.indexOf('components will be attested'))
+        expect(confirm, 'the raw enum must not reach operator-facing copy')
+            .not.toContain('{{ sbomAppliedFilter }}')
+    })
+
+    /**
+     * concurrentWriteDetected is only sound when sweptFilter is the filter the walk ran
+     * under. Passing the live ref instead can both suppress a genuine colleague race and
+     * fire the "somebody else recorded them" accusation about a walk that was never
+     * UNATTESTED.
+     */
+    it('submits under the filter the ids were collected with', () => {
+        const body = functionBody('runBulkAttest')
+        expect(body).toContain('bulkCollected.value.filter')
+        expect(body, 'the live ref would be a different set').not.toContain('sbomAppliedFilter.value')
+    })
+
+    /**
+     * The compose stage stays mounted for the whole walk, so the values validated before
+     * "Review selection" are not necessarily the values sent. reason is a UI-only rule --
+     * the server accepts a null reason -- so an unvalidated submit writes thousands of
+     * attestations with no audit reason at all.
+     */
+    it('freezes the form during the walk and re-validates at the write', () => {
+        const form = source.slice(source.indexOf('<n-form label-placement="top" '))
+        expect(form.slice(0, 120)).toContain(':disabled="bulk.collecting.value"')
+        expect(functionBody('runBulkAttest')).toMatch(/bulkErrors\.value\.length/)
+    })
+
+    /**
+     * naive-ui checks closeOnEsc independently of closable and maskClosable, so locking
+     * those two does not stop Esc from dismissing the modal mid-sweep -- discarding the
+     * only report of what a no-undo write did. SignUpFlow.vue already sets this.
+     */
+    it('cannot be dismissed with Esc while writing', () => {
+        expect(source).toContain(':close-on-esc="!bulk.submitting.value"')
+    })
+
+    /**
+     * A refresh failure is not a write failure. Unguarded, it pops a bare red "Error" over
+     * "800 attested." and the operator cannot tell which half went wrong. The per-component
+     * path in this same file already separates them.
+     */
+    it('reports a failed post-sweep refresh separately from the write', () => {
+        const body = functionBody('runBulkAttest')
+        expect(body).toMatch(/try\s*\{[\s\S]*loadSbomComponents\(true\)[\s\S]*\}\s*catch/)
+    })
+
+    /**
+     * unknownOutcomes exists so the four counters cannot silently stop summing. If nothing
+     * renders it, a server that renames an outcome reports "0 attested." over components
+     * that were written -- the exact failure the counter was added to catch.
+     */
+    it('renders unknownOutcomes rather than computing it into a void', () => {
+        const done = source.slice(source.indexOf('<!-- DONE:'))
+        expect(done, 'it must be rendered, not merely mentioned')
+            .toContain('v-if="bulkResult.unknownOutcomes"')
+        expect(done).toContain('({{ bulkResult.unknownOutcomes }} of them)')
+    })
+
+    /**
+     * An aborted sweep that wrote nothing must not render as a green success, and the
+     * "re-running is safe" advice must not be attached to a drifted server, where re-running
+     * can never work.
+     */
+    it('does not paint an aborted sweep green, or promise a retry that cannot work', () => {
+        const done = source.slice(source.indexOf('<!-- DONE:'))
+        expect(done.slice(0, 400), 'the banner type must consult aborted').toContain('bulkResult.aborted')
+        const errAlert = done.slice(done.indexOf('{{ bulkResult.error }}'))
+        expect(errAlert.slice(0, 300)).toContain('v-if="bulkResult.retryable"')
+    })
+
+    /**
+     * The composable owns the refusal message ("more than the 5000 a browser sweep will
+     * attempt") and clears it only inside collect/submit -- so reopening after narrowing
+     * the filter would show a fresh empty form still carrying the old refusal.
+     */
+    it('clears the composable error when the modal reopens', () => {
+        expect(functionBody('openBulkAttest')).toContain('bulk.error.value = null')
+    })
+
+    /** party is exported on the BOM; a mis-set attribution is invisible without this. */
+    it('shows party and the audit reason at the last checkpoint', () => {
+        const confirm = source.slice(source.indexOf('<!-- CONFIRM'), source.indexOf('<!-- DONE:'))
+        expect(confirm).toContain('partyLabel(bulkForm.party)')
+        expect(confirm).toContain('bulkForm.reason')
+    })
+
+    /**
+     * "Stop after this batch" says re-running completes the remainder, but the only way back
+     * in is openBulkAttest. Wiping the form there would make the operator retype the whole
+     * attestation, so half of one sweep could carry a different justification than the other.
+     */
+    it('keeps the form when reopening after a deliberate stop', () => {
+        const body = functionBody('openBulkAttest')
+        expect(body).toMatch(/stoppedEarly/)
+        expect(body).toMatch(/if \(!resuming\) Object\.assign\(bulkForm/)
+    })
 
     it('surfaces SKIPPED_ATTESTED rather than hiding it', () => {
         expect(source).toContain('concurrentWriteDetected')

--- a/ui/src/utils/bulkAttestSchemaDrift.spec.ts
+++ b/ui/src/utils/bulkAttestSchemaDrift.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
+import { BULK_SET_SUPPORT } from './useBulkAttest'
+
+/**
+ * Validates the bulk mutation against both schemas.
+ *
+ * Every query on this track gets one of these, and this is the reason: an invented field or
+ * an enum value the schema does not declare is a GraphQL VALIDATION error, which
+ * isSchemaDriftError reports as drift -- so a typo of mine surfaces to the operator as
+ * "your server is out of date". This feature has produced that exact disguise twice.
+ */
+const CE = fileURLToPath(new URL('../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO = fileURLToPath(new URL('../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const load = (p: string): GraphQLSchema | null => existsSync(p) ? buildSchema(readFileSync(p, 'utf8')) : null
+const ce = load(CE)
+const pro = load(PRO)
+const errs = (s: GraphQLSchema) => validate(s, parse(BULK_SET_SUPPORT.loc!.source.body)).map(e => e.message)
+
+describe('bulk attestation mutation vs the schemas', () => {
+    it.runIf(pro)('is valid on Pro', () => expect(errs(pro as GraphQLSchema)).toEqual([]))
+
+    it('has the CE mirror schema available', () => {
+        expect(ce, `CE mirror schema not found at ${CE}`).not.toBeNull()
+    })
+
+    /**
+     * Pro-only, so bulk refuses on CE for the same reason the single write does: a narrower
+     * server cannot store a level or a justification, and a write must never degrade. Fails
+     * by design when the CE sync lands.
+     */
+    it.runIf(ce)('is Pro-only', () => {
+        expect(errs(ce as GraphQLSchema).length,
+            'bulk now validates on CE -- re-check the refusal path').toBeGreaterThan(0)
+    })
+
+    // No supportNotes argument: per-component evidence cannot be fanned out.
+    it('does not send supportNotes', () => {
+        expect(BULK_SET_SUPPORT.loc!.source.body).not.toContain('supportNotes')
+    })
+})

--- a/ui/src/utils/useBulkAttest.spec.ts
+++ b/ui/src/utils/useBulkAttest.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+import { useBulkAttest, BULK_BATCH_SIZE, BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+
+/** A client whose page responses are scripted, and whose mutations are recorded. */
+function scripted (pages: Array<{ items: string[], hasMore: boolean }>) {
+    let call = 0
+    const query = vi.fn(async () => {
+        const p = pages[call++]
+        return {
+            data: {
+                getReleaseSbomComponentsPage: {
+                    items: p.items.map(id => ({ sbomComponentUuid: id, component: { uuid: id } })),
+                    totalCount: 999,
+                    endCursor: p.items[p.items.length - 1] ?? null,
+                    hasMore: p.hasMore
+                }
+            }
+        }
+    })
+    const mutate = vi.fn(async (opts: any) => ({
+        data: {
+            bulkSetSbomComponentSupport: {
+                appliedCount: opts.variables.sbomComponentUuids.length,
+                skippedCount: 0,
+                failedCount: 0,
+                results: opts.variables.sbomComponentUuids.map((id: string) =>
+                    ({ sbomComponentUuid: id, outcome: 'APPLIED', message: null }))
+            }
+        }
+    }))
+    return { client: { query, mutate } as any, query, mutate }
+}
+const ids = (n: number, p = 'c') => Array.from({ length: n }, (_, i) => `${p}${i}`)
+
+describe('collecting the work queue', () => {
+    it('walks every page before writing anything', async () => {
+        const { client, query, mutate } = scripted([
+            { items: ids(500), hasMore: true },
+            { items: ids(120, 'd'), hasMore: false }
+        ])
+        const b = useBulkAttest()
+        const res = await b.collect(client, 'rel-1', 'UNATTESTED', '')
+        expect(res.ids.length).toBe(620)
+        expect(query).toHaveBeenCalledTimes(2)
+        // COLLECT-THEN-WRITE: nothing is written during the walk. Keyset makes interleaving
+        // safe, but each APPLIED shrinks the UNATTESTED set under the cursor, and a walk that
+        // does not write cannot be wrong about it at all.
+        expect(mutate).not.toHaveBeenCalled()
+    })
+
+    it('walks at the page limit the ruling fixed', async () => {
+        const { client, query } = scripted([{ items: ids(3), hasMore: false }])
+        const b = useBulkAttest()
+        await b.collect(client, 'rel-1', 'UNATTESTED', '')
+        expect(query.mock.calls[0][0].variables.limit).toBe(BULK_WALK_LIMIT)
+        expect(query.mock.calls[0][0].variables.attestation).toBe('UNATTESTED')
+    })
+
+    it('follows the cursor rather than re-reading page one', async () => {
+        const { client, query } = scripted([
+            { items: ids(500), hasMore: true },
+            { items: ids(10, 'd'), hasMore: false }
+        ])
+        const b = useBulkAttest()
+        await b.collect(client, 'rel-1', 'UNATTESTED', '')
+        expect(query.mock.calls[0][0].variables.after).toBeNull()
+        expect(query.mock.calls[1][0].variables.after).toBe('c499')
+    })
+
+    /**
+     * A browser is the wrong place to hold an unbounded id list, and an operator who has
+     * accidentally cleared the filter should be stopped rather than served. Refuses with an
+     * instruction, not a truncated result -- a silently truncated sweep would report success
+     * over a fraction of the release.
+     */
+    it('refuses a release larger than the cap instead of truncating', async () => {
+        const pages = Array.from({ length: 12 }, () => ({ items: ids(500), hasMore: true }))
+        const { client } = scripted(pages)
+        const b = useBulkAttest()
+        const res = await b.collect(client, 'rel-1', 'UNATTESTED', '')
+        expect(res.tooLarge).toBe(true)
+        expect(res.ids.length).toBeLessThanOrEqual(BULK_MAX_IDS + BULK_WALK_LIMIT)
+        expect(b.error.value).toMatch(/narrow/i)
+    })
+
+    it('stops cleanly on an empty release', async () => {
+        const { client } = scripted([{ items: [], hasMore: false }])
+        const b = useBulkAttest()
+        expect((await b.collect(client, 'rel-1', 'UNATTESTED', '')).ids).toEqual([])
+    })
+})
+
+describe('submitting', () => {
+    it('batches at the ruled size', async () => {
+        const { client, mutate } = scripted([])
+        const b = useBulkAttest()
+        await b.submit(client, ids(450), { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept' })
+        expect(mutate).toHaveBeenCalledTimes(3)
+        expect(mutate.mock.calls[0][0].variables.sbomComponentUuids.length).toBe(BULK_BATCH_SIZE)
+        expect(mutate.mock.calls[2][0].variables.sbomComponentUuids.length).toBe(50)
+    })
+
+    it('aggregates outcomes across batches', async () => {
+        const { client } = scripted([])
+        const b = useBulkAttest()
+        const r = await b.submit(client, ids(250), { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept' })
+        expect(r.applied).toBe(250)
+        expect(r.results.length).toBe(250)
+    })
+
+    /**
+     * Zero on a fresh walk, because the walk collected only UNATTESTED components. Non-zero
+     * means somebody attested one of them between the walk and the write -- worth surfacing,
+     * not hiding: it tells the operator their sweep raced a colleague.
+     */
+    it('surfaces SKIPPED_ATTESTED as a concurrency signal', async () => {
+        const mutate = vi.fn(async (opts: any) => ({
+            data: { bulkSetSbomComponentSupport: {
+                appliedCount: 1, skippedCount: 1, failedCount: 0,
+                results: [
+                    { sbomComponentUuid: 'a', outcome: 'APPLIED', message: null },
+                    { sbomComponentUuid: 'b', outcome: 'SKIPPED_ATTESTED', message: null }
+                ]
+            } }
+        }))
+        const b = useBulkAttest()
+        const r = await b.submit({ mutate } as any, ['a', 'b'], { justification: 'swept' })
+        expect(r.skippedAttested).toBe(1)
+        expect(r.concurrentWriteDetected).toBe(true)
+    })
+
+    /**
+     * A batch failing mid-sweep must not discard the batches that landed: the operator needs
+     * to know how much of the work is done before deciding whether to re-run.
+     */
+    it('keeps the outcomes of batches that landed when a later one throws', async () => {
+        let n = 0
+        const mutate = vi.fn(async (opts: any) => {
+            if (++n === 2) throw new Error('gateway timeout')
+            return { data: { bulkSetSbomComponentSupport: {
+                appliedCount: opts.variables.sbomComponentUuids.length, skippedCount: 0, failedCount: 0,
+                results: opts.variables.sbomComponentUuids.map((id: string) =>
+                    ({ sbomComponentUuid: id, outcome: 'APPLIED', message: null }))
+            } } }
+        })
+        const b = useBulkAttest()
+        const r = await b.submit({ mutate } as any, ids(300), { justification: 'swept' })
+        expect(r.applied).toBe(BULK_BATCH_SIZE)
+        expect(r.aborted).toBe(true)
+        expect(r.error).toContain('gateway timeout')
+    })
+})

--- a/ui/src/utils/useBulkAttest.spec.ts
+++ b/ui/src/utils/useBulkAttest.spec.ts
@@ -245,7 +245,8 @@ describe('submitting', () => {
     it('batches at the ruled size', async () => {
         const { client, mutate } = scripted([])
         const b = useBulkAttest()
-        await b.submit(client, ids(450), { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept' })
+        await b.submit(client, ids(450),
+            { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept', reason: 'r' } as any)
         expect(mutate).toHaveBeenCalledTimes(3)
         expect(mutate.mock.calls[0][0].variables.sbomComponentUuids.length).toBe(BULK_BATCH_SIZE)
         expect(mutate.mock.calls[2][0].variables.sbomComponentUuids.length).toBe(50)
@@ -254,7 +255,8 @@ describe('submitting', () => {
     it('aggregates outcomes across batches', async () => {
         const { client } = scripted([])
         const b = useBulkAttest()
-        const r = await b.submit(client, ids(250), { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept' })
+        const r = await b.submit(client, ids(250),
+            { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept', reason: 'r' } as any)
         expect(r.applied).toBe(250)
         expect(r.results.length).toBe(250)
     })
@@ -275,7 +277,8 @@ describe('submitting', () => {
             } }
         }))
         const b = useBulkAttest()
-        const r = await b.submit({ mutate } as any, ['a', 'b'], { justification: 'swept' })
+        const r = await b.submit({ mutate } as any, ['a', 'b'],
+            { justification: 'swept', reason: 'r' } as any)
         expect(r.skippedAttested).toBe(1)
         expect(r.concurrentWriteDetected).toBe(true)
     })
@@ -288,6 +291,31 @@ describe('submitting', () => {
      * The counters must not silently stop summing to results.length. A server that renames
      * or adds an outcome would otherwise report "0 attested." over components it wrote.
      */
+    /**
+     * The reason rule must not be enforceable only by the caller's disabled-button binding.
+     * A sweep with no reason produces hundreds of audit rows that record nothing about why
+     * the batch happened, and the server will accept every one of them.
+     */
+    it('refuses to write a sweep with no reason, whatever the caller did', async () => {
+        const { client, mutate } = scripted([])
+        const out = await useBulkAttest().submit(client, ids(3),
+            { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'j', reason: '   ' } as any)
+        expect(mutate, 'nothing may be written').not.toHaveBeenCalled()
+        expect(out.applied).toBe(0)
+        expect(out.aborted).toBe(true)
+        expect(out.retryable).toBe(false)
+        expect(out.error).toMatch(/needs a reason/)
+    })
+
+    /** The same gate covers the rest of validateBulkInput, not just the reason. */
+    it('refuses a negative level with no basis at the write, not only in the form', async () => {
+        const { client, mutate } = scripted([])
+        const out = await useBulkAttest().submit(client, ids(3),
+            { levelOfSupport: 'ABANDONED', justification: '', reason: 'r' } as any)
+        expect(mutate).not.toHaveBeenCalled()
+        expect(out.error).toMatch(/negative claim/)
+    })
+
     it('counts an outcome it does not recognise rather than dropping it', async () => {
         const { client, mutate } = scripted([])
         mutate.mockImplementation(async (o: any) => ({
@@ -401,7 +429,8 @@ describe('submitting', () => {
             } } }
         })
         const b = useBulkAttest()
-        const r = await b.submit({ mutate } as any, ids(300), { justification: 'swept' })
+        const r = await b.submit({ mutate } as any, ids(300),
+            { justification: 'swept', reason: 'r' } as any)
         expect(r.applied).toBe(BULK_BATCH_SIZE)
         expect(r.aborted).toBe(true)
         expect(r.error).toContain('gateway timeout')

--- a/ui/src/utils/useBulkAttest.spec.ts
+++ b/ui/src/utils/useBulkAttest.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import { useBulkAttest, BULK_BATCH_SIZE, BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+import {
+    useBulkAttest, validateBulkInput,
+    BULK_BATCH_SIZE, BULK_WALK_LIMIT, BULK_MAX_IDS
+} from './useBulkAttest'
 
 /** A client whose page responses are scripted, and whose mutations are recorded. */
 function scripted (pages: Array<{ items: string[], hasMore: boolean }>) {
@@ -201,6 +204,40 @@ describe('the walk refuses anything it cannot vouch for', () => {
         const b = useBulkAttest()
         await b.collect(client, 'rel-1', 'UNATTESTED', 'log4j')
         expect(query.mock.calls[0][0].variables.search).toBe('log4j')
+    })
+})
+
+describe('the sweep is recorded as one action', () => {
+    /**
+     * One instant for the whole sweep, captured at confirmation. Omitted, the server stamps
+     * `now` inside each per-item transaction, so the components carry instants spread across
+     * the sweep -- and that instant is what the exported BOM publishes as "a human looked,
+     * and when". Spread instants describe a stream of individual assessments.
+     */
+    it('sends the same assessedAt on every batch', async () => {
+        const { client, mutate } = scripted([])
+        const b = useBulkAttest()
+        const at = '2026-09-05T13:40:00Z'
+        await b.submit(client, ids(450), {
+            levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'swept',
+            reason: 'closing the backlog', assessedAt: at
+        })
+        expect(mutate).toHaveBeenCalledTimes(3)
+        for (const call of mutate.mock.calls) expect(call[0].variables.assessedAt).toBe(at)
+    })
+
+    // Mandatory for bulk even though the server only requires it for un-retracting.
+    it('refuses a sweep with no reason', () => {
+        expect(validateBulkInput({ levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'x' })
+            .some(e => e.includes('needs a reason'))).toBe(true)
+        expect(validateBulkInput({
+            levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'x', reason: 'closing the backlog'
+        })).toEqual([])
+    })
+
+    it('still refuses a negative level with no basis, reason or not', () => {
+        expect(validateBulkInput({ levelOfSupport: 'ABANDONED', reason: 'r' })
+            .some(e => e.includes('negative claim'))).toBe(true)
     })
 })
 

--- a/ui/src/utils/useBulkAttest.spec.ts
+++ b/ui/src/utils/useBulkAttest.spec.ts
@@ -74,12 +74,21 @@ describe('collecting the work queue', () => {
      * over a fraction of the release.
      */
     it('refuses a release larger than the cap instead of truncating', async () => {
-        const pages = Array.from({ length: 12 }, () => ({ items: ids(500), hasMore: true }))
-        const { client } = scripted(pages)
+        const client = {
+            query: vi.fn(async () => ({ data: { getReleaseSbomComponentsPage: {
+                items: ids(500).map(id => ({ sbomComponentUuid: id, component: { uuid: id } })),
+                totalCount: 12000, endCursor: 'c499', hasMore: true
+            } } }))
+        } as any
         const b = useBulkAttest()
         const res = await b.collect(client, 'rel-1', 'UNATTESTED', '')
-        expect(res.tooLarge).toBe(true)
-        expect(res.ids.length).toBeLessThanOrEqual(BULK_MAX_IDS + BULK_WALK_LIMIT)
+        expect(res.refused).toBe(true)
+        // Unusable, not truncated. The previous version asserted the overshoot length,
+        // encoding the very leak the refusal exists to prevent: a caller destructuring
+        // { ids } got up to 5,499 and could sweep a fraction of the release reporting
+        // success.
+        expect(res.ids).toEqual([])
+        expect(b.collected.value).toEqual([])
         expect(b.error.value).toMatch(/narrow/i)
     })
 
@@ -87,6 +96,111 @@ describe('collecting the work queue', () => {
         const { client } = scripted([{ items: [], hasMore: false }])
         const b = useBulkAttest()
         expect((await b.collect(client, 'rel-1', 'UNATTESTED', '')).ids).toEqual([])
+    })
+})
+
+describe('the walk refuses anything it cannot vouch for', () => {
+    /**
+     * THE critical one, flagged independently by four review lenses. loadSbomComponentsPage
+     * falls back to the UNPAGED, UNFILTERED query on schema drift -- and isSchemaDriftError
+     * treats ANY http 400 as drift, including one whose body an edge proxy stripped. So a
+     * transient 400 turns "sweep the 40 undisclosed matching openssl" into "sweep every
+     * undisclosed component in the release", with hasMore false so the walk looks complete.
+     *
+     * The count in the confirmation would be honest about the size and wrong about WHICH.
+     * The cap does not catch it: the set is a legitimate size, just the wrong set.
+     */
+    it('refuses a degraded page instead of sweeping the whole release', async () => {
+        // Routed by document: the paged query drifts, the unpaged fallback answers with the
+        // whole release. That is exactly what a stripped-body 400 at the edge produces.
+        const drifting = vi.fn(async (opts: any) => {
+            const body = opts.query?.loc?.source?.body ?? ''
+            if (body.includes('getReleaseSbomComponentsPage')) {
+                // The realistic trigger: a server that does not declare the paged query.
+                // isSchemaDriftError matches on the validation phrasing (or an HTTP 400
+                // signal), and this is what a CE backend actually returns.
+                throw new Error('Cannot query field "getReleaseSbomComponentsPage" on type "Query"')
+            }
+            return { data: { getReleaseSbomComponents:
+                Array.from({ length: 700 }, (_, i) => ({ sbomComponentUuid: `x${i}` })) } }
+        })
+        const b = useBulkAttest()
+        const res = await b.collect({ query: drifting } as any, 'rel-1', 'UNATTESTED', 'openssl')
+        expect(res.refused).toBe(true)
+        expect(res.ids).toEqual([])
+        expect(b.error.value).toMatch(/cannot filter|unavailable/i)
+    })
+
+    /**
+     * A walk that dies half way must not present a prefix as the work queue. The backend
+     * documents a rejected cursor as a ROUTINE event -- leave the tab open while the SBOM is
+     * re-uploaded -- and errors deliberately so the caller can decide. Swallowing that into
+     * a partial list throws the decision away.
+     */
+    it('refuses when the walk fails part way rather than returning a prefix', async () => {
+        let n = 0
+        const query = vi.fn(async () => {
+            if (++n === 2) throw new Error('unknown pagination cursor: abc')
+            return { data: { getReleaseSbomComponentsPage: {
+                items: ids(500).map(id => ({ sbomComponentUuid: id, component: { uuid: id } })),
+                totalCount: 900, endCursor: 'c499', hasMore: true
+            } } }
+        })
+        const b = useBulkAttest()
+        const res = await b.collect({ query } as any, 'rel-1', 'UNATTESTED', '')
+        expect(res.refused).toBe(true)
+        expect(res.ids).toEqual([])
+    })
+
+    // Refusing on page one, from the server's own total, rather than after eleven round
+    // trips that fetch full component rows to keep one field each.
+    it('refuses on the first page when the server says the set is too large', async () => {
+        const query = vi.fn(async () => ({ data: { getReleaseSbomComponentsPage: {
+            items: ids(500).map(id => ({ sbomComponentUuid: id, component: { uuid: id } })),
+            totalCount: 12000, endCursor: 'c499', hasMore: true
+        } } }))
+        const b = useBulkAttest()
+        const res = await b.collect({ query } as any, 'rel-1', 'UNATTESTED', '')
+        expect(res.refused).toBe(true)
+        expect(query).toHaveBeenCalledTimes(1)
+        expect(b.error.value).toContain('12000')
+    })
+
+    it('stops rather than looping when a page adds nothing but claims more', async () => {
+        const query = vi.fn(async () => ({ data: { getReleaseSbomComponentsPage: {
+            items: [], totalCount: 10, endCursor: 'stuck', hasMore: true
+        } } }))
+        const b = useBulkAttest()
+        const res = await b.collect({ query } as any, 'rel-1', 'UNATTESTED', '')
+        expect(res.refused).toBe(true)
+        expect(query.mock.calls.length).toBeLessThan(5)
+    })
+
+    it('dedupes, so no component is written twice across batches', async () => {
+        const dup = ['a', 'b', 'a', 'c', 'b']
+        const query = vi.fn(async () => ({ data: { getReleaseSbomComponentsPage: {
+            items: dup.map(id => ({ sbomComponentUuid: id, component: { uuid: id } })),
+            totalCount: 5, endCursor: 'b', hasMore: false
+        } } }))
+        const b = useBulkAttest()
+        expect((await b.collect({ query } as any, 'rel-1', 'UNATTESTED', '')).ids)
+            .toEqual(['a', 'b', 'c'])
+    })
+
+    it('skips a row with no sbomComponentUuid rather than sending undefined', async () => {
+        const query = vi.fn(async () => ({ data: { getReleaseSbomComponentsPage: {
+            items: [{ sbomComponentUuid: 'a' }, { component: {} }, { sbomComponentUuid: 'c' }],
+            totalCount: 3, endCursor: 'c', hasMore: false
+        } } }))
+        const b = useBulkAttest()
+        expect((await b.collect({ query } as any, 'rel-1', 'UNATTESTED', '')).ids).toEqual(['a', 'c'])
+    })
+
+    it('passes the search through -- its silent loss is what the degraded case costs', async () => {
+        const { client, query } = scripted([{ items: ids(2), hasMore: false }])
+        const b = useBulkAttest()
+        await b.collect(client, 'rel-1', 'UNATTESTED', 'log4j')
+        expect(query.mock.calls[0][0].variables.search).toBe('log4j')
     })
 })
 

--- a/ui/src/utils/useBulkAttest.spec.ts
+++ b/ui/src/utils/useBulkAttest.spec.ts
@@ -284,6 +284,112 @@ describe('submitting', () => {
      * A batch failing mid-sweep must not discard the batches that landed: the operator needs
      * to know how much of the work is done before deciding whether to re-run.
      */
+    /**
+     * The counters must not silently stop summing to results.length. A server that renames
+     * or adds an outcome would otherwise report "0 attested." over components it wrote.
+     */
+    it('counts an outcome it does not recognise rather than dropping it', async () => {
+        const { client, mutate } = scripted([])
+        mutate.mockImplementation(async (o: any) => ({
+            data: {
+                bulkSetSbomComponentSupport: {
+                    results: o.variables.sbomComponentUuids.map((id: string, i: number) =>
+                        ({ sbomComponentUuid: id, outcome: i === 0 ? 'DEFERRED' : 'APPLIED',
+                            message: null }))
+                }
+            }
+        }))
+        const b = useBulkAttest()
+        const out = await b.submit(client, ids(4), { levelOfSupport: 'ACTIVELY_MAINTAINED',
+            justification: 'j', reason: 'r' } as any)
+        expect(out.unknownOutcomes).toBe(1)
+        expect(out.applied).toBe(3)
+        expect(out.applied + out.skippedAttested + out.skippedRoot + out.failed
+            + out.unknownOutcomes).toBe(out.results.length)
+    })
+
+    /**
+     * "Stop after this batch" is the only honest offer: a batch already sent has committed
+     * item by item. So the cancel must take effect BETWEEN batches -- not lose the batch in
+     * flight, and not keep going.
+     */
+    it('stops between batches, keeping what the batch in flight wrote', async () => {
+        const { client, mutate } = scripted([])
+        const b = useBulkAttest()
+        mutate.mockImplementation(async (o: any) => {
+            b.requestCancel()
+            return {
+                data: {
+                    bulkSetSbomComponentSupport: {
+                        results: o.variables.sbomComponentUuids.map((id: string) =>
+                            ({ sbomComponentUuid: id, outcome: 'APPLIED', message: null }))
+                    }
+                }
+            }
+        })
+        const out = await b.submit(client, ids(BULK_BATCH_SIZE * 3),
+            { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'j', reason: 'r' } as any)
+        expect(mutate).toHaveBeenCalledTimes(1)
+        expect(out.stoppedEarly).toBe(true)
+        expect(out.applied).toBe(BULK_BATCH_SIZE)
+        // Re-running is the advertised recovery, so it must not be reported as unretryable.
+        expect(out.aborted).toBe(false)
+    })
+
+    /**
+     * Two concurrent submits with the same ids both see an empty already-attested set
+     * server-side, so both write -- the second re-asserting and re-dating what the first
+     * just recorded. The refusal must also not claim a retry will help while the first is
+     * still running.
+     */
+    it('refuses a second concurrent sweep, and does not offer a retry', async () => {
+        const { client, mutate } = scripted([])
+        let release: () => void = () => {}
+        mutate.mockImplementation(async (o: any) => {
+            await new Promise<void>(r => { release = r })
+            return {
+                data: {
+                    bulkSetSbomComponentSupport: {
+                        results: o.variables.sbomComponentUuids.map((id: string) =>
+                            ({ sbomComponentUuid: id, outcome: 'APPLIED', message: null }))
+                    }
+                }
+            }
+        })
+        const b = useBulkAttest()
+        const input = { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'j', reason: 'r' }
+        const first = b.submit(client, ids(2), input as any)
+        await Promise.resolve()
+        const second = await b.submit(client, ids(2), input as any)
+        expect(second.applied).toBe(0)
+        expect(second.aborted).toBe(true)
+        expect(second.retryable).toBe(false)
+        expect(second.error).toMatch(/already running/)
+        release()
+        expect((await first).applied).toBe(2)
+        expect(mutate).toHaveBeenCalledTimes(1)
+    })
+
+    /**
+     * A drifted server can never accept this mutation, so "re-running completes the
+     * remainder" is advice that cannot come true. A transient failure is the opposite. The
+     * UI must not have to tell them apart by reading the message.
+     */
+    it('marks drift unretryable and a transient failure retryable', async () => {
+        const input = { levelOfSupport: 'ACTIVELY_MAINTAINED', justification: 'j', reason: 'r' }
+        const drift = scripted([])
+        drift.mutate.mockRejectedValue(new Error(
+            'Unknown field \'bulkSetSbomComponentSupport\' on type \'Mutation\''))
+        const a = await useBulkAttest().submit(drift.client, ids(2), input as any)
+        expect(a.retryable).toBe(false)
+        expect(a.error).toMatch(/does not.*support the bulk mutation/)
+
+        const flaky = scripted([])
+        flaky.mutate.mockRejectedValue(new Error('Network error: 503'))
+        const c = await useBulkAttest().submit(flaky.client, ids(2), input as any)
+        expect(c.retryable).toBe(true)
+    })
+
     it('keeps the outcomes of batches that landed when a later one throws', async () => {
         let n = 0
         const mutate = vi.fn(async (opts: any) => {

--- a/ui/src/utils/useBulkAttest.ts
+++ b/ui/src/utils/useBulkAttest.ts
@@ -1,0 +1,202 @@
+import { ref, type Ref } from 'vue'
+import gql from 'graphql-tag'
+import { loadSbomComponentsPage } from './sbomComponentsQuery'
+import type { SupportAttestationFilter } from './sbomComponentsQuery'
+import type { MutationClient } from './setSbomComponentSupport'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+
+/** Page size for the collect walk. */
+export const BULK_WALK_LIMIT = 500
+
+/**
+ * Components per write.
+ *
+ * There is no server-side cap on the id list, and each item runs in its own REQUIRES_NEW
+ * transaction so a batch holds no long lock. The real bound is wall-clock per request against
+ * the ingress timeout, and per-item outcomes make a mid-batch failure recoverable. 200 keeps
+ * a batch to a few seconds and means one 500-id collect page never fans out to more than
+ * three writes.
+ */
+export const BULK_BATCH_SIZE = 200
+
+/**
+ * Ceiling on a single sweep.
+ *
+ * A browser is the wrong place to hold an unbounded id list, and an operator who has
+ * accidentally cleared the filter should be stopped rather than served. Refusing beats
+ * truncating: a silently truncated sweep would report success over a fraction of the release.
+ */
+export const BULK_MAX_IDS = 5000
+
+export const BULK_SET_SUPPORT = gql`
+    mutation bulkSetSbomComponentSupport(
+        $sbomComponentUuids: [ID!]!
+        $levelOfSupport: LevelOfSupport
+        $justification: String
+        $supportParty: SupportParty
+        $endOfGuaranteedSupportDate: String
+        $endOfSupportDate: String
+        $endOfLifeDate: String
+        $reason: String
+    ) {
+        bulkSetSbomComponentSupport(
+            sbomComponentUuids: $sbomComponentUuids
+            levelOfSupport: $levelOfSupport
+            justification: $justification
+            supportParty: $supportParty
+            endOfGuaranteedSupportDate: $endOfGuaranteedSupportDate
+            endOfSupportDate: $endOfSupportDate
+            endOfLifeDate: $endOfLifeDate
+            reason: $reason
+        ) {
+            appliedCount
+            skippedCount
+            failedCount
+            results { sbomComponentUuid outcome message }
+        }
+    }`
+
+/**
+ * NO supportNotes argument, deliberately.
+ *
+ * Notes are stored against a milestone and are the evidence for THAT date on THAT component.
+ * A fan-out cannot carry per-component evidence: one notes string applied to hundreds of
+ * components would assert the same act of checking for every one of them. Bulk is for the
+ * unattested backlog -- level, basis, party -- and the per-component form is where evidence
+ * belongs.
+ */
+export interface BulkAttestInput {
+    levelOfSupport?: string | null
+    justification?: string | null
+    party?: string | null
+    endOfGuaranteedSupportDate?: string | null
+    endOfSupportDate?: string | null
+    endOfLifeDate?: string | null
+    reason?: string | null
+}
+
+export interface BulkOutcome {
+    applied: number
+    skippedAttested: number
+    skippedRoot: number
+    failed: number
+    results: Array<{ sbomComponentUuid: string, outcome: string, message: string | null }>
+    /** A batch threw; earlier batches still landed. */
+    aborted: boolean
+    error: string | null
+    /**
+     * True when anything came back SKIPPED_ATTESTED. On a fresh walk that should be zero --
+     * the walk collected only UNATTESTED components -- so a non-zero count means somebody
+     * attested one between the walk and the write. Surfaced rather than hidden: it tells the
+     * operator their sweep raced a colleague.
+     */
+    concurrentWriteDetected: boolean
+}
+
+export function useBulkAttest () {
+    const collecting = ref(false)
+    const submitting = ref(false)
+    const collected: Ref<string[]> = ref([])
+    const progress = ref(0)
+    const error: Ref<string | null> = ref(null)
+
+    /**
+     * Walk the filter and collect ids. WRITES NOTHING.
+     *
+     * Collect-then-write, never interleaved. A keyset cursor is safe to walk while writing,
+     * but every APPLIED removes a row from the UNATTESTED set the cursor is walking, and a
+     * walk that does not write cannot be wrong about that at all. Obvious beats clever on a
+     * surface that records a regulatory claim.
+     */
+    async function collect (
+        client: DriftFallbackClient,
+        releaseUuid: string,
+        attestation: SupportAttestationFilter,
+        search: string
+    ): Promise<{ ids: string[], tooLarge: boolean }> {
+        collecting.value = true
+        error.value = null
+        const ids: string[] = []
+        let after: string | null = null
+        let tooLarge = false
+        try {
+            for (;;) {
+                const page = await loadSbomComponentsPage(client, releaseUuid, {
+                    attestation, search, limit: BULK_WALK_LIMIT, after
+                })
+                for (const row of page.items) {
+                    ids.push(row.sbomComponentUuid || row.component?.uuid)
+                }
+                if (ids.length > BULK_MAX_IDS) {
+                    tooLarge = true
+                    error.value = `This selection has more than ${BULK_MAX_IDS} components --`
+                        + ' too large for bulk attest from the browser. Narrow it with the'
+                        + ' search box and sweep in parts.'
+                    break
+                }
+                if (!page.hasMore || !page.endCursor) break
+                after = page.endCursor
+            }
+        } catch (err: any) {
+            error.value = err?.message || String(err)
+        } finally {
+            collecting.value = false
+        }
+        collected.value = tooLarge ? [] : ids
+        return { ids, tooLarge }
+    }
+
+    /** Write in batches, aggregating per-item outcomes. */
+    async function submit (
+        client: MutationClient,
+        ids: string[],
+        input: BulkAttestInput
+    ): Promise<BulkOutcome> {
+        submitting.value = true
+        progress.value = 0
+        const out: BulkOutcome = {
+            applied: 0, skippedAttested: 0, skippedRoot: 0, failed: 0,
+            results: [], aborted: false, error: null, concurrentWriteDetected: false
+        }
+        try {
+            for (let i = 0; i < ids.length; i += BULK_BATCH_SIZE) {
+                const slice = ids.slice(i, i + BULK_BATCH_SIZE)
+                const resp = await client.mutate({
+                    mutation: BULK_SET_SUPPORT,
+                    variables: {
+                        sbomComponentUuids: slice,
+                        levelOfSupport: input.levelOfSupport || null,
+                        justification: input.justification || null,
+                        supportParty: input.party || null,
+                        endOfGuaranteedSupportDate: input.endOfGuaranteedSupportDate || null,
+                        endOfSupportDate: input.endOfSupportDate || null,
+                        endOfLifeDate: input.endOfLifeDate || null,
+                        reason: input.reason || null
+                    }
+                })
+                const r = (resp.data as any)?.bulkSetSbomComponentSupport
+                if (!r) throw new Error('the server returned no result for this batch')
+                out.results.push(...r.results)
+                for (const item of r.results) {
+                    if (item.outcome === 'APPLIED') out.applied += 1
+                    else if (item.outcome === 'SKIPPED_ATTESTED') out.skippedAttested += 1
+                    else if (item.outcome === 'SKIPPED_ROOT') out.skippedRoot += 1
+                    else if (item.outcome === 'FAILED') out.failed += 1
+                }
+                progress.value = Math.min(i + slice.length, ids.length)
+            }
+        } catch (err: any) {
+            // Batches that landed are kept: the operator needs to know how much of the work
+            // is done before deciding whether to re-run. Re-running is safe -- already
+            // attested components come back SKIPPED_ATTESTED -- but only if they can see it.
+            out.aborted = true
+            out.error = err?.message || String(err)
+        } finally {
+            submitting.value = false
+        }
+        out.concurrentWriteDetected = out.skippedAttested > 0
+        return out
+    }
+
+    return { collect, submit, collecting, submitting, collected, progress, error }
+}

--- a/ui/src/utils/useBulkAttest.ts
+++ b/ui/src/utils/useBulkAttest.ts
@@ -106,6 +106,15 @@ export interface BulkOutcome {
     stoppedEarly: boolean
     error: string | null
     /**
+     * Whether re-running the same sweep can complete the remainder. False for schema drift
+     * (the server will never accept it) and for a refused re-entry (another sweep owns the
+     * work). The distinction is carried here rather than left to the UI to infer from the
+     * message text: "re-running is safe and completes the remainder" is actively false
+     * advice on a drifted server, and telling an operator to retry a write that cannot
+     * succeed is worse than saying nothing.
+     */
+    retryable: boolean
+    /**
      * True when anything came back SKIPPED_ATTESTED. On a fresh walk that should be zero --
      * the walk collected only UNATTESTED components -- so a non-zero count means somebody
      * attested one between the walk and the write. Surfaced rather than hidden: it tells the
@@ -116,6 +125,14 @@ export interface BulkOutcome {
 
 /** How many components the confirmation shows by name. A count alone hides a wrong filter. */
 export const SAMPLE_SIZE = 10
+
+/** The empty form. One definition, so adding a field cannot miss the reset site. */
+export function emptyBulkForm (): BulkAttestInput {
+    return {
+        levelOfSupport: null, party: null, justification: '',
+        endOfSupportDate: null, reason: ''
+    }
+}
 
 export interface BulkCollectResult {
     ids: string[]
@@ -163,7 +180,7 @@ function emptyOutcome (why: string): BulkOutcome {
     return {
         applied: 0, skippedAttested: 0, skippedRoot: 0, failed: 0, results: [],
         aborted: true, error: why, concurrentWriteDetected: false, stoppedEarly: false,
-        unknownOutcomes: 0
+        unknownOutcomes: 0, retryable: false
     }
 }
 
@@ -304,7 +321,7 @@ export function useBulkAttest () {
         const out: BulkOutcome = {
             applied: 0, skippedAttested: 0, skippedRoot: 0, failed: 0,
             results: [], aborted: false, error: null, concurrentWriteDetected: false,
-            stoppedEarly: false, unknownOutcomes: 0
+            stoppedEarly: false, unknownOutcomes: 0, retryable: false
         }
         try {
             for (let i = 0; i < ids.length; i += BULK_BATCH_SIZE) {
@@ -351,6 +368,7 @@ export function useBulkAttest () {
                 out.aborted = true
                 out.error = 'This server cannot perform a bulk attestation: it does not'
                     + ' support the bulk mutation, so nothing further was written.'
+                out.retryable = false
                 submitting.value = false
                 out.concurrentWriteDetected = false
                 return out
@@ -360,6 +378,7 @@ export function useBulkAttest () {
             // attested components come back SKIPPED_ATTESTED -- but only if they can see it.
             out.aborted = true
             out.error = err?.message || String(err)
+            out.retryable = true
         } finally {
             submitting.value = false
         }

--- a/ui/src/utils/useBulkAttest.ts
+++ b/ui/src/utils/useBulkAttest.ts
@@ -4,31 +4,12 @@ import { loadSbomComponentsPage } from './sbomComponentsQuery'
 import type { SupportAttestationFilter } from './sbomComponentsQuery'
 import { isSchemaDriftError } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
+import type { MutationClient } from './setSbomComponentSupport'
+import type { LevelOfSupport, SupportParty } from './supportAttestationInput'
 
-/**
- * DriftFallbackClient declares only `query`; the write needs `mutate`.
- *
- * Declared here rather than imported because the attestation-form branch that owns the
- * shared version is not merged yet -- and an earlier revision imported it anyway. That
- * escaped every gate: a type-only import is erased by esbuild, so vite build, vitest and
- * eslint all passed while the symbol was silently `any`. Consolidate when that branch lands.
- */
-export interface MutationClient extends DriftFallbackClient {
-    mutate (opts: { mutation: unknown, variables: Record<string, unknown> }): Promise<{ data?: any }>
-}
-
-/**
- * The backend enums, mirrored exactly. NOT `string`.
- *
- * This feature has already shipped two invented members (MANUFACTURER, SUPPLIER, borrowed
- * from unrelated enums) which reached the operator as "your server is out of date", because
- * a bad enum value is a variable-coercion failure, which is a validation error, which
- * isSchemaDriftError reports as drift. The document drift spec cannot see variable values --
- * only the coercion spec beside it can, and it exists for that reason.
- */
-export type BulkLevelOfSupport = 'ACTIVELY_MAINTAINED' | 'NO_LONGER_MAINTAINED' | 'ABANDONED'
-export type BulkSupportParty = 'FIRST_PARTY' | 'THIRD_PARTY'
-export type BulkOutcomeKind = 'APPLIED' | 'SKIPPED_ROOT' | 'SKIPPED_ATTESTED' | 'FAILED'
+// One definition of the backend enums, shared with the per-component form. A local copy
+// would be a second place for them to drift from the schema, and this feature has already
+// shipped two invented members that reached the operator as "your server is out of date".
 
 /** Page size for the collect walk. */
 export const BULK_WALK_LIMIT = 500
@@ -63,6 +44,7 @@ export const BULK_SET_SUPPORT = gql`
         $endOfSupportDate: String
         $endOfLifeDate: String
         $reason: String
+        $assessedAt: String
     ) {
         bulkSetSbomComponentSupport(
             sbomComponentUuids: $sbomComponentUuids
@@ -73,6 +55,7 @@ export const BULK_SET_SUPPORT = gql`
             endOfSupportDate: $endOfSupportDate
             endOfLifeDate: $endOfLifeDate
             reason: $reason
+            assessedAt: $assessedAt
         ) {
             appliedCount
             skippedCount
@@ -91,13 +74,22 @@ export const BULK_SET_SUPPORT = gql`
  * belongs.
  */
 export interface BulkAttestInput {
-    levelOfSupport?: BulkLevelOfSupport | null
+    levelOfSupport?: LevelOfSupport | null
     justification?: string | null
-    party?: BulkSupportParty | null
+    party?: SupportParty | null
     endOfGuaranteedSupportDate?: string | null
     endOfSupportDate?: string | null
     endOfLifeDate?: string | null
     reason?: string | null
+    /**
+     * ONE instant for the whole sweep, captured when the operator confirms.
+     *
+     * Omitting it makes the server stamp `now` inside each per-item transaction, so 800
+     * components carry 800 slightly different assessment instants SPREAD ACROSS the sweep --
+     * a record that reads as a stream of individual assessments rather than the one action
+     * it was. The instant is what the exported BOM publishes as "a human looked, and when".
+     */
+    assessedAt?: string | null
 }
 
 export interface BulkOutcome {
@@ -148,6 +140,15 @@ export function validateBulkInput (input: BulkAttestInput): string[] {
         || input.endOfLifeDate)
     if (!input.levelOfSupport && !hasDate && !hasBasis) {
         out.push('Record something: a level of support, a date, or a justification.')
+    }
+    // Mandatory for a sweep even though the server only demands it for un-retracting.
+    // Nothing else in the record distinguishes one action across 800 components from 800
+    // individual judgements: assessmentSource is MANUAL either way. reason is per-write,
+    // audit-only and never exported, which makes it the right carrier for the method.
+    if (!input.reason || !input.reason.trim()) {
+        out.push('A bulk sweep needs a reason. It is written to every audit row and is the'
+            + ' only record of why this batch happened -- and the only thing that marks these'
+            + ' as one action rather than hundreds of separate judgements.')
     }
     if ((input.levelOfSupport === 'NO_LONGER_MAINTAINED'
             || input.levelOfSupport === 'ABANDONED') && !hasBasis) {
@@ -322,7 +323,8 @@ export function useBulkAttest () {
                         endOfGuaranteedSupportDate: input.endOfGuaranteedSupportDate || null,
                         endOfSupportDate: input.endOfSupportDate || null,
                         endOfLifeDate: input.endOfLifeDate || null,
-                        reason: input.reason || null
+                        reason: input.reason || null,
+                        assessedAt: input.assessedAt || null
                     }
                 })
                 const r = (resp.data as any)?.bulkSetSbomComponentSupport

--- a/ui/src/utils/useBulkAttest.ts
+++ b/ui/src/utils/useBulkAttest.ts
@@ -312,6 +312,15 @@ export function useBulkAttest () {
         // empty already-attested set server-side and both write, so the second re-asserts
         // and re-dates an attestation the first just made.
         if (submitting.value) return emptyOutcome('a sweep is already running')
+        // Checked HERE, not only in the caller's gate. validateBulkInput was exported and
+        // never called by the composable, so the mandatory-reason rule lived entirely in
+        // ReleaseView's disabled-button binding -- and the server accepts a null reason. A
+        // second caller, or a refactor of that binding, would silently write a sweep whose
+        // audit rows say nothing about why it happened, which is the one thing that marks
+        // thousands of writes as a single act rather than thousands of separate judgements.
+        // The composable is the reusable unit, so the invariant belongs on it.
+        const invalid = validateBulkInput(input)
+        if (invalid.length) return emptyOutcome(invalid.join(' '))
         submitting.value = true
         cancelRequested = false
         // One composable, one place to read a failure from. Leaving a failed collect's

--- a/ui/src/utils/useBulkAttest.ts
+++ b/ui/src/utils/useBulkAttest.ts
@@ -2,8 +2,33 @@ import { ref, type Ref } from 'vue'
 import gql from 'graphql-tag'
 import { loadSbomComponentsPage } from './sbomComponentsQuery'
 import type { SupportAttestationFilter } from './sbomComponentsQuery'
-import type { MutationClient } from './setSbomComponentSupport'
+import { isSchemaDriftError } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
+
+/**
+ * DriftFallbackClient declares only `query`; the write needs `mutate`.
+ *
+ * Declared here rather than imported because the attestation-form branch that owns the
+ * shared version is not merged yet -- and an earlier revision imported it anyway. That
+ * escaped every gate: a type-only import is erased by esbuild, so vite build, vitest and
+ * eslint all passed while the symbol was silently `any`. Consolidate when that branch lands.
+ */
+export interface MutationClient extends DriftFallbackClient {
+    mutate (opts: { mutation: unknown, variables: Record<string, unknown> }): Promise<{ data?: any }>
+}
+
+/**
+ * The backend enums, mirrored exactly. NOT `string`.
+ *
+ * This feature has already shipped two invented members (MANUFACTURER, SUPPLIER, borrowed
+ * from unrelated enums) which reached the operator as "your server is out of date", because
+ * a bad enum value is a variable-coercion failure, which is a validation error, which
+ * isSchemaDriftError reports as drift. The document drift spec cannot see variable values --
+ * only the coercion spec beside it can, and it exists for that reason.
+ */
+export type BulkLevelOfSupport = 'ACTIVELY_MAINTAINED' | 'NO_LONGER_MAINTAINED' | 'ABANDONED'
+export type BulkSupportParty = 'FIRST_PARTY' | 'THIRD_PARTY'
+export type BulkOutcomeKind = 'APPLIED' | 'SKIPPED_ROOT' | 'SKIPPED_ATTESTED' | 'FAILED'
 
 /** Page size for the collect walk. */
 export const BULK_WALK_LIMIT = 500
@@ -66,9 +91,9 @@ export const BULK_SET_SUPPORT = gql`
  * belongs.
  */
 export interface BulkAttestInput {
-    levelOfSupport?: string | null
+    levelOfSupport?: BulkLevelOfSupport | null
     justification?: string | null
-    party?: string | null
+    party?: BulkSupportParty | null
     endOfGuaranteedSupportDate?: string | null
     endOfSupportDate?: string | null
     endOfLifeDate?: string | null
@@ -81,8 +106,12 @@ export interface BulkOutcome {
     skippedRoot: number
     failed: number
     results: Array<{ sbomComponentUuid: string, outcome: string, message: string | null }>
+    /** Outcomes this build does not recognise, so the counters cannot silently stop summing. */
+    unknownOutcomes: number
     /** A batch threw; earlier batches still landed. */
     aborted: boolean
+    /** The operator stopped it between batches; everything already sent has landed. */
+    stoppedEarly: boolean
     error: string | null
     /**
      * True when anything came back SKIPPED_ATTESTED. On a fresh walk that should be zero --
@@ -93,12 +122,69 @@ export interface BulkOutcome {
     concurrentWriteDetected: boolean
 }
 
+/** How many components the confirmation shows by name. A count alone hides a wrong filter. */
+export const SAMPLE_SIZE = 10
+
+export interface BulkCollectResult {
+    ids: string[]
+    /** Refused outright -- too large, drift, or an error. `ids` is empty. */
+    refused: boolean
+    /** The filter's total from the server, for "800 of 2,431 undisclosed". */
+    backlogTotal: number
+    sample: Array<{ uuid: string, name: string, version: string }>
+}
+
+/**
+ * Problems that would fail EVERY item, checked before a multi-minute walk.
+ *
+ * Without this the operator picks ABANDONED, leaves the basis blank, waits for the walk, and
+ * gets back 800 identical FAILED outcomes -- the server rejects a negative level with no
+ * justification per item, and rejects a wholly empty attestation as "must record something".
+ */
+export function validateBulkInput (input: BulkAttestInput): string[] {
+    const out: string[] = []
+    const hasBasis = !!(input.justification && input.justification.trim())
+    const hasDate = !!(input.endOfGuaranteedSupportDate || input.endOfSupportDate
+        || input.endOfLifeDate)
+    if (!input.levelOfSupport && !hasDate && !hasBasis) {
+        out.push('Record something: a level of support, a date, or a justification.')
+    }
+    if ((input.levelOfSupport === 'NO_LONGER_MAINTAINED'
+            || input.levelOfSupport === 'ABANDONED') && !hasBasis) {
+        out.push(`A level of ${input.levelOfSupport} is a negative claim about someone else's`
+            + ' project, so it needs a justification -- and in a sweep that one basis is'
+            + ' asserted for every component selected.')
+    }
+    return out
+}
+
+function emptyOutcome (why: string): BulkOutcome {
+    return {
+        applied: 0, skippedAttested: 0, skippedRoot: 0, failed: 0, results: [],
+        aborted: true, error: why, concurrentWriteDetected: false, stoppedEarly: false,
+        unknownOutcomes: 0
+    }
+}
+
+/**
+ * Bulk support attestation: walk a filter, collect ids, write them in batches.
+ *
+ * The shape is collect-then-write and the reasoning is in `collect`. Everything else here
+ * exists because a sweep writes a regulatory claim across up to five thousand components on
+ * one operator action, so every ambiguous state has to resolve toward refusing.
+ */
 export function useBulkAttest () {
     const collecting = ref(false)
     const submitting = ref(false)
     const collected: Ref<string[]> = ref([])
     const progress = ref(0)
     const error: Ref<string | null> = ref(null)
+    const sample: Ref<Array<{ uuid: string, name: string, version: string }>> = ref([])
+    const backlogTotal = ref(0)
+    let cancelRequested = false
+
+    /** Stop after the batch in flight. Nothing already sent can be recalled. */
+    function requestCancel (): void { cancelRequested = true }
 
     /**
      * Walk the filter and collect ids. WRITES NOTHING.
@@ -113,53 +199,118 @@ export function useBulkAttest () {
         releaseUuid: string,
         attestation: SupportAttestationFilter,
         search: string
-    ): Promise<{ ids: string[], tooLarge: boolean }> {
+    ): Promise<BulkCollectResult> {
         collecting.value = true
         error.value = null
+        collected.value = []
+        sample.value = []
+        backlogTotal.value = 0
         const ids: string[] = []
         let after: string | null = null
-        let tooLarge = false
+        let refused = false
         try {
             for (;;) {
                 const page = await loadSbomComponentsPage(client, releaseUuid, {
                     attestation, search, limit: BULK_WALK_LIMIT, after
                 })
-                for (const row of page.items) {
-                    ids.push(row.sbomComponentUuid || row.component?.uuid)
-                }
-                if (ids.length > BULK_MAX_IDS) {
-                    tooLarge = true
-                    error.value = `This selection has more than ${BULK_MAX_IDS} components --`
-                        + ' too large for bulk attest from the browser. Narrow it with the'
-                        + ' search box and sweep in parts.'
+                // A DEGRADED page is the whole release, unfiltered -- the loader falls back
+                // to the unpaged query when the server cannot page or filter. Walking it
+                // would turn "sweep the 800 undisclosed matching log4j" into "sweep
+                // everything", and the confirmation count would be honest about the size
+                // while being wrong about WHICH. The cap does not catch this: the set is a
+                // legitimate size, just the wrong set. Abort.
+                if (page.degraded) {
+                    refused = true
+                    error.value = 'This server cannot filter or page SBOM components, so a'
+                        + ' bulk sweep here would attest every component in the release'
+                        + ' rather than the ones you selected. Bulk attest is unavailable.'
                     break
                 }
+                if (!ids.length) backlogTotal.value = page.totalCount
+                // Refused on the FIRST page when the server already says the set is too big,
+                // rather than after eleven round trips that fetch full component rows to
+                // keep one field each.
+                if (page.totalCount > BULK_MAX_IDS) {
+                    refused = true
+                    error.value = `This selection has ${page.totalCount} components, more than`
+                        + ` the ${BULK_MAX_IDS} a browser sweep will attempt. Narrow it with`
+                        + ' the search box and sweep in parts.'
+                    break
+                }
+                const before = ids.length
+                for (const row of page.items) {
+                    // Skip rather than substitute the component uuid: the two are equal today
+                    // but the mutation wants sbom_components.uuid, and guessing manufactures
+                    // a FAILED outcome out of missing data.
+                    const id = row.sbomComponentUuid
+                    if (!id) continue
+                    ids.push(id)
+                    if (sample.value.length < SAMPLE_SIZE) {
+                        sample.value.push({
+                            uuid: id,
+                            name: row.component?.name ?? '(unnamed)',
+                            version: row.component?.version ?? ''
+                        })
+                    }
+                }
                 if (!page.hasMore || !page.endCursor) break
+                // A page that adds nothing while claiming more would loop forever. The
+                // current server cannot do that, but the loop should not depend on a
+                // server invariant to terminate.
+                if (ids.length === before) {
+                    refused = true
+                    error.value = 'The server returned an empty page while reporting more'
+                        + ' results. Bulk attest stopped rather than looping.'
+                    break
+                }
                 after = page.endCursor
             }
         } catch (err: any) {
+            refused = true
             error.value = err?.message || String(err)
         } finally {
             collecting.value = false
         }
-        collected.value = tooLarge ? [] : ids
-        return { ids, tooLarge }
+        // NO ids when refusing. Handing back a partial list next to a flag invites a caller
+        // to destructure { ids } and sweep a truncated set -- exactly the silent partial the
+        // refusal exists to prevent.
+        if (refused) return { ids: [], refused: true, backlogTotal: backlogTotal.value, sample: [] }
+        // Deduped. A duplicate straddling two batches is written twice, and the second write
+        // re-asserts and re-dates the attestation the first just made -- the server dedupes
+        // only within one request.
+        const unique = Array.from(new Set(ids))
+        collected.value = unique
+        return { ids: unique, refused: false, backlogTotal: backlogTotal.value, sample: sample.value }
     }
 
     /** Write in batches, aggregating per-item outcomes. */
     async function submit (
         client: MutationClient,
         ids: string[],
-        input: BulkAttestInput
+        input: BulkAttestInput,
+        sweptFilter: SupportAttestationFilter = 'UNATTESTED'
     ): Promise<BulkOutcome> {
+        // Checked, not merely set. Two concurrent submits with the same ids both see an
+        // empty already-attested set server-side and both write, so the second re-asserts
+        // and re-dates an attestation the first just made.
+        if (submitting.value) return emptyOutcome('a sweep is already running')
         submitting.value = true
+        cancelRequested = false
+        // One composable, one place to read a failure from. Leaving a failed collect's
+        // message on screen through a successful submit is its own kind of wrong answer.
+        error.value = null
         progress.value = 0
         const out: BulkOutcome = {
             applied: 0, skippedAttested: 0, skippedRoot: 0, failed: 0,
-            results: [], aborted: false, error: null, concurrentWriteDetected: false
+            results: [], aborted: false, error: null, concurrentWriteDetected: false,
+            stoppedEarly: false, unknownOutcomes: 0
         }
         try {
             for (let i = 0; i < ids.length; i += BULK_BATCH_SIZE) {
+                // Checked between batches, never mid-batch: a batch already sent has already
+                // committed, item by item, so there is nothing to stop. "Stop after the
+                // current batch" is the only honest offer.
+                if (cancelRequested) { out.stoppedEarly = true; break }
                 const slice = ids.slice(i, i + BULK_BATCH_SIZE)
                 const resp = await client.mutate({
                     mutation: BULK_SET_SUPPORT,
@@ -182,10 +333,26 @@ export function useBulkAttest () {
                     else if (item.outcome === 'SKIPPED_ATTESTED') out.skippedAttested += 1
                     else if (item.outcome === 'SKIPPED_ROOT') out.skippedRoot += 1
                     else if (item.outcome === 'FAILED') out.failed += 1
+                    // No silent else. A future or misspelled outcome would otherwise be
+                    // counted nowhere, so the four counters would stop summing to
+                    // results.length and a batch that did something would report 0/0/0.
+                    else out.unknownOutcomes += 1
                 }
                 progress.value = Math.min(i + slice.length, ids.length)
             }
         } catch (err: any) {
+            // A write must never degrade. The CE mirror does not declare this mutation at
+            // all, so a drifted server means the sweep cannot be performed -- not that it
+            // should be attempted narrower. Named, so the operator knows it is the server
+            // and not their input.
+            if (isSchemaDriftError(err)) {
+                out.aborted = true
+                out.error = 'This server cannot perform a bulk attestation: it does not'
+                    + ' support the bulk mutation, so nothing further was written.'
+                submitting.value = false
+                out.concurrentWriteDetected = false
+                return out
+            }
             // Batches that landed are kept: the operator needs to know how much of the work
             // is done before deciding whether to re-run. Re-running is safe -- already
             // attested components come back SKIPPED_ATTESTED -- but only if they can see it.
@@ -194,9 +361,17 @@ export function useBulkAttest () {
         } finally {
             submitting.value = false
         }
-        out.concurrentWriteDetected = out.skippedAttested > 0
+        // Only a race signal when the walk selected UNATTESTED components. Sweeping under
+        // ALL returns SKIPPED_ATTESTED for every already-attested row by design, and so does
+        // the recommended re-run after a partial failure. Telling the operator a colleague
+        // intervened in either case would be crying wolf, and the wolf message names a
+        // colleague.
+        out.concurrentWriteDetected = sweptFilter === 'UNATTESTED' && out.skippedAttested > 0
         return out
     }
 
-    return { collect, submit, collecting, submitting, collected, progress, error }
+    return {
+        collect, submit, requestCancel, validateBulkInput,
+        collecting, submitting, collected, progress, error, sample, backlogTotal
+    }
 }


### PR DESCRIPTION
Last of the four PR-5 UI slices. Adds "Attest all shown": walk the currently applied
filter, confirm the exact set, then write the same attestation to every component in
batches.

Stacked on `fda-readiness-1-dev` (5.1 paged list, 5.2 coverage gauge, 5.3 attestation
form). CE sync is PR 6, separately.

## What it does

- **Collect, then write. Never interleaved.** The walk pages at `limit: 500` and writes
  nothing; batches of 200 go out only after the operator confirms. Each `APPLIED` shrinks
  the `UNATTESTED` set under the cursor, so a walk that also writes cannot be trusted
  about its own remainder.
- **Confirmation stage.** A count alone cannot catch a filter that silently reset, so it
  names the exact count, the filter and search the walk actually ran under, ten components
  by name, and every value about to be written -- including `party`, which is exported on
  the BOM, and the audit reason, which is not.
- **Refuses rather than truncates.** Over 5,000 ids it refuses with the real total. A
  degraded (CE-fallback) page is refused outright: a degraded page is unfiltered, so
  sweeping it would attest the whole release under a filter label that is a lie.
- **A write never degrades.** CE takes 4 mutation arguments to Pro's 12; a fallback would
  drop the level and the justification while reporting success. Schema drift is a refusal.
- `reason` is mandatory, `assessedAt` is one instant captured at confirmation, and a
  negative level (`NO_LONGER_MAINTAINED` / `ABANDONED`) needs a justification -- in a
  sweep that one basis is asserted about every component selected.
- `SKIPPED_ATTESTED` on an `UNATTESTED` walk is surfaced, not hidden: those components
  were undisclosed when the sweep started, so a colleague recorded them while it ran.

## Gate

Both layers ran on the settled diff and the findings are fixed in `7fd40973` (see the
commit body for the full list). The load-bearing ones:

- The form stayed editable through the walk and the Attest button never re-validated, so
  clearing **Reason** mid-walk wrote thousands of attestations with no audit reason --
  `reason` is a UI-only rule the server does not enforce.
- **Esc dismissed the modal mid-sweep.** naive-ui checks `closeOnEsc` independently of
  `closable`/`maskClosable`, so locking those two was not enough. The sweep ran on into a
  closed modal and its only report was lost.
- An aborted sweep rendered as a green "0 attested.", and "re-running is safe" was
  appended to schema drift, where a retry can never succeed. `BulkOutcome.retryable` now
  carries the distinction.
- `unknownOutcomes` was computed as a safety signal and never rendered.
- The confirmation and the write read the filter live; the search debounce and a degraded
  page can both move it behind the open modal.

**Validation.** 417 specs (416 pass; the one failure, `routeInputSchemaDrift`
`notifyComponentOwner`, is pre-existing on `fda-readiness-1-dev` and untouched by this
diff -- worth a separate look). Every new wiring assertion was revert-probed; one passed
against the reverted code and was tightened, and the spec helper silently matched only
`async function`, so every assertion about `openBulkAttest` had been running against an
empty string.

Browser-probed on the sandbox, because `ui/` has no `vue-tsc` and a green build proves
nothing about the DOM: form frozen during the walk (0 disabled controls before, 5
during), Esc blocked with the sweep genuinely in flight, and both done-stage branches
rendered -- amber "0 attested." with no retry advice on drift, the unknown-outcome alert
on a mixed batch. Zero page exceptions. The source scans passed the Esc fix; the browser
showed it firing at the wrong moment.

**Recommend `/code-review ultra` before merge** -- this writes a regulatory claim across
thousands of components on one click, with no bulk undo. I cannot launch it.

## Follow-up, already filed

`t20260905-134808-29907` (rearm-saas, before PR 6): server-minted `batchId` (V84 column +
optional arg + response field), a server-side 1,000-id cap, and `findAllById` -> array-bound
lookup at `SbomComponentService:1367`.