### PR TITLE
FDA-Readiness-1 7f step 2: CE backend sync (prose storage, prose bound, SUPPORT_WINDOW enum)

### DIFF
--- a/backend/src/main/java/io/reliza/model/OrganizationData.java
+++ b/backend/src/main/java/io/reliza/model/OrganizationData.java
@@ -105,6 +105,58 @@ public class OrganizationData extends RelizaDataParent implements RelizaObject {
 		@JsonProperty
 		private Integer notificationRetentionDays;
 
+		/**
+		 * FDA-Readiness-1 section 7f. Manufacturer-authored prose that the generated
+		 * submission documents render. Org-level because all four say something about how
+		 * THIS manufacturer assesses and supports, not about one device.
+		 *
+		 * <p>Nullable throughout, and null is a real state rather than a default to paper
+		 * over: a document with an empty required slot is BLOCKED rather than generated with
+		 * the section missing. On a submission a reviewer expects gaps, but on the
+		 * patient-facing Device Support Statement a silent gap is itself the misleading
+		 * thing under 502(a)(1).
+		 *
+		 * <p>There is deliberately NO product-shipped default text for any of them. These
+		 * are the manufacturer's own commitments; shipping wording they did not write and
+		 * then putting it over their name is the failure this feature exists to avoid.
+		 */
+		@JsonProperty
+		private String fdaAssessmentNarrative;
+
+		/** Statement that patches/updates may cease at end of support (labeling VI.A.2). */
+		@JsonProperty
+		private String fdaPatchesMayCeaseStatement;
+
+		/**
+		 * REFERENCE to the controlled risk-transfer process (labeling VI.A.3) -- an
+		 * identifier or URL, not the process itself. Plans and processes are
+		 * design-history-file records; pasting one into a generated artifact creates a
+		 * second, unversioned copy that drifts from the controlled original.
+		 */
+		@JsonProperty
+		private String fdaRiskTransferProcessRef;
+
+		/** Notice that end-user cybersecurity risk increases over time (labeling VI.A.4). */
+		@JsonProperty
+		private String fdaRiskIncreasesNotice;
+
+		/**
+		 * Bound on each prose field.
+		 *
+		 * <p>8,000 rather than the 20,000 an earlier revision used, and the reason is the
+		 * READ side rather than the write. These live on the organization record, which
+		 * {@code getOrganizationData} materialises fresh on every call -- including from
+		 * {@code AuthorizationService}, i.e. on the authorization path of ordinary requests.
+		 * Four fields at 20,000 was up to 80KB of extra JSONB parsed per request to carry
+		 * text that is read when a document is generated.
+		 *
+		 * <p>Still generous for what these are. Three of the four are single statements, and
+		 * the risk-transfer slot is a REFERENCE to a controlled document by design, not the
+		 * process. Only the assessment narrative is prose of any length, and 8,000
+		 * characters is several pages of it.
+		 */
+		public static final int FDA_PROSE_MAX_LENGTH = 8000;
+
 		public static final int NOTIFICATION_RETENTION_DAYS_DEFAULT = 90;
 		public static final int NOTIFICATION_RETENTION_DAYS_MIN = 14;
 		public static final int NOTIFICATION_RETENTION_DAYS_MAX = 730;

--- a/backend/src/main/java/io/reliza/service/OrganizationService.java
+++ b/backend/src/main/java/io/reliza/service/OrganizationService.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -693,6 +694,17 @@ public class OrganizationService {
 				settings.setVexComplianceFramework(settingsPatch.getVexComplianceFramework());
 			}
 
+			// PATCH, same as every field above and same as the attestation write: omitted
+			// leaves the stored value alone, supplied-blank clears it to null.
+			applyProse(settingsPatch.getFdaAssessmentNarrative(), settings::setFdaAssessmentNarrative,
+					"fdaAssessmentNarrative");
+			applyProse(settingsPatch.getFdaPatchesMayCeaseStatement(), settings::setFdaPatchesMayCeaseStatement,
+					"fdaPatchesMayCeaseStatement");
+			applyProse(settingsPatch.getFdaRiskTransferProcessRef(), settings::setFdaRiskTransferProcessRef,
+					"fdaRiskTransferProcessRef");
+			applyProse(settingsPatch.getFdaRiskIncreasesNotice(), settings::setFdaRiskIncreasesNotice,
+					"fdaRiskIncreasesNotice");
+
 			Integer retentionDays = settingsPatch.getNotificationRetentionDays();
 			if (retentionDays != null) {
 				if (retentionDays < OrganizationData.Settings.NOTIFICATION_RETENTION_DAYS_MIN
@@ -723,6 +735,44 @@ public class OrganizationService {
 			log.error("Exception when updating organization settings", e);
 			throw new RelizaException("Could not update organization settings");
 		}
+	}
+
+	/**
+	 * One prose field of the FDA document set, under this codebase's existing PATCH
+	 * contract: OMITTED (null) leaves the stored value alone, SUPPLIED-BLANK is a
+	 * deliberate CLEAR, and anything else is trimmed and stored.
+	 *
+	 * <p>Same BLANK-VS-OMITTED rule as the attestation write
+	 * ({@code SbomComponentService.applySupport}, via {@code blankToNull}); this one also
+	 * strips, which that one does not. Deliberately not a second idiom for the same thing --
+	 * an earlier revision here refused blanks and reserved clearing for a future
+	 * {@code clearFdaProse} list, which is one contract too many for one codebase.
+	 *
+	 * <p>Blank normalises to NULL rather than to an empty string, so storage never holds
+	 * whitespace that a later reader would have to re-check. That keeps the document
+	 * generator's "required slot is missing" test a null test.
+	 *
+	 * <p>Refusing a blank was also worse for the operator: someone who empties a wrong
+	 * risk-transfer reference and saves would be told nothing while the stale value
+	 * survived -- and the generator would later ship it into a patient-facing document.
+	 * That is precisely the fabrication the empty-slot block exists to prevent.
+	 */
+	private static void applyProse(String value, Consumer<String> setter,
+			String fieldName) throws RelizaException {
+		if (null == value) return;
+		// Raw length BEFORE strip(). Raw length is an upper bound on stripped length, so
+		// this cannot reject anything valid, and it avoids allocating one more full copy of
+		// a hostile body just to refuse it.
+		if (value.length() > OrganizationData.Settings.FDA_PROSE_MAX_LENGTH) {
+			throw new RelizaException(fieldName + " exceeds the "
+					+ OrganizationData.Settings.FDA_PROSE_MAX_LENGTH + " character limit");
+		}
+		String trimmed = value.strip();
+		if (trimmed.length() > OrganizationData.Settings.FDA_PROSE_MAX_LENGTH) {
+			throw new RelizaException(fieldName + " exceeds the "
+					+ OrganizationData.Settings.FDA_PROSE_MAX_LENGTH + " character limit");
+		}
+		setter.accept(trimmed.isEmpty() ? null : trimmed);
 	}
 
 	/**

--- a/backend/src/main/resources/schema/schema.graphqls
+++ b/backend/src/main/resources/schema/schema.graphqls
@@ -2343,6 +2343,33 @@ type Settings {
 	deliveries, read marks). Null means the 90-day default.
 	"""
 	notificationRetentionDays: Int
+	"""
+	The submission-level justification: what FDA L1021-1022 asks for literally, the reason
+	per-component support information cannot be included. At the measured 2.3% upstream
+	coverage this is the centre of a submission rather than a footnote.
+
+	Null is a real state, not a default. A document with an empty REQUIRED slot is blocked
+	rather than generated with the section missing -- on a submission a reviewer expects
+	gaps, but on the patient-facing Device Support Statement a silent gap is itself
+	misleading under 502(a)(1). No product-shipped default text: these are the
+	manufacturer's own commitments.
+	"""
+	fdaAssessmentNarrative: String
+	"""
+	Labeling VI.A.2: that patches and software updates may cease at end of support.
+	"""
+	fdaPatchesMayCeaseStatement: String
+	"""
+	Labeling VI.A.3: a REFERENCE to the controlled risk-transfer process -- an identifier or
+	URL, never the process itself. Plans are design-history-file records, and a pasted copy
+	becomes a second, unversioned original that drifts from the controlled one.
+	"""
+	fdaRiskTransferProcessRef: String
+	"""
+	Labeling VI.A.4: that end-user cybersecurity risk can be expected to increase over
+	time.
+	"""
+	fdaRiskIncreasesNotice: String
 }
 
 """
@@ -4283,6 +4310,57 @@ input SettingsInput {
 	value unchanged (90-day default applies when never set).
 	"""
 	notificationRetentionDays: Int
+	"""
+	The submission-level justification: what FDA L1021-1022 asks for literally, the reason
+	per-component support information cannot be included. At the measured 2.3% upstream
+	coverage this is the centre of a submission rather than a footnote.
+
+	Null is a real state, not a default. A document with an empty REQUIRED slot is blocked
+	rather than generated with the section missing -- on a submission a reviewer expects
+	gaps, but on the patient-facing Device Support Statement a silent gap is itself
+	misleading under 502(a)(1). No product-shipped default text: these are the
+	manufacturer's own commitments.
+	PATCH: OMIT to leave unchanged, send an EMPTY STRING to clear. Blank normalises to null
+	in storage, so a generator's "required slot missing" test stays a null test.
+
+	An explicit null is treated as OMITTED, not as a clear -- the clear signal is "", the
+	same as on the attestation write. Worth knowing because null-to-clear is the more common
+	convention elsewhere.
+	"""
+	fdaAssessmentNarrative: String
+	"""
+	Labeling VI.A.2: that patches and software updates may cease at end of support.
+	PATCH: OMIT to leave unchanged, send an EMPTY STRING to clear. Blank normalises to null
+	in storage, so a generator's "required slot missing" test stays a null test.
+
+	An explicit null is treated as OMITTED, not as a clear -- the clear signal is "", the
+	same as on the attestation write. Worth knowing because null-to-clear is the more common
+	convention elsewhere.
+	"""
+	fdaPatchesMayCeaseStatement: String
+	"""
+	Labeling VI.A.3: a REFERENCE to the controlled risk-transfer process -- an identifier or
+	URL, never the process itself. Plans are design-history-file records, and a pasted copy
+	becomes a second, unversioned original that drifts from the controlled one.
+	PATCH: OMIT to leave unchanged, send an EMPTY STRING to clear. Blank normalises to null
+	in storage, so a generator's "required slot missing" test stays a null test.
+
+	An explicit null is treated as OMITTED, not as a clear -- the clear signal is "", the
+	same as on the attestation write. Worth knowing because null-to-clear is the more common
+	convention elsewhere.
+	"""
+	fdaRiskTransferProcessRef: String
+	"""
+	Labeling VI.A.4: that end-user cybersecurity risk can be expected to increase over
+	time.
+	PATCH: OMIT to leave unchanged, send an EMPTY STRING to clear. Blank normalises to null
+	in storage, so a generator's "required slot missing" test stays a null test.
+
+	An explicit null is treated as OMITTED, not as a clear -- the clear signal is "", the
+	same as on the attestation write. Worth knowing because null-to-clear is the more common
+	convention elsewhere.
+	"""
+	fdaRiskIncreasesNotice: String
 }
 
 input PermissionInput {
@@ -5556,6 +5634,11 @@ enum ReleaseUpdateScopeEnum {
 	TRIGGER
 	INPUT_TRIGGER
 	APPROVED_ENVIRONMENT
+	# The section-524B device support window (eos/eol). Present in the Java enum since the
+	# window landed; missing here until 2026-09-07, which meant a release that had ever had
+	# its window set could not be SERIALIZED -- the whole release query failed with
+	# "Unknown value 'SUPPORT_WINDOW'" and the page would not load.
+	SUPPORT_WINDOW
 }
 
 enum ReleaseUpdateActionEnum {

--- a/backend/src/test/java/io/reliza/service/FdaProseSettingsTest.java
+++ b/backend/src/test/java/io/reliza/service/FdaProseSettingsTest.java
@@ -1,0 +1,257 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.Organization;
+import io.reliza.model.OrganizationData;
+import io.reliza.model.VexComplianceFramework;
+import io.reliza.model.WhoUpdated;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * The four manufacturer-authored prose slots the FDA document set renders (plan 7f).
+ *
+ * <p>What is asserted here is mostly about ABSENCE being preserved. The documents block
+ * generation on an empty required slot, and that check is only trustworthy if the storage
+ * layer cannot quietly turn "nothing recorded" into "something that looks recorded" -- a
+ * blank string being the obvious way that happens.
+ */
+@SpringBootTest(classes = { App.class })
+class FdaProseSettingsTest {
+
+	@Autowired private OrganizationService organizationService;
+	@Autowired private GetOrganizationService getOrganizationService;
+	@Autowired private TestInitializer testInitializer;
+
+	private OrganizationData.Settings patch() {
+		return new OrganizationData.Settings();
+	}
+
+	private OrganizationData.Settings settingsOf(UUID orgUuid) {
+		return getOrganizationService.getOrganizationData(orgUuid).orElseThrow().getSettings();
+	}
+
+	@Test
+	void storesAllFourAndLeavesEveryOtherSettingAlone() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings p = patch();
+		p.setFdaAssessmentNarrative("No upstream publishes a machine-readable support level"
+				+ " for the majority of these components; each was checked against its"
+				+ " project's published policy on 2026-09-07.");
+		p.setFdaPatchesMayCeaseStatement("After end of support we may no longer issue"
+				+ " security patches or software updates for this device.");
+		p.setFdaRiskTransferProcessRef("DHF-PROC-4471 rev C");
+		p.setFdaRiskIncreasesNotice("Cybersecurity risk to users can be expected to increase"
+				+ " over time after end of support.");
+		organizationService.updateSettings(org.getUuid(), p, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings s = settingsOf(org.getUuid());
+		assertTrue(s.getFdaAssessmentNarrative().startsWith("No upstream publishes"));
+		assertTrue(s.getFdaPatchesMayCeaseStatement().startsWith("After end of support"));
+		assertEquals("DHF-PROC-4471 rev C", s.getFdaRiskTransferProcessRef());
+		assertTrue(s.getFdaRiskIncreasesNotice().contains("increase"));
+	}
+
+	/**
+	 * The prose block was inserted BEFORE the existing field handling in updateSettings, so
+	 * the question "did that change anything for its neighbours" needs an answer that is not
+	 * a reading of the diff. Seeds the other settings, patches only prose, and asserts they
+	 * survive.
+	 */
+	@Test
+	void aProseOnlyPatchLeavesTheOtherSettingsIntact() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings seed = patch();
+		seed.setJustificationMandatory(true);
+		seed.setVexComplianceFramework(VexComplianceFramework.CISA);
+		seed.setNotificationRetentionDays(180);
+		organizationService.updateSettings(org.getUuid(), seed, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings proseOnly = patch();
+		proseOnly.setFdaAssessmentNarrative("only the narrative changes here");
+		organizationService.updateSettings(org.getUuid(), proseOnly, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings s = settingsOf(org.getUuid());
+		assertEquals(Boolean.TRUE, s.getJustificationMandatory());
+		assertEquals(VexComplianceFramework.CISA, s.getVexComplianceFramework());
+		assertEquals(Integer.valueOf(180), s.getNotificationRetentionDays());
+		assertEquals("only the narrative changes here", s.getFdaAssessmentNarrative());
+	}
+
+	/**
+	 * Exactly at the bound is ACCEPTED. Only MAX+1 was covered, so a flip to >= would have
+	 * passed the suite while silently refusing a document someone had already written.
+	 */
+	@Test
+	void exactlyTheBoundIsAccepted() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		String atLimit = "y".repeat(OrganizationData.Settings.FDA_PROSE_MAX_LENGTH);
+		OrganizationData.Settings p = patch();
+		p.setFdaAssessmentNarrative(atLimit);
+		organizationService.updateSettings(org.getUuid(), p, WhoUpdated.getTestWhoUpdated());
+		assertEquals(atLimit.length(), settingsOf(org.getUuid()).getFdaAssessmentNarrative().length());
+	}
+
+	/**
+	 * A patch that is valid in one field and over-long in another must write NEITHER.
+	 *
+	 * <p>Holds today because getOrganizationData materialises a fresh POJO per call, so the
+	 * half-mutated object is unreachable when the throw happens and saveOrganization is the
+	 * only write. That is a property of the current structure rather than an explicit
+	 * guarantee, which is exactly why it is worth pinning: moving the save earlier, or
+	 * splitting the method, would break it silently.
+	 */
+	@Test
+	void aPatchThatFailsPartWayWritesNothing() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings p = patch();
+		p.setFdaPatchesMayCeaseStatement("this one is fine");
+		p.setFdaAssessmentNarrative("z".repeat(OrganizationData.Settings.FDA_PROSE_MAX_LENGTH + 1));
+		assertThrows(RelizaException.class,
+				() -> organizationService.updateSettings(org.getUuid(), p, WhoUpdated.getTestWhoUpdated()));
+
+		OrganizationData.Settings after = settingsOf(org.getUuid());
+		assertTrue(after == null || after.getFdaPatchesMayCeaseStatement() == null,
+				"the valid field must not survive a patch that failed on another field");
+	}
+
+	/**
+	 * PATCH semantics: an omitted field leaves the stored value alone. Without this, saving
+	 * the settings form to change one unrelated toggle would erase prose a manufacturer
+	 * signed -- and erase it silently, since nothing else reads these until a document is
+	 * generated.
+	 */
+	@Test
+	void omittingAFieldLeavesItUnchanged() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings first = patch();
+		first.setFdaAssessmentNarrative("original narrative");
+		first.setFdaRiskTransferProcessRef("DHF-1");
+		organizationService.updateSettings(org.getUuid(), first, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings second = patch();
+		second.setFdaRiskTransferProcessRef("DHF-2");
+		organizationService.updateSettings(org.getUuid(), second, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings s = settingsOf(org.getUuid());
+		assertEquals("original narrative", s.getFdaAssessmentNarrative(),
+				"an unrelated settings save must not erase prose the manufacturer authored");
+		assertEquals("DHF-2", s.getFdaRiskTransferProcessRef());
+	}
+
+	/**
+	 * SUPPLIED-BLANK CLEARS. Same contract as the attestation write, and the reason is the
+	 * operator's: someone who empties a wrong risk-transfer reference and saves must end up
+	 * with it gone. Refusing the blank instead would leave the stale value in place while
+	 * telling them nothing, and the generator would later ship it into a patient-facing
+	 * document -- the exact fabrication the empty-slot block exists to prevent.
+	 *
+	 * <p>Normalised to NULL, not to "", so the generator's missing-slot test stays a null
+	 * test and storage never holds whitespace that reads as content.
+	 */
+	@Test
+	void blankClearsToNull() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings seed = patch();
+		seed.setFdaRiskTransferProcessRef("DHF-WRONG-9 rev A");
+		organizationService.updateSettings(org.getUuid(), seed, WhoUpdated.getTestWhoUpdated());
+		assertEquals("DHF-WRONG-9 rev A", settingsOf(org.getUuid()).getFdaRiskTransferProcessRef());
+
+		for (String blank : new String[] { "", "   ", "\n\t " }) {
+			OrganizationData.Settings reseed = patch();
+			reseed.setFdaRiskTransferProcessRef("DHF-WRONG-9 rev A");
+			organizationService.updateSettings(org.getUuid(), reseed, WhoUpdated.getTestWhoUpdated());
+
+			OrganizationData.Settings clear = patch();
+			clear.setFdaRiskTransferProcessRef(blank);
+			organizationService.updateSettings(org.getUuid(), clear, WhoUpdated.getTestWhoUpdated());
+			assertNull(settingsOf(org.getUuid()).getFdaRiskTransferProcessRef(),
+					"blank must clear to null, not store whitespace: " + blank.length() + " chars");
+		}
+	}
+
+	/** Clearing one slot must not disturb the other three. */
+	@Test
+	void clearingOneSlotLeavesTheOthers() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings seed = patch();
+		seed.setFdaAssessmentNarrative("narrative stays");
+		seed.setFdaPatchesMayCeaseStatement("patches stays");
+		seed.setFdaRiskTransferProcessRef("ref goes");
+		seed.setFdaRiskIncreasesNotice("notice stays");
+		organizationService.updateSettings(org.getUuid(), seed, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings clear = patch();
+		clear.setFdaRiskTransferProcessRef("");
+		organizationService.updateSettings(org.getUuid(), clear, WhoUpdated.getTestWhoUpdated());
+
+		OrganizationData.Settings s = settingsOf(org.getUuid());
+		assertNull(s.getFdaRiskTransferProcessRef());
+		assertEquals("narrative stays", s.getFdaAssessmentNarrative());
+		assertEquals("patches stays", s.getFdaPatchesMayCeaseStatement());
+		assertEquals("notice stays", s.getFdaRiskIncreasesNotice());
+	}
+
+	@Test
+	void proseIsTrimmedAndBounded() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		OrganizationData.Settings p = patch();
+		p.setFdaRiskIncreasesNotice("   padded on both sides   ");
+		organizationService.updateSettings(org.getUuid(), p, WhoUpdated.getTestWhoUpdated());
+		assertEquals("padded on both sides", settingsOf(org.getUuid()).getFdaRiskIncreasesNotice());
+
+		OrganizationData.Settings tooBig = patch();
+		tooBig.setFdaAssessmentNarrative("x".repeat(
+				OrganizationData.Settings.FDA_PROSE_MAX_LENGTH + 1));
+		RelizaException e = assertThrows(RelizaException.class,
+				() -> organizationService.updateSettings(org.getUuid(), tooBig, WhoUpdated.getTestWhoUpdated()));
+		assertTrue(e.getMessage().contains("character limit"), e.getMessage());
+	}
+
+	/**
+	 * Each field's error names THAT field.
+	 *
+	 * <p>applyProse pairs a setter reference with a field-name string by hand, four times.
+	 * A copy-paste that hands field A's label to field B's setter compiles, passes every
+	 * other test here, and shows an operator the wrong field name when their text is too
+	 * long -- on a form with four textareas, which is precisely when naming the right one
+	 * matters.
+	 */
+	@Test
+	void anOverlongValueNamesTheFieldItCameFrom() throws Exception {
+		Organization org = testInitializer.obtainOrganization();
+		String tooBig = "x".repeat(OrganizationData.Settings.FDA_PROSE_MAX_LENGTH + 1);
+
+		record Case(String field, java.util.function.BiConsumer<OrganizationData.Settings, String> set) {}
+		var cases = java.util.List.of(
+				new Case("fdaAssessmentNarrative", OrganizationData.Settings::setFdaAssessmentNarrative),
+				new Case("fdaPatchesMayCeaseStatement", OrganizationData.Settings::setFdaPatchesMayCeaseStatement),
+				new Case("fdaRiskTransferProcessRef", OrganizationData.Settings::setFdaRiskTransferProcessRef),
+				new Case("fdaRiskIncreasesNotice", OrganizationData.Settings::setFdaRiskIncreasesNotice));
+
+		for (Case c : cases) {
+			OrganizationData.Settings p = patch();
+			c.set().accept(p, tooBig);
+			RelizaException e = assertThrows(RelizaException.class,
+					() -> organizationService.updateSettings(org.getUuid(), p, WhoUpdated.getTestWhoUpdated()));
+			assertTrue(e.getMessage().startsWith(c.field()),
+					"the error must name the field it came from, not a sibling: expected "
+							+ c.field() + ", got: " + e.getMessage());
+		}
+	}
+}

--- a/backend/src/test/java/io/reliza/ws/ReleaseUpdateScopeSchemaEnumSyncTest.java
+++ b/backend/src/test/java/io/reliza/ws/ReleaseUpdateScopeSchemaEnumSyncTest.java
@@ -1,0 +1,106 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+
+package io.reliza.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import io.reliza.model.ReleaseData.ReleaseUpdateScope;
+
+/**
+ * Regression guard for {@code ReleaseUpdateScope} drift between Java and the GraphQL schema.
+ *
+ * <p>Written because the drift shipped and the failure was not the one you would expect.
+ * {@code SUPPORT_WINDOW} was added to the Java enum when the device support window landed and
+ * never added to {@code ReleaseUpdateScopeEnum}. Nothing failed at startup, nothing failed on
+ * write, and the audit row was recorded correctly. It failed on READ, and not on the field:
+ * DGS could not serialize the enum value, so the WHOLE {@code release} query errored and the
+ * release page would not load at all.
+ *
+ * <p>So the blast radius of one missing enum value is every consumer of the release, for any
+ * release that has ever had its support window set. Found by setting a window through the
+ * API and watching the page go blank.
+ *
+ * <p>Equality, not subset: an update scope the schema declares but Java cannot produce is
+ * dead wire surface, and one Java produces but the schema lacks is the bug above. Both fail.
+ */
+class ReleaseUpdateScopeSchemaEnumSyncTest {
+
+	/** "enum Foo { ... }" block -- captures the body between the braces. */
+	private static final Pattern ENUM_BLOCK = Pattern.compile(
+			"enum\\s+(\\w+)\\s*\\{([^}]*)\\}", Pattern.DOTALL);
+
+	private static final Pattern DOCSTRING = Pattern.compile("\"\"\"[\\s\\S]*?\"\"\"");
+
+	@Test
+	void releaseUpdateScopeEnumIsInSync() {
+		Set<String> schemaValues = readSchemaEnum("ReleaseUpdateScopeEnum");
+		Set<String> javaValues = new TreeSet<>(
+				Arrays.stream(ReleaseUpdateScope.values()).map(Enum::name).toList());
+
+		assertEquals(javaValues, schemaValues,
+				"ReleaseUpdateScope and ReleaseUpdateScopeEnum have drifted."
+						+ " Missing in schema: " + diff(javaValues, schemaValues)
+						+ "; extra in schema: " + diff(schemaValues, javaValues)
+						+ ". A value Java can produce but the schema lacks does NOT fail on"
+						+ " write -- it fails when the release is READ, and it fails the whole"
+						+ " query, so the release page stops loading for every release that"
+						+ " ever recorded it.");
+	}
+
+	private static Set<String> diff(Set<String> a, Set<String> b) {
+		Set<String> r = new LinkedHashSet<>(a);
+		r.removeAll(b);
+		return r;
+	}
+
+	/** Returns the enum values declared in the GraphQL schema file. */
+	private static Set<String> readSchemaEnum(String enumName) {
+		Matcher m = ENUM_BLOCK.matcher(readSchema());
+		while (m.find()) {
+			if (!enumName.equals(m.group(1))) continue;
+			Set<String> out = new TreeSet<>();
+			// Strip """...""" descriptions before splitting, and trailing # comments as well
+			// as whole-line ones -- the parse SupportEnumsSchemaEnumSyncTest arrived at after
+			// the first enum to document its MEMBERS had each doc line read as a value.
+			String body = DOCSTRING.matcher(m.group(2)).replaceAll("");
+			for (String raw : body.split("\\R")) {
+				String line = raw.trim();
+				int hash = line.indexOf('#');
+				if (hash >= 0) line = line.substring(0, hash).trim();
+				if (line.isEmpty()) continue;
+				out.add(line);
+			}
+			return out;
+		}
+		throw new AssertionError("Did not find enum " + enumName + " in schema.graphqls");
+	}
+
+	/**
+	 * From the CLASSPATH, like every sibling sync test -- not a CWD-relative path. The
+	 * taxonomy guard had to be fixed for exactly that two commits ago (#489): a relative
+	 * path resolves against the maven basedir and silently finds nothing anywhere else.
+	 */
+	private static String readSchema() {
+		try (InputStream in = ReleaseUpdateScopeSchemaEnumSyncTest.class.getResourceAsStream(
+				"/schema/schema.graphqls")) {
+			if (in == null) throw new IllegalStateException("schema.graphqls not on test classpath");
+			return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
Mechanical mirror, reproducible rather than trusted:

```
git -C rearm-saas checkout 1296cfd3
bash rearm-saas/backend/copy-src.sh <rearm>/backend
```

Brings rearm-saas #498 (four manufacturer prose slots + the `SUPPORT_WINDOW` enum fix) and
#499 (prose bound lowered to 8,000). Five files, no hand edits.

## Why this lands before the UI

The four `fda*` fields are selected by `store.ts`'s `organizations` query, which runs on
**every page load**, and `fetchMyOrganizations` catches a failure and returns **no org** — so
a CE install running the UI against a CE backend without these fields is *unusable*, not
merely degraded. That is also why no drift fallback was added there: the fix is this
ordering, not a runtime workaround.

## It also closes a page-breaking bug already in CE

Before this, CE's schema documented `SUPPORT_WINDOW` in prose while the enum did not declare
it. Any CE release that ever had its device support window set could not be serialized, and
the **whole** release query failed — the page would not load at all. PR #324 synced from a SHA
predating the fix, so CE carried it.

## Confirmations in the CE tree after syncing

| | |
|---|---|
| `fdaAssessmentNarrative`, `fdaPatchesMayCeaseStatement`, `fdaRiskTransferProcessRef`, `fdaRiskIncreasesNotice` | present on **both** the `Settings` type and `SettingsInput` |
| `SUPPORT_WINDOW` | inside `enum ReleaseUpdateScopeEnum` itself, not merely in a description |
| `eos`, `eol`, `clearEos`, `clearEol` | on `ReleaseInput` |
| `FDA_PROSE_MAX_LENGTH` | `8000` |

## Gates

- **Taxonomy doc**: `git diff --exit-code` clean, and all three copies (source, CE root, CE
  backend) byte-identical.
- **`CyclonedxTaxonomyDocSyncTest`**: 2/2 green *inside the CE build*.
- **`ReleaseUpdateScopeSchemaEnumSyncTest`**: 1/1 green inside the CE build — this is the
  guard that would have caught the bug above.
- **Full CE suite: 1777 tests, 0 failures, 0 errors.** The known
  `anUnreadablePayloadIsExcludedWithoutFailingTheBatch` flake did not recur.

Per operator ruling there is no `dev -> main` for this track until the feature is complete and
demoed, so CE main stays exposed to the forged-provenance hole and to the `SUPPORT_WINDOW`
serialization bug until then.