### PR TITLE
feat(instance): filterable target version picker; edit extra configuration after deployment

### DIFF
--- a/ui/src/components/CreateRelease.vue
+++ b/ui/src/components/CreateRelease.vue
@@ -45,6 +45,8 @@
                         v-if="releaseCandidates && releaseCandidates.length"
                         v-model="release.uuid"
                         v-on:update:value="value => checkIfCreateNewRelease(value)"
+                        filterable
+                        placeholder="Select or type to filter by version"
                         :options="releaseCandidates" />
                 <div v-if="!isReleasesLoading && releaseCandidates && releaseCandidates.length === 0" style="color: #999; font-style: italic;">
                     No releases discovered.

--- a/ui/src/components/InstanceHistory.vue
+++ b/ui/src/components/InstanceHistory.vue
@@ -155,6 +155,7 @@ function formatChangeType(raw: any): string {
     // Cosmetic relabeling so the table reads naturally.
     s = s.replace('PRODUCT_RELEASE', 'Product Release')
     s = s.replace('TARGET_RELEASE', 'Target Release')
+    s = s.replace('CONFIGURATION', 'Configuration')
     s = s.replace('AGENT_DATA', 'Agent Data')
     s = s.replace('PRODUCT_MATCH', 'Product Match')
     s = s.replace('DEPLOYMENT', 'Deployment')

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -394,6 +394,24 @@
                             @approvalsChanged="fetchInstance" @closeRelease="showReleaseViewModal=false"/>
         </n-modal>
         <n-modal
+            v-model:show="showEditConfigurationModal"
+            preset="dialog"
+            :show-icon="false"
+            style="width: 90%;"
+            title="Edit Extra Configuration"
+        >
+            <n-form-item :label="'Extra Configuration for ' + (focusedProduct?.featureSetDetails?.name || featureSetLabel) + ' (e.g. Helm values file, optional)'">
+                <n-input
+                            type="textarea"
+                            rows="4"
+                            data-testid="product-config-input"
+                            v-model:value="updatedProductConfiguration"
+                            placeholder="Enter extra configuration" />
+            </n-form-item>
+            <n-button type="success" data-testid="product-config-save" @click="saveConfiguration()">Submit</n-button>
+            <n-button type="warning" @click="updatedProductConfiguration = focusedProduct.configuration || ''">Reset</n-button>
+        </n-modal>
+        <n-modal
             v-model:show="showEditPropertyModal"
             preset="dialog"
             :show-icon="false"
@@ -616,6 +634,7 @@ const planChangeTypeOptions = [
     { label: 'Any', key: 'ANY' },
     { label: 'Product Release', key: 'PRODUCT_RELEASE' },
     { label: 'Target Release', key: 'TARGET_RELEASE' },
+    { label: 'Configuration', key: 'CONFIGURATION' },
     { label: 'Property', key: 'PROPERTY' },
     { label: 'Environment', key: 'ENVIRONMENT' }
 ]
@@ -1355,14 +1374,19 @@ const targetReleaseSet = async function (rlz: any) {
     showSelectTargetReleaseModal.value = false
 }
 
-const updateConfiguration = async function (e: any, prl: any) {
-    const updatedProduct = updatedInstance.value.productPlans.find((product: any) => 
+const showEditConfigurationModal = ref(false)
+const updatedProductConfiguration = ref('')
+const saveConfiguration = async function () {
+    const prl = focusedProduct.value
+    const updatedProduct = updatedInstance.value.productPlans.find((product: any) =>
         product.featureSet === prl.featureSet && product.namespace === prl.namespace
     )
-    if (updatedProduct.configuration !== e.target.innerText) {
-        updatedProduct.configuration = e.target.innerText
-        await save() 
+    const newValue = updatedProductConfiguration.value.trim()
+    if (updatedProduct && (updatedProduct.configuration || '') !== newValue) {
+        updatedProduct.configuration = newValue
+        await save()
     }
+    showEditConfigurationModal.value = false
 }
 
 const clearAgentData = async function () {
@@ -1681,16 +1705,24 @@ matchedProductFields.push({
     key: 'config',
     title: 'Config',
     render: (row: any) => {
-        if(isWritable){
-            return h('span', {
-                contenteditable: true,
-                onblur: (e: Event) => {
-                    updateConfiguration(e, row)
+        // Extra configuration (e.g. Helm values file) stays editable after
+        // deployment: every save lands as a plan revision, which the Plan
+        // History tab classifies as a Configuration change.
+        const els: any[] = [h('span', { 'data-testid': 'product-config-value' }, row.configuration || '')]
+        if (isWritable) {
+            els.push(h(NIcon, {
+                title: 'Edit Extra Configuration',
+                class: 'icons clickable',
+                size: 16,
+                'data-testid': 'product-config-edit',
+                onClick: () => {
+                    focusedProduct.value = row
+                    updatedProductConfiguration.value = row.configuration || ''
+                    showEditConfigurationModal.value = true
                 }
-            }, {default: () => row.configuration})
-        }else{
-            return h('span', row.configuration)
+            }, { default: () => h(Edit24Regular) }))
         }
+        return els
     }
 })
 if(props.instanceType === InstanceType.STANDALONE_INSTANCE){


### PR DESCRIPTION
Two changes on the instance page:

1. **Set Target Release**: the release dropdown is filterable, so the version can be typed to narrow the list.
2. **Extra configuration after deployment**: the Config column of a linked feature set showed a bare contenteditable span (easy to miss, easy to change by accident). It now shows the value with an edit icon that opens a modal (textarea, Submit, Reset). Saving writes a plan revision like every other plan change, so it is recorded in the Plan History tab, which gains a **Configuration** change type filter and label.

The Configuration change type is classified by the backend (Pro backend change shipping separately). Until that backend is deployed, picking the Configuration filter is unknown to the server; everything else works against the current backend.

Verification: `vite build` clean; eslint errors in `InstanceView.vue` are pre-existing on main (56 on main, 55 on the branch, all in an untouched block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)