### PR TITLE
The FDA support addendum, rendered from one client-side collector (7g)

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -112,8 +112,22 @@
                             <n-radio-button value="JSON">CycloneDX 1.6 (JSON)</n-radio-button>
                             <n-radio-button value="CSV">CSV</n-radio-button>
                             <n-radio-button value="EXCEL">EXCEL</n-radio-button>
+                            <!-- Its own export TYPE, not a toggle on the BOM export. The
+                                 addendum is a different document that happens to share this
+                                 modal: it is assembled in the browser from the support
+                                 attestations and the org prose, and the BOM-shaping options
+                                 below do not apply to it. A checkbox would imply it rides
+                                 along with whichever format was picked. -->
+                            <n-radio-button value="FDA_ADDENDUM">FDA support addendum (CSV)</n-radio-button>
                         </n-radio-group>
                     </n-form-item>
+                    <n-alert v-if="selectedSbomMediaType === 'FDA_ADDENDUM'" type="default"
+                        :show-icon="false" style="font-size: 12px; max-width: 620px; margin-bottom: 10px;">
+                        Every component in this release with its level of support, the end-of-support
+                        date where one is attested and the justification where none is, plus the
+                        device support window and the assessment justification. The counts come from
+                        the coverage gauge, so this document and the page always agree.
+                    </n-alert>
                     <n-form-item v-if="selectedSbomMediaType === 'JSON'">
                         <template #label>
                             <span style="display: inline-flex; align-items: center;">
@@ -1685,6 +1699,8 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
+import { collectAddendumData } from '@/utils/addendumData'
+import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
 import { formatSupportWindow } from '@/utils/supportWindowDisplay'
 import { deviceWindowVariables } from '@/utils/deviceSupportWindowInput'
 import graphqlQueries from '@/utils/graphqlQueries'
@@ -4946,7 +4962,47 @@ async function uploadNewBomVersion (art: any) {
     
 }
 
+/**
+ * The FDA support addendum: a DIFFERENT DOCUMENT that shares the export modal.
+ *
+ * Assembled client-side by collectAddendumData, which is deliberately document-agnostic --
+ * the PDF and the Device Support Statement consume the same collector unchanged. A
+ * server-rendered CSV would have been a second source of truth for the same document.
+ *
+ * REFUSES rather than downloading a partial. A truncated addendum is the dangerous output:
+ * a regulatory document that looks complete while under-reporting how many components have
+ * no support attestation, which is the one number a reviewer is looking for. The collector
+ * returns no data at all on any refusal, so there is nothing here to accidentally save.
+ */
+async function exportFdaAddendum () {
+    try {
+        bomExportPending.value = true
+        const result = await collectAddendumData(
+            graphqlClient as any, updatedRelease.value.uuid,
+            updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid)
+        if (!result.ok) {
+            Swal.fire('Addendum not generated', result.error, 'error')
+            return
+        }
+        const blob = new Blob([renderAddendumCsv(result.data)], { type: 'text/csv;charset=utf-8' })
+        const link = document.createElement('a')
+        link.href = window.URL.createObjectURL(blob)
+        link.download = addendumFileName(result.data)
+        link.click()
+        window.URL.revokeObjectURL(link.href)
+        notify('success', 'Addendum exported',
+            `${result.data.totalComponents} components, ${result.data.unassessedComponents} with no attestation.`)
+    } catch (err: any) {
+        Swal.fire('Error!', commonFunctions.extractGraphQLErrorMessage(err), 'error')
+    } finally {
+        bomExportPending.value = false
+    }
+}
+
 async function exportReleaseSbom (tldOnly: boolean, ignoreDev: boolean, selectedBomStructureType: string, selectedRebomType: string, mediaType: string) {
+    // Routed here rather than from the template so the button keeps one handler and the
+    // modal cannot end up with two spinners disagreeing about whether an export is running.
+    if (mediaType === 'FDA_ADDENDUM') return exportFdaAddendum()
     try {
         bomExportPending.value = true
         const excludeCoverageTypes = computedExcludeCoverageTypes.value.length > 0 ? computedExcludeCoverageTypes.value : null

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -81,7 +81,11 @@
                     </n-radio-group>
                 </n-form-item>
                 <n-form v-if="exportBomType === 'SBOM'">
-                    <n-form-item>
+                    <!-- Hidden for the addendum rather than left enabled and ignored. The
+                         addendum always walks the whole release scope, so an operator who
+                         ticked "Top Level Dependencies Only" and got a full-scope document
+                         would have no way to tell the control had been dropped on the floor. -->
+                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
                         <template #label>
                             <span style="display: inline-flex; align-items: center;">
                                 Select SBOM configuration for export
@@ -153,7 +157,7 @@
                             />
                         </n-radio-group>
                     </n-form-item>
-                    <n-form-item>
+                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
                         <span style="display: inline-flex; align-items: center;">
                             Top Level Dependencies Only:
                             <n-tooltip trigger="hover">
@@ -167,7 +171,7 @@
                         </span>
                         <n-switch style="margin-left: 5px;" v-model:value="tldOnly"/>
                     </n-form-item>
-                    <n-form-item>
+                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
                         <span style="display: inline-flex; align-items: center;">
                             Ignore Optional Dependencies:
                             <n-tooltip trigger="hover">
@@ -4963,7 +4967,8 @@ async function uploadNewBomVersion (art: any) {
 }
 
 /**
- * The FDA support addendum: a DIFFERENT DOCUMENT that shares the export modal.
+ * The FDA support addendum (FDA-Readiness-1 7g): a DIFFERENT DOCUMENT that shares the
+ * export modal.
  *
  * Assembled client-side by collectAddendumData, which is deliberately document-agnostic --
  * the PDF and the Device Support Statement consume the same collector unchanged. A
@@ -4977,9 +4982,18 @@ async function uploadNewBomVersion (art: any) {
 async function exportFdaAddendum () {
     try {
         bomExportPending.value = true
+        const orgUuid = updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
+        if (!orgUuid) {
+            // Refused in the same voice as every other refusal. Without this the operator
+            // gets a raw GraphQL variable-coercion message about $orgUuid, which reads as a
+            // server fault rather than as "this release did not carry its org".
+            Swal.fire('Addendum not generated',
+                'This release did not carry an organization, so the labeling statements'
+                + ' cannot be resolved. Reload the page and try again.', 'error')
+            return
+        }
         const result = await collectAddendumData(
-            graphqlClient as any, updatedRelease.value.uuid,
-            updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid)
+            graphqlClient as any, updatedRelease.value.uuid, orgUuid)
         if (!result.ok) {
             Swal.fire('Addendum not generated', result.error, 'error')
             return
@@ -4988,11 +5002,22 @@ async function exportFdaAddendum () {
         const link = document.createElement('a')
         link.href = window.URL.createObjectURL(blob)
         link.download = addendumFileName(result.data)
+        // append -> click -> remove -> revoke, following utils/bovExport.ts rather than the
+        // older exports in this file: revoking the URL of a DETACHED anchor races the
+        // browser's own fetch of it in some engines, and a silently empty download is a
+        // particularly bad failure for a document someone is about to file.
+        document.body.appendChild(link)
         link.click()
+        document.body.removeChild(link)
         window.URL.revokeObjectURL(link.href)
         notify('success', 'Addendum exported',
             `${result.data.totalComponents} components, ${result.data.unassessedComponents} with no attestation.`)
     } catch (err: any) {
+        // extractGraphQLErrorMessage, not the parseGraphQLError(err.message) its neighbours
+        // use: this catch only fires on throws collectAddendumData did NOT convert into a
+        // refusal, so err may be anything -- and parseGraphQLError calls startsWith on its
+        // argument, throwing a TypeError out of the catch itself when there is no string
+        // message. That exact defect was found on the previous PR in this feature.
         Swal.fire('Error!', commonFunctions.extractGraphQLErrorMessage(err), 'error')
     } finally {
         bomExportPending.value = false

--- a/ui/src/components/addendumExportWiring.spec.ts
+++ b/ui/src/components/addendumExportWiring.spec.ts
@@ -14,6 +14,26 @@ import { ADDENDUM_COLUMNS } from '@/utils/addendumCsv'
 const source = readFileSync(
     fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
 
+/**
+ * The handler's body, sliced to its own closing brace by BRACE DEPTH.
+ *
+ * An earlier version cut at the next `\nasync function`, which silently produced the wrong
+ * text -- or an empty string -- the moment a helper was inserted between the two functions.
+ * A spec that reads as protection and checks nothing is worse than no spec.
+ */
+function handlerBody (): string {
+    const start = source.indexOf('async function exportFdaAddendum')
+    if (start < 0) throw new Error('no exportFdaAddendum in ReleaseView.vue')
+    let depth = 0
+    let i = source.indexOf('{', start)
+    const open = i
+    for (; i < source.length; i++) {
+        if (source[i] === '{') depth++
+        else if (source[i] === '}' && --depth === 0) break
+    }
+    return source.slice(open, i + 1)
+}
+
 describe('the FDA addendum export is wired into the export modal', () => {
     it.each([
         ['collectAddendumData', '@/utils/addendumData'],
@@ -44,16 +64,29 @@ describe('the FDA addendum export is wired into the export modal', () => {
     // The refusal must reach the operator. A silent failure here means they believe they
     // hold a complete document.
     it('surfaces a refusal instead of downloading anything', () => {
-        const fn = source.slice(source.indexOf('async function exportFdaAddendum'))
-        const body = fn.slice(0, fn.indexOf('\nasync function', 1))
+        const body = handlerBody()
         expect(body).toMatch(/if \(!result\.ok\)/)
         expect(body.indexOf('if (!result.ok)')).toBeLessThan(body.indexOf('new Blob'))
     })
 
-    it('releases the object URL it creates', () => {
-        const fn = source.slice(source.indexOf('async function exportFdaAddendum'))
-        const body = fn.slice(0, fn.indexOf('\nasync function', 1))
+    it('refuses before querying when the release carries no org', () => {
+        const body = handlerBody()
+        expect(body.indexOf('if (!orgUuid)')).toBeLessThan(body.indexOf('collectAddendumData('))
+    })
+
+    // The BOM-shaping controls do not apply to the addendum, so they are HIDDEN rather than
+    // left enabled and silently ignored -- an operator who ticked "Top Level Dependencies
+    // Only" and got a full-scope document would have no way to tell.
+    it('hides the BOM-shaping controls when the addendum is selected', () => {
+        const gates = source.match(/v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'"/g) || []
+        expect(gates.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('appends, clicks, removes, then revokes the object URL', () => {
+        const body = handlerBody()
         expect(body).toContain('revokeObjectURL')
+        expect(body.indexOf('appendChild')).toBeLessThan(body.indexOf('link.click()'))
+        expect(body.indexOf('link.click()')).toBeLessThan(body.indexOf('revokeObjectURL'))
     })
 })
 

--- a/ui/src/components/addendumExportWiring.spec.ts
+++ b/ui/src/components/addendumExportWiring.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { ADDENDUM_COLUMNS } from '@/utils/addendumCsv'
+
+/**
+ * Import and wiring assertions for the FDA addendum export.
+ *
+ * Same reason as releaseViewBulkWiring.spec.ts and fdaProseWiring.spec.ts: no vue-tsc, so
+ * an undefined identifier in <script setup> is a RUNTIME error the build ignores. On the
+ * previous PR that cost a working feature -- the build, 427 unit tests and eslint were all
+ * green while every save threw in the browser.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+describe('the FDA addendum export is wired into the export modal', () => {
+    it.each([
+        ['collectAddendumData', '@/utils/addendumData'],
+        ['renderAddendumCsv', '@/utils/addendumCsv'],
+        ['addendumFileName', '@/utils/addendumCsv']
+    ])('imports %s from %s', (symbol, module) => {
+        expect(source).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
+    })
+
+    it('declares the handler the export button routes to', () => {
+        expect(source).toMatch(/async function exportFdaAddendum \(/)
+    })
+
+    // Its own export TYPE, not a toggle: the addendum is a different document that happens
+    // to share the modal, and the BOM-shaping options do not apply to it.
+    it('offers the addendum as a radio option beside the BOM formats', () => {
+        expect(source).toContain('<n-radio-button value="FDA_ADDENDUM">')
+        expect(source).not.toMatch(/n-switch[^>]*addendum/i)
+    })
+
+    // One handler, so the modal cannot end up with two spinners disagreeing about whether
+    // an export is running.
+    it('routes the addendum through the single export button', () => {
+        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM'\) return exportFdaAddendum\(\)/)
+    })
+
+    // The refusal must reach the operator. A silent failure here means they believe they
+    // hold a complete document.
+    it('surfaces a refusal instead of downloading anything', () => {
+        const fn = source.slice(source.indexOf('async function exportFdaAddendum'))
+        const body = fn.slice(0, fn.indexOf('\nasync function', 1))
+        expect(body).toMatch(/if \(!result\.ok\)/)
+        expect(body.indexOf('if (!result.ok)')).toBeLessThan(body.indexOf('new Blob'))
+    })
+
+    it('releases the object URL it creates', () => {
+        const fn = source.slice(source.indexOf('async function exportFdaAddendum'))
+        const body = fn.slice(0, fn.indexOf('\nasync function', 1))
+        expect(body).toContain('revokeObjectURL')
+    })
+})
+
+describe('the addendum column set', () => {
+    // Named here so a column added to the renderer without a matching header, or reordered
+    // against the row builder, fails rather than shipping a shifted document.
+    it('is the eight documented columns, in order', () => {
+        expect(ADDENDUM_COLUMNS).toEqual([
+            'Component', 'Version', 'PURL', 'Level of support', 'End of support',
+            'Justification', 'Attestation state', 'Last assessed'
+        ])
+    })
+})

--- a/ui/src/utils/addendumCsv.spec.ts
+++ b/ui/src/utils/addendumCsv.spec.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { addendumRow, addendumHeaderRows, renderAddendumCsv, addendumFileName,
+    ADDENDUM_COLUMNS, NOT_ASSESSED } from './addendumCsv'
+import type { AddendumComponent, AddendumData } from './addendumData'
+
+function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
+    return {
+        sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+        purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+        levelOfSupport: 'actively maintained', endOfSupportDate: '2030-01-01',
+        justification: null, assessedAt: '2026-09-01T00:00:00Z', ...over
+    }
+}
+
+function data (over: Partial<AddendumData> = {}): AddendumData {
+    return {
+        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump',
+        deviceEos: '2030-06-30', deviceEol: '2033-01-01',
+        narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
+        patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null,
+        totalComponents: 1, attestedComponents: 1, unassessedComponents: 0,
+        components: [comp()], generatedAt: '2026-09-07T12:00:00Z', ...over
+    }
+}
+
+describe('addendumRow', () => {
+    it('states the FDA phrase verbatim for an attested component', () => {
+        expect(addendumRow(comp())[3]).toBe('actively maintained')
+    })
+
+    it('qualifies the name with its group', () => {
+        expect(addendumRow(comp())[0]).toBe('org.apache:log4j-core')
+        expect(addendumRow(comp({ group: null }))[0]).toBe('log4j-core')
+    })
+
+    // L1021-1022: a level and a justification are ALTERNATIVES. Emitting both suggests the
+    // justification qualifies the level, when it exists because there is no level to give.
+    it('emits the level and no justification when a level is attested', () => {
+        const row = addendumRow(comp({ justification: 'checked upstream' }))
+        expect(row[3]).toBe('actively maintained')
+        expect(row[5]).toBeNull()
+    })
+
+    it('emits the justification when there is no level', () => {
+        const row = addendumRow(comp({ levelOfSupport: null, justification: 'no upstream date published' }))
+        expect(row[3]).toBe(NOT_ASSESSED)
+        expect(row[5]).toBe('no upstream date published')
+    })
+
+    // Blank would read as an omission -- something the exporter forgot. The honest claim is
+    // that nothing is recorded, and the row has to say which it is.
+    it('says "not assessed" rather than leaving the cell blank', () => {
+        const row = addendumRow(comp({ attestationState: null, levelOfSupport: null }))
+        expect(row[3]).toBe(NOT_ASSESSED)
+        expect(row[6]).toBe(NOT_ASSESSED)
+    })
+
+    // A WITHDRAWN attestation is not injected into exports, so treating it as live here
+    // would make the addendum disagree with the BOM it accompanies.
+    it('treats WITHDRAWN as not assessed and suppresses its stale dates', () => {
+        const row = addendumRow(comp({ attestationState: 'WITHDRAWN' }))
+        expect(row[3]).toBe(NOT_ASSESSED)
+        expect(row[4]).toBeNull()
+        expect(row[6]).toBe('WITHDRAWN')
+        expect(row[7]).toBeNull()
+    })
+
+    it('has exactly one cell per declared column', () => {
+        expect(addendumRow(comp())).toHaveLength(ADDENDUM_COLUMNS.length)
+        expect(addendumRow(comp({ attestationState: null }))).toHaveLength(ADDENDUM_COLUMNS.length)
+    })
+})
+
+describe('addendumHeaderRows', () => {
+    // Two questions, two facts: when patching stops, and when selling stops. One merged
+    // "support window" cell forces the reader to guess which a lone date is.
+    it('states device EOS and EOL as two separate labelled facts', () => {
+        const flat = addendumHeaderRows(data()).map(r => r[0])
+        expect(flat).toContain('Device end of support (EOS)')
+        expect(flat).toContain('Device end of sale / end of life (EOL)')
+    })
+
+    it('says "not declared" for an absent device date rather than leaving it blank', () => {
+        const rows = addendumHeaderRows(data({ deviceEos: null }))
+        expect(rows.find(r => r[0] === 'Device end of support (EOS)')![1]).toBe('not declared')
+    })
+
+    it('carries the assessed and unassessed counts', () => {
+        const rows = addendumHeaderRows(data({ totalComponents: 10, attestedComponents: 4, unassessedComponents: 6 }))
+        expect(rows.find(r => r[0] === 'Components with no support attestation')![1]).toBe(6)
+        expect(rows.find(r => r[0] === 'Components with a support attestation')![1]).toBe(4)
+    })
+
+    it('states the narrative scope beside the text', () => {
+        const org = addendumHeaderRows(data())
+        expect(org.find(r => r[0] === 'Justification scope')![1]).toBe('organization default')
+        const rel = addendumHeaderRows(data({ narrativeIsPerRelease: true }))
+        expect(rel.find(r => r[0] === 'Justification scope')![1]).toBe('this release')
+    })
+
+    // A blank "Assessment justification" heading reads as "we had nothing to say" rather
+    // than "nobody has written this yet".
+    it('omits the justification block entirely when neither level has one', () => {
+        const rows = addendumHeaderRows(data({ narrative: null }))
+        expect(rows.map(r => r[0])).not.toContain('Assessment justification')
+        expect(rows.map(r => r[0])).not.toContain('Justification scope')
+    })
+
+    it('includes each labeling statement only when authored', () => {
+        expect(addendumHeaderRows(data()).map(r => r[0]))
+            .not.toContain('Patches may cease at end of support')
+        expect(addendumHeaderRows(data({ patchesMayCeaseStatement: 'patches stop' })).map(r => r[0]))
+            .toContain('Patches may cease at end of support')
+    })
+})
+
+describe('renderAddendumCsv', () => {
+    it('emits the header block, the column row, then one row per component', () => {
+        const csv = renderAddendumCsv(data({ components: [comp(), comp({ name: 'other' })] }))
+        // slice(1) drops the UTF-8 BOM, which is part of the document, not of the first cell
+        const lines = csv.slice(1).split('\r\n')
+        expect(lines[0]).toBe('FDA software support addendum')
+        expect(lines).toContain(ADDENDUM_COLUMNS.join(','))
+        const idx = lines.indexOf(ADDENDUM_COLUMNS.join(','))
+        expect(lines.slice(idx + 1).filter(l => l.length).length).toBe(2)
+    })
+
+    // THE probe assertion, asserted here too so it does not depend on a browser: the number
+    // of data rows must equal the total the header states.
+    it('emits exactly totalComponents data rows', () => {
+        const comps = Array.from({ length: 7 }, (_, i) => comp({ sbomComponentUuid: `sc-${i}` }))
+        const csv = renderAddendumCsv(data({ components: comps, totalComponents: 7, attestedComponents: 7, unassessedComponents: 0 }))
+        const lines = csv.split('\r\n')
+        const idx = lines.indexOf(ADDENDUM_COLUMNS.join(','))
+        expect(lines.slice(idx + 1).filter(l => l.length).length).toBe(7)
+    })
+
+    // The prose fields are up to 8,000 characters of operator free text. A quoting failure
+    // here shifts every column on the row.
+    it('escapes a narrative containing commas, quotes and newlines', () => {
+        const csv = renderAddendumCsv(data({ narrative: 'We checked, then\nsaid "no date".' }))
+        expect(csv).toContain('"We checked, then\nsaid ""no date""."')
+    })
+
+    it('neutralises a formula planted in a justification', () => {
+        const csv = renderAddendumCsv(data({
+            components: [comp({ levelOfSupport: null, justification: '=HYPERLINK("http://x","ok")' })]
+        }))
+        expect(csv).toContain("'=HYPERLINK")
+    })
+
+    it('renders an empty release as a header block and a column row only', () => {
+        const csv = renderAddendumCsv(data({ components: [], totalComponents: 0, attestedComponents: 0, unassessedComponents: 0 }))
+        const lines = csv.split('\r\n')
+        const idx = lines.indexOf(ADDENDUM_COLUMNS.join(','))
+        expect(idx).toBeGreaterThan(-1)
+        expect(lines.slice(idx + 1).filter(l => l.length).length).toBe(0)
+    })
+})
+
+describe('addendumFileName', () => {
+    it('identifies the release without the file being opened', () => {
+        expect(addendumFileName(data())).toBe('fda-support-addendum-1.4.5.csv')
+    })
+
+    it('falls back to the uuid and strips anything path-unsafe', () => {
+        expect(addendumFileName(data({ releaseVersion: null }))).toBe('fda-support-addendum-r-1.csv')
+        expect(addendumFileName(data({ releaseVersion: 'feature/x y' }))).toBe('fda-support-addendum-feature-x-y.csv')
+    })
+})

--- a/ui/src/utils/addendumCsv.spec.ts
+++ b/ui/src/utils/addendumCsv.spec.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import { addendumRow, addendumHeaderRows, renderAddendumCsv, addendumFileName,
-    ADDENDUM_COLUMNS, NOT_ASSESSED } from './addendumCsv'
+    ADDENDUM_COLUMNS, NOT_ASSESSED, LEVEL_NOT_STATED } from './addendumCsv'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
     return {
         sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
         purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
-        levelOfSupport: 'actively maintained', endOfSupportDate: '2030-01-01',
+        levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+        endOfSupportDate: '2030-01-01',
         justification: null, assessedAt: '2026-09-01T00:00:00Z', ...over
     }
 }
@@ -43,8 +44,25 @@ describe('addendumRow', () => {
 
     it('emits the justification when there is no level', () => {
         const row = addendumRow(comp({ levelOfSupport: null, justification: 'no upstream date published' }))
-        expect(row[3]).toBe(NOT_ASSESSED)
         expect(row[5]).toBe('no upstream date published')
+    })
+
+    // REGRESSION: a level is OPTIONAL on an attestation, and a justification-only
+    // attestation is exactly the L1021-1022 case. Printing "not assessed" for it made the
+    // table contradict its own header -- "10 with a support attestation" above ten rows
+    // each reading not assessed.
+    it('distinguishes an attested component with no level from an unassessed one', () => {
+        expect(addendumRow(comp({ levelOfSupport: null }))[3]).toBe(LEVEL_NOT_STATED)
+        expect(addendumRow(comp({ attestationState: null, levelOfSupport: null }))[3]).toBe(NOT_ASSESSED)
+        expect(LEVEL_NOT_STATED).not.toBe(NOT_ASSESSED)
+    })
+
+    // A retracted attestation is not injected into exports. Emitting its justification would
+    // republish a claim the manufacturer formally withdrew.
+    it('states nothing at all for a WITHDRAWN component, justification included', () => {
+        const row = addendumRow(comp({ attestationState: 'WITHDRAWN', levelOfSupport: null,
+            justification: 'retracted reasoning' }))
+        expect(row[5]).toBeNull()
     })
 
     // Blank would read as an omission -- something the exporter forgot. The honest claim is
@@ -119,7 +137,8 @@ describe('renderAddendumCsv', () => {
         const csv = renderAddendumCsv(data({ components: [comp(), comp({ name: 'other' })] }))
         // slice(1) drops the UTF-8 BOM, which is part of the document, not of the first cell
         const lines = csv.slice(1).split('\r\n')
-        expect(lines[0]).toBe('FDA software support addendum')
+        // padded to the table width, so a strict reader (pandas) can parse the whole file
+        expect(lines[0]).toBe('FDA software support addendum' + ','.repeat(ADDENDUM_COLUMNS.length - 1))
         expect(lines).toContain(ADDENDUM_COLUMNS.join(','))
         const idx = lines.indexOf(ADDENDUM_COLUMNS.join(','))
         expect(lines.slice(idx + 1).filter(l => l.length).length).toBe(2)

--- a/ui/src/utils/addendumCsv.ts
+++ b/ui/src/utils/addendumCsv.ts
@@ -1,0 +1,111 @@
+// The FDA support addendum, as CSV.
+//
+// One of three renderers over the SAME collected data (addendumData.ts). This file decides
+// only how to SAY the facts; it must not fetch, count or resolve anything, or the PDF and
+// the Device Support Statement will disagree with it about what the release contains.
+
+import { csvDocument } from './csv'
+import type { AddendumComponent, AddendumData } from './addendumData'
+import { isLiveAttestation } from './addendumData'
+
+export const ADDENDUM_COLUMNS = [
+    'Component', 'Version', 'PURL', 'Level of support', 'End of support',
+    'Justification', 'Attestation state', 'Last assessed'
+]
+
+/**
+ * The value stated when a component carries no live attestation.
+ *
+ * NOT an empty cell, and the distinction is the point of the document. Blank reads as an
+ * omission -- something the exporter forgot -- whereas the honest claim is that the
+ * manufacturer looked and has nothing recorded. A reviewer counting blanks cannot tell those
+ * apart; this way the row says which it is.
+ */
+export const NOT_ASSESSED = 'not assessed'
+
+/** Fully-qualified name: group is part of a component's identity, not decoration. */
+function displayName (c: AddendumComponent): string | null {
+    if (c.group && c.name) return `${c.group}:${c.name}`
+    return c.name || c.group || null
+}
+
+/**
+ * One component row.
+ *
+ * LEVEL AND JUSTIFICATION ARE ALTERNATIVES, per L1021-1022: a component with an attested
+ * level states it, and one without states WHY the information cannot be given. Emitting both
+ * would suggest the justification qualifies the level, when it exists precisely because
+ * there is no level to give.
+ *
+ * A WITHDRAWN attestation is treated as not assessed -- it keeps its history but is not
+ * injected into exports, so counting it here would make the addendum disagree with the BOM
+ * it accompanies.
+ */
+export function addendumRow (c: AddendumComponent): unknown[] {
+    const live = isLiveAttestation(c)
+    return [
+        displayName(c),
+        c.version,
+        c.purl,
+        live ? (c.levelOfSupport || NOT_ASSESSED) : NOT_ASSESSED,
+        live ? c.endOfSupportDate : null,
+        live && c.levelOfSupport ? null : c.justification,
+        live ? 'ATTESTED' : (c.attestationState || NOT_ASSESSED),
+        live ? c.assessedAt : null
+    ]
+}
+
+/**
+ * The header block: what a reviewer reads before the table.
+ *
+ * Device EOS and EOL are stated as TWO SEPARATE FACTS. They answer different questions --
+ * when patching stops, and when selling stops -- and merging them into one "support window"
+ * line forces the reader to guess which a lone date is.
+ *
+ * The assessed / unassessed counts live HERE rather than being counted from the rows below.
+ * They come from the same resolver as the on-screen gauge, so the document cannot state a
+ * number the page disagrees with; addendumData refuses outright if the two ever diverge.
+ */
+export function addendumHeaderRows (d: AddendumData): unknown[][] {
+    const rows: unknown[][] = [
+        ['FDA software support addendum'],
+        ['Organization', d.orgName],
+        ['Device', d.componentName],
+        ['Release', d.releaseVersion],
+        ['Release UUID', d.releaseUuid],
+        ['Generated', d.generatedAt],
+        [],
+        ['Device end of support (EOS)', d.deviceEos || 'not declared'],
+        ['Device end of sale / end of life (EOL)', d.deviceEol || 'not declared'],
+        [],
+        ['Components in this release', d.totalComponents],
+        ['Components with a support attestation', d.attestedComponents],
+        ['Components with no support attestation', d.unassessedComponents],
+        []
+    ]
+    if (d.narrative) {
+        rows.push(['Assessment justification', d.narrative])
+        rows.push(['Justification scope', d.narrativeIsPerRelease ? 'this release' : 'organization default'])
+        rows.push([])
+    }
+    if (d.patchesMayCeaseStatement) rows.push(['Patches may cease at end of support', d.patchesMayCeaseStatement])
+    if (d.riskTransferProcessRef) rows.push(['Risk-transfer process reference', d.riskTransferProcessRef])
+    if (d.riskIncreasesNotice) rows.push(['Risk increases over time', d.riskIncreasesNotice])
+    if (d.patchesMayCeaseStatement || d.riskTransferProcessRef || d.riskIncreasesNotice) rows.push([])
+    return rows
+}
+
+/** The whole document. */
+export function renderAddendumCsv (d: AddendumData): string {
+    return csvDocument([
+        ...addendumHeaderRows(d),
+        ADDENDUM_COLUMNS,
+        ...d.components.map(addendumRow)
+    ])
+}
+
+/** Stable, sortable, and identifies the release without needing the file to be opened. */
+export function addendumFileName (d: AddendumData): string {
+    const slug = (d.releaseVersion || d.releaseUuid).replace(/[^A-Za-z0-9._-]+/g, '-')
+    return `fda-support-addendum-${slug}.csv`
+}

--- a/ui/src/utils/addendumCsv.ts
+++ b/ui/src/utils/addendumCsv.ts
@@ -23,6 +23,18 @@ export const ADDENDUM_COLUMNS = [
  */
 export const NOT_ASSESSED = 'not assessed'
 
+/**
+ * The value stated when a component IS attested but the assessor recorded no level.
+ *
+ * Distinct from NOT_ASSESSED, and the distinction is not cosmetic. A level is optional on an
+ * attestation, and a justification-only attestation is precisely the L1021-1022 case this
+ * document exists to carry -- the assessor looked, could not determine a level, and said
+ * why. The gauge counts those rows as ATTESTED. Printing "not assessed" in the level column
+ * for them produced a document whose table contradicted its own header: "10 components with
+ * a support attestation" above ten rows each saying not assessed.
+ */
+export const LEVEL_NOT_STATED = 'not stated -- see justification'
+
 /** Fully-qualified name: group is part of a component's identity, not decoration. */
 function displayName (c: AddendumComponent): string | null {
     if (c.group && c.name) return `${c.group}:${c.name}`
@@ -43,13 +55,21 @@ function displayName (c: AddendumComponent): string | null {
  */
 export function addendumRow (c: AddendumComponent): unknown[] {
     const live = isLiveAttestation(c)
+    // Two rules at once, and they are separate:
+    //   LEVEL AND JUSTIFICATION ARE ALTERNATIVES (L1021-1022) -- a component with a level
+    //   states it, one without states WHY, and emitting both would suggest the justification
+    //   qualifies the level rather than standing in for it.
+    //   A WITHDRAWN attestation states NOTHING, justification included. It is retracted and
+    //   not injected into exports, and an earlier revision emitted its prose anyway --
+    //   republishing a claim the manufacturer had formally withdrawn, in the one document
+    //   where that matters most.
     return [
         displayName(c),
         c.version,
         c.purl,
-        live ? (c.levelOfSupport || NOT_ASSESSED) : NOT_ASSESSED,
+        live ? (c.levelOfSupport || LEVEL_NOT_STATED) : NOT_ASSESSED,
         live ? c.endOfSupportDate : null,
-        live && c.levelOfSupport ? null : c.justification,
+        live && !c.levelOfSupport ? c.justification : null,
         live ? 'ATTESTED' : (c.attestationState || NOT_ASSESSED),
         live ? c.assessedAt : null
     ]
@@ -95,12 +115,42 @@ export function addendumHeaderRows (d: AddendumData): unknown[][] {
     return rows
 }
 
+/**
+ * Header rows padded to the table's width.
+ *
+ * Excel and LibreOffice tolerate ragged rows, but a strict reader does not -- pandas fails
+ * outright with "Expected 1 fields in line 8, saw 2". A regulatory export that opens by
+ * double-click but not in the tool a reviewer scripts against is half a document, and the
+ * padding is invisible in every viewer.
+ */
+function padded (row: unknown[]): unknown[] {
+    return row.length >= ADDENDUM_COLUMNS.length
+        ? row
+        : [...row, ...Array(ADDENDUM_COLUMNS.length - row.length).fill(null)]
+}
+
+/**
+ * Stable display order, applied HERE rather than in the collector.
+ *
+ * The walk returns cursor (uuid) order, which is effectively random to a reviewer. Sorting
+ * in the renderer keeps the collector free of presentation decisions -- the PDF may well
+ * want a different order (by risk, say) and must not have to undo one imposed upstream.
+ */
+function displayOrder (components: AddendumComponent[]): AddendumComponent[] {
+    return [...components].sort((a, b) => {
+        const an = (displayName(a) || '').toLowerCase()
+        const bn = (displayName(b) || '').toLowerCase()
+        if (an !== bn) return an < bn ? -1 : 1
+        return (a.version || '').localeCompare(b.version || '')
+    })
+}
+
 /** The whole document. */
 export function renderAddendumCsv (d: AddendumData): string {
     return csvDocument([
-        ...addendumHeaderRows(d),
+        ...addendumHeaderRows(d).map(padded),
         ADDENDUM_COLUMNS,
-        ...d.components.map(addendumRow)
+        ...displayOrder(d.components).map(addendumRow)
     ])
 }
 

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -100,7 +100,10 @@ function fakeClient (opts: {
                 throw new Error('boom')
             }
             if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: 'release' in opts ? opts.release : { uuid: 'r1' } } }
-            if (query === ADDENDUM_ORG_QUERY) return { data: { organization: 'org' in opts ? opts.org : { uuid: 'o1' } } }
+            if (query === ADDENDUM_ORG_QUERY) {
+                const o = 'org' in opts ? opts.org : { uuid: 'o1' }
+                return { data: { organizations: o ? [o] : [] } }
+            }
             if (query === ADDENDUM_PAGE_QUERY) {
                 const page = pages.shift()
                 if (page === undefined) throw new Error('walked past the end of the fixture')
@@ -339,6 +342,39 @@ describe('collectAddendumData', () => {
 
     // The org carries three of the four labeling statements; tolerating a null organization
     // would emit a document silently missing what it exists to carry.
+    // REGRESSION: this used organization(orgUuid:), which is declared in the schema but has
+    // NO RESOLVER and always returns null. Nothing static caught it -- the field exists, so
+    // validate-graphql and the drift spec both passed. Only the live probe did, by refusing.
+    it('reads the org from the organizations LIST, which has a resolver', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.orgName).toBe('Acme')
+    })
+
+    it('picks the right org out of a multi-org list', async () => {
+        const client = {
+            query: async ({ query }: any) => {
+                if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: okRelease } }
+                if (query === ADDENDUM_ORG_QUERY) return { data: { organizations: [
+                    { uuid: 'other', name: 'Wrong Org', settings: { fdaAssessmentNarrative: 'wrong' } },
+                    okOrg
+                ] } }
+                if (query === ADDENDUM_PAGE_QUERY) return { data: { getReleaseSbomComponentsPage: { items: [], totalCount: 0, endCursor: null, hasMore: false } } }
+                return { data: { sbomComponentSupportCoverage: { total: 0, attested: 0, supportExportState: 'FULL' } } }
+            }
+        }
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.orgName).toBe('Acme')
+        expect(res.data.narrative).toBe('org words')
+    })
+
     it('REFUSES when the organization cannot be loaded', async () => {
         const client = fakeClient({ release: okRelease, org: null,
             coverage: { total: 0, attested: 0 },

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi } from 'vitest'
+import { resolveNarrative, toAddendumComponent, isLiveAttestation, collectAddendumData,
+    ADDENDUM_PAGE_QUERY, ADDENDUM_RELEASE_QUERY, ADDENDUM_ORG_QUERY } from './addendumData'
+import { BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+
+describe('resolveNarrative', () => {
+    // The seam every document reads through. Reading either stored field directly is the
+    // rework it exists to prevent -- both failure modes produce a plausible document.
+    it('prefers the per-release override', () => {
+        expect(resolveNarrative({ fdaAssessmentNarrative: 'device' }, { fdaAssessmentNarrative: 'org' }))
+            .toEqual({ narrative: 'device', perRelease: true })
+    })
+
+    it('falls back to the org default', () => {
+        expect(resolveNarrative({ fdaAssessmentNarrative: null }, { fdaAssessmentNarrative: 'org' }))
+            .toEqual({ narrative: 'org', perRelease: false })
+    })
+
+    it('treats a blank override as absent, so it cannot shadow a real default', () => {
+        expect(resolveNarrative({ fdaAssessmentNarrative: '   ' }, { fdaAssessmentNarrative: 'org' }))
+            .toEqual({ narrative: 'org', perRelease: false })
+    })
+
+    it('returns null when neither level has one, so callers can refuse to render', () => {
+        expect(resolveNarrative({}, {})).toEqual({ narrative: null, perRelease: false })
+        expect(resolveNarrative(null, null)).toEqual({ narrative: null, perRelease: false })
+    })
+
+    it('reports the SCOPE, which the document states beside the text', () => {
+        expect(resolveNarrative({ fdaAssessmentNarrative: 'x' }, null).perRelease).toBe(true)
+        expect(resolveNarrative(null, { fdaAssessmentNarrative: 'x' }).perRelease).toBe(false)
+    })
+})
+
+describe('toAddendumComponent', () => {
+    it('flattens a page row without rendering anything', () => {
+        expect(toAddendumComponent({
+            sbomComponentUuid: 'sc-1',
+            component: {
+                name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+                canonicalPurl: 'pkg:maven/org.apache/log4j-core@2.14.1',
+                attestationState: 'ATTESTED', attestedLevelOfSupportText: 'actively maintained',
+                endOfSupportDate: '2030-01-01', justification: null, assessedAt: '2026-09-01T00:00:00Z'
+            }
+        })).toEqual({
+            sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+            purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+            levelOfSupport: 'actively maintained', endOfSupportDate: '2030-01-01',
+            justification: null, assessedAt: '2026-09-01T00:00:00Z'
+        })
+    })
+
+    it('normalises blank strings to null so a renderer can tell absent from empty', () => {
+        const c = toAddendumComponent({ component: { name: '  ', justification: '' } })
+        expect(c.name).toBeNull()
+        expect(c.justification).toBeNull()
+    })
+
+    it('survives a row with no component object at all', () => {
+        expect(toAddendumComponent({}).name).toBeNull()
+        expect(toAddendumComponent(null).purl).toBeNull()
+    })
+})
+
+describe('isLiveAttestation', () => {
+    // WITHDRAWN keeps its history but is not injected into exports, so counting it as
+    // assessed would make the addendum disagree with the BOM it accompanies.
+    it('counts ATTESTED only', () => {
+        expect(isLiveAttestation({ attestationState: 'ATTESTED' } as any)).toBe(true)
+        expect(isLiveAttestation({ attestationState: 'WITHDRAWN' } as any)).toBe(false)
+        expect(isLiveAttestation({ attestationState: null } as any)).toBe(false)
+    })
+})
+
+// ---- the walk ----
+
+function componentRow (i: number, state = 'ATTESTED') {
+    return { sbomComponentUuid: `sc-${i}`, component: {
+        name: `c${i}`, version: '1.0.0', canonicalPurl: `pkg:generic/c${i}@1.0.0`,
+        attestationState: state, attestedLevelOfSupportText: 'actively maintained',
+        endOfSupportDate: '2030-01-01', justification: null, assessedAt: '2026-09-01T00:00:00Z'
+    } }
+}
+
+/**
+ * A client that answers each document. `pages` is consumed in order for the paged walk.
+ */
+function fakeClient (opts: {
+    pages?: any[], release?: any, org?: any, coverage?: any, throwOn?: string
+}) {
+    const pages = [...(opts.pages || [])]
+    return {
+        query: vi.fn(async ({ query, variables }: any) => {
+            if (opts.throwOn && query === (({ page: ADDENDUM_PAGE_QUERY, release: ADDENDUM_RELEASE_QUERY,
+                org: ADDENDUM_ORG_QUERY } as any)[opts.throwOn])) {
+                throw new Error('boom')
+            }
+            if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: opts.release ?? { uuid: 'r1' } } }
+            if (query === ADDENDUM_ORG_QUERY) return { data: { organization: opts.org ?? { uuid: 'o1' } } }
+            if (query === ADDENDUM_PAGE_QUERY) {
+                const page = pages.shift()
+                if (page === undefined) throw new Error('walked past the end of the fixture')
+                return { data: { getReleaseSbomComponentsPage: page } }
+            }
+            // the coverage document, reached through loadReleaseSupportCoverage
+            return { data: { sbomComponentSupportCoverage: opts.coverage ?? { total: 0, attested: 0, supportExportState: 'FULL' } } }
+        })
+    }
+}
+
+const okRelease = { uuid: 'r1', version: '1.4.5', eos: '2030-06-30', eol: '2033-01-01',
+    fdaAssessmentNarrative: null, componentDetails: { name: 'Pump', type: 'PRODUCT' } }
+const okOrg = { uuid: 'o1', name: 'Acme', settings: { fdaAssessmentNarrative: 'org words' } }
+
+describe('collectAddendumData', () => {
+    it('collects one page and reports the facts unrendered', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 2, attested: 2 },
+            pages: [{ items: [componentRow(1), componentRow(2)], totalCount: 2, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.components).toHaveLength(2)
+        expect(res.data.deviceEos).toBe('2030-06-30')
+        expect(res.data.deviceEol).toBe('2033-01-01')
+        expect(res.data.narrative).toBe('org words')
+        expect(res.data.narrativeIsPerRelease).toBe(false)
+        expect(res.data.unassessedComponents).toBe(0)
+    })
+
+    it('follows the cursor across pages', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 3, attested: 3 },
+            pages: [
+                { items: [componentRow(1), componentRow(2)], totalCount: 3, endCursor: 'sc-2', hasMore: true },
+                { items: [componentRow(3)], totalCount: 3, endCursor: null, hasMore: false }
+            ]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.components.map(c => c.sbomComponentUuid)).toEqual(['sc-1', 'sc-2', 'sc-3'])
+    })
+
+    it('walks with the same page size the bulk sweep uses', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 1, attested: 1 },
+            pages: [{ items: [componentRow(1)], totalCount: 1, endCursor: null, hasMore: false }]
+        })
+        await collectAddendumData(client as any, 'r1', 'o1')
+        const pageCall = client.query.mock.calls.find((c: any) => c[0].query === ADDENDUM_PAGE_QUERY)
+        expect(pageCall[0].variables.limit).toBe(BULK_WALK_LIMIT)
+    })
+
+    // A truncated addendum is the dangerous output: a document that looks complete and
+    // under-reports how many components are unassessed.
+    it('REFUSES above the sweep ceiling rather than truncating', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: BULK_MAX_IDS + 1, attested: 0 },
+            pages: [{ items: [componentRow(1)], totalCount: BULK_MAX_IDS + 1, endCursor: 'sc-1', hasMore: true }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        if (res.ok) return
+        expect(res.error).toContain(String(BULK_MAX_IDS))
+    })
+
+    it('REFUSES on an empty page that claims more, rather than looping forever', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 5, attested: 0 },
+            pages: [{ items: [], totalCount: 5, endCursor: 'x', hasMore: true }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+    })
+
+    // The counts are what a reviewer actually reads. A document stating a number its own
+    // rows contradict is worse than no document.
+    it('REFUSES when the gauge total and the collected rows disagree', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 9, attested: 1 },
+            pages: [{ items: [componentRow(1)], totalCount: 9, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        if (res.ok) return
+        expect(res.error).toContain('1 rows collected, 9 reported')
+    })
+
+    // A schema-drift error means the server could not serve the support selection. There is
+    // deliberately NO narrower fallback: a degraded document would be missing exactly the
+    // columns the addendum exists to carry, and would look like an unassessed release.
+    it('REFUSES when a query throws, returning no data at all', async () => {
+        const client = fakeClient({ release: okRelease, org: okOrg, coverage: { total: 1, attested: 1 },
+            throwOn: 'page',
+            pages: [{ items: [componentRow(1)], totalCount: 1, endCursor: null, hasMore: false }] })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        expect((res as any).data).toBeUndefined()
+    })
+
+    it('REFUSES when the release cannot be loaded', async () => {
+        const client = fakeClient({ release: null, org: okOrg, coverage: { total: 0, attested: 0 }, pages: [] })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+    })
+
+    it('prefers a per-release narrative and says so', async () => {
+        const client = fakeClient({
+            release: { ...okRelease, fdaAssessmentNarrative: 'device words' },
+            org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.narrative).toBe('device words')
+        expect(res.data.narrativeIsPerRelease).toBe(true)
+    })
+
+    it('reports unassessed as total minus attested, from the gauge', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 2, attested: 1 },
+            pages: [{ items: [componentRow(1), componentRow(2, 'WITHDRAWN')], totalCount: 2, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.unassessedComponents).toBe(1)
+    })
+
+    // PDF-READY: the next PR consumes this unchanged, so nothing here may be CSV-shaped.
+    it('returns raw facts, never rendered text', async () => {
+        const client = fakeClient({
+            release: { ...okRelease, eos: null, eol: null }, org: okOrg,
+            coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.deviceEos).toBeNull()
+        expect(res.data.deviceEol).toBeNull()
+        // No renderer-specific vocabulary may leak into the collected data: 'not declared'
+        // and 'not assessed' are things the CSV SAYS, and a PDF may well word them
+        // differently. If they appear here, the second document inherits a spreadsheet's
+        // phrasing or re-derives them and the two drift.
+        const serialised = JSON.stringify(res.data)
+        expect(serialised).not.toContain('not declared')
+        expect(serialised).not.toContain('not assessed')
+        expect(serialised).not.toContain('\r\n')
+    })
+})

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { resolveNarrative, toAddendumComponent, isLiveAttestation, collectAddendumData,
-    ADDENDUM_PAGE_QUERY, ADDENDUM_RELEASE_QUERY, ADDENDUM_ORG_QUERY } from './addendumData'
-import { BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+    ADDENDUM_PAGE_QUERY, ADDENDUM_RELEASE_QUERY, ADDENDUM_ORG_QUERY,
+    ADDENDUM_MAX_COMPONENTS } from './addendumData'
+import { BULK_WALK_LIMIT } from './useBulkAttest'
 
 describe('resolveNarrative', () => {
     // The seam every document reads through. Reading either stored field directly is the
@@ -39,13 +40,15 @@ describe('toAddendumComponent', () => {
             component: {
                 name: 'log4j-core', group: 'org.apache', version: '2.14.1',
                 canonicalPurl: 'pkg:maven/org.apache/log4j-core@2.14.1',
-                attestationState: 'ATTESTED', attestedLevelOfSupportText: 'actively maintained',
+                attestationState: 'ATTESTED', attestedLevelOfSupport: 'ACTIVELY_MAINTAINED',
+                attestedLevelOfSupportText: 'actively maintained',
                 endOfSupportDate: '2030-01-01', justification: null, assessedAt: '2026-09-01T00:00:00Z'
             }
         })).toEqual({
             sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
             purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
-            levelOfSupport: 'actively maintained', endOfSupportDate: '2030-01-01',
+            levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+            endOfSupportDate: '2030-01-01',
             justification: null, assessedAt: '2026-09-01T00:00:00Z'
         })
     })
@@ -77,7 +80,8 @@ describe('isLiveAttestation', () => {
 function componentRow (i: number, state = 'ATTESTED') {
     return { sbomComponentUuid: `sc-${i}`, component: {
         name: `c${i}`, version: '1.0.0', canonicalPurl: `pkg:generic/c${i}@1.0.0`,
-        attestationState: state, attestedLevelOfSupportText: 'actively maintained',
+        attestationState: state, attestedLevelOfSupport: 'ACTIVELY_MAINTAINED',
+        attestedLevelOfSupportText: 'actively maintained',
         endOfSupportDate: '2030-01-01', justification: null, assessedAt: '2026-09-01T00:00:00Z'
     } }
 }
@@ -95,8 +99,8 @@ function fakeClient (opts: {
                 org: ADDENDUM_ORG_QUERY } as any)[opts.throwOn])) {
                 throw new Error('boom')
             }
-            if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: opts.release ?? { uuid: 'r1' } } }
-            if (query === ADDENDUM_ORG_QUERY) return { data: { organization: opts.org ?? { uuid: 'o1' } } }
+            if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: 'release' in opts ? opts.release : { uuid: 'r1' } } }
+            if (query === ADDENDUM_ORG_QUERY) return { data: { organization: 'org' in opts ? opts.org : { uuid: 'o1' } } }
             if (query === ADDENDUM_PAGE_QUERY) {
                 const page = pages.shift()
                 if (page === undefined) throw new Error('walked past the end of the fixture')
@@ -157,13 +161,13 @@ describe('collectAddendumData', () => {
     // under-reports how many components are unassessed.
     it('REFUSES above the sweep ceiling rather than truncating', async () => {
         const client = fakeClient({
-            release: okRelease, org: okOrg, coverage: { total: BULK_MAX_IDS + 1, attested: 0 },
-            pages: [{ items: [componentRow(1)], totalCount: BULK_MAX_IDS + 1, endCursor: 'sc-1', hasMore: true }]
+            release: okRelease, org: okOrg, coverage: { total: ADDENDUM_MAX_COMPONENTS + 1, attested: 0 },
+            pages: [{ items: [componentRow(1)], totalCount: ADDENDUM_MAX_COMPONENTS + 1, endCursor: 'sc-1', hasMore: true }]
         })
         const res = await collectAddendumData(client as any, 'r1', 'o1')
         expect(res.ok).toBe(false)
         if (res.ok) return
-        expect(res.error).toContain(String(BULK_MAX_IDS))
+        expect(res.error).toContain(String(ADDENDUM_MAX_COMPONENTS))
     })
 
     it('REFUSES on an empty page that claims more, rather than looping forever', async () => {
@@ -250,5 +254,139 @@ describe('collectAddendumData', () => {
         expect(serialised).not.toContain('not declared')
         expect(serialised).not.toContain('not assessed')
         expect(serialised).not.toContain('\r\n')
+    })
+
+    // LAYER 1 HIGH, proved with a throwaway spec before it was fixed: a cursor that does not
+    // advance was walked 200 times, and because the duplicated row count happened to equal
+    // the gauge total, the reconciliation PASSED -- ok:true, a regulatory document listing
+    // one component 200 times. With a non-matching total the same input never terminated at
+    // all: frozen tab, spinner stuck, finally never reached.
+    it('REFUSES a cursor that does not advance, rather than looping', async () => {
+        // DISTINCT rows each time, so the dedupe and empty-page guards do not fire first and
+        // this actually exercises the cursor check.
+        let n = 0
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 200, attested: 200 },
+            pages: Array.from({ length: 50 }, () => ({
+                get items () { return [componentRow(++n)] },
+                totalCount: 200, endCursor: 'same', hasMore: true
+            }))
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        if (res.ok) return
+        expect(res.error).toContain('same page cursor twice')
+    })
+
+    // The identical-rows form of the same failure, which the dedupe catches one guard
+    // earlier. Asserted separately because BOTH inputs must refuse -- before the fix this
+    // one produced ok:true with the same component listed 200 times, because the duplicated
+    // row count happened to equal the gauge total.
+    it('REFUSES a stuck cursor that repeats the same row', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 200, attested: 200 },
+            pages: Array.from({ length: 50 }, () => ({
+                items: [componentRow(1)], totalCount: 200, endCursor: 'same', hasMore: true
+            }))
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+    })
+
+    it('dedupes a component repeated across pages rather than inflating the count', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 2, attested: 2 },
+            pages: [
+                { items: [componentRow(1), componentRow(2)], totalCount: 2, endCursor: 'a', hasMore: true },
+                { items: [componentRow(1)], totalCount: 2, endCursor: null, hasMore: false }
+            ]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.components).toHaveLength(2)
+    })
+
+    // The ceiling now bounds rows actually held, not just the server's self-reported total.
+    it('REFUSES when the rows collected exceed the ceiling regardless of totalCount', async () => {
+        const many = Array.from({ length: 600 }, (_, i) => componentRow(i))
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 1, attested: 1 },
+            pages: Array.from({ length: 12 }, (_, p) => ({
+                items: many.map((r, i) => componentRow(p * 600 + i)),
+                totalCount: 1, endCursor: `cur-${p}`, hasMore: true
+            }))
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        if (res.ok) return
+        expect(res.error).toContain(String(ADDENDUM_MAX_COMPONENTS))
+    })
+
+    // isLiveAttestation reads attestationState; the gauge additionally requires a MANUAL
+    // source. They agree today, and this makes the day they stop agreeing loud.
+    it('REFUSES when the attested count disagrees with the live rows', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 2, attested: 2 },
+            pages: [{ items: [componentRow(1), componentRow(2, 'WITHDRAWN')], totalCount: 2,
+                endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+        if (res.ok) return
+        expect(res.error).toContain('attestation counts do not agree')
+    })
+
+    // The org carries three of the four labeling statements; tolerating a null organization
+    // would emit a document silently missing what it exists to carry.
+    it('REFUSES when the organization cannot be loaded', async () => {
+        const client = fakeClient({ release: okRelease, org: null,
+            coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }] })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+    })
+
+    // A null SETTINGS is different from a null org: nobody has authored the prose yet.
+    it('accepts an organization with no settings authored', async () => {
+        const client = fakeClient({ release: okRelease, org: { uuid: 'o1', name: 'Acme' },
+            coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }] })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.narrative).toBeNull()
+        expect(res.data.patchesMayCeaseStatement).toBeNull()
+    })
+
+    // loadReleaseSupportCoverage throws rather than returning null, so this is the path a
+    // real coverage failure takes.
+    it('REFUSES when the coverage query throws', async () => {
+        const client = {
+            query: async ({ query }: any) => {
+                if (query === ADDENDUM_RELEASE_QUERY) return { data: { release: okRelease } }
+                if (query === ADDENDUM_ORG_QUERY) return { data: { organization: okOrg } }
+                if (query === ADDENDUM_PAGE_QUERY) {
+                    return { data: { getReleaseSbomComponentsPage: { items: [], totalCount: 0, endCursor: null, hasMore: false } } }
+                }
+                return { data: { sbomComponentSupportCoverage: null } }
+            }
+        }
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(false)
+    })
+
+    // PDF-readiness: the FDA text cannot be mapped back to the enum (the schema says so
+    // explicitly), so a renderer wanting to group or style by level needs the token.
+    it('carries the level as an enum token alongside the FDA phrase', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 1, attested: 1 },
+            pages: [{ items: [componentRow(1)], totalCount: 1, endCursor: null, hasMore: false }]
+        })
+        const res = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        if (!res.ok) return
+        expect(res.data.components[0].levelOfSupportEnum).toBe('ACTIVELY_MAINTAINED')
+        expect(res.data.components[0].levelOfSupport).toBe('actively maintained')
     })
 })

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -1,0 +1,289 @@
+// One client-side assembly of everything the FDA documents are made of.
+//
+// DELIBERATELY DOCUMENT-AGNOSTIC. The CSV addendum is the first consumer; the PDF and the
+// Device Support Statement follow and consume this UNCHANGED. That is why nothing here
+// formats, rounds, joins or localises: the moment this module returns a rendered string,
+// the second document either re-derives it from the raw values -- two sources of truth for
+// one regulatory claim -- or inherits a shape chosen for a spreadsheet.
+//
+// The rule for adding to this file: collect FACTS, and let each renderer decide how to say
+// them. `deviceEos` is a date string or null, never "not declared".
+
+import gql from 'graphql-tag'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import { BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+// The counts come from the GAUGE's own loader, not a second copy of its query. The header
+// block states "N of M assessed" and the screen states the same thing; two queries would be
+// two chances for the document to disagree with the page the operator generated it from.
+import { loadReleaseSupportCoverage } from './releaseSupportCoverage'
+
+/**
+ * The per-component selection the addendum needs, built by APPENDING to the fields the
+ * component list already selects.
+ *
+ * Appending rather than text-substituting is the lesson sbomComponentsQuery.ts records in
+ * its own comment: a `.replace()` keyed on an indentation match silently no-ops when the
+ * source is reformatted, and the fields simply stop being requested. Here that would mean
+ * an addendum whose support columns were all blank, which reads exactly like a release
+ * nobody has assessed.
+ */
+const ADDENDUM_COMPONENT_SELECTION = `
+                uuid
+                name
+                group
+                version
+                canonicalPurl
+                attestationState
+                attestedLevelOfSupportText
+                endOfSupportDate
+                justification
+                assessedAt`
+
+export const ADDENDUM_PAGE_QUERY = gql`
+    query getAddendumComponentsPage($releaseUuid: ID!, $limit: Int, $after: ID) {
+        getReleaseSbomComponentsPage(releaseUuid: $releaseUuid, attestation: ALL, limit: $limit, after: $after) {
+            items {
+                uuid
+                sbomComponentUuid
+                component {${ADDENDUM_COMPONENT_SELECTION}
+                }
+            }
+            totalCount
+            endCursor
+            hasMore
+        }
+    }`
+
+export const ADDENDUM_RELEASE_QUERY = gql`
+    query getAddendumRelease($releaseUuid: ID!, $orgUuid: ID) {
+        release(releaseUuid: $releaseUuid, orgUuid: $orgUuid) {
+            uuid
+            version
+            eos
+            eol
+            fdaAssessmentNarrative
+            componentDetails { name type }
+        }
+    }`
+
+export const ADDENDUM_ORG_QUERY = gql`
+    query getAddendumOrg($orgUuid: ID!) {
+        organization(orgUuid: $orgUuid) {
+            uuid
+            name
+            settings {
+                fdaAssessmentNarrative
+                fdaPatchesMayCeaseStatement
+                fdaRiskTransferProcessRef
+                fdaRiskIncreasesNotice
+            }
+        }
+    }`
+
+/** One component's support facts, exactly as stored. No rendering. */
+export interface AddendumComponent {
+    sbomComponentUuid: string | null
+    name: string | null
+    group: string | null
+    version: string | null
+    purl: string | null
+    /** ATTESTED or WITHDRAWN. A WITHDRAWN attestation reads as unassessed, not as a claim. */
+    attestationState: string | null
+    /** FDA's phrase, verbatim and lowercase, or null when no level was attested. */
+    levelOfSupport: string | null
+    endOfSupportDate: string | null
+    justification: string | null
+    assessedAt: string | null
+}
+
+export interface AddendumData {
+    releaseUuid: string
+    releaseVersion: string | null
+    componentName: string | null
+    /**
+     * The two device facts, SEPARATE. End of support and end of sale answer different
+     * questions -- when patching stops, and when selling stops -- and a single "support
+     * window" cell forces a reader to guess which one a lone date is.
+     */
+    deviceEos: string | null
+    deviceEol: string | null
+    /** Resolved through resolveNarrative: release override else org default, else null. */
+    narrative: string | null
+    /** True when the narrative came from the release rather than the org. */
+    narrativeIsPerRelease: boolean
+    orgName: string | null
+    patchesMayCeaseStatement: string | null
+    riskTransferProcessRef: string | null
+    riskIncreasesNotice: string | null
+    /** From the gauge resolver, NOT counted from the rows -- see collectAddendumData. */
+    totalComponents: number
+    attestedComponents: number
+    unassessedComponents: number
+    components: AddendumComponent[]
+    generatedAt: string
+}
+
+export interface AddendumRefusal {
+    ok: false
+    error: string
+}
+
+export type AddendumResult = { ok: true, data: AddendumData } | AddendumRefusal
+
+/**
+ * THE narrative resolution seam, mirroring ReleaseData.resolveFdaAssessmentNarrative on the
+ * server.
+ *
+ * Release override else org default. Every document goes through here rather than reading
+ * either field: a generator reading only the org field silently ignores every override, and
+ * one reading only the release field renders a blank justification section for the
+ * overwhelming majority of releases, which never set one. Both produce a document that looks
+ * complete.
+ *
+ * Blank counts as absent on both sides, matching the server, so a value that somehow got
+ * stored as whitespace does not shadow a real default.
+ */
+export function resolveNarrative (
+    release: { fdaAssessmentNarrative?: string | null } | null | undefined,
+    orgSettings: { fdaAssessmentNarrative?: string | null } | null | undefined
+): { narrative: string | null, perRelease: boolean } {
+    const override = release?.fdaAssessmentNarrative
+    if (override && override.trim()) return { narrative: override, perRelease: true }
+    const orgDefault = orgSettings?.fdaAssessmentNarrative
+    if (orgDefault && orgDefault.trim()) return { narrative: orgDefault, perRelease: false }
+    return { narrative: null, perRelease: false }
+}
+
+function blankToNull (v: unknown): string | null {
+    if (null === v || undefined === v) return null
+    const s = String(v)
+    return s.trim() ? s : null
+}
+
+/** Map one page row to the flat, render-free shape the documents consume. */
+export function toAddendumComponent (row: any): AddendumComponent {
+    const c = row?.component || {}
+    return {
+        sbomComponentUuid: row?.sbomComponentUuid || null,
+        name: blankToNull(c.name),
+        group: blankToNull(c.group),
+        version: blankToNull(c.version),
+        purl: blankToNull(c.canonicalPurl),
+        attestationState: blankToNull(c.attestationState),
+        levelOfSupport: blankToNull(c.attestedLevelOfSupportText),
+        endOfSupportDate: blankToNull(c.endOfSupportDate),
+        justification: blankToNull(c.justification),
+        assessedAt: blankToNull(c.assessedAt)
+    }
+}
+
+/**
+ * True when this component carries a LIVE attestation.
+ *
+ * WITHDRAWN is deliberately not live: a retracted attestation keeps its history but is not
+ * injected into exports, so treating it as assessed here would make the addendum disagree
+ * with the BOM the addendum accompanies.
+ */
+export function isLiveAttestation (c: AddendumComponent): boolean {
+    return c.attestationState === 'ATTESTED'
+}
+
+/**
+ * Walk the WHOLE release scope and assemble every fact the documents need.
+ *
+ * REFUSES rather than returning a partial. A truncated addendum is the dangerous output: it
+ * is a regulatory document that looks complete and under-reports the number of components
+ * whose support status is unknown, which is the single number a reviewer is looking for.
+ * Every refusal path returns no data at all rather than data plus a flag, for the same
+ * reason the bulk sweep does -- a caller who destructures the data and ignores the flag
+ * must not be able to ship a partial document.
+ *
+ * Same walk limit and same ceiling as the bulk sweep, deliberately: they walk the same
+ * scope with the same server, so a release the sweep refuses is one this must refuse too.
+ */
+export async function collectAddendumData (
+    client: DriftFallbackClient,
+    releaseUuid: string,
+    orgUuid: string
+): Promise<AddendumResult> {
+    try {
+        const [releaseResp, orgResp, coverageResp] = await Promise.all([
+            client.query({ query: ADDENDUM_RELEASE_QUERY, variables: { releaseUuid, orgUuid }, fetchPolicy: 'network-only' }),
+            client.query({ query: ADDENDUM_ORG_QUERY, variables: { orgUuid }, fetchPolicy: 'network-only' }),
+            loadReleaseSupportCoverage(client, orgUuid, releaseUuid)
+        ])
+        const release = (releaseResp.data as any)?.release
+        if (!release) return { ok: false, error: 'The release could not be loaded. No addendum was generated.' }
+        const org = (orgResp.data as any)?.organization
+        const coverage = coverageResp
+        if (!coverage) {
+            return { ok: false, error: 'Support coverage could not be loaded, so the assessed and'
+                + ' unassessed counts cannot be stated. No addendum was generated.' }
+        }
+
+        const components: AddendumComponent[] = []
+        let after: string | null = null
+        let totalCount = 0
+        for (;;) {
+            const resp: any = await client.query({
+                query: ADDENDUM_PAGE_QUERY,
+                variables: { releaseUuid, limit: BULK_WALK_LIMIT, after },
+                fetchPolicy: 'network-only'
+            })
+            const page = resp?.data?.getReleaseSbomComponentsPage
+            if (!page) return { ok: false, error: 'The component list could not be loaded. No addendum was generated.' }
+            if (!components.length) totalCount = page.totalCount || 0
+            if (totalCount > BULK_MAX_IDS) {
+                return { ok: false, error: `This release has ${totalCount} components, more than the`
+                    + ` ${BULK_MAX_IDS} a browser-side document will assemble. Generate it from a`
+                    + ' narrower release, or ask for the server-rendered report.' }
+            }
+            const before = components.length
+            for (const row of page.items || []) components.push(toAddendumComponent(row))
+            if (!page.hasMore || !page.endCursor) break
+            // A page that adds nothing while claiming more would loop forever. The current
+            // server cannot do that; the loop must not depend on a server invariant.
+            if (components.length === before) {
+                return { ok: false, error: 'The server returned an empty page while reporting more'
+                    + ' results. The addendum was not generated rather than being truncated.' }
+            }
+            after = page.endCursor
+        }
+
+        // The row count and the gauge must AGREE. They are two reads of the same scope taken
+        // moments apart, so a mismatch means the BOM changed underneath the walk -- and the
+        // resulting document would state a count its own rows contradict. That is worth
+        // refusing over: the counts are the part a reviewer actually reads.
+        if (coverage.total !== components.length) {
+            return { ok: false, error: `The component list changed while the addendum was being`
+                + ` assembled (${components.length} rows collected, ${coverage.total} reported).`
+                + ' No addendum was generated. Try again.' }
+        }
+
+        const settings = org?.settings || null
+        const resolved = resolveNarrative(release, settings)
+        return {
+            ok: true,
+            data: {
+                releaseUuid,
+                releaseVersion: blankToNull(release.version),
+                componentName: blankToNull(release.componentDetails?.name),
+                deviceEos: blankToNull(release.eos),
+                deviceEol: blankToNull(release.eol),
+                narrative: resolved.narrative,
+                narrativeIsPerRelease: resolved.perRelease,
+                orgName: blankToNull(org?.name),
+                patchesMayCeaseStatement: blankToNull(settings?.fdaPatchesMayCeaseStatement),
+                riskTransferProcessRef: blankToNull(settings?.fdaRiskTransferProcessRef),
+                riskIncreasesNotice: blankToNull(settings?.fdaRiskIncreasesNotice),
+                totalComponents: coverage.total,
+                attestedComponents: coverage.attested,
+                unassessedComponents: coverage.total - coverage.attested,
+                components,
+                generatedAt: new Date().toISOString()
+            }
+        }
+    } catch (err: any) {
+        return { ok: false, error: err?.message || String(err) }
+    }
+}

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -11,7 +11,9 @@
 
 import gql from 'graphql-tag'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
-import { BULK_WALK_LIMIT, BULK_MAX_IDS } from './useBulkAttest'
+// PAGE SIZE only. That reuse is uncontroversial: it is one server, one resolver, and the
+// same round-trip economics. The CEILING below is deliberately NOT borrowed -- see it.
+import { BULK_WALK_LIMIT } from './useBulkAttest'
 // The counts come from the GAUGE's own loader, not a second copy of its query. The header
 // block states "N of M assessed" and the screen states the same thing; two queries would be
 // two chances for the document to disagree with the page the operator generated it from.
@@ -34,6 +36,7 @@ const ADDENDUM_COMPONENT_SELECTION = `
                 version
                 canonicalPurl
                 attestationState
+                attestedLevelOfSupport
                 attestedLevelOfSupportText
                 endOfSupportDate
                 justification
@@ -80,6 +83,22 @@ export const ADDENDUM_ORG_QUERY = gql`
         }
     }`
 
+/**
+ * The most components this will assemble into a document.
+ *
+ * Its OWN constant, not the bulk sweep's. An earlier revision borrowed BULK_MAX_IDS and
+ * justified it as "the same scope, so a release the sweep refuses this must refuse too" --
+ * which is simply false. The sweep walks the operator's current FILTER and search; this
+ * always walks `attestation: ALL`. On a 6,000-component release with 4,000 unattested the
+ * sweep proceeds and this refuses, the opposite of what that claim asserted.
+ *
+ * The number bounds a different thing for a different reason: every row is held in memory
+ * and rendered into a single string the browser must also hold. It is set equal to the
+ * sweep's ceiling today because both are "about as much as a browser should be asked to do
+ * in one go", not because either derives from the other.
+ */
+export const ADDENDUM_MAX_COMPONENTS = 5000
+
 /** One component's support facts, exactly as stored. No rendering. */
 export interface AddendumComponent {
     sbomComponentUuid: string | null
@@ -91,6 +110,13 @@ export interface AddendumComponent {
     attestationState: string | null
     /** FDA's phrase, verbatim and lowercase, or null when no level was attested. */
     levelOfSupport: string | null
+    /**
+     * The same claim as an ENUM member. Carried alongside the text because the mapping is
+     * one-way by design -- schema.graphqls warns against reversing text back to the enum --
+     * and a PDF renderer that wants to style or group by level needs the stable token, not
+     * the sentence.
+     */
+    levelOfSupportEnum: string | null
     endOfSupportDate: string | null
     justification: string | null
     assessedAt: string | null
@@ -171,6 +197,7 @@ export function toAddendumComponent (row: any): AddendumComponent {
         purl: blankToNull(c.canonicalPurl),
         attestationState: blankToNull(c.attestationState),
         levelOfSupport: blankToNull(c.attestedLevelOfSupportText),
+        levelOfSupportEnum: blankToNull(c.attestedLevelOfSupport),
         endOfSupportDate: blankToNull(c.endOfSupportDate),
         justification: blankToNull(c.justification),
         assessedAt: blankToNull(c.assessedAt)
@@ -215,13 +242,21 @@ export async function collectAddendumData (
         const release = (releaseResp.data as any)?.release
         if (!release) return { ok: false, error: 'The release could not be loaded. No addendum was generated.' }
         const org = (orgResp.data as any)?.organization
-        const coverage = coverageResp
-        if (!coverage) {
-            return { ok: false, error: 'Support coverage could not be loaded, so the assessed and'
-                + ' unassessed counts cannot be stated. No addendum was generated.' }
+        // Refused, symmetrically with the release above. The org carries three of the four
+        // labeling statements; tolerating a null organization would emit a document that is
+        // silently missing exactly what it exists to carry. A null SETTINGS is different and
+        // is fine -- that just means nobody has authored the prose yet.
+        if (!org) {
+            return { ok: false, error: 'The organization could not be loaded, so the labeling'
+                + ' statements cannot be included. No addendum was generated.' }
         }
+        // loadReleaseSupportCoverage THROWS rather than returning null when the response is
+        // malformed, so there is no null branch to write here -- a coverage failure lands in
+        // the catch below and refuses there.
+        const coverage = coverageResp
 
         const components: AddendumComponent[] = []
+        const seen = new Set<string>()
         let after: string | null = null
         let totalCount = 0
         for (;;) {
@@ -233,19 +268,44 @@ export async function collectAddendumData (
             const page = resp?.data?.getReleaseSbomComponentsPage
             if (!page) return { ok: false, error: 'The component list could not be loaded. No addendum was generated.' }
             if (!components.length) totalCount = page.totalCount || 0
-            if (totalCount > BULK_MAX_IDS) {
+            if (totalCount > ADDENDUM_MAX_COMPONENTS) {
                 return { ok: false, error: `This release has ${totalCount} components, more than the`
-                    + ` ${BULK_MAX_IDS} a browser-side document will assemble. Generate it from a`
+                    + ` ${ADDENDUM_MAX_COMPONENTS} a browser-side document will assemble. Generate it from a`
                     + ' narrower release, or ask for the server-rendered report.' }
             }
             const before = components.length
-            for (const row of page.items || []) components.push(toAddendumComponent(row))
+            for (const row of page.items || []) {
+                const c = toAddendumComponent(row)
+                // Deduped as we go, as the bulk sweep does. A duplicate is not a cosmetic
+                // problem here: a component listed twice inflates the row count, and the
+                // count is what a reviewer reads.
+                if (c.sbomComponentUuid && seen.has(c.sbomComponentUuid)) continue
+                if (c.sbomComponentUuid) seen.add(c.sbomComponentUuid)
+                components.push(c)
+            }
+            // The REAL bound, on rows actually held rather than on the number the server
+            // reported. totalCount is latched from the first page and is the server's own
+            // claim; a walk that keeps yielding rows past it must stop regardless.
+            if (components.length > ADDENDUM_MAX_COMPONENTS) {
+                return { ok: false, error: `This release yielded more than the`
+                    + ` ${ADDENDUM_MAX_COMPONENTS} components a browser-side document will`
+                    + ' assemble. No addendum was generated.' }
+            }
             if (!page.hasMore || !page.endCursor) break
             // A page that adds nothing while claiming more would loop forever. The current
             // server cannot do that; the loop must not depend on a server invariant.
             if (components.length === before) {
                 return { ok: false, error: 'The server returned an empty page while reporting more'
                     + ' results. The addendum was not generated rather than being truncated.' }
+            }
+            // A cursor that does not ADVANCE is the same failure wearing a different mask,
+            // and the empty-page guard above does not catch it: a stuck cursor that keeps
+            // returning the same row appends every time, so the walk runs forever -- or, if
+            // the duplicated total happens to match the gauge, produces a document listing
+            // one component thousands of times that passes every other check here.
+            if (page.endCursor === after) {
+                return { ok: false, error: 'The server returned the same page cursor twice.'
+                    + ' The addendum was not generated rather than looping.' }
             }
             after = page.endCursor
         }
@@ -254,6 +314,18 @@ export async function collectAddendumData (
         // moments apart, so a mismatch means the BOM changed underneath the walk -- and the
         // resulting document would state a count its own rows contradict. That is worth
         // refusing over: the counts are the part a reviewer actually reads.
+        // The ATTESTED count is reconciled as well, and for a sharper reason than the total.
+        // isLiveAttestation reads attestationState; the gauge's numerator additionally
+        // requires a MANUAL assessment source. Those agree today because MANUAL is the only
+        // write path that exists -- the moment a SUPPLIER or ENRICHED writer lands they
+        // diverge, and the document would say "0 attested" above a table showing levels and
+        // dates. Comparing them here makes that divergence refuse instead of print.
+        const liveRows = components.filter(isLiveAttestation).length
+        if (coverage.attested !== liveRows) {
+            return { ok: false, error: `The attestation counts do not agree (${liveRows} rows`
+                + ` carry a live attestation, ${coverage.attested} reported). No addendum was`
+                + ' generated.' }
+        }
         if (coverage.total !== components.length) {
             return { ok: false, error: `The component list changed while the addendum was being`
                 + ` assembled (${components.length} rows collected, ${coverage.total} reported).`

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -69,9 +69,22 @@ export const ADDENDUM_RELEASE_QUERY = gql`
         }
     }`
 
+/**
+ * The ORGANIZATIONS LIST, filtered client-side -- not organization(orgUuid:).
+ *
+ * That single-organization query is declared in the schema but HAS NO RESOLVER and always
+ * returns null; it appears under "Unmapped fields" in the DGS schema report at startup.
+ * graphqlQueries.ts records the same trap in the comment above ORG_DEFAULT_VIEW_GQL, which
+ * is where this should have been read from the first time.
+ *
+ * Nothing static catches it: the field exists, so validate-graphql passes and the schema
+ * drift spec passes. It surfaced only when the live probe refused with "the organization
+ * could not be loaded" -- which is the refusal working exactly as intended, on a bug of ours
+ * rather than a server's.
+ */
 export const ADDENDUM_ORG_QUERY = gql`
-    query getAddendumOrg($orgUuid: ID!) {
-        organization(orgUuid: $orgUuid) {
+    query getAddendumOrg {
+        organizations {
             uuid
             name
             settings {
@@ -236,12 +249,13 @@ export async function collectAddendumData (
     try {
         const [releaseResp, orgResp, coverageResp] = await Promise.all([
             client.query({ query: ADDENDUM_RELEASE_QUERY, variables: { releaseUuid, orgUuid }, fetchPolicy: 'network-only' }),
-            client.query({ query: ADDENDUM_ORG_QUERY, variables: { orgUuid }, fetchPolicy: 'network-only' }),
+            client.query({ query: ADDENDUM_ORG_QUERY, variables: {}, fetchPolicy: 'network-only' }),
             loadReleaseSupportCoverage(client, orgUuid, releaseUuid)
         ])
         const release = (releaseResp.data as any)?.release
         if (!release) return { ok: false, error: 'The release could not be loaded. No addendum was generated.' }
-        const org = (orgResp.data as any)?.organization
+        const orgs = (orgResp.data as any)?.organizations || []
+        const org = orgs.find((o: any) => o?.uuid === orgUuid) || null
         // Refused, symmetrically with the release above. The org carries three of the four
         // labeling statements; tolerating a null organization would emit a document that is
         // silently missing exactly what it exists to carry. A null SETTINGS is different and

--- a/ui/src/utils/addendumSchemaDrift.spec.ts
+++ b/ui/src/utils/addendumSchemaDrift.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
+import { ADDENDUM_PAGE_QUERY, ADDENDUM_RELEASE_QUERY, ADDENDUM_ORG_QUERY } from './addendumData'
+
+/**
+ * The only static validation ADDENDUM_PAGE_QUERY gets.
+ *
+ * Same hole, same feature, as sbomComponentsSchemaDrift.spec.ts one file over:
+ * scripts/validate-graphql.mjs skips any body containing `${` -- and it skips it BEFORE
+ * incrementing its counter, so the document does not even appear in the "N skipped" line.
+ * ADDENDUM_PAGE_QUERY interpolates the component selection, so the script is blind to it.
+ *
+ * What that leaves uncovered: a typo or an unbalanced brace in ADDENDUM_COMPONENT_SELECTION.
+ * The unit specs mock the client, `vite build` sees a template literal, and at runtime it
+ * surfaces as a GraphQL validation error -- which isSchemaDriftError classifies as the
+ * server being out of date. A typo of ours wearing somebody else's outdated backend as a
+ * costume. That has now happened twice on this feature, which is why the sibling file exists
+ * and why this one does.
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+function loadSchema (path: string): GraphQLSchema | null {
+    return existsSync(path) ? buildSchema(readFileSync(path, 'utf8')) : null
+}
+const ceSchema = loadSchema(CE_SCHEMA_PATH)
+const proSchema = loadSchema(PRO_SCHEMA_PATH)
+
+function errorsAgainst (schema: GraphQLSchema, doc: any): string[] {
+    return validate(schema, parse(doc.loc.source.body)).map(e => e.message)
+}
+
+/**
+ * Validated against BOTH schemas: these select only fields CE already carries.
+ *
+ * ADDENDUM_RELEASE_QUERY is deliberately absent -- it selects fdaAssessmentNarrative, which
+ * CE gains at the deferred sync. It is checked against Pro alone below, and the CE gap is
+ * the one drift warning validate-graphql reports. Splitting the list this way keeps the CE
+ * assertion meaningful for the documents that CAN hold it, instead of dropping the check for
+ * all three because one of them is ahead.
+ */
+const CE_AND_PRO: Array<[string, any]> = [
+    ['page', ADDENDUM_PAGE_QUERY],
+    ['org', ADDENDUM_ORG_QUERY]
+]
+const PRO_ONLY: Array<[string, any]> = [
+    ['release', ADDENDUM_RELEASE_QUERY]
+]
+
+describe('the addendum documents', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
+    })
+
+    it.each([...CE_AND_PRO, ...PRO_ONLY])('%s: parses after interpolation', (_name, doc) => {
+        expect(() => parse(doc.loc.source.body)).not.toThrow()
+    })
+
+    it.each(CE_AND_PRO)('%s: validates against the CE schema', (_name, doc) => {
+        expect(errorsAgainst(ceSchema as GraphQLSchema, doc)).toEqual([])
+    })
+
+    /**
+     * runIf, not an early return: an early return reports PASSED when the rearm-core
+     * checkout is absent, which hides that Pro went unchecked.
+     */
+    it.runIf(proSchema).each([...CE_AND_PRO, ...PRO_ONLY])(
+        '%s: validates against the Pro schema', (_name, doc) => {
+            expect(errorsAgainst(proSchema as GraphQLSchema, doc)).toEqual([])
+        })
+
+    /**
+     * The CE gap is an EXPECTED, TEMPORARY state, asserted so it cannot quietly become
+     * permanent: when the deferred sync lands, this test fails and the release query moves
+     * into CE_AND_PRO above.
+     */
+    it.runIf(ceSchema)('release: is still ahead of CE, pending the deferred sync', () => {
+        const errs = errorsAgainst(ceSchema as GraphQLSchema, ADDENDUM_RELEASE_QUERY)
+        expect(errs.join(' ')).toContain('fdaAssessmentNarrative')
+    })
+})

--- a/ui/src/utils/csv.spec.ts
+++ b/ui/src/utils/csv.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { csvCell, csvRow, csvDocument } from './csv'
+
+describe('csvCell', () => {
+    it('leaves a plain value bare', () => {
+        expect(csvCell('log4j-core')).toBe('log4j-core')
+        expect(csvCell(42)).toBe('42')
+    })
+
+    // The distinction the document depends on: an empty EOS cell means no date was
+    // attested. The word "null" in a regulatory table reads as a system fault.
+    it('renders null and undefined as empty, never as the words', () => {
+        expect(csvCell(null)).toBe('')
+        expect(csvCell(undefined)).toBe('')
+    })
+
+    it('quotes a value containing a comma', () => {
+        expect(csvCell('Reliza, Incorporated')).toBe('"Reliza, Incorporated"')
+    })
+
+    // RFC 4180 quote-doubling. Getting this wrong terminates the field early and shifts
+    // every remaining column on the row.
+    it('doubles embedded quotes and wraps the cell', () => {
+        expect(csvCell('he said "maintained"')).toBe('"he said ""maintained"""')
+    })
+
+    it('quotes a value containing a newline, keeping the newline intact', () => {
+        expect(csvCell('line one\nline two')).toBe('"line one\nline two"')
+        expect(csvCell('crlf\r\ninside')).toBe('"crlf\r\ninside"')
+    })
+
+    it('quotes a value with leading or trailing whitespace so it survives a round trip', () => {
+        expect(csvCell('  padded  ')).toBe('"  padded  "')
+    })
+
+    // Formula injection. A justification is free text an operator types, and several
+    // spreadsheets evaluate a leading =/+/-/@ on open -- so the exported evidence would not
+    // say what the record says.
+    it.each([
+        ['=HYPERLINK("http://evil","ok")'],
+        ['+1234'],
+        ['-1+2'],
+        ['@SUM(A1:A9)']
+    ])('neutralises %s with a leading apostrophe', (payload) => {
+        const out = csvCell(payload)
+        expect(out.startsWith("'") || out.startsWith('"\'')).toBe(true)
+        expect(out).toContain("'" + payload[0])
+    })
+
+    it('neutralises a formula that also needs quoting, in that order', () => {
+        expect(csvCell('=A1,B1')).toBe('"\'=A1,B1"')
+    })
+
+    it('does not touch a minus sign that is not leading', () => {
+        expect(csvCell('utf-8')).toBe('utf-8')
+    })
+
+    it('neutralises leading tab and carriage return, which some tools also evaluate', () => {
+        expect(csvCell('\tvalue')).toBe('"\'\tvalue"')
+    })
+})
+
+describe('csvRow', () => {
+    it('joins cells with commas', () => {
+        expect(csvRow(['a', 'b', 'c'])).toBe('a,b,c')
+    })
+
+    it('keeps empty cells positional rather than collapsing them', () => {
+        expect(csvRow(['a', null, 'c'])).toBe('a,,c')
+        expect(csvRow([null, null])).toBe(',')
+    })
+
+    it('escapes each cell independently', () => {
+        expect(csvRow(['plain', 'has,comma', 'has"quote'])).toBe('plain,"has,comma","has""quote"')
+    })
+})
+
+describe('csvDocument', () => {
+    it('separates records with CRLF and ends with one', () => {
+        expect(csvDocument([['a'], ['b']])).toBe('\ufeffa\r\nb\r\n')
+    })
+
+    // Without the BOM, Excel decodes as the system codepage and any non-ASCII component
+    // name or accented justification opens as mojibake.
+    it('starts with a UTF-8 BOM so a double-click open decodes correctly', () => {
+        expect(csvDocument([['a']]).charCodeAt(0)).toBe(0xfeff)
+    })
+
+    // The end-to-end property that matters: a cell with the three hostile characters at once
+    // must survive a naive RFC-4180 parse back to its original value.
+    it('round-trips a cell containing a quote, a comma and a newline', () => {
+        const nasty = 'said "yes", then\nleft'
+        const doc = csvDocument([['before', nasty, 'after']])
+        const body = doc.slice(1, -2)
+        const parsed = parseRfc4180Row(body)
+        expect(parsed).toEqual(['before', nasty, 'after'])
+    })
+})
+
+/** A deliberately naive parser: if the writer only satisfies a lenient reader, it is wrong. */
+function parseRfc4180Row (row: string): string[] {
+    const out: string[] = []
+    let cur = ''
+    let inQuotes = false
+    for (let i = 0; i < row.length; i++) {
+        const c = row[i]
+        if (inQuotes) {
+            if (c === '"') {
+                if (row[i + 1] === '"') { cur += '"'; i++ } else { inQuotes = false }
+            } else cur += c
+        } else if (c === '"') inQuotes = true
+        else if (c === ',') { out.push(cur); cur = '' }
+        else cur += c
+    }
+    out.push(cur)
+    return out
+}

--- a/ui/src/utils/csv.ts
+++ b/ui/src/utils/csv.ts
@@ -1,0 +1,69 @@
+// RFC 4180 CSV rendering.
+//
+// Hand-rolled rather than pulled in: the whole surface is one escaper and one joiner, and
+// the cells here carry operator-authored prose -- up to 8,000 characters of justification
+// with whatever punctuation the author used. A quoting bug in that cell does not produce a
+// visibly broken file, it produces a file that opens with the columns shifted, which on a
+// regulatory document is worse than a crash.
+
+/**
+ * Cells that begin with one of these are prefixed with a single quote before quoting.
+ *
+ * FORMULA INJECTION, and it is not theoretical for this document: a justification field is
+ * free text an operator types, and several spreadsheet applications evaluate a cell starting
+ * with these characters on open. `=HYPERLINK(...)` in a justification would render as a link
+ * rather than as the words the assessor wrote -- so the exported evidence would not say what
+ * the record says.
+ *
+ * The prefix is visible in the cell, which is the correct trade: a leading apostrophe on the
+ * rare cell that starts with an operator is obvious and harmless, while silent evaluation is
+ * neither.
+ */
+const FORMULA_LEADERS = ['=', '+', '-', '@', '\t', '\r']
+
+/** Characters that force quoting. A cell containing any of them cannot be written bare. */
+const MUST_QUOTE = /[",\r\n]/
+
+/**
+ * One cell.
+ *
+ * Null and undefined render as EMPTY, never as the strings "null"/"undefined". That
+ * distinction is the whole point in this document: an empty EOS cell means "no date was
+ * attested", and the word "null" printed in a regulatory table reads as a system fault.
+ */
+export function csvCell (value: unknown): string {
+    if (null === value || undefined === value) return ''
+    const raw = String(value)
+    // Decided from the RAW value, before the apostrophe goes on. Prefixing first would hide
+    // a leading tab behind a non-whitespace character, so the cell would be written bare and
+    // a parser free to strip that tab -- losing a character the operator typed.
+    const needsQuote = MUST_QUOTE.test(raw) || raw !== raw.trim()
+    const s = (raw.length > 0 && FORMULA_LEADERS.includes(raw[0])) ? "'" + raw : raw
+    // Quote-doubling, per RFC 4180: a literal " inside a quoted field is written "".
+    if (needsQuote) return '"' + s.replace(/"/g, '""') + '"'
+    return s
+}
+
+/** One record. */
+export function csvRow (cells: unknown[]): string {
+    return cells.map(csvCell).join(',')
+}
+
+/**
+ * A whole document.
+ *
+ * CRLF line endings, which RFC 4180 specifies and which Excel on Windows needs to avoid
+ * running the file together into one row.
+ *
+ * A UTF-8 BOM is prepended. Without it Excel decodes the file as the system codepage, so a
+ * component named with anything outside ASCII -- or a justification written in any language
+ * that needs accents -- opens as mojibake. The BOM is invisible in every tool that matters
+ * and is what makes the file open correctly by double-click, which is how it will be opened.
+ */
+export function csvDocument (rows: unknown[][]): string {
+    // Escaped, never a literal U+FEFF in the source: the CI invisible-character check
+    // hard-fails the build (exit 123) BEFORE maven runs, and a BOM is exactly the kind of
+    // character it exists to catch. It is also unreviewable as a literal -- it renders as
+    // nothing in a diff.
+    return '\ufeff' + rows.map(csvRow).join('\r\n') + '\r\n'
+}


### PR DESCRIPTION
Step 4b. Pairs with rearm-saas#500, which adds the per-release narrative and the resolution
seam this reads through.

## Why the browser renders it

The PDF and the Device Support Statement are frontend-rendered by the plan, so **one
client-side assembly feeds all three documents**. A backend-rendered CSV would be a second
source of truth for the same document -- two codebases computing "how many components have
no attestation".

It also could not have reused the existing CSV path even if we wanted to: that proxies to
the separate **rebom** service (`ReleaseService.java:879`), which only ever sees the merged
BOM -- and the strip work guarantees that document carries no support properties at all
(matrix EGRESS 4 asserts "CSV carries no reliza properties"). The addendum is made entirely
of facts rebom cannot see.

## The collector is deliberately document-agnostic

`addendumData.ts` returns FACTS, never rendered text. `deviceEos` is a date string or null,
never `"not declared"` -- that phrase is something the CSV *says*, and a PDF may word it
differently. A spec asserts no renderer vocabulary leaks into the collected data, so the
next PR inherits raw values rather than a spreadsheet's phrasing. **The next PR consumes
this unchanged.**

## It refuses rather than truncating

A partial addendum is the dangerous output: a regulatory document that looks complete while
under-reporting how many components have no support attestation -- the one number a reviewer
is looking for. Every refusal returns **no data at all** rather than data plus a flag, the
same rule the bulk sweep follows, so a caller cannot destructure past the flag.

It refuses above the sweep's ceiling, on an empty page that claims more, on a query failure,
and when the collected row count disagrees with the gauge. That last one matters: they are
two reads of the same scope moments apart, so a mismatch means the BOM changed underneath
the walk and the document would state a count its own rows contradict.

**No narrower fallback, deliberately.** A degraded document would be missing exactly the
columns the addendum exists to carry, and would read as an unassessed release. Same walk
limit and ceiling as bulk attest -- same scope, same server, so a release the sweep refuses
this must refuse too. Counts come from the gauge's own loader, not a second copy of its
query, so the document and the page cannot disagree.

## The CSV writer

Hand-rolled rather than a dependency: the surface is one escaper, and the cells carry up to
8,000 characters of operator prose. RFC 4180 quote-doubling, embedded newlines, CRLF, and
`=`/`+`/`-`/`@` neutralised -- formula injection is not theoretical when the cell is free
text an operator typed, and a justification that renders as a hyperlink means the exported
evidence does not say what the record says.

**Three revert-probes**: dropping quote-doubling fails 3, dropping neutralisation fails 6,
narrowing the quote trigger fails 4. The round-trip test parses with a deliberately naive
RFC-4180 reader, because a writer that only satisfies a lenient parser is wrong.

## Document decisions worth reviewing

- **Level and justification are alternatives**, per L1021-1022 -- the justification exists
  *because* there is no level to give, so emitting both would suggest it qualifies the level.
- **WITHDRAWN reads as not assessed** and its stale dates are suppressed: a withdrawn
  attestation is not injected into exports, so counting it would make the addendum disagree
  with the BOM it accompanies.
- **Absent facts say "not assessed"**, not a blank cell -- blank reads as something the
  exporter forgot rather than as "we looked and have nothing recorded".
- **Device EOS and EOL are two separate labelled facts.** One merged "support window" line
  forces the reader to guess which a lone date is.

## The BOM would have hard-failed CI

`csvDocument` prepends a UTF-8 BOM so Excel decodes the file on a double-click open --
without it any non-ASCII component name opens as mojibake. It was a **literal U+FEFF in the
source** until the ASCII sweep caught it: exactly the invisible character the CI check exits
123 on, before maven runs. Escaped to `'﻿'`, with the reason in a comment so it does
not come back.

## Checks

- **516 tests / 39 files** (was 448/35). Build clean.
- **One CE drift warning, expected and unfixed by design**: the release query selects
  `fdaAssessmentNarrative`, which CE gains at the deferred sync. Per the ruling drift is
  informational and there is deliberately no fallback.
- Zero non-ASCII bytes added.
- `addendumExportWiring.spec.ts` continues the `*Wiring.spec.ts` pattern -- no vue-tsc here,
  and on the previous PR that cost a working feature while build, tests and eslint were all
  green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>