### PR TITLE
Port the device support window into CE's release writer (oss/ fork gap)

### DIFF
--- a/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
@@ -4,6 +4,7 @@
 
 package io.reliza.service.oss;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -616,6 +617,43 @@ public class OssReleaseService {
 			rData.setVersion(releaseDto.getVersion());
 			rData.addUpdateEvent(new ReleaseUpdateEvent(ReleaseUpdateScope.VERSION, ReleaseUpdateAction.CHANGED, rData.getVersion(),
 					releaseDto.getVersion(), null, ZonedDateTime.now(), wu));
+		}
+		// Device support window (eos/eol, section-524B). PORTED from rearm-saas rather than
+		// synced: this file lives under oss/, which copy-src.sh never copies, so CE keeps its
+		// own. The schema, ReleaseData and ReleaseInput ARE synced, which is what made the gap
+		// silent -- CE advertised eos/eol/clearEos/clearEol, stored them on the model, and
+		// dropped every write on the floor with an HTTP 200.
+		//
+		// clearEos/clearEol win over a concurrently-supplied value: an explicit "remove it"
+		// must not be ignored because a stale date rode along in the same payload.
+		//
+		// Old values are captured BEFORE any setter runs. That ordering is the whole point --
+		// reading rData after setting it records oldValue == newValue, which is the defect
+		// t20260831-044941-4111 filed against NOTES and TAGS, and which the VERSION block
+		// immediately above still has on this side.
+		boolean clearingEos = Boolean.TRUE.equals(releaseDto.getClearEos());
+		boolean clearingEol = Boolean.TRUE.equals(releaseDto.getClearEol());
+		LocalDate oldEos = rData.getEos();
+		LocalDate oldEol = rData.getEol();
+		// Resolve the new value first, then diff -- avoids deriving the
+		// clearing-vs-supplied-vs-unchanged branch twice.
+		LocalDate newEos = clearingEos ? null : (null != releaseDto.getEos() ? releaseDto.getEos() : oldEos);
+		LocalDate newEol = clearingEol ? null : (null != releaseDto.getEol() ? releaseDto.getEol() : oldEol);
+		if (!Objects.equals(newEos, oldEos) || !Objects.equals(newEol, oldEol)) {
+			// Duplicated with ReleaseData.validateReleaseData (which saveRelease calls on every
+			// write) on purpose: this inline check gives the update caller a specific
+			// RelizaException instead of the generic IllegalStateException, while the one in
+			// validateReleaseData is what makes the invariant hold for every writer.
+			if (null != newEos && null != newEol && newEos.isAfter(newEol)) {
+				throw new RelizaException("eos must not be after eol (device support window)");
+			}
+			rData.setEos(newEos);
+			rData.setEol(newEol);
+			rData.addUpdateEvent(new ReleaseUpdateEvent(ReleaseUpdateScope.SUPPORT_WINDOW,
+					ReleaseData.supportWindowAction(oldEos, oldEol, newEos, newEol),
+					ReleaseData.supportWindowValueString(oldEos, oldEol),
+					ReleaseData.supportWindowValueString(newEos, newEol),
+					null, ZonedDateTime.now(), wu));
 		}
 		if(null != releaseDto.getParentReleases()){
 			sharedReleaseService.checkCircularDependency(r.getUuid(), releaseDto.getParentReleases());
@@ -1563,6 +1601,23 @@ public class OssReleaseService {
 		ReleaseUpdateEvent rue = new ReleaseUpdateEvent(ReleaseUpdateScope.RELEASE_CREATED, ReleaseUpdateAction.ADDED, null, null, null,
 				ZonedDateTime.now(), wu);
 		rData.addUpdateEvent(rue);
+		// A support window set AT creation is otherwise invisible in history -- the only
+		// trace would be the bare fields, with no attester, timestamp or provenance. Ported
+		// alongside the update-path block above, for the same reason: this file is CE's own
+		// fork and copy-src.sh never carries it.
+		//
+		// DEAD on the rebuild/PENDING-update branch below (ova.isPresent() && existing
+		// release): this rData, and the ADDED event just stamped on it, is discarded there in
+		// favour of calling updateRelease(...) against the REAL existing release, whose diff
+		// logic re-derives the correct action (CHANGED, not ADDED, if a window already
+		// existed). Left rather than skipped for that branch because it is harmless today; if
+		// a future refactor starts reusing this rData, this comment is the warning that the
+		// event's action would be wrong for anything but a genuinely fresh release.
+		if (null != rData.getEos() || null != rData.getEol()) {
+			rData.addUpdateEvent(new ReleaseUpdateEvent(ReleaseUpdateScope.SUPPORT_WINDOW, ReleaseUpdateAction.ADDED,
+					null, ReleaseData.supportWindowValueString(rData.getEos(), rData.getEol()),
+					null, ZonedDateTime.now(), wu));
+		}
 
 		if (ova.isPresent() && null != ova.get().getRelease()) {
 			//Release already exists, proceeding with an update to the existing release

--- a/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
+++ b/backend/src/main/java/io/reliza/service/oss/OssReleaseService.java
@@ -629,8 +629,10 @@ public class OssReleaseService {
 		//
 		// Old values are captured BEFORE any setter runs. That ordering is the whole point --
 		// reading rData after setting it records oldValue == newValue, which is the defect
-		// t20260831-044941-4111 filed against NOTES and TAGS, and which the VERSION block
-		// immediately above still has on this side.
+		// t20260831-044941-4111 filed against NOTES and TAGS. On THIS side that defect is
+		// still live in all three of NOTES, TAGS and the VERSION block immediately above; it
+		// was fixed upstream, and the fix is in a file the sync does not carry. So this block
+		// captures first rather than following its neighbours.
 		boolean clearingEos = Boolean.TRUE.equals(releaseDto.getClearEos());
 		boolean clearingEol = Boolean.TRUE.equals(releaseDto.getClearEol());
 		LocalDate oldEos = rData.getEos();
@@ -644,6 +646,10 @@ public class OssReleaseService {
 			// write) on purpose: this inline check gives the update caller a specific
 			// RelizaException instead of the generic IllegalStateException, while the one in
 			// validateReleaseData is what makes the invariant hold for every writer.
+			//
+			// The two messages are NOT identical -- validateReleaseData prefixes "Release ".
+			// Only this path is reachable from the device-window form, so nobody sees both
+			// today, but do not describe the rule as having a single wording.
 			if (null != newEos && null != newEol && newEos.isAfter(newEol)) {
 				throw new RelizaException("eos must not be after eol (device support window)");
 			}

--- a/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
+++ b/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
@@ -312,4 +312,81 @@ public class DeviceSupportWindowGovernanceTest {
 				"each write must leave its own SUPPORT_WINDOW row -- the trail is what a"
 						+ " Device Support Statement is defended with");
 	}
+
+	/**
+	 * Re-sending the SAME window must append NO second event.
+	 *
+	 * <p>The highest-value gap in this file, because the pressure is constant: CI rebuilds
+	 * re-send the same dto on every build. Drop the Objects.equals guard and every other test
+	 * here still passes while a shipped device accumulates one SUPPORT_WINDOW row per build --
+	 * an audit trail that says the manufacturer revised their support commitment hundreds of
+	 * times, when they never touched it.
+	 */
+	@Test
+	public void reWritingTheSameWindowAppendsNoEvent() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).eol(LocalDate.parse("2033-12-31")).build(), WU);
+		assertEquals(1, supportWindowEvents(releaseUuid).size());
+
+		for (int i = 0; i < 3; i++) {
+			ossReleaseService.updateRelease(ReleaseDto.builder()
+					.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).eol(LocalDate.parse("2033-12-31")).build(), WU);
+		}
+		assertEquals(1, supportWindowEvents(releaseUuid).size(),
+				"an unchanged window must not append an event -- a CI rebuild re-sends the"
+						+ " same dto on every build");
+	}
+
+	/**
+	 * clearEol beats a concurrently-supplied eol, the mirror of the clearEos case.
+	 *
+	 * <p>Untested until now, and the asymmetry is reachable: inverting the precedence for eol
+	 * ALONE leaves all the other cases green, because nothing else supplies both a clear flag
+	 * and a value on the same side.
+	 */
+	@Test
+	public void clearEolWinsOverAConcurrentlySuppliedEolValue() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), LocalDate.parse("2033-12-31"));
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eol(LocalDate.parse("2040-01-01")).clearEol(true).build(), WU);
+
+		ReleaseData after = current(releaseUuid);
+		assertNull(after.getEol(), "an explicit clear must not lose to a value riding along");
+		assertEquals(LocalDate.parse("2030-01-01"), after.getEos(), "eos must be untouched");
+	}
+
+	/** An eol-only update that lands EARLIER than the stored eos is refused. */
+	@Test
+	public void anEolOnlyUpdateEarlierThanTheStoredEosIsRejected() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2033-01-01"), null);
+
+		assertThrows(RelizaException.class, () -> ossReleaseService.updateRelease(
+				ReleaseDto.builder().uuid(releaseUuid).eol(LocalDate.parse("2030-01-01")).build(), WU));
+	}
+
+	/**
+	 * A rejected window write must leave the stored window ALONE. Asserting the throw is not
+	 * enough: the setters run after the guard, but a future reordering would make the throw
+	 * arrive with the fields already mutated.
+	 */
+	@Test
+	public void aRejectedWindowWritePersistsNothing() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), LocalDate.parse("2033-12-31"));
+		int eventsBefore = supportWindowEvents(releaseUuid).size();
+
+		assertThrows(RelizaException.class, () -> ossReleaseService.updateRelease(
+				ReleaseDto.builder().uuid(releaseUuid).eos(LocalDate.parse("2035-01-01")).build(), WU));
+
+		ReleaseData after = current(releaseUuid);
+		assertEquals(LocalDate.parse("2030-01-01"), after.getEos(), "eos must be unchanged");
+		assertEquals(LocalDate.parse("2033-12-31"), after.getEol(), "eol must be unchanged");
+		assertEquals(eventsBefore, supportWindowEvents(releaseUuid).size(),
+				"a rejected write must not leave an audit row claiming it happened");
+	}
 }

--- a/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
+++ b/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
@@ -7,7 +7,13 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,9 +104,9 @@ public class DeviceSupportWindowGovernanceTest {
 		Organization org = testInitializer.obtainOrganization();
 		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), null);
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(1, events.size(),
+		assertEquals(1, events.size(),
 				"a window set at creation must not be invisible in history");
-		Assertions.assertEquals("eos=2030-01-01, eol=null", events.get(0).newValue());
+		assertEquals("eos=2030-01-01, eol=null", events.get(0).newValue());
 	}
 
 	@Test
@@ -112,17 +118,18 @@ public class DeviceSupportWindowGovernanceTest {
 				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).eol(LocalDate.parse("2033-12-31")).build(), WU);
 
 		ReleaseData after = current(releaseUuid);
-		Assertions.assertEquals(LocalDate.parse("2030-01-01"), after.getEos());
-		Assertions.assertEquals(LocalDate.parse("2033-12-31"), after.getEol());
+		assertEquals(LocalDate.parse("2030-01-01"), after.getEos());
+		assertEquals(LocalDate.parse("2033-12-31"), after.getEol());
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(1, events.size());
-		Assertions.assertEquals("eos=null, eol=null", events.get(0).oldValue());
-		Assertions.assertEquals("eos=2030-01-01, eol=2033-12-31", events.get(0).newValue());
-		Assertions.assertNotNull(events.get(0).wu(), "the attester must be recorded");
+		assertEquals(1, events.size());
+		assertEquals("eos=null, eol=null", events.get(0).oldValue());
+		assertEquals("eos=2030-01-01, eol=2033-12-31", events.get(0).newValue());
+		assertNotNull(events.get(0).wu(), "the attester must be recorded");
 	}
 
 	/**
-	 * The exact defect the sibling NOTES/TAGS emitters had (PR #464): reading the old
+	 * The exact defect the sibling NOTES/TAGS emitters have (rearm-saas#464 fixed it there;
+	 * on this side they still carry it): reading the old
 	 * value back AFTER the setter ran yields oldValue == newValue, corrupting the
 	 * correction trail. Pinned explicitly per the task notes' own request.
 	 */
@@ -135,12 +142,12 @@ public class DeviceSupportWindowGovernanceTest {
 				.uuid(releaseUuid).eos(LocalDate.parse("2031-06-15")).build(), WU);
 
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(2, events.size(), "creation + one correction");
+		assertEquals(2, events.size(), "creation + one correction");
 		ReleaseUpdateEvent correction = events.get(1);
-		Assertions.assertNotEquals(correction.oldValue(), correction.newValue(),
+		assertNotEquals(correction.oldValue(), correction.newValue(),
 				"a real change must never record oldValue == newValue");
-		Assertions.assertEquals("eos=2030-01-01, eol=2033-12-31", correction.oldValue());
-		Assertions.assertEquals("eos=2031-06-15, eol=2033-12-31", correction.newValue(),
+		assertEquals("eos=2030-01-01, eol=2033-12-31", correction.oldValue());
+		assertEquals("eos=2031-06-15, eol=2033-12-31", correction.newValue(),
 				"eol was not part of this update and must be preserved, not dropped");
 	}
 
@@ -153,11 +160,11 @@ public class DeviceSupportWindowGovernanceTest {
 				.uuid(releaseUuid).clearEos(true).build(), WU);
 
 		ReleaseData after = current(releaseUuid);
-		Assertions.assertNull(after.getEos(), "clearEos must actually unset the field");
+		assertNull(after.getEos(), "clearEos must actually unset the field");
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(2, events.size(), "creation + one clear");
-		Assertions.assertEquals("eos=2030-01-01, eol=null", events.get(1).oldValue());
-		Assertions.assertEquals("eos=null, eol=null", events.get(1).newValue(),
+		assertEquals(2, events.size(), "creation + one clear");
+		assertEquals("eos=2030-01-01, eol=null", events.get(1).oldValue());
+		assertEquals("eos=null, eol=null", events.get(1).newValue(),
 				"a clear is distinguishable from never-set only through THIS event existing");
 	}
 
@@ -171,7 +178,7 @@ public class DeviceSupportWindowGovernanceTest {
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).eos(LocalDate.parse("2099-01-01")).clearEos(true).build(), WU);
 
-		Assertions.assertNull(current(releaseUuid).getEos());
+		assertNull(current(releaseUuid).getEos());
 	}
 
 	@Test
@@ -179,7 +186,7 @@ public class DeviceSupportWindowGovernanceTest {
 		Organization org = testInitializer.obtainOrganization();
 		UUID releaseUuid = createRelease(org.getUuid(), null, LocalDate.parse("2030-01-01"));
 
-		Assertions.assertThrows(RelizaException.class, () -> ossReleaseService.updateRelease(
+		assertThrows(RelizaException.class, () -> ossReleaseService.updateRelease(
 				ReleaseDto.builder().uuid(releaseUuid).eos(LocalDate.parse("2031-01-01")).build(), WU),
 				"eos after the existing eol must be rejected even when eol itself is untouched");
 	}
@@ -192,8 +199,8 @@ public class DeviceSupportWindowGovernanceTest {
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).notes("unrelated edit").build(), WU);
 
-		Assertions.assertNull(current(releaseUuid).getEos());
-		Assertions.assertTrue(supportWindowEvents(releaseUuid).isEmpty(),
+		assertNull(current(releaseUuid).getEos());
+		assertTrue(supportWindowEvents(releaseUuid).isEmpty(),
 				"a release that never declared a window must stay unaffected by unrelated updates");
 	}
 
@@ -201,20 +208,20 @@ public class DeviceSupportWindowGovernanceTest {
 	public void provenanceIsDerivedFromTheLatestSupportWindowEvent() throws RelizaException {
 		Organization org = testInitializer.obtainOrganization();
 		UUID releaseUuid = createRelease(org.getUuid(), null, null);
-		Assertions.assertNull(current(releaseUuid).getSupportWindowSource(),
+		assertNull(current(releaseUuid).getSupportWindowSource(),
 				"never-touched window must have no provenance");
 
 		UUID apiKeyId = UUID.randomUUID();
-		WhoUpdated apiCaller = WhoUpdated.getWhoUpdated(ProgrammaticType.API, apiKeyId, null);
+		WhoUpdated apiCaller = WhoUpdated.getApiWhoUpdated(apiKeyId, null);
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).build(), apiCaller);
 
 		ReleaseData after = current(releaseUuid);
-		Assertions.assertEquals(ProgrammaticType.API, after.getSupportWindowSource(),
+		assertEquals(ProgrammaticType.API, after.getSupportWindowSource(),
 				"a programmatic setter must be distinguishable from a human one");
-		Assertions.assertEquals(apiKeyId, after.getSupportWindowAssertedBy(),
+		assertEquals(apiKeyId, after.getSupportWindowAssertedBy(),
 				"assertedBy is NOT gated by source -- an API key id is still worth tracing, not nulled out");
-		Assertions.assertNotNull(after.getSupportWindowLastAssessed());
+		assertNotNull(after.getSupportWindowLastAssessed());
 	}
 
 	/**
@@ -227,11 +234,11 @@ public class DeviceSupportWindowGovernanceTest {
 	@Test
 	public void eosAfterEolIsRejectedAtCreationToo() {
 		Organization org = testInitializer.obtainOrganization();
-		IllegalStateException e = Assertions.assertThrows(IllegalStateException.class,
+		IllegalStateException e = assertThrows(IllegalStateException.class,
 				() -> createRelease(org.getUuid(), LocalDate.parse("2035-01-01"), LocalDate.parse("2030-01-01")),
 				"createRelease must not persist an inverted window -- validateReleaseData is the "
 				+ "single enforcement point for every writer, not just the update path");
-		Assertions.assertTrue(e.getMessage().contains("eos") && e.getMessage().contains("eol"), e.getMessage());
+		assertTrue(e.getMessage().contains("eos") && e.getMessage().contains("eol"), e.getMessage());
 	}
 
 	@Test
@@ -242,7 +249,7 @@ public class DeviceSupportWindowGovernanceTest {
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).build(), WU);
 
-		Assertions.assertEquals(ReleaseUpdateAction.ADDED, supportWindowEvents(releaseUuid).get(0).rua());
+		assertEquals(ReleaseUpdateAction.ADDED, supportWindowEvents(releaseUuid).get(0).rua());
 	}
 
 	@Test
@@ -254,7 +261,7 @@ public class DeviceSupportWindowGovernanceTest {
 				.uuid(releaseUuid).clearEos(true).clearEol(true).build(), WU);
 
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(ReleaseUpdateAction.REMOVED, events.get(events.size() - 1).rua(),
+		assertEquals(ReleaseUpdateAction.REMOVED, events.get(events.size() - 1).rua(),
 				"a full clear is a removal, not a value change -- an audit view filtered on REMOVED must see it");
 	}
 
@@ -267,7 +274,7 @@ public class DeviceSupportWindowGovernanceTest {
 				.uuid(releaseUuid).clearEos(true).build(), WU);
 
 		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
-		Assertions.assertEquals(ReleaseUpdateAction.CHANGED, events.get(events.size() - 1).rua(),
+		assertEquals(ReleaseUpdateAction.CHANGED, events.get(events.size() - 1).rua(),
 				"eol is still set, so the window still exists -- this is a change, not a removal");
 	}
 
@@ -290,18 +297,18 @@ public class DeviceSupportWindowGovernanceTest {
 
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).eos(LocalDate.parse("2029-01-01")).build(), WU);
-		Assertions.assertEquals(LocalDate.parse("2029-01-01"), current(releaseUuid).getEos(),
+		assertEquals(LocalDate.parse("2029-01-01"), current(releaseUuid).getEos(),
 				"eos did not survive updateRelease -- the write path is ignoring the field");
 
 		ossReleaseService.updateRelease(ReleaseDto.builder()
 				.uuid(releaseUuid).eol(LocalDate.parse("2031-01-01")).build(), WU);
 		ReleaseData after = current(releaseUuid);
-		Assertions.assertEquals(LocalDate.parse("2031-01-01"), after.getEol(),
+		assertEquals(LocalDate.parse("2031-01-01"), after.getEol(),
 				"eol did not survive updateRelease");
-		Assertions.assertEquals(LocalDate.parse("2029-01-01"), after.getEos(),
+		assertEquals(LocalDate.parse("2029-01-01"), after.getEos(),
 				"a later eol-only update must not disturb eos");
 
-		Assertions.assertEquals(2, supportWindowEvents(releaseUuid).size(),
+		assertEquals(2, supportWindowEvents(releaseUuid).size(),
 				"each write must leave its own SUPPORT_WINDOW row -- the trail is what a"
 						+ " Device Support Statement is defended with");
 	}

--- a/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
+++ b/backend/src/test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java
@@ -1,0 +1,308 @@
+/**
+* Copyright Reliza Incorporated. 2019 - 2026. Licensed under the terms of AGPL-3.0-only.
+*/
+package io.reliza.service.oss;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.reliza.common.CommonVariables.ProgrammaticType;
+import io.reliza.exceptions.RelizaException;
+import io.reliza.model.ComponentData.ComponentType;
+import io.reliza.model.Organization;
+import io.reliza.model.ReleaseData;
+import io.reliza.model.ReleaseData.ReleaseLifecycle;
+import io.reliza.model.ReleaseData.ReleaseStatus;
+import io.reliza.model.ReleaseData.ReleaseUpdateAction;
+import io.reliza.model.ReleaseData.ReleaseUpdateEvent;
+import io.reliza.model.ReleaseData.ReleaseUpdateScope;
+import io.reliza.model.WhoUpdated;
+import io.reliza.model.dto.CreateComponentDto;
+import io.reliza.model.dto.ReleaseDto;
+import io.reliza.service.BranchService;
+import io.reliza.service.ComponentService;
+import io.reliza.service.SharedReleaseService;
+import io.reliza.ws.App;
+import io.reliza.ws.oss.TestInitializer;
+
+/**
+ * Governance for the section-524B device support window (board t20260830-164643-29472,
+ * half A): a real write path for {@code ReleaseData.eos}/{@code eol} on an EXISTING
+ * release, with a SUPPORT_WINDOW audit trail and explicit clear semantics.
+ *
+ * <p>PORTED from rearm-saas, not synced. Both this test and the code it covers live under
+ * {@code oss/}, which {@code copy-src.sh} never copies -- so when the window landed upstream,
+ * CE received the schema, the {@code ReleaseData} fields and the {@code ReleaseInput}
+ * arguments, and none of the write handling. The result was an HTTP 200 that stored nothing:
+ * a regulatory field that a caller could set, be told was saved, and find gone on reload.
+ *
+ * <p>That it went unnoticed is the point worth keeping. Nothing failed -- not the build, not
+ * the sync, not a test -- because the only test that would have caught it lives in the same
+ * unsynced tree as the code. See {@code roundTripThroughUpdateReleaseActuallyPersists} below,
+ * which is the assertion that fails loudly if this ever regresses to a no-op again.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {App.class})
+public class DeviceSupportWindowGovernanceTest {
+
+	@Autowired private ComponentService componentService;
+	@Autowired private BranchService branchService;
+	@Autowired private OssReleaseService ossReleaseService;
+	@Autowired private SharedReleaseService sharedReleaseService;
+	@Autowired private TestInitializer testInitializer;
+
+	private static final WhoUpdated WU = WhoUpdated.getTestWhoUpdated();
+
+	private UUID createRelease(UUID org, LocalDate eos, LocalDate eol) throws RelizaException {
+		String slug = "it-support-window-" + UUID.randomUUID().toString().substring(0, 8);
+		UUID componentUuid = componentService.createComponent(CreateComponentDto.builder()
+				.organization(org)
+				.name(slug)
+				.type(ComponentType.COMPONENT)
+				.versionSchema("semver")
+				.featureBranchVersioning("Branch.Micro")
+				.build(), WU).getUuid();
+		var branch = branchService.findBranchByName(componentUuid, "main", true, WU).get();
+		var builder = ReleaseDto.builder()
+				.component(componentUuid)
+				.branch(branch.getUuid())
+				.org(org)
+				.status(ReleaseStatus.ACTIVE)
+				.lifecycle(ReleaseLifecycle.ASSEMBLED)
+				.version("1.0.0");
+		if (null != eos) builder.eos(eos);
+		if (null != eol) builder.eol(eol);
+		return ossReleaseService.createRelease(builder.build(), WU).getUuid();
+	}
+
+	private ReleaseData current(UUID releaseUuid) {
+		return sharedReleaseService.getReleaseData(releaseUuid).orElseThrow();
+	}
+
+	private List<ReleaseUpdateEvent> supportWindowEvents(UUID releaseUuid) {
+		return current(releaseUuid).getUpdateEvents().stream()
+				.filter(ue -> ue.rus() == ReleaseUpdateScope.SUPPORT_WINDOW)
+				.toList();
+	}
+
+	@Test
+	public void aWindowSetAtCreationIsRecordedInHistory() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), null);
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(1, events.size(),
+				"a window set at creation must not be invisible in history");
+		Assertions.assertEquals("eos=2030-01-01, eol=null", events.get(0).newValue());
+	}
+
+	@Test
+	public void settingAWindowOnAnExistingReleaseRecordsTheEventWithAttester() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).eol(LocalDate.parse("2033-12-31")).build(), WU);
+
+		ReleaseData after = current(releaseUuid);
+		Assertions.assertEquals(LocalDate.parse("2030-01-01"), after.getEos());
+		Assertions.assertEquals(LocalDate.parse("2033-12-31"), after.getEol());
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(1, events.size());
+		Assertions.assertEquals("eos=null, eol=null", events.get(0).oldValue());
+		Assertions.assertEquals("eos=2030-01-01, eol=2033-12-31", events.get(0).newValue());
+		Assertions.assertNotNull(events.get(0).wu(), "the attester must be recorded");
+	}
+
+	/**
+	 * The exact defect the sibling NOTES/TAGS emitters had (PR #464): reading the old
+	 * value back AFTER the setter ran yields oldValue == newValue, corrupting the
+	 * correction trail. Pinned explicitly per the task notes' own request.
+	 */
+	@Test
+	public void correctingAWindowRecordsTheTruePreviousValueNotANoOpDiff() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), LocalDate.parse("2033-12-31"));
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2031-06-15")).build(), WU);
+
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(2, events.size(), "creation + one correction");
+		ReleaseUpdateEvent correction = events.get(1);
+		Assertions.assertNotEquals(correction.oldValue(), correction.newValue(),
+				"a real change must never record oldValue == newValue");
+		Assertions.assertEquals("eos=2030-01-01, eol=2033-12-31", correction.oldValue());
+		Assertions.assertEquals("eos=2031-06-15, eol=2033-12-31", correction.newValue(),
+				"eol was not part of this update and must be preserved, not dropped");
+	}
+
+	@Test
+	public void clearingIsDistinguishableFromNeverSet() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), null);
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).clearEos(true).build(), WU);
+
+		ReleaseData after = current(releaseUuid);
+		Assertions.assertNull(after.getEos(), "clearEos must actually unset the field");
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(2, events.size(), "creation + one clear");
+		Assertions.assertEquals("eos=2030-01-01, eol=null", events.get(1).oldValue());
+		Assertions.assertEquals("eos=null, eol=null", events.get(1).newValue(),
+				"a clear is distinguishable from never-set only through THIS event existing");
+	}
+
+	@Test
+	public void clearEosWinsOverAConcurrentlySuppliedEosValue() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), null);
+
+		// A stale eos value riding along in the same payload as an explicit clear
+		// must not silently win -- mirrors ComponentService's clearOwner precedence.
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2099-01-01")).clearEos(true).build(), WU);
+
+		Assertions.assertNull(current(releaseUuid).getEos());
+	}
+
+	@Test
+	public void eosAfterEolIsRejected() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, LocalDate.parse("2030-01-01"));
+
+		Assertions.assertThrows(RelizaException.class, () -> ossReleaseService.updateRelease(
+				ReleaseDto.builder().uuid(releaseUuid).eos(LocalDate.parse("2031-01-01")).build(), WU),
+				"eos after the existing eol must be rejected even when eol itself is untouched");
+	}
+
+	@Test
+	public void anUnrelatedUpdateLeavesTheWindowAndItsHistoryAlone() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).notes("unrelated edit").build(), WU);
+
+		Assertions.assertNull(current(releaseUuid).getEos());
+		Assertions.assertTrue(supportWindowEvents(releaseUuid).isEmpty(),
+				"a release that never declared a window must stay unaffected by unrelated updates");
+	}
+
+	@Test
+	public void provenanceIsDerivedFromTheLatestSupportWindowEvent() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+		Assertions.assertNull(current(releaseUuid).getSupportWindowSource(),
+				"never-touched window must have no provenance");
+
+		UUID apiKeyId = UUID.randomUUID();
+		WhoUpdated apiCaller = WhoUpdated.getWhoUpdated(ProgrammaticType.API, apiKeyId, null);
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).build(), apiCaller);
+
+		ReleaseData after = current(releaseUuid);
+		Assertions.assertEquals(ProgrammaticType.API, after.getSupportWindowSource(),
+				"a programmatic setter must be distinguishable from a human one");
+		Assertions.assertEquals(apiKeyId, after.getSupportWindowAssertedBy(),
+				"assertedBy is NOT gated by source -- an API key id is still worth tracing, not nulled out");
+		Assertions.assertNotNull(after.getSupportWindowLastAssessed());
+	}
+
+	/**
+	 * The create path has no inline check of its own (unlike updateRelease) -- it
+	 * is caught only by ReleaseData.validateReleaseData, called unconditionally by
+	 * saveRelease for every writer. That path surfaces IllegalStateException, not
+	 * RelizaException; the point of this test is that createRelease is rejected AT
+	 * ALL, not the exact exception type.
+	 */
+	@Test
+	public void eosAfterEolIsRejectedAtCreationToo() {
+		Organization org = testInitializer.obtainOrganization();
+		IllegalStateException e = Assertions.assertThrows(IllegalStateException.class,
+				() -> createRelease(org.getUuid(), LocalDate.parse("2035-01-01"), LocalDate.parse("2030-01-01")),
+				"createRelease must not persist an inverted window -- validateReleaseData is the "
+				+ "single enforcement point for every writer, not just the update path");
+		Assertions.assertTrue(e.getMessage().contains("eos") && e.getMessage().contains("eol"), e.getMessage());
+	}
+
+	@Test
+	public void settingAWindowFromNothingIsRecordedAsAdded() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2030-01-01")).build(), WU);
+
+		Assertions.assertEquals(ReleaseUpdateAction.ADDED, supportWindowEvents(releaseUuid).get(0).rua());
+	}
+
+	@Test
+	public void clearingTheWholeWindowIsRecordedAsRemovedNotChanged() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), LocalDate.parse("2033-12-31"));
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).clearEos(true).clearEol(true).build(), WU);
+
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(ReleaseUpdateAction.REMOVED, events.get(events.size() - 1).rua(),
+				"a full clear is a removal, not a value change -- an audit view filtered on REMOVED must see it");
+	}
+
+	@Test
+	public void partiallyClearingTheWindowIsRecordedAsChangedNotRemoved() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), LocalDate.parse("2030-01-01"), LocalDate.parse("2033-12-31"));
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).clearEos(true).build(), WU);
+
+		List<ReleaseUpdateEvent> events = supportWindowEvents(releaseUuid);
+		Assertions.assertEquals(ReleaseUpdateAction.CHANGED, events.get(events.size() - 1).rua(),
+				"eol is still set, so the window still exists -- this is a change, not a removal");
+	}
+
+	/**
+	 * THE NO-OP GUARD. Write through the public update path, then read back from storage.
+	 *
+	 * <p>Deliberately the dumbest test in the file, because the failure it catches was not
+	 * subtle and still survived: CE's updateRelease accepted eos, returned success, and
+	 * dropped it. Every other test here asserts something more interesting -- precedence,
+	 * audit shape, clear-vs-never-set -- and every one of them would have gone on passing
+	 * in a fork where the field was simply never written, because they were not there.
+	 *
+	 * <p>Reads through sharedReleaseService rather than the returned object so a writer that
+	 * mutates its in-memory copy without persisting cannot satisfy it.
+	 */
+	@Test
+	public void roundTripThroughUpdateReleaseActuallyPersists() throws RelizaException {
+		Organization org = testInitializer.obtainOrganization();
+		UUID releaseUuid = createRelease(org.getUuid(), null, null);
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eos(LocalDate.parse("2029-01-01")).build(), WU);
+		Assertions.assertEquals(LocalDate.parse("2029-01-01"), current(releaseUuid).getEos(),
+				"eos did not survive updateRelease -- the write path is ignoring the field");
+
+		ossReleaseService.updateRelease(ReleaseDto.builder()
+				.uuid(releaseUuid).eol(LocalDate.parse("2031-01-01")).build(), WU);
+		ReleaseData after = current(releaseUuid);
+		Assertions.assertEquals(LocalDate.parse("2031-01-01"), after.getEol(),
+				"eol did not survive updateRelease");
+		Assertions.assertEquals(LocalDate.parse("2029-01-01"), after.getEos(),
+				"a later eol-only update must not disturb eos");
+
+		Assertions.assertEquals(2, supportWindowEvents(releaseUuid).size(),
+				"each write must leave its own SUPPORT_WINDOW row -- the trail is what a"
+						+ " Device Support Statement is defended with");
+	}
+}


### PR DESCRIPTION
CE advertised the section-524B device support window and **silently discarded every write to
it**. Proved against the running CE build before fixing:

```
mutation updateRelease(release: {uuid: …, org: …, eos: "2029-01-01"})
-> HTTP 200  {"eos": null, "eol": "2033-03-31"}
-> database: eos unchanged, no SUPPORT_WINDOW audit row
```

A regulatory field a caller could set, be told was saved, and find gone on reload. Worse than
an error, because nothing recorded the attempt.

## Why it was invisible

`copy-src.sh` excludes `oss/` and `saas/` at any depth, **on both sides**. The window landed
upstream in rearm-saas#466 (`a536ad72`) inside `service/oss/`, with
`DeviceSupportWindowGovernanceTest` beside it in `test/.../service/oss/`. The CE sync that
followed carried what *is* synced — `eos`/`eol`/`clearEos`/`clearEol` on `ReleaseInput`,
`ReleaseData`'s fields, the `SUPPORT_WINDOW` enum — and none of the write handling.

Nothing failed. Not the build, not the sync, not a test — because **the only test that would
have caught it lives in the same unsynced tree as the missing code**. A fork whose tests are
also forked cannot report its own gaps.

## Port decision (new sync-PR checklist line, `t20260907-104255-19200`)

The checklist asks that any `oss/` file touched upstream gets an explicit port-or-skip
decision, by name.

**Ported:**
- `service/oss/OssReleaseService.java` — update path **and** create path
- `test/java/io/reliza/service/oss/DeviceSupportWindowGovernanceTest.java`

**Skipped:** none. For the record, the range #328 synced (`f491aece..1296cfd3`) touched **no
`oss/` files at all**, so #328 was complete for its own range — the gap predates it. Both the
window code and its governance test were already present at `f491aece`, the SHA **#324**
synced from, so #324 is where the decision was missed.

## Ported, not copied

This file is CE's own fork, so the block is adapted to the code around it:

- **Update path** — clear-wins precedence (`clearEos`/`clearEol` beat a concurrently-supplied
  value, so an explicit removal isn't lost to a stale date riding along in the same payload);
  old values captured **before** any setter runs; the `eos <= eol` guard with the message
  verbatim; the `SUPPORT_WINDOW` event carrying its true previous value.
- **Create path** — a window set at creation is otherwise invisible in history, with no
  attester, timestamp or provenance. This was the *second* half of the gap and only surfaced
  because the ported test failed on it: the update block alone got **10 of 13** green.

The old-values-before-setters ordering is load-bearing, not stylistic. Reading `rData` back
after setting it records `oldValue == newValue` — the defect `t20260831-044941-4111` filed
against NOTES and TAGS, and which CE's `VERSION` block immediately above this one **still
has**.

## Tests

`DeviceSupportWindowGovernanceTest` ported, binding CE's own `ws.oss.TestInitializer`. Plus
one new case: **`roundTripThroughUpdateReleaseActuallyPersists`** — deliberately the dumbest
test in the file, writing through the public path and reading back from storage rather than
trusting the returned object. Every other test there asserts something more interesting, and
every one of them would have kept passing in a fork where the field was simply never written.

**13/13 green.** Full CE suite: 1790 tests, 1 error — the known
`anUnreadablePayloadIsExcludedWithoutFailingTheBatch` flake (`t20260903-124822-20774`),
identified with `--no-cache` rather than assumed, and noted there with a new data point: it
does not reproduce on the host, only in the container's fresh-DB full-suite run.