### PR TITLE
Author the FDA prose slots and the device support window in the UI (7f)

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -944,11 +944,9 @@
                              are the manufacturer's own commitments, and words nobody here
                              wrote going out over their name is the failure the whole
                              feature exists to avoid. -->
-                        <n-divider style="margin: 22px 0 10px;">
-                            <span style="font-size: 13px;">FDA submission and labeling text</span>
-                        </n-divider>
-                        <n-alert type="default" :show-icon="false"
-                            style="font-size: 12px; margin-bottom: 14px; max-width: 760px;">
+                        <n-divider />
+                        <h6>FDA submission and labeling text</h6>
+                        <p class="text-muted" style="max-width: 760px;">
                             Written once here, rendered into every generated document. A
                             document whose required text is missing is <strong>not
                             generated</strong> rather than generated with the section
@@ -957,11 +955,12 @@
                             To remove text, clear the box and save &mdash; an emptied field
                             is recorded as deliberately blank, and a field you do not touch
                             is left exactly as it was.
-                        </n-alert>
+                        </p>
 
                         <n-form-item label="Assessment justification (submission)">
                             <div style="display: flex; flex-direction: column; width: 100%;">
                                 <n-input v-model:value="orgSettings.fdaAssessmentNarrative"
+                                    :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
                                     type="textarea" :rows="5" style="max-width: 760px;"
                                     placeholder="How components were assessed, and why an upstream end-of-support date is unavailable for most of them." />
                                 <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
@@ -976,6 +975,7 @@
 
                         <n-form-item label="Patches may cease at end of support (labeling)">
                             <n-input v-model:value="orgSettings.fdaPatchesMayCeaseStatement"
+                                    :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
                                 type="textarea" :rows="3" style="max-width: 760px;"
                                 placeholder="After end of support, security patches and software updates may no longer be provided." />
                         </n-form-item>
@@ -983,6 +983,7 @@
                         <n-form-item label="Risk-transfer process reference (labeling)">
                             <div style="display: flex; flex-direction: column; width: 100%;">
                                 <n-input v-model:value="orgSettings.fdaRiskTransferProcessRef"
+                                    :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
                                     style="max-width: 760px;"
                                     placeholder="e.g. DHF-PROC-4471 rev C, or a URL to the controlled document" />
                                 <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
@@ -995,6 +996,7 @@
 
                         <n-form-item label="Risk increases over time (labeling)">
                             <n-input v-model:value="orgSettings.fdaRiskIncreasesNotice"
+                                    :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
                                 type="textarea" :rows="3" style="max-width: 760px;"
                                 placeholder="Cybersecurity risk to users can be expected to increase after end of support." />
                         </n-form-item>
@@ -1218,6 +1220,7 @@ import { Edit as EditIcon, Trash, CirclePlus, Eye, QuestionMark, Search, FolderP
 import { Info20Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
+import { FDA_PROSE_FIELDS, FDA_PROSE_MAX_LENGTH, proseDiff, proseBaselineFrom } from '@/utils/fdaProseInput'
 import Swal, { SweetAlertOptions } from 'sweetalert2'
 import { Marked } from '@ts-stack/markdown'
 import gql from 'graphql-tag'
@@ -3504,39 +3507,6 @@ async function saveOrgDefaultView() {
     }
 }
 
-const FDA_PROSE_FIELDS = ['fdaAssessmentNarrative', 'fdaPatchesMayCeaseStatement',
-    'fdaRiskTransferProcessRef', 'fdaRiskIncreasesNotice'] as const
-
-/**
- * What the server last told us each prose field holds. Refreshed on load and after a
- * successful save, so the diff below compares against stored state rather than against
- * whatever the form happened to start with.
- */
-const proseBaseline: Record<string, string> = {}
-
-/**
- * The four prose fields, DIFFED against the baseline -- same shape as the attestation
- * form's attestationVariables(uuid, form, baseline).
- *
- *   unchanged           -> omitted, so saving an unrelated toggle cannot touch prose
- *   emptied from text   -> sent as '', which the server reads as a deliberate CLEAR
- *   changed             -> sent trimmed
- *
- * Sending '' for a field that was ALREADY empty is pointless traffic, but worse than
- * that it would be a clear the user did not ask for on a field somebody else may have
- * filled in since this form loaded. So only a genuine emptying is sent.
- */
-function proseDiff (): Record<string, string> {
-    const out: Record<string, string> = {}
-    for (const f of FDA_PROSE_FIELDS) {
-        const current = (orgSettings[f] || '').trim()
-        const stored = (proseBaseline[f] || '').trim()
-        if (current === stored) continue
-        out[f] = current
-    }
-    return out
-}
-
 async function loadOrgSettings() {
     await loadOrgDefaultView()
     const s = myorg.value?.settings
@@ -3548,9 +3518,10 @@ async function loadOrgSettings() {
     orgSettings.sidAuthoritySegments = Array.isArray(s?.sidAuthoritySegments)
         ? [...s.sidAuthoritySegments]
         : []
+    const seeded = proseBaselineFrom(s)
     for (const f of FDA_PROSE_FIELDS) {
-        orgSettings[f] = (s as any)?.[f] || ''
-        proseBaseline[f] = orgSettings[f]
+        orgSettings[f] = seeded[f]
+        proseBaseline[f] = seeded[f]
     }
 }
 
@@ -3609,7 +3580,7 @@ async function saveOrgSettings() {
                     // Diffed, not dumped: untouched fields are omitted so an unrelated
                     // toggle cannot disturb prose, and a field the user emptied goes as ''
                     // which the server reads as a deliberate clear.
-                    ...proseDiff()
+                    ...proseDiff(orgSettings, proseBaseline)
                 }
             },
             fetchPolicy: 'no-cache'
@@ -3618,8 +3589,20 @@ async function saveOrgSettings() {
         const result = (resp.data as any)?.updateOrganizationSettings
         if (result) {
             store.commit('UPDATE_ORGANIZATION', result)
-            // Sync local form with server-canonicalized values.
-            await loadOrgSettings()
+            // BEFORE anything that can throw. The mutation has COMMITTED by this point, so
+            // the baseline it implies is now the truth, and it is already in hand -- the
+            // mutation selects all four fields. Refreshing it via the re-read below instead
+            // meant a failed re-read left the baseline stale AND reported the committed
+            // save as a failure; the operator's next clear then compared '' against a stale
+            // '', omitted the field, and said "Settings Saved" while the server still held
+            // the text. That is fabricated prose reaching a patient-facing document, which
+            // is the exact failure this feature exists to prevent.
+            const savedSettings = (result as any)?.settings
+            const refreshed = proseBaselineFrom(savedSettings)
+            for (const f of FDA_PROSE_FIELDS) {
+                orgSettings[f] = refreshed[f]
+                proseBaseline[f] = refreshed[f]
+            }
             notify('success', 'Settings Saved', 'Organization settings updated successfully.')
         } else {
             notify('warning', 'Save Warning', 'Save completed but no response received.')
@@ -3628,6 +3611,17 @@ async function saveOrgSettings() {
         notify('error', 'Save Failed', commonFunctions.extractGraphQLErrorMessage(err))
     } finally {
         savingOrgSettings.value = false
+    }
+
+    // Deliberately AFTER the try and outside it: this is a convenience re-read that syncs
+    // the non-prose fields with whatever the server canonicalised. It does a network round
+    // trip and can fail on its own; when it does, the save above still happened and has
+    // already been reported honestly, so a failure here must not be dressed up as one.
+    try {
+        await loadOrgSettings()
+    } catch (err: any) {
+        notify('warning', 'Refresh Failed',
+            'Settings were saved, but reloading them failed. Reload the page to see the stored values.')
     }
 }
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -939,6 +939,67 @@
                             <span class="ml-2 text-muted">{{ orgSettings.justificationMandatory ? 'Justification is required when creating finding analysis' : 'Justification is optional when creating finding analysis' }}</span>
                         </n-form-item>
 
+                        <!-- FDA-Readiness-1 7f. These four are rendered into the generated
+                             submission and labeling documents. No default text ships: they
+                             are the manufacturer's own commitments, and words nobody here
+                             wrote going out over their name is the failure the whole
+                             feature exists to avoid. -->
+                        <n-divider style="margin: 22px 0 10px;">
+                            <span style="font-size: 13px;">FDA submission and labeling text</span>
+                        </n-divider>
+                        <n-alert type="default" :show-icon="false"
+                            style="font-size: 12px; margin-bottom: 14px; max-width: 760px;">
+                            Written once here, rendered into every generated document. A
+                            document whose required text is missing is <strong>not
+                            generated</strong> rather than generated with the section
+                            blank &mdash; on a submission a reviewer expects gaps, but on a
+                            patient-facing statement a silent gap is itself misleading.
+                            Text saved here cannot yet be cleared from this form; edit it
+                            instead.
+                        </n-alert>
+
+                        <n-form-item label="Assessment justification (submission)">
+                            <div style="display: flex; flex-direction: column; width: 100%;">
+                                <n-input v-model:value="orgSettings.fdaAssessmentNarrative"
+                                    type="textarea" :rows="5" style="max-width: 760px;"
+                                    placeholder="How components were assessed, and why an upstream end-of-support date is unavailable for most of them." />
+                                <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
+                                    What the guidance asks for literally: the justification
+                                    for why per-component support information cannot be
+                                    included. Most components in a real SBOM have no
+                                    published upstream date, so this is the centre of the
+                                    submission, not a footnote.
+                                </span>
+                            </div>
+                        </n-form-item>
+
+                        <n-form-item label="Patches may cease at end of support (labeling)">
+                            <n-input v-model:value="orgSettings.fdaPatchesMayCeaseStatement"
+                                type="textarea" :rows="3" style="max-width: 760px;"
+                                placeholder="After end of support, security patches and software updates may no longer be provided." />
+                        </n-form-item>
+
+                        <n-form-item label="Risk-transfer process reference (labeling)">
+                            <div style="display: flex; flex-direction: column; width: 100%;">
+                                <n-input v-model:value="orgSettings.fdaRiskTransferProcessRef"
+                                    style="max-width: 760px;"
+                                    placeholder="e.g. DHF-PROC-4471 rev C, or a URL to the controlled document" />
+                                <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
+                                    A <strong>reference</strong>, not the process itself.
+                                    Pasting the process here creates a second, unversioned
+                                    copy that will drift from the controlled original.
+                                </span>
+                            </div>
+                        </n-form-item>
+
+                        <n-form-item label="Risk increases over time (labeling)">
+                            <n-input v-model:value="orgSettings.fdaRiskIncreasesNotice"
+                                type="textarea" :rows="3" style="max-width: 760px;"
+                                placeholder="Cybersecurity risk to users can be expected to increase after end of support." />
+                        </n-form-item>
+
+                        <n-divider style="margin: 22px 0 10px;" />
+
                         <n-form-item>
                             <template #label>
                                 <span style="display: inline-flex; align-items: center; gap: 6px;">
@@ -1341,7 +1402,14 @@ const orgSettings = reactive({
     sidPurlMode: 'DISABLED' as SidPurlMode,
     // Authority segments are stored as a list of decoded strings ("Acme Robotics",
     // not "Acme%20Robotics"). The backend percent-encodes when emitting sid PURLs.
-    sidAuthoritySegments: [] as string[]
+    sidAuthoritySegments: [] as string[],
+    // FDA-Readiness-1 7f. Manufacturer-authored prose rendered into the generated
+    // submission and labeling documents. Empty string here means "not authored yet";
+    // it is never SENT as an empty string -- see the save handler.
+    fdaAssessmentNarrative: '',
+    fdaPatchesMayCeaseStatement: '',
+    fdaRiskTransferProcessRef: '',
+    fdaRiskIncreasesNotice: ''
 })
 
 const vexComplianceFrameworkOptions = [
@@ -3435,6 +3503,21 @@ async function saveOrgDefaultView() {
     }
 }
 
+/**
+ * The four FDA prose fields, with empty ones left OUT of the payload entirely.
+ * Returns a partial object to spread into the settings variables.
+ */
+function proseOrOmit (): Record<string, string> {
+    const out: Record<string, string> = {}
+    const fields = ['fdaAssessmentNarrative', 'fdaPatchesMayCeaseStatement',
+        'fdaRiskTransferProcessRef', 'fdaRiskIncreasesNotice'] as const
+    for (const f of fields) {
+        const v = (orgSettings[f] || '').trim()
+        if (v) out[f] = v
+    }
+    return out
+}
+
 async function loadOrgSettings() {
     await loadOrgDefaultView()
     const s = myorg.value?.settings
@@ -3446,6 +3529,10 @@ async function loadOrgSettings() {
     orgSettings.sidAuthoritySegments = Array.isArray(s?.sidAuthoritySegments)
         ? [...s.sidAuthoritySegments]
         : []
+    orgSettings.fdaAssessmentNarrative = s?.fdaAssessmentNarrative || ''
+    orgSettings.fdaPatchesMayCeaseStatement = s?.fdaPatchesMayCeaseStatement || ''
+    orgSettings.fdaRiskTransferProcessRef = s?.fdaRiskTransferProcessRef || ''
+    orgSettings.fdaRiskIncreasesNotice = s?.fdaRiskIncreasesNotice || ''
 }
 
 async function saveOrgSettings() {
@@ -3483,6 +3570,10 @@ async function saveOrgSettings() {
                             vexComplianceFramework
                             sidPurlMode
                             sidAuthoritySegments
+                            fdaAssessmentNarrative
+                            fdaPatchesMayCeaseStatement
+                            fdaRiskTransferProcessRef
+                            fdaRiskIncreasesNotice
                         }
                     }
                 }`,
@@ -3495,7 +3586,18 @@ async function saveOrgSettings() {
                     sidPurlMode: orgSettings.sidPurlMode,
                     // DISABLED implies "no segments"; sending an empty list lets the server
                     // null them out cleanly per applySidPurlPatch.
-                    sidAuthoritySegments: orgSettings.sidPurlMode === 'DISABLED' ? [] : trimmedSegments
+                    sidAuthoritySegments: orgSettings.sidPurlMode === 'DISABLED' ? [] : trimmedSegments,
+                    // OMITTED when empty, never sent as ''. Two reasons, and both bite:
+                    // the server REFUSES a blank (it is the one value that would satisfy a
+                    // "slot is present" check while carrying nothing), so sending '' would
+                    // make an unrelated settings save fail; and under PATCH semantics
+                    // omitting leaves the stored prose alone, so editing a toggle cannot
+                    // silently erase text a manufacturer signed.
+                    //
+                    // The cost, stated rather than hidden: prose cannot currently be
+                    // CLEARED from this form. Clearing needs an explicit signal, the way
+                    // the attestation mutation uses clearMilestones -- not yet built.
+                    ...proseOrOmit()
                 }
             },
             fetchPolicy: 'no-cache'

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -3507,6 +3507,15 @@ async function saveOrgDefaultView() {
     }
 }
 
+/**
+ * What the four prose fields held when this form last agreed with the server.
+ *
+ * proseDiff reads it to tell an untouched field (omit) from an emptied one (send '', a
+ * deliberate clear), so it must be refreshed from every write that COMMITS -- see
+ * saveOrgSettings, which takes it from the mutation response rather than a follow-up read.
+ */
+const proseBaseline: Record<string, string> = {}
+
 async function loadOrgSettings() {
     await loadOrgDefaultView()
     const s = myorg.value?.settings

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -954,8 +954,9 @@
                             generated</strong> rather than generated with the section
                             blank &mdash; on a submission a reviewer expects gaps, but on a
                             patient-facing statement a silent gap is itself misleading.
-                            Text saved here cannot yet be cleared from this form; edit it
-                            instead.
+                            To remove text, clear the box and save &mdash; an emptied field
+                            is recorded as deliberately blank, and a field you do not touch
+                            is left exactly as it was.
                         </n-alert>
 
                         <n-form-item label="Assessment justification (submission)">

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -3503,17 +3503,35 @@ async function saveOrgDefaultView() {
     }
 }
 
+const FDA_PROSE_FIELDS = ['fdaAssessmentNarrative', 'fdaPatchesMayCeaseStatement',
+    'fdaRiskTransferProcessRef', 'fdaRiskIncreasesNotice'] as const
+
 /**
- * The four FDA prose fields, with empty ones left OUT of the payload entirely.
- * Returns a partial object to spread into the settings variables.
+ * What the server last told us each prose field holds. Refreshed on load and after a
+ * successful save, so the diff below compares against stored state rather than against
+ * whatever the form happened to start with.
  */
-function proseOrOmit (): Record<string, string> {
+const proseBaseline: Record<string, string> = {}
+
+/**
+ * The four prose fields, DIFFED against the baseline -- same shape as the attestation
+ * form's attestationVariables(uuid, form, baseline).
+ *
+ *   unchanged           -> omitted, so saving an unrelated toggle cannot touch prose
+ *   emptied from text   -> sent as '', which the server reads as a deliberate CLEAR
+ *   changed             -> sent trimmed
+ *
+ * Sending '' for a field that was ALREADY empty is pointless traffic, but worse than
+ * that it would be a clear the user did not ask for on a field somebody else may have
+ * filled in since this form loaded. So only a genuine emptying is sent.
+ */
+function proseDiff (): Record<string, string> {
     const out: Record<string, string> = {}
-    const fields = ['fdaAssessmentNarrative', 'fdaPatchesMayCeaseStatement',
-        'fdaRiskTransferProcessRef', 'fdaRiskIncreasesNotice'] as const
-    for (const f of fields) {
-        const v = (orgSettings[f] || '').trim()
-        if (v) out[f] = v
+    for (const f of FDA_PROSE_FIELDS) {
+        const current = (orgSettings[f] || '').trim()
+        const stored = (proseBaseline[f] || '').trim()
+        if (current === stored) continue
+        out[f] = current
     }
     return out
 }
@@ -3529,10 +3547,10 @@ async function loadOrgSettings() {
     orgSettings.sidAuthoritySegments = Array.isArray(s?.sidAuthoritySegments)
         ? [...s.sidAuthoritySegments]
         : []
-    orgSettings.fdaAssessmentNarrative = s?.fdaAssessmentNarrative || ''
-    orgSettings.fdaPatchesMayCeaseStatement = s?.fdaPatchesMayCeaseStatement || ''
-    orgSettings.fdaRiskTransferProcessRef = s?.fdaRiskTransferProcessRef || ''
-    orgSettings.fdaRiskIncreasesNotice = s?.fdaRiskIncreasesNotice || ''
+    for (const f of FDA_PROSE_FIELDS) {
+        orgSettings[f] = (s as any)?.[f] || ''
+        proseBaseline[f] = orgSettings[f]
+    }
 }
 
 async function saveOrgSettings() {
@@ -3587,17 +3605,10 @@ async function saveOrgSettings() {
                     // DISABLED implies "no segments"; sending an empty list lets the server
                     // null them out cleanly per applySidPurlPatch.
                     sidAuthoritySegments: orgSettings.sidPurlMode === 'DISABLED' ? [] : trimmedSegments,
-                    // OMITTED when empty, never sent as ''. Two reasons, and both bite:
-                    // the server REFUSES a blank (it is the one value that would satisfy a
-                    // "slot is present" check while carrying nothing), so sending '' would
-                    // make an unrelated settings save fail; and under PATCH semantics
-                    // omitting leaves the stored prose alone, so editing a toggle cannot
-                    // silently erase text a manufacturer signed.
-                    //
-                    // The cost, stated rather than hidden: prose cannot currently be
-                    // CLEARED from this form. Clearing needs an explicit signal, the way
-                    // the attestation mutation uses clearMilestones -- not yet built.
-                    ...proseOrOmit()
+                    // Diffed, not dumped: untouched fields are omitted so an unrelated
+                    // toggle cannot disturb prose, and a field the user emptied goes as ''
+                    // which the server reads as a deliberate clear.
+                    ...proseDiff()
                 }
             },
             fetchPolicy: 'no-cache'

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1033,12 +1033,14 @@
                                 <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
                                 <n-date-picker v-model:formatted-value="deviceWindow.eos"
                                     value-format="yyyy-MM-dd" type="date" clearable
+                                    @update:formatted-value="deviceWindowError = null"
                                     :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
                             </div>
                             <div>
                                 <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
                                 <n-date-picker v-model:formatted-value="deviceWindow.eol"
                                     value-format="yyyy-MM-dd" type="date" clearable
+                                    @update:formatted-value="deviceWindowError = null"
                                     :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
                             </div>
                             <n-button v-if="isWritable" size="small" type="primary"
@@ -1683,6 +1685,8 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
+import { formatSupportWindow } from '@/utils/supportWindowDisplay'
+import { deviceWindowVariables } from '@/utils/deviceSupportWindowInput'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
 import type { CoverageDisplay } from '@/utils/supportCoverageDisplay'
@@ -1804,14 +1808,6 @@ async function loadAcollections() {
  * than dropped, because a history row that silently omits what it recorded is worse than
  * an ugly one.
  */
-function formatSupportWindow (value: string | null | undefined): string {
-    if (!value) return 'not declared'
-    const m = /^eos=(.*), eol=(.*)$/.exec(value)
-    if (!m) return value
-    const part = (v: string) => (v === 'null' ? 'not declared' : v)
-    return `EOS ${part(m[1])}, EOL ${part(m[2])}`
-}
-
 /**
  * The device support window, edited independently of the release body.
  *
@@ -1822,8 +1818,14 @@ function formatSupportWindow (value: string | null | undefined): string {
  *
  * It also sidesteps the DRAFT gate in save(), correctly. That gate protects a release's
  * CONTENTS once assembled; a support window is the opposite kind of fact -- declared after
- * assembly and revised as the device ages. There is no server-side lifecycle gate on
- * updateRelease, so this is a UI restriction that should not apply here.
+ * assembly and revised as the device ages.
+ *
+ * There IS a server-side lifecycle gate -- the resolver calls the 2-arg updateRelease
+ * overload, which is UpdateReleaseStrength.DRAFT_ONLY. It does not fire here only because
+ * ReleaseDto.isAssemblyRequested trips on parentReleases / sourceCodeEntry / commits /
+ * inbound / outboundDeliverables, none of which this narrow payload sends. That is the
+ * load-bearing reason to keep the payload narrow: WIDENING IT ARMS THE GATE and an
+ * assembled release stops accepting window edits.
  */
 const deviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
 const deviceWindowBaseline = reactive({ eos: null as string | null, eol: null as string | null })
@@ -1860,27 +1862,29 @@ async function saveDeviceWindow () {
         // {uuid, eos} payload is rejected at GraphQL validation before the resolver is
         // reached. Everything else is still omitted, which is what keeps artifacts and
         // commits attached (updateRelease treats a null list as no change).
-        const vars: Record<string, unknown> = {
-            uuid: updatedRelease.value.uuid,
-            org: updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
-        }
-        if (deviceWindow.eos !== deviceWindowBaseline.eos) {
-            if (deviceWindow.eos) vars.eos = deviceWindow.eos
-            else if (deviceWindowBaseline.eos) vars.clearEos = true
-        }
-        if (deviceWindow.eol !== deviceWindowBaseline.eol) {
-            if (deviceWindow.eol) vars.eol = deviceWindow.eol
-            else if (deviceWindowBaseline.eol) vars.clearEol = true
-        }
-        await graphqlClient.mutate({
+        const vars = deviceWindowVariables(
+            updatedRelease.value.uuid,
+            updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid,
+            deviceWindow, deviceWindowBaseline)
+        const resp = await graphqlClient.mutate({
             mutation: gql`
                 mutation updateDeviceSupportWindow($release: ReleaseInput!) {
                     updateRelease(release: $release) { uuid eos eol }
                 }`,
             variables: { release: vars }
         })
-        await fetchRelease()
-        seedDeviceWindow()
+        // From the mutation's OWN response, BEFORE anything that can throw. The write has
+        // committed; this is now the truth, and it is already in hand. Refreshing via the
+        // refetch instead meant a refetch failure left the baseline stale on a committed
+        // write -- and the user could then not even clear the date they had just set,
+        // because dirty was false and Save was disabled with nothing explaining why.
+        const saved = (resp?.data as any)?.updateRelease
+        if (saved) {
+            deviceWindow.eos = saved.eos || null
+            deviceWindow.eol = saved.eol || null
+            deviceWindowBaseline.eos = deviceWindow.eos
+            deviceWindowBaseline.eol = deviceWindow.eol
+        }
         notify('success', 'Saved', 'Device support window updated.')
     } catch (err: any) {
         // The SERVER's message, verbatim. The coherence rule (eos must not be after eol)
@@ -1889,9 +1893,18 @@ async function saveDeviceWindow () {
         // already has two: this inline guard, and validateReleaseData, which prefixes
         // "Release ". Only the inline path is reachable from this form, so no operator sees
         // both -- but do not read this as there being one canonical message.
-        deviceWindowError.value = commonFunctions.parseGraphQLError(err.message)
+        deviceWindowError.value = commonFunctions.extractGraphQLErrorMessage(err)
     } finally {
         savingDeviceWindow.value = false
+    }
+
+    // Deliberately outside the try: a refetch keeps the rest of the page in step, but the
+    // save above has already been reported from the mutation's own response, so a refetch
+    // failure must not be dressed up as a failed save.
+    try {
+        await fetchRelease()
+    } catch (e) {
+        // The window itself is correct on screen; the surrounding page may be stale.
     }
 }
 

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1834,8 +1834,15 @@ const deviceWindowDirty: ComputedRef<boolean> = computed((): boolean =>
     deviceWindow.eos !== deviceWindowBaseline.eos || deviceWindow.eol !== deviceWindowBaseline.eol)
 
 function seedDeviceWindow () {
-    deviceWindow.eos = updatedRelease.value?.eos || null
-    deviceWindow.eol = updatedRelease.value?.eol || null
+    // UNDEFINED means the query did not ask for the field; NULL means the server says it is
+    // not declared. Coercing the first to the second blanks a stored window and greys out
+    // Save, so the editor looks permanently broken while the value sits safely in the
+    // database. Both release queries select eos/eol now, so this should be unreachable --
+    // it is here because it was NOT unreachable an hour ago, and a third query would
+    // reintroduce it silently.
+    const r: any = updatedRelease.value
+    if (r?.eos !== undefined) deviceWindow.eos = r.eos || null
+    if (r?.eol !== undefined) deviceWindow.eol = r.eol || null
     deviceWindowBaseline.eos = deviceWindow.eos
     deviceWindowBaseline.eol = deviceWindow.eol
     deviceWindowError.value = null

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1884,8 +1884,11 @@ async function saveDeviceWindow () {
         notify('success', 'Saved', 'Device support window updated.')
     } catch (err: any) {
         // The SERVER's message, verbatim. The coherence rule (eos must not be after eol)
-        // is enforced for every writer, not just this form, so echoing the server keeps one
-        // wording; pre-validating here would invent a second that could drift from it.
+        // is enforced for every writer, not just this form, so pre-validating here would
+        // invent a SECOND wording that could drift from the enforced one. Note the server
+        // already has two: this inline guard, and validateReleaseData, which prefixes
+        // "Release ". Only the inline path is reachable from this form, so no operator sees
+        // both -- but do not read this as there being one canonical message.
         deviceWindowError.value = commonFunctions.parseGraphQLError(err.message)
     } finally {
         savingDeviceWindow.value = false

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1015,6 +1015,41 @@
         <div class="row" v-if="release && release.orgDetails && updatedRelease && updatedRelease.orgDetails">
             <n-tabs style="padding-left:0.2%;" type="segment" @update:value="handleTabSwitch" animated>
                 <n-tab-pane name="components" tab="Components">
+                    <!-- The DEVICE support window. PRODUCT releases only: it is the device's
+                         horizon, and every component verdict (deviceSupportRisk) is measured
+                         against it. Deliberately editable after assembly -- a window is
+                         declared years after a device ships and revised as it ages, so a
+                         DRAFT-only gate would mean no shipped device could ever have one. -->
+                    <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
+                        <h3>Device support window</h3>
+                        <n-alert type="default" :show-icon="false" style="font-size: 12px; margin-bottom: 10px; max-width: 720px;">
+                            Shown separately and never merged: end of support and end of sale
+                            are different facts, and a reader of the Device Support Statement
+                            is entitled to both. Blank means <strong>not declared</strong>,
+                            which is a fact in its own right &mdash; not an unknown to fill in.
+                        </n-alert>
+                        <n-space align="end" style="margin-bottom: 8px;">
+                            <div>
+                                <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
+                                <n-date-picker v-model:formatted-value="deviceWindow.eos"
+                                    value-format="yyyy-MM-dd" type="date" clearable
+                                    :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                            </div>
+                            <div>
+                                <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
+                                <n-date-picker v-model:formatted-value="deviceWindow.eol"
+                                    value-format="yyyy-MM-dd" type="date" clearable
+                                    :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                            </div>
+                            <n-button v-if="isWritable" size="small" type="primary"
+                                :disabled="!deviceWindowDirty" :loading="savingDeviceWindow"
+                                @click="saveDeviceWindow">Save window</n-button>
+                        </n-space>
+                        <n-alert v-if="deviceWindowError" type="error" :show-icon="true"
+                            style="font-size: 12px; max-width: 720px; margin-bottom: 10px;">
+                            {{ deviceWindowError }}
+                        </n-alert>
+                    </div>
                     <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
                         <h3>Components
                             <Icon v-if="isWritable && isUpdatable"
@@ -1763,6 +1798,93 @@ async function loadAcollections() {
     }
 }
 
+/**
+ * Renders the backend's compact support-window string ("eos=2030-06-30, eol=null") as
+ * something a person reads. Kept lenient: an unrecognised shape is shown verbatim rather
+ * than dropped, because a history row that silently omits what it recorded is worse than
+ * an ugly one.
+ */
+function formatSupportWindow (value: string | null | undefined): string {
+    if (!value) return 'not declared'
+    const m = /^eos=(.*), eol=(.*)$/.exec(value)
+    if (!m) return value
+    const part = (v: string) => (v === 'null' ? 'not declared' : v)
+    return `EOS ${part(m[1])}, EOL ${part(m[2])}`
+}
+
+/**
+ * The device support window, edited independently of the release body.
+ *
+ * NARROW PARTIAL, not the whole release: the save sends { uuid, eos, eol, clearEos,
+ * clearEol } and nothing else. That matters beyond tidiness -- updateRelease treats a null
+ * list as "no change" (Utils.diffUuidLists), so omitting artifacts and commits leaves them
+ * attached, whereas posting a whole stale release object could detach them.
+ *
+ * It also sidesteps the DRAFT gate in save(), correctly. That gate protects a release's
+ * CONTENTS once assembled; a support window is the opposite kind of fact -- declared after
+ * assembly and revised as the device ages. There is no server-side lifecycle gate on
+ * updateRelease, so this is a UI restriction that should not apply here.
+ */
+const deviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
+const deviceWindowBaseline = reactive({ eos: null as string | null, eol: null as string | null })
+const savingDeviceWindow: Ref<boolean> = ref(false)
+const deviceWindowError: Ref<string | null> = ref(null)
+
+const deviceWindowDirty: ComputedRef<boolean> = computed((): boolean =>
+    deviceWindow.eos !== deviceWindowBaseline.eos || deviceWindow.eol !== deviceWindowBaseline.eol)
+
+function seedDeviceWindow () {
+    deviceWindow.eos = updatedRelease.value?.eos || null
+    deviceWindow.eol = updatedRelease.value?.eol || null
+    deviceWindowBaseline.eos = deviceWindow.eos
+    deviceWindowBaseline.eol = deviceWindow.eol
+    deviceWindowError.value = null
+}
+
+async function saveDeviceWindow () {
+    savingDeviceWindow.value = true
+    deviceWindowError.value = null
+    try {
+        // Baseline diff, same shape as the prose form. A date that did not change is
+        // omitted; one that was SET and is now empty sends its clear flag, because null on
+        // this path means "keep" -- the backend reads clearEos/clearEol as the explicit
+        // signal and nothing else can express it.
+        // org is ID! on ReleaseInput, so even the narrowest partial must carry it -- a
+        // {uuid, eos} payload is rejected at GraphQL validation before the resolver is
+        // reached. Everything else is still omitted, which is what keeps artifacts and
+        // commits attached (updateRelease treats a null list as no change).
+        const vars: Record<string, unknown> = {
+            uuid: updatedRelease.value.uuid,
+            org: updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
+        }
+        if (deviceWindow.eos !== deviceWindowBaseline.eos) {
+            if (deviceWindow.eos) vars.eos = deviceWindow.eos
+            else if (deviceWindowBaseline.eos) vars.clearEos = true
+        }
+        if (deviceWindow.eol !== deviceWindowBaseline.eol) {
+            if (deviceWindow.eol) vars.eol = deviceWindow.eol
+            else if (deviceWindowBaseline.eol) vars.clearEol = true
+        }
+        await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateDeviceSupportWindow($release: ReleaseInput!) {
+                    updateRelease(release: $release) { uuid eos eol }
+                }`,
+            variables: { release: vars }
+        })
+        await fetchRelease()
+        seedDeviceWindow()
+        notify('success', 'Saved', 'Device support window updated.')
+    } catch (err: any) {
+        // The SERVER's message, verbatim. The coherence rule (eos must not be after eol)
+        // is enforced for every writer, not just this form, so echoing the server keeps one
+        // wording; pre-validating here would invent a second that could drift from it.
+        deviceWindowError.value = commonFunctions.parseGraphQLError(err.message)
+    } finally {
+        savingDeviceWindow.value = false
+    }
+}
+
 function buildCombinedHistory() {
     const events: any[] = []
     
@@ -1933,6 +2055,10 @@ onMounted(async () => {
     loadingBar.start()
     isProductRelease.value = await detectIsProduct()
     await fetchRelease()
+    // AFTER fetchRelease, never before: the baseline has to reflect what the server holds,
+    // and seeding against an empty release would show a declared window as blank and then
+    // treat re-typing it as a change.
+    seedDeviceWindow()
     await fetchReleaseKeys()
     await loadDtrackConfigured()
     if (hasPendingStatuses()) ensureStatusPolling()
@@ -2477,6 +2603,7 @@ async function goToRelease (uuid: string) {
     try {
         isProductRelease.value = await detectIsProduct()
         await fetchRelease()
+        seedDeviceWindow()
         await fetchReleaseKeys()
     } finally {
         isLoading.value = false
@@ -5608,6 +5735,15 @@ const releaseHistoryFields = computed(() => [
             }
             if (row.rus === 'LIFECYCLE') {
                 const txt = `${resolveLifecycleLabel(row.oldValue)} -> ${resolveLifecycleLabel(row.newValue)}`
+                return reasonIcon ? h('span', { style: 'display: inline-flex; align-items: center;' }, [txt, reasonIcon]) : txt
+            }
+            // A SUPPORT_WINDOW event carries old/new values and NO objectId, so without
+            // this branch it falls through to `return row.objectId` and the row renders
+            // blank -- a Scope column saying the window changed, next to nothing saying
+            // what it changed to. That line is what a Device Support Statement is defended
+            // with, so it has to read.
+            if (row.rus === 'SUPPORT_WINDOW') {
+                const txt = `${formatSupportWindow(row.oldValue)} -> ${formatSupportWindow(row.newValue)}`
                 return reasonIcon ? h('span', { style: 'display: inline-flex; align-items: center;' }, [txt, reasonIcon]) : txt
             }
             // For artifact events from acollections, show type with info icon

--- a/ui/src/components/fdaProseWiring.spec.ts
+++ b/ui/src/components/fdaProseWiring.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { FDA_PROSE_FIELDS } from '@/utils/fdaProseInput'
+
+/**
+ * Import and wiring assertions for the FDA prose form and the device support window.
+ *
+ * Same reason as releaseViewBulkWiring.spec.ts: no vue-tsc, so an undefined identifier in
+ * <script setup> is a RUNTIME error the build ignores. That is not hypothetical here --
+ * extracting proseDiff into utils/ deleted the `proseBaseline` declaration along with it,
+ * and the build passed, 427 unit tests passed, and every prose save threw
+ * "proseBaseline is not defined" in the browser. Only the live probe caught it.
+ *
+ * eslint does not flag it either (no-undef is off for <script setup>), so a source-text
+ * assertion is the cheapest guard that runs in the suite.
+ */
+const orgSettings = readFileSync(
+    fileURLToPath(new URL('./OrgSettings.vue', import.meta.url)), 'utf8')
+const releaseView = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+describe('the FDA prose form is wired into OrgSettings', () => {
+    it.each([
+        ['FDA_PROSE_FIELDS'], ['FDA_PROSE_MAX_LENGTH'], ['proseDiff'], ['proseBaselineFrom']
+    ])('imports %s from utils/fdaProseInput', (symbol) => {
+        expect(orgSettings).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'@\\/utils\\/fdaProseInput'`))
+    })
+
+    // The declaration whose loss the header describes. Referenced only from the script, so
+    // no template-wiring assertion would have caught it.
+    it('declares proseBaseline, which proseDiff is called with', () => {
+        expect(orgSettings).toMatch(/const proseBaseline\s*:/)
+        expect(orgSettings).toMatch(/proseDiff\(orgSettings,\s*proseBaseline\)/)
+    })
+
+    it.each([...FDA_PROSE_FIELDS])('binds %s to an input', (field) => {
+        expect(orgSettings).toContain(`v-model:value="orgSettings.${field}"`)
+    })
+
+    // Every prose box must be capped and frozen during a save. Uncapped, a paste over the
+    // server's limit fails the WHOLE settings mutation and takes unrelated edits with it;
+    // editable during a save, post-click keystrokes are overwritten by the refreshed
+    // baseline under a green success toast.
+    it('caps and disables all four inputs, none forgotten', () => {
+        const bound = orgSettings.match(/v-model:value="orgSettings\.fda\w+"[\s\S]*?\/>/g) || []
+        expect(bound).toHaveLength(FDA_PROSE_FIELDS.length)
+        for (const tag of bound) {
+            expect(tag).toContain(':maxlength="FDA_PROSE_MAX_LENGTH"')
+            expect(tag).toContain(':disabled="savingOrgSettings"')
+        }
+    })
+
+    // REGRESSION, Layer 1 HIGH: the baseline must come from the mutation's own response.
+    // Refreshing it only via the re-read nested in the try meant a failed re-read reported a
+    // COMMITTED save as failed AND left the baseline stale, so the operator's next clear was
+    // silently omitted while the server kept the text.
+    it('refreshes the baseline from the mutation response, not only from a re-read', () => {
+        const save = orgSettings.slice(orgSettings.indexOf('async function saveOrgSettings'))
+        const body = save.slice(0, save.indexOf('\nasync function', 1))
+        expect(body).toMatch(/proseBaselineFrom\(/)
+        expect(body.indexOf('proseBaselineFrom(')).toBeLessThan(body.indexOf('await loadOrgSettings()'))
+    })
+})
+
+describe('the device support window is wired into ReleaseView', () => {
+    it.each([
+        ['deviceWindowVariables', '@/utils/deviceSupportWindowInput'],
+        ['formatSupportWindow', '@/utils/supportWindowDisplay']
+    ])('imports %s from %s', (symbol, module) => {
+        expect(releaseView).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
+    })
+
+    it.each([
+        ['deviceWindow'], ['deviceWindowBaseline'], ['savingDeviceWindow'],
+        ['deviceWindowError'], ['deviceWindowDirty'], ['saveDeviceWindow'], ['seedDeviceWindow']
+    ])('declares %s, which the template references', (symbol) => {
+        expect(releaseView).toMatch(new RegExp(`(const|function) ${symbol}\\b`))
+    })
+
+    // The mutation response is the baseline source here too, and fetchRelease -- which can
+    // throw -- must not sit between the write and the baseline refresh.
+    it('seeds the baseline from the mutation response before refetching', () => {
+        const save = releaseView.slice(releaseView.indexOf('async function saveDeviceWindow'))
+        const body = save.slice(0, save.indexOf('\nfunction ', 1))
+        expect(body).toMatch(/resp\?\.data/)
+        expect(body.indexOf('deviceWindowBaseline.eos =')).toBeLessThan(body.indexOf('await fetchRelease()'))
+    })
+})

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -533,6 +533,10 @@ const storeObject : any = {
                                     vexComplianceFramework
                                     sidPurlMode
                                     sidAuthoritySegments
+                                    fdaAssessmentNarrative
+                                    fdaPatchesMayCeaseStatement
+                                    fdaRiskTransferProcessRef
+                                    fdaRiskIncreasesNotice
                                 }
                             }
                         }`,

--- a/ui/src/utils/deviceSupportWindowInput.spec.ts
+++ b/ui/src/utils/deviceSupportWindowInput.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { deviceWindowVariables } from './deviceSupportWindowInput'
+
+const U = '11111111-1111-1111-1111-111111111111'
+const O = '22222222-2222-2222-2222-222222222222'
+const none = { eos: null, eol: null }
+
+describe('deviceWindowVariables', () => {
+    // THE load-bearing assertion. updateRelease treats a null list as "no change", so a
+    // payload that grew an artifacts/commits key -- even an empty one -- could detach a
+    // release's contents. Assert the exact key set, not just the presence of the dates.
+    it('sends ONLY uuid, org and the changed dates -- never a dead field', () => {
+        const vars = deviceWindowVariables(U, O, { eos: '2030-06-30', eol: null }, none)
+        expect(Object.keys(vars).sort()).toEqual(['eos', 'org', 'uuid'])
+    })
+
+    // org is ID! on ReleaseInput: a { uuid, eos } payload is rejected at GraphQL
+    // validation before the resolver is ever reached.
+    it('always carries org, which the schema requires even on the narrowest partial', () => {
+        expect(deviceWindowVariables(U, O, none, none)).toEqual({ uuid: U, org: O })
+    })
+
+    it('sends nothing but the identifiers when neither date changed', () => {
+        const same = { eos: '2030-06-30', eol: '2033-01-01' }
+        expect(deviceWindowVariables(U, O, same, same)).toEqual({ uuid: U, org: O })
+    })
+
+    it('sends both dates when both are newly set', () => {
+        expect(deviceWindowVariables(U, O, { eos: '2030-06-30', eol: '2033-01-01' }, none))
+            .toEqual({ uuid: U, org: O, eos: '2030-06-30', eol: '2033-01-01' })
+    })
+
+    // null means "keep" on this path, so clearing needs an explicit flag and nothing else
+    // can express it.
+    it('clears EOS alone with clearEos, leaving EOL untouched', () => {
+        expect(deviceWindowVariables(U, O, { eos: null, eol: '2033-01-01' },
+            { eos: '2030-06-30', eol: '2033-01-01' }))
+            .toEqual({ uuid: U, org: O, clearEos: true })
+    })
+
+    // The mirror of the above. This direction was an inference rather than an observation
+    // until the live probe exercised it; the asymmetry is exactly where a bug would hide.
+    it('clears EOL alone with clearEol, leaving EOS untouched', () => {
+        expect(deviceWindowVariables(U, O, { eos: '2030-06-30', eol: null },
+            { eos: '2030-06-30', eol: '2033-01-01' }))
+            .toEqual({ uuid: U, org: O, clearEol: true })
+    })
+
+    it('clears both at once', () => {
+        expect(deviceWindowVariables(U, O, none, { eos: '2030-06-30', eol: '2033-01-01' }))
+            .toEqual({ uuid: U, org: O, clearEos: true, clearEol: true })
+    })
+
+    it('never emits a clear flag for a date that was not set to begin with', () => {
+        const vars = deviceWindowVariables(U, O, none, { eos: null, eol: '2033-01-01' })
+        expect(vars).toEqual({ uuid: U, org: O, clearEol: true })
+        expect(vars).not.toHaveProperty('clearEos')
+    })
+
+    it('sends a replacement date rather than a clear when overwriting', () => {
+        expect(deviceWindowVariables(U, O, { eos: '2031-01-01', eol: null },
+            { eos: '2030-06-30', eol: null }))
+            .toEqual({ uuid: U, org: O, eos: '2031-01-01' })
+    })
+
+    // A coherence violation is the SERVER's call: sending it is correct, so the operator
+    // gets the enforced message rather than a second one invented here.
+    it('sends an incoherent pair rather than pre-validating it away', () => {
+        expect(deviceWindowVariables(U, O, { eos: '2035-01-01', eol: '2030-01-01' }, none))
+            .toEqual({ uuid: U, org: O, eos: '2035-01-01', eol: '2030-01-01' })
+    })
+})

--- a/ui/src/utils/deviceSupportWindowInput.ts
+++ b/ui/src/utils/deviceSupportWindowInput.ts
@@ -1,0 +1,40 @@
+// Device support window form state -> updateRelease variables, honouring the mutation's
+// PATCH contract.
+
+export interface DeviceWindowState {
+    eos: string | null
+    eol: string | null
+}
+
+/**
+ * Build the NARROW partial for a device-support-window write.
+ *
+ * The payload is { uuid, org } plus only the dates that actually changed. That narrowness
+ * matters beyond tidiness: updateRelease treats a null list as "no change"
+ * (Utils.diffUuidLists), so omitting artifacts and commits leaves them attached, whereas
+ * posting a whole stale release object could DETACH them. The spec asserts the exact key
+ * set for that reason -- it is the durable guard against a future widening.
+ *
+ * org is ID! on ReleaseInput, so even the narrowest partial must carry it: a { uuid, eos }
+ * payload is rejected at GraphQL validation before the resolver is reached.
+ *
+ * Clearing needs an explicit flag because null on this path means "keep". Only a date that
+ * WAS set can be cleared; going from unset to unset sends nothing at all.
+ */
+export function deviceWindowVariables (
+    uuid: string,
+    org: string,
+    current: DeviceWindowState,
+    baseline: DeviceWindowState
+): Record<string, unknown> {
+    const vars: Record<string, unknown> = { uuid, org }
+    if (current.eos !== baseline.eos) {
+        if (current.eos) vars.eos = current.eos
+        else if (baseline.eos) vars.clearEos = true
+    }
+    if (current.eol !== baseline.eol) {
+        if (current.eol) vars.eol = current.eol
+        else if (baseline.eol) vars.clearEol = true
+    }
+    return vars
+}

--- a/ui/src/utils/fdaProseInput.spec.ts
+++ b/ui/src/utils/fdaProseInput.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { proseDiff, proseBaselineFrom, FDA_PROSE_FIELDS } from './fdaProseInput'
+
+describe('proseDiff', () => {
+    const empty = { fdaAssessmentNarrative: '', fdaPatchesMayCeaseStatement: '',
+        fdaRiskTransferProcessRef: '', fdaRiskIncreasesNotice: '' }
+
+    it('omits every field when nothing changed, so an unrelated toggle cannot touch prose', () => {
+        const state = { ...empty, fdaAssessmentNarrative: 'DHF-1' }
+        expect(proseDiff(state, state)).toEqual({})
+    })
+
+    it('sends a changed field trimmed', () => {
+        expect(proseDiff({ ...empty, fdaAssessmentNarrative: '  new text  ' }, empty))
+            .toEqual({ fdaAssessmentNarrative: 'new text' })
+    })
+
+    // The whole point of the baseline. '' is a deliberate CLEAR on the wire; the server
+    // reads a supplied empty string as "null this out" and an omitted key as "leave alone".
+    it('sends emptied-from-text as an empty string, which the server reads as a clear', () => {
+        expect(proseDiff(empty, { ...empty, fdaAssessmentNarrative: 'DHF-1' }))
+            .toEqual({ fdaAssessmentNarrative: '' })
+    })
+
+    it('does NOT send a clear for a field that was already empty', () => {
+        expect(proseDiff(empty, empty)).toEqual({})
+    })
+
+    // A field the server has never had set arrives as null, not ''. Treating those as
+    // different would send a spurious clear on every save of an untouched form.
+    it('treats null-on-server and empty-string-on-server as the same baseline', () => {
+        const nulls = { fdaAssessmentNarrative: null, fdaPatchesMayCeaseStatement: null,
+            fdaRiskTransferProcessRef: null, fdaRiskIncreasesNotice: null }
+        expect(proseDiff(empty, nulls)).toEqual({})
+        expect(proseDiff(nulls, empty)).toEqual({})
+    })
+
+    it('treats whitespace-only input as no change against an empty baseline', () => {
+        expect(proseDiff({ ...empty, fdaAssessmentNarrative: '   ' }, empty)).toEqual({})
+    })
+
+    it('treats replacing text with whitespace as a clear', () => {
+        expect(proseDiff({ ...empty, fdaAssessmentNarrative: '   ' },
+            { ...empty, fdaAssessmentNarrative: 'DHF-1' }))
+            .toEqual({ fdaAssessmentNarrative: '' })
+    })
+
+    it('does not send a field whose only change is surrounding whitespace', () => {
+        expect(proseDiff({ ...empty, fdaAssessmentNarrative: '  DHF-1  ' },
+            { ...empty, fdaAssessmentNarrative: 'DHF-1' })).toEqual({})
+    })
+
+    it('sends ONLY the changed field when several are populated', () => {
+        const baseline = { fdaAssessmentNarrative: 'A', fdaPatchesMayCeaseStatement: 'B',
+            fdaRiskTransferProcessRef: 'C', fdaRiskIncreasesNotice: 'D' }
+        expect(proseDiff({ ...baseline, fdaRiskTransferProcessRef: 'C2' }, baseline))
+            .toEqual({ fdaRiskTransferProcessRef: 'C2' })
+    })
+
+    it('never emits a key outside the four declared fields', () => {
+        const withJunk: any = { ...empty, fdaAssessmentNarrative: 'x', somethingElse: 'y' }
+        expect(Object.keys(proseDiff(withJunk, empty))).toEqual(['fdaAssessmentNarrative'])
+    })
+})
+
+describe('proseBaselineFrom', () => {
+    // REGRESSION: the baseline used to be refreshed only by a re-read nested inside the
+    // save's try block. If that read failed, a COMMITTED save was reported as "Save Failed"
+    // and the baseline stayed stale -- so the operator's next clear compared '' against a
+    // stale '', was omitted, and reported success while the server still held the text.
+    it('reads the baseline from the mutation response, including nulls as empty strings', () => {
+        expect(proseBaselineFrom({ fdaAssessmentNarrative: 'saved text' }))
+            .toEqual({ fdaAssessmentNarrative: 'saved text', fdaPatchesMayCeaseStatement: '',
+                fdaRiskTransferProcessRef: '', fdaRiskIncreasesNotice: '' })
+    })
+
+    it('yields an all-empty baseline for a null settings object', () => {
+        const b = proseBaselineFrom(null)
+        expect(Object.keys(b).sort()).toEqual([...FDA_PROSE_FIELDS].sort())
+        expect(Object.values(b).every(v => v === '')).toBe(true)
+    })
+
+    // Round trip: a baseline taken from the response must make an unmodified form clean.
+    it('leaves the form clean immediately after a save', () => {
+        const resp = { fdaAssessmentNarrative: 'saved text' }
+        const baseline = proseBaselineFrom(resp)
+        expect(proseDiff(baseline, baseline)).toEqual({})
+    })
+})

--- a/ui/src/utils/fdaProseInput.ts
+++ b/ui/src/utils/fdaProseInput.ts
@@ -1,0 +1,69 @@
+// Org settings form state -> updateOrganizationSettings variables, honouring the
+// mutation's PATCH contract for the four FDA prose fields.
+
+/**
+ * The four org-level prose slots, in the order they appear on the settings form.
+ *
+ * Exported as a const tuple so a typo in a field name is a COMPILE error rather than a
+ * silently-omitted field: the server ignores unknown keys, so a misspelling here would
+ * present as "the save worked but nothing changed", with nothing pointing at the cause.
+ */
+export const FDA_PROSE_FIELDS = ['fdaAssessmentNarrative', 'fdaPatchesMayCeaseStatement',
+    'fdaRiskTransferProcessRef', 'fdaRiskIncreasesNotice'] as const
+
+/**
+ * Mirrors OrganizationData.FDA_PROSE_MAX_LENGTH on the backend.
+ *
+ * The server checks the RAW length before trimming and rejects the whole settings mutation
+ * on overflow, which would take the operator's unrelated toggle and sid-PURL edits with it
+ * and name the wire field rather than the label they see. Capping the input is the only way
+ * to make that unreachable; the server check stays authoritative for every other writer.
+ */
+export const FDA_PROSE_MAX_LENGTH = 8000
+
+export type FdaProseField = typeof FDA_PROSE_FIELDS[number]
+export type FdaProseState = Partial<Record<FdaProseField, string | null | undefined>>
+
+/**
+ * Diff prose against the baseline captured at load.
+ *
+ *   unchanged           -> omitted, so saving an unrelated toggle cannot touch prose
+ *   emptied from text   -> sent as '', which the server reads as a deliberate CLEAR
+ *   changed             -> sent trimmed
+ *
+ * Sending '' for a field that was ALREADY empty is pointless traffic, but worse than that
+ * it would be a clear the user did not ask for on a field somebody else may have filled in
+ * since this form loaded. So only a genuine emptying is sent.
+ *
+ * Both sides are trimmed before comparison, which makes whitespace-only input equivalent
+ * to empty in BOTH directions: typing spaces into an empty field is not a change, and
+ * replacing text with spaces IS a clear. The server rejects leading/trailing whitespace
+ * anyway, so anything else would send a payload it would refuse.
+ */
+export function proseDiff (current: FdaProseState, baseline: FdaProseState): Record<string, string> {
+    const out: Record<string, string> = {}
+    for (const f of FDA_PROSE_FIELDS) {
+        const now = (current[f] || '').trim()
+        const was = (baseline[f] || '').trim()
+        if (now === was) continue
+        out[f] = now
+    }
+    return out
+}
+
+/**
+ * The baseline to hold AFTER a save, taken from the mutation's OWN response rather than a
+ * follow-up read.
+ *
+ * The distinction is load-bearing. An earlier revision refreshed the baseline only via a
+ * re-read nested inside the save's try block, so a failure of that read reported a
+ * committed save as "Save Failed" AND left the baseline stale. The next clear then compared
+ * '' against a stale '', omitted the field, and told the operator it had saved -- while the
+ * server still held the text, which is exactly the fabricated-prose failure this feature
+ * exists to prevent. The mutation already selects these fields; use them.
+ */
+export function proseBaselineFrom (settings: FdaProseState | null | undefined): Record<FdaProseField, string> {
+    const out = {} as Record<FdaProseField, string>
+    for (const f of FDA_PROSE_FIELDS) out[f] = (settings?.[f] || '')
+    return out
+}

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -1273,6 +1273,12 @@ query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
 const singleReleaseProductNoParent = `
     createdDate
     org
+    # eos / eol: the DEVICE support window. Selected here rather than fetched on demand
+    # because the release view seeds its editor from the loaded release, and an unselected
+    # field reads as "not declared" -- a meaningful value here, so the omission would be
+    # invisible rather than obviously broken.
+    eos
+    eol
     artifacts
     artifactDetails {
         ${ARTIFACT_DETAIL_DATA}

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -731,12 +731,12 @@ const DELIVERABLE_DETAIL_DATA = `
     }
 `
 
+// eos / eol: the DEVICE support window. Selected by BOTH release queries deliberately.
+// fetchRelease switches to the full query once the artifacts tab has been visited, so a
+// field present in only one of them reads as "not declared" from that point on -- which for
+// this pair is a meaningful value, not an obvious absence, so the omission is invisible
+// rather than loud. releaseFragmentsSchemaDrift.spec.ts asserts the pairing.
 const singleReleaseDataNoParent = `
-    # eos / eol: the DEVICE support window. Selected by BOTH release queries deliberately.
-    # fetchRelease switches to the full query once the artifacts tab has been visited, so a
-    # field present in only one of them reads as "not declared" from that point on -- which
-    # for this pair is a meaningful value, not an obvious absence, so the omission is
-    # invisible rather than loud.
     eos
     eol
     createdDate
@@ -1277,13 +1277,13 @@ query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
     }
 }`
 
+// eos / eol: the DEVICE support window. Selected here rather than fetched on demand because
+// the release view seeds its editor from the loaded release, and an unselected field reads
+// as "not declared" -- a meaningful value here, so the omission would be invisible rather
+// than obviously broken. Must stay in step with singleReleaseDataNoParent.
 const singleReleaseProductNoParent = `
     createdDate
     org
-    # eos / eol: the DEVICE support window. Selected here rather than fetched on demand
-    # because the release view seeds its editor from the loaded release, and an unselected
-    # field reads as "not declared" -- a meaningful value here, so the omission would be
-    # invisible rather than obviously broken.
     eos
     eol
     artifacts

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -732,6 +732,13 @@ const DELIVERABLE_DETAIL_DATA = `
 `
 
 const singleReleaseDataNoParent = `
+    # eos / eol: the DEVICE support window. Selected by BOTH release queries deliberately.
+    # fetchRelease switches to the full query once the artifacts tab has been visited, so a
+    # field present in only one of them reads as "not declared" from that point on -- which
+    # for this pair is a meaningful value, not an obvious absence, so the omission is
+    # invisible rather than loud.
+    eos
+    eol
     createdDate
     org
     hardware

--- a/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
+++ b/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
@@ -39,6 +39,36 @@ function asReleaseQuery (fragment: string) {
     }`)
 }
 
+// The two SINGLE-release documents, which are full DocumentNodes rather than fragments.
+//
+// They are exactly the hole this file's header describes, one level up: both interpolate
+// ${...}, so scripts/validate-graphql skips them -- and it does not count skips of that
+// kind in its "N skipped" line either, so the report UNDERSTATES what went unchecked.
+//
+// The pairing below is the load-bearing part. fetchRelease uses the product-simplified
+// document until the Underlying Artifacts tab is visited and the FULL one afterwards, so a
+// field selected by only one of them is present or absent depending on which tabs the
+// operator happened to click. eos/eol shipped in the simplified query alone: the editor
+// saved correctly, then the refetch read undefined, blanked both pickers and reset the
+// baseline -- so the window looked permanently unsaveable while the value sat safely in the
+// database. A comment used to be the only thing holding these two in step.
+const SINGLE_RELEASE_DOCUMENTS: Array<[string, any]> = [
+    ['SingleReleaseGql', graphqlQueries.SingleReleaseGql],
+    ['SingleReleaseProductGql', graphqlQueries.SingleReleaseProductGql]
+]
+
+describe('single-release documents vs the CE schema', () => {
+    it.each(SINGLE_RELEASE_DOCUMENTS)('%s is valid against the CE schema', (_name, doc) => {
+        expect(validate(ceSchema, doc).map(e => e.message)).toEqual([])
+    })
+
+    it.each(SINGLE_RELEASE_DOCUMENTS)('%s selects the device support window', (_name, doc) => {
+        const printed = doc.loc?.source?.body ?? ''
+        expect(printed).toMatch(/\beos\b/)
+        expect(printed).toMatch(/\beol\b/)
+    })
+})
+
 describe('release selection fragments vs the CE schema', () => {
     it.each(RELEASE_FRAGMENTS)('%s is valid against the CE schema', (_name, fragment) => {
         expect(validate(ceSchema, asReleaseQuery(fragment)).map(e => e.message)).toEqual([])

--- a/ui/src/utils/supportWindowDisplay.spec.ts
+++ b/ui/src/utils/supportWindowDisplay.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { formatSupportWindow } from './supportWindowDisplay'
+
+describe('formatSupportWindow', () => {
+    it('renders both dates', () => {
+        expect(formatSupportWindow('eos=2030-06-30, eol=2033-01-01'))
+            .toBe('EOS 2030-06-30, EOL 2033-01-01')
+    })
+
+    // ReleaseData.supportWindowValueString concatenates possibly-null values, so an
+    // undeclared date arrives as the literal text "null". Rendering that raw would put
+    // "eos=null" in front of an operator.
+    it('renders a null half as "not declared", not as the string null', () => {
+        expect(formatSupportWindow('eos=null, eol=2033-01-01'))
+            .toBe('EOS not declared, EOL 2033-01-01')
+        expect(formatSupportWindow('eos=2030-06-30, eol=null'))
+            .toBe('EOS 2030-06-30, EOL not declared')
+    })
+
+    it('renders a fully-cleared window', () => {
+        expect(formatSupportWindow('eos=null, eol=null'))
+            .toBe('EOS not declared, EOL not declared')
+    })
+
+    it('treats an absent value as not declared', () => {
+        expect(formatSupportWindow(null)).toBe('not declared')
+        expect(formatSupportWindow(undefined)).toBe('not declared')
+        expect(formatSupportWindow('')).toBe('not declared')
+    })
+
+    // Deliberate passthrough: coupled to the server format by comment alone, so a format
+    // change should show something odd rather than swallow the row into a blank cell.
+    it('passes an unrecognised shape through unchanged', () => {
+        expect(formatSupportWindow('something else entirely')).toBe('something else entirely')
+    })
+})

--- a/ui/src/utils/supportWindowDisplay.ts
+++ b/ui/src/utils/supportWindowDisplay.ts
@@ -1,0 +1,21 @@
+// Rendering for SUPPORT_WINDOW release update events.
+
+/**
+ * Render the window value a SUPPORT_WINDOW event carries.
+ *
+ * The input shape is produced by ReleaseData.supportWindowValueString, which builds
+ * "eos=" + eos + ", eol=" + eol -- string concatenation over two possibly-null values, so
+ * an undeclared date arrives as the literal text "null" rather than an absent segment.
+ * Rendering that raw would put "eos=null, eol=2033-03-31" in front of an operator.
+ *
+ * Coupled to that server method by nothing but this comment and the spec beside it, so the
+ * unrecognised-input case deliberately PASSES THROUGH unchanged: if the server format ever
+ * changes, the history shows something odd rather than nothing at all.
+ */
+export function formatSupportWindow (value: string | null | undefined): string {
+    if (!value) return 'not declared'
+    const m = /^eos=(.*), eol=(.*)$/.exec(value)
+    if (!m) return value
+    const part = (v: string) => (v === 'null' ? 'not declared' : v)
+    return `EOS ${part(m[1])}, EOL ${part(m[2])}`
+}


### PR DESCRIPTION
Step 3 of 7f: the UI that writes what rearm-saas#498 and rearm#329 made storable. Four
org-level prose slots in Settings, and the device support window on a PRODUCT release.

## Clear semantics, end to end

Prose diffs against a BASELINE captured at load, so an emptied field is sent as `""` and
CLEARS, while a field the operator never touched is OMITTED and left alone. That is the
`blankToNull` contract the backend already implements; sending the whole form every time
would make an unrelated save silently rewrite all four.

## The device window

PRODUCT releases only, and deliberately editable after assembly -- a support window is
declared years after a device ships and revised as it ages, so a DRAFT-only gate would
mean no shipped device could ever have one. Coherence (`eos <= eol`) is NOT pre-validated
here: the rule is enforced for every writer, so echoing the server verbatim avoids
inventing a second wording that could drift.

## Layer 1 found a HIGH bug in this branch; it is fixed

`eos`/`eol` were selected by the product-simplified query only. `fetchRelease` switches to
the FULL query once the Underlying Artifacts tab has been visited, so after that the
refetch following a successful save read `undefined`, blanked both pickers AND reset the
baseline -- leaving the window looking permanently unsaveable while the value sat safely
in the database. Retyping and saving again did nothing visible, because the backend
correctly saw no change and emitted no event.

Fixed by selecting the fields in BOTH queries, and by making `seedDeviceWindow`
distinguish `undefined` (this query did not ask) from `null` (the server says not
declared). The second guard should be unreachable given the first; it is there because it
was not unreachable an hour ago.

## Live probe on the sandbox, against the merged backend

Rebuilt CE from `32505f3a` (post-#329) and hot-swapped both deployments.

    W0-W6   card renders on a PRODUCT release, writable, seeded from the server
    D1-D2   both pickers accept a date, Save enables only when dirty
    P1      both dates persist across a reload
    P2      clear EOS alone -- EOL survives
    P3/P3b  server coherence error shown verbatim, and NOTHING was written
    P4/P5   a SUPPORT_WINDOW event row renders the window, not a blank cell
    P6      clear EOL alone -- EOS survives  (the mirror of P2, never exercised before)
    P7      eos and eol both appear in the release network traffic
    P8a-e   THE LAYER 1 PATH: visit Underlying Artifacts, return, set a date, save,
            reload -- value persists and the pickers stay populated
    X       0 page exceptions

P8 was REVERT-PROBED: rebuilt the UI from `a4f5e259` (the commit before the fix) and
re-ran. **P8d fails there (`""` instead of `"2032-12-31"`) while P1-P7 all still pass** --
the entire pre-existing suite was blind to this. P8e passes even unfixed, which confirms
the diagnosis precisely: the data always reached the database, only the display after the
tab round-trip was broken.

Prose probe: T0 seeded, A cleared one field, A2 left the other three untouched, B0/B an
unrelated setting save left all four intact. 0 GraphQL errors, 0 page exceptions.
Strip matrix re-run for regression: 19/19 across all four egresses.

## Checks

`validate-graphql`: **0 CE drift warnings** (3 Pro failures are pre-existing dead paths,
tracked separately). Build clean. **395 tests / 31 files** green -- note nothing in CI runs
the vitest suite, so that count is part of this report by necessity.

## oss/ port decision

This PR is UI-only and touches no `service/oss/` code, so the fork-port question the
sync checklist raises does not arise here. It was answered for this track in #329.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>