### PR TITLE
feat(landing): pricing users wording, Book Demo CTA, DevOps/BYOC, SBOM Aggregation and VEX use cases

### DIFF
--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -483,8 +483,7 @@
         "Pinned Composition",
         "Aggregated SBOM"
       ],
-      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS",
-      "stepsLabel": "HOW PRODUCT SECURITY TEAMS USE ReARM FOR THIS"
+      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS"
     },
     {
       "id": "3f",

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -526,7 +526,7 @@
       "path": "/use-cases/deployment-governance",
       "label": "Deployment Governance, DevOps, BYOC",
       "persona": "FOR PLATFORM + DEVOPS TEAMS, AND VENDORS SHIPPING INTO CUSTOMER CLOUDS",
-      "h1": "Your software, their cloud. ReARM decides what runs there.",
+      "h1": "DevOps, BYOC, Air-Gap at Scale.",
       "pain": "Bring Your Own Cloud means your product runs on infrastructure you do not operate: a customer's VPC, a partner's cluster, an air-gapped site. CI cannot push there, and once it ships nobody can say which version is live. ReARM holds the plan; ReARM CD inside each cluster pulls it, applies it, and reports back.",
       "a1": "rgba(240,138,75,0.10)",
       "a2": "rgba(244,176,75,0.10)",

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -71,6 +71,12 @@
       "c2": "#5EEBC3"
     },
     {
+      "q": "Drowning in CVEs that don't apply?",
+      "name": "VEX Exploitability eXchange",
+      "c1": "#C86CD8",
+      "c2": "#5B7CFA"
+    },
+    {
       "q": "Shipping a regulated medical device?",
       "name": "Medical Devices",
       "c1": "#5EEBC3",
@@ -484,6 +490,64 @@
         "Aggregated SBOM"
       ],
       "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS"
+    },
+    {
+      "label": "VEX Exploitability eXchange",
+      "path": "/use-cases/vex-exploitability-exchange",
+      "persona": "FOR PRODUCT SECURITY TEAMS RECEIVING AND ISSUING VEX",
+      "h1": "Vendor said \"not affected\". Prove it, apply it, and pass it on.",
+      "pain": "Scanners flag thousands of CVEs; most do not apply to how the code is actually used. Vendors send VEX documents saying so, your own reviews produce more, and the decisions end up in tickets and spreadsheets where nobody can trace who decided what, for which version, on what evidence.",
+      "steps": [
+        {
+          "num": "01",
+          "title": "VEX is just another artifact",
+          "cap": "SBOM/XBOM Management",
+          "body": "Attach a CycloneDX-VEX or OpenVEX document to a release from the UI, the CLI or your pipeline. ReARM matches every statement against the release's SBOM inventory, so a claim only lands where the affected component actually is."
+        },
+        {
+          "num": "02",
+          "title": "Trust depends on who is talking",
+          "cap": "Findings Aggregation",
+          "body": "A vendor's \"exploitable\" is accepted at once; a vendor's \"not affected\" is staged for your review, because that is where downplaying happens. Your own analyses auto-accept; third-party claims always wait. Import mode and issuer trust compose, and the least permissive wins."
+        },
+        {
+          "num": "03",
+          "title": "One decision, the right scope",
+          "cap": "Findings Aggregation",
+          "body": "A claim can apply to one release, a branch, a whole component, or the entire portfolio. ReARM records it once at the scope you choose, and stages any claim that contradicts an existing broader decision for review instead of silently overriding it."
+        },
+        {
+          "num": "04",
+          "title": "Conditional claims wait for evidence",
+          "cap": "Release Policies",
+          "body": "\"Not affected, protected at perimeter\" is only true while the perimeter holds. ReARM defers such decisions until someone attests the mitigation is in place, with the evidence recorded; waive it and the decision is never written."
+        },
+        {
+          "num": "05",
+          "title": "Review with the original in view",
+          "cap": "Audit Evidence",
+          "body": "Every staged statement is reviewed next to the verbatim VEX it came from and any existing analysis it would touch. Accept, modify, or reject with a required comment; who decided what, and when, stays on record."
+        },
+        {
+          "num": "06",
+          "title": "Export VEX for your customers",
+          "cap": "Distribution",
+          "body": "Your decisions re-emit as CycloneDX-VEX or OpenVEX per release, so the VEX you ship downstream carries the same provenance you demanded upstream, and survives a round trip."
+        }
+      ],
+      "note": false,
+      "shot": false,
+      "a1": "rgba(200,108,216,0.10)",
+      "a2": "rgba(91,124,250,0.10)",
+      "id": "3d",
+      "href": "#3d",
+      "publicDemo": true,
+      "stripLabel": "EVIDENCE",
+      "strip": [
+        "CycloneDX-VEX · OpenVEX",
+        "Trust Gate"
+      ],
+      "evidence": "VEX IMPORT · TRUST GATE · SCOPED ANALYSIS · MITIGATION ATTESTATIONS · VEX EXPORT"
     },
     {
       "id": "3f",

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -672,7 +672,7 @@
     {
       "name": "Enterprise",
       "price": "$75",
-      "unit": "/write user/mo",
+      "unit": "/user/mo",
       "border": "#E3E5EC",
       "bg": "#fff",
       "popular": false,

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -432,13 +432,13 @@
       "path": "/use-cases/sbom-aggregation",
       "persona": "FOR PRODUCT SECURITY + ENGINEERING TEAMS SHIPPING MULTI-COMPONENT PRODUCTS",
       "h1": "One SBOM per product version, assembled from what actually shipped.",
-      "pain": "A product is dozens of components, each with its own repository, pipeline and SBOM. The customer asks for one SBOM for the version they received. Stitching it together by hand means guessing which component versions went into that release, and guessing wrong.",
+      "pain": "A product is dozens of components, each with its own repository, pipeline and SBOM. The customer asks for one SBOM for the version they received. Stitching it together by hand means guessing which component versions went into that release.",
       "steps": [
         {
           "num": "01",
           "title": "Component releases arrive from CI",
           "cap": "SBOM/XBOM Management",
-          "body": "Every pipeline run creates a component release in ReARM and attaches the SBOM it produced. Nothing to collect later: the SBOM is recorded at build time, against the exact version it describes."
+          "body": "Every pipeline run creates a component release in ReARM and attaches the SBOMs it produced. Nothing to collect later: the SBOMs are recorded at build time, against the exact version they describe."
         },
         {
           "num": "02",
@@ -462,7 +462,7 @@
           "num": "05",
           "title": "Delivered with the product",
           "cap": "Distribution",
-          "body": "Aggregated SBOMs are ready to be served downstream, so each customer can receive the SBOM for the version they run, and the versions before it."
+          "body": "Aggregated SBOMs are ready to be served downstream, so each customer can receive the SBOM for each version they run."
         },
         {
           "num": "06",
@@ -483,7 +483,8 @@
         "Pinned Composition",
         "Aggregated SBOM"
       ],
-      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS"
+      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS",
+      "stepsLabel": "HOW PRODUCT SECURITY TEAMS USE ReARM FOR THIS"
     },
     {
       "id": "3f",

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -78,7 +78,7 @@
     },
     {
       "q": "Need to know what's actually running?",
-      "name": "Deployment Governance",
+      "name": "Deployment Governance, DevOps, BYOC",
       "c1": "#F08A4B",
       "c2": "#F4B04B"
     },
@@ -104,7 +104,7 @@
     },
     {
       "q": "What exactly is deployed in production right now?",
-      "page": "Deployment Governance"
+      "page": "Deployment Governance, DevOps, BYOC"
     },
     {
       "q": "Which of our code did agents write, and under what approval?",
@@ -524,10 +524,10 @@
       "id": "3h",
       "href": "#3h",
       "path": "/use-cases/deployment-governance",
-      "label": "Deployment Governance",
-      "persona": "FOR PLATFORM + DEVOPS LEADS",
-      "h1": "What should be running, what is actually running, and the delta.",
-      "pain": "Release records say what was approved. Nobody can prove what is deployed where right now. ReARM closes the loop between plan and actual.",
+      "label": "Deployment Governance, DevOps, BYOC",
+      "persona": "FOR PLATFORM + DEVOPS TEAMS, AND VENDORS SHIPPING INTO CUSTOMER CLOUDS",
+      "h1": "Your software, their cloud. ReARM decides what runs there.",
+      "pain": "Bring Your Own Cloud means your product runs on infrastructure you do not operate: a customer's VPC, a partner's cluster, an air-gapped site. CI cannot push there, and once it ships nobody can say which version is live. ReARM holds the plan; ReARM CD inside each cluster pulls it, applies it, and reports back.",
       "a1": "rgba(240,138,75,0.10)",
       "a2": "rgba(244,176,75,0.10)",
       "stripLabel": "EVIDENCE",
@@ -538,43 +538,49 @@
       "evidence": "INSTANCES · ENVIRONMENTS · FEATURE-SET TARGETING · RUNTIME EVIDENCE",
       "publicDemo": true,
       "shot": "[ SCREENSHOT 8: instances page, plan vs actual side by side ]",
-      "note": false,
+      "note": "Instances, secrets, feature-set deploys and ReARM CD control are part of ReARM Pro.",
       "steps": [
         {
           "num": "01",
-          "title": "Instances and environments registered",
-          "body": "Every instance and environment is a first-class object in ReARM, not a spreadsheet row.",
-          "cap": "Deployment Model"
+          "title": "Each target is an instance",
+          "cap": "Deployment Model",
+          "body": "Every cluster, namespace or site you deploy into is registered as an instance in ReARM, grouped into clusters, with its own secrets and configuration. Customer infrastructure becomes a first-class object in ReARM."
         },
         {
           "num": "02",
-          "title": "Plan vs actual, continuously reconciled",
-          "body": "Approved and expected state vs observed state, resolved side by side and kept current.",
-          "cap": "Reconciliation"
+          "title": "Ship by pointing, not pushing",
+          "cap": "Feature Sets",
+          "body": "A feature set pins the exact component and product releases that ship together. Point an instance at it and ReARM records the target. Nothing is pushed from CI, and no CI credentials ever reach the customer's cloud."
         },
         {
           "num": "03",
-          "title": "Drift surfaced immediately",
-          "body": "The moment actual diverges from plan, it is visible. No quarterly audits to find out.",
-          "cap": "Drift Detection"
+          "title": "ReARM CD pulls it in",
+          "cap": "ReARM CD",
+          "body": "A small open-source agent installed in the customer's cluster connects outbound to ReARM, watches the instance's target, reconciles the running workloads to match, and reports what actually landed. Sensitive configuration is transmitted securely: encrypted for that cluster alone, so only it can open it."
         },
         {
           "num": "04",
-          "title": "Feature-set targeting",
-          "body": "Point an instance at a feature set; ReARM reconciles what should land there. Your CI/CD queries ReARM for the latest release that passed all required approval gates and promotes only that version. No approved status in ReARM, no deployment.",
-          "cap": "Feature Sets"
+          "title": "Promotion follows approvals",
+          "cap": "Release Policies",
+          "body": "Which releases each environment takes is configurable per environment: for example, test instances take every release while staging and production take only releases that passed the approval gates you define. Promotion is a change of target in ReARM, and rollback is the previous feature set."
         },
         {
           "num": "05",
-          "title": "Evidence, extended to runtime",
-          "body": "The same evidence trail that covers releases now covers what actually runs.",
-          "cap": "Audit Evidence"
+          "title": "Plan versus actual, per instance or per customer",
+          "cap": "Drift Detection",
+          "body": "Every instance shows expected against observed state side by side. When a cluster drifts, a manual hotfix or a failed rollout, it is visible immediately, not at the next support call."
         },
         {
           "num": "06",
-          "title": "ReARM CD closes the loop",
-          "body": "ReARM CD, the open-source deployment controller, pulls each instance's expected state from ReARM, applies it, and reports back what actually landed. The reconcile loop that keeps plan and actual honest.",
-          "cap": "ReARM CD"
+          "title": "Evidence follows the deployment",
+          "cap": "Audit Evidence",
+          "body": "What was approved, what was targeted, what ran and when, per instance, in one immutable history. The SBOM, findings and approvals attached to a release travel with it into the deployment record."
+        },
+        {
+          "num": "07",
+          "title": "Air-gapped sites",
+          "cap": "Distribution",
+          "body": "Where nothing can connect, the release goes out instead of the agent coming in. The CLI resolves which release an environment is cleared for under your approvals, packages it with its artifacts and evidence as a bundle you carry across the gap, and ReARM records the transfer against the site, as a distribution target or a placeholder instance, so what landed there is still on record."
         }
       ],
       "img": "/screenshots/19-instance-page.png"

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -65,6 +65,12 @@
   ],
   "useCasePanels": [
     {
+      "q": "Shipping products made of many components?",
+      "name": "SBOM Aggregation",
+      "c1": "#7B6CF6",
+      "c2": "#5EEBC3"
+    },
+    {
       "q": "Shipping a regulated medical device?",
       "name": "Medical Devices",
       "c1": "#5EEBC3",
@@ -421,6 +427,64 @@
     }
   ],
   "ucPages": [
+    {
+      "label": "SBOM Aggregation",
+      "path": "/use-cases/sbom-aggregation",
+      "persona": "FOR PRODUCT SECURITY + ENGINEERING TEAMS SHIPPING MULTI-COMPONENT PRODUCTS",
+      "h1": "One SBOM per product version, assembled from what actually shipped.",
+      "pain": "A product is dozens of components, each with its own repository, pipeline and SBOM. The customer asks for one SBOM for the version they received. Stitching it together by hand means guessing which component versions went into that release, and guessing wrong.",
+      "steps": [
+        {
+          "num": "01",
+          "title": "Component releases arrive from CI",
+          "cap": "SBOM/XBOM Management",
+          "body": "Every pipeline run creates a component release in ReARM and attaches the SBOM it produced. Nothing to collect later: the SBOM is recorded at build time, against the exact version it describes."
+        },
+        {
+          "num": "02",
+          "title": "Products are assembled by rules",
+          "cap": "Feature Sets",
+          "body": "A product's feature set defines which component branches belong to it. Rules decide when a new component release rolls into a new product release, automatically or after approval. No one maintains a version matrix by hand."
+        },
+        {
+          "num": "03",
+          "title": "Every product release is pinned",
+          "cap": "Feature Sets",
+          "body": "Each product release records the exact component releases it contains. Ask ReARM what went into product version 3.2.1 and the answer is a list of pinned versions, not a best guess from dates."
+        },
+        {
+          "num": "04",
+          "title": "Aggregated SBOM on demand",
+          "cap": "SBOM/XBOM Management",
+          "body": "For any product release, ReARM merges the component SBOMs into one product SBOM: one document that covers everything shipped in that version, ready to hand to a customer, a regulator or a scanner."
+        },
+        {
+          "num": "05",
+          "title": "Delivered with the product",
+          "cap": "Distribution",
+          "body": "Aggregated SBOMs are ready to be served downstream, so each customer can receive the SBOM for the version they run, and the versions before it."
+        },
+        {
+          "num": "06",
+          "title": "Findings follow the aggregate",
+          "cap": "Findings Aggregation",
+          "body": "New vulnerabilities are evaluated against every component pinned in every shipped product version, so a finding in one library maps straight to the product versions and customers it affects."
+        }
+      ],
+      "note": false,
+      "shot": false,
+      "a1": "rgba(123,108,246,0.10)",
+      "a2": "rgba(94,235,195,0.10)",
+      "id": "3e",
+      "href": "#3e",
+      "publicDemo": true,
+      "stripLabel": "EVIDENCE",
+      "strip": [
+        "Pinned Composition",
+        "Aggregated SBOM"
+      ],
+      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS"
+    },
     {
       "id": "3f",
       "href": "#3f",

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -22,7 +22,7 @@ export const productNav = [
 export const useCaseNav = [
   { label: 'Medical Devices', href: '/use-cases/medical-devices/' },
   { label: 'Field Digital Twin', href: '/use-cases/field-digital-twin/' },
-  { label: 'Deployment Governance', href: '/use-cases/deployment-governance/' },
+  { label: 'Deployment Governance, DevOps, BYOC', href: '/use-cases/deployment-governance/' },
   { label: 'EU CRA Compliance', href: '/use-cases/eu-cra/' },
 ];
 
@@ -35,6 +35,7 @@ export const pageHrefs: Record<string, string> = {
   'Medical Devices': '/use-cases/medical-devices/',
   'Field Digital Twin': '/use-cases/field-digital-twin/',
   'Deployment Governance': '/use-cases/deployment-governance/',
+  'Deployment Governance, DevOps, BYOC': '/use-cases/deployment-governance/',
   'EU CRA': '/use-cases/eu-cra/',
   'EU CRA Compliance': '/use-cases/eu-cra/',
   Pricing: '/pricing/',

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -54,6 +54,7 @@ export type UcPage = {
   id: string; path: string; label: string; persona: string; h1: string; pain: string;
   a1: string; a2: string; stripLabel: string; strip: string[]; evidence: string;
   publicDemo: boolean; shot: string | false; note: string | false; steps: UcStep[];
+  stepsLabel?: string;
 };
 
 export const levels = design.levels as string[];

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -20,6 +20,7 @@ export const productNav = [
 ];
 
 export const useCaseNav = [
+  { label: 'SBOM Aggregation', href: '/use-cases/sbom-aggregation/' },
   { label: 'Medical Devices', href: '/use-cases/medical-devices/' },
   { label: 'Field Digital Twin', href: '/use-cases/field-digital-twin/' },
   { label: 'Deployment Governance, DevOps, BYOC', href: '/use-cases/deployment-governance/' },
@@ -32,6 +33,7 @@ export const pageHrefs: Record<string, string> = {
   'Findings Aggregation': '/product/findings-aggregation/',
   'Release Policies': '/product/release-policies/',
   'AI Governance': '/product/ai-governance/',
+  'SBOM Aggregation': '/use-cases/sbom-aggregation/',
   'Medical Devices': '/use-cases/medical-devices/',
   'Field Digital Twin': '/use-cases/field-digital-twin/',
   'Deployment Governance': '/use-cases/deployment-governance/',

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -54,7 +54,6 @@ export type UcPage = {
   id: string; path: string; label: string; persona: string; h1: string; pain: string;
   a1: string; a2: string; stripLabel: string; strip: string[]; evidence: string;
   publicDemo: boolean; shot: string | false; note: string | false; steps: UcStep[];
-  stepsLabel?: string;
 };
 
 export const levels = design.levels as string[];

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -21,6 +21,7 @@ export const productNav = [
 
 export const useCaseNav = [
   { label: 'SBOM Aggregation', href: '/use-cases/sbom-aggregation/' },
+  { label: 'VEX Exploitability eXchange', href: '/use-cases/vex-exploitability-exchange/' },
   { label: 'Medical Devices', href: '/use-cases/medical-devices/' },
   { label: 'Field Digital Twin', href: '/use-cases/field-digital-twin/' },
   { label: 'Deployment Governance, DevOps, BYOC', href: '/use-cases/deployment-governance/' },
@@ -34,6 +35,7 @@ export const pageHrefs: Record<string, string> = {
   'Release Policies': '/product/release-policies/',
   'AI Governance': '/product/ai-governance/',
   'SBOM Aggregation': '/use-cases/sbom-aggregation/',
+  'VEX Exploitability eXchange': '/use-cases/vex-exploitability-exchange/',
   'Medical Devices': '/use-cases/medical-devices/',
   'Field Digital Twin': '/use-cases/field-digital-twin/',
   'Deployment Governance': '/use-cases/deployment-governance/',

--- a/landing_site/src/pages/pricing-faq.astro
+++ b/landing_site/src/pages/pricing-faq.astro
@@ -10,18 +10,17 @@ const faqs: { question: string; answer: string[]; link?: { text: string; href: s
   {
     question: 'How is the number of users calculated?',
     answer: [
-      'Each paid seat corresponds to one write user - someone who can create, modify, or manage releases, components, artifacts, and settings within ReARM.',
-      'For ReARM Pro Starter plan, for every 3 write users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes.',
-      'For ReARM Pro Standard and Enterprise plans, for every 2 write users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes.',
-      'For example, on Standard or Enterprise, if you purchase a plan for 20 write users, you get up to 10 additional read-only users (30 total).',
+      'Each paid seat corresponds to one user - someone who can create, modify, or manage releases, components, artifacts, and settings within ReARM.',
+      'On ReARM Pro Standard and Enterprise plans, for every 2 users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes. The Starter plan does not include additional read-only users.',
+      'For example, on Standard or Enterprise, if you purchase a plan for 20 users, you get up to 10 additional read-only users (30 total).',
     ],
   },
   {
-    question: 'How many write user licenses do I need?',
+    question: 'How many user licenses do I need?',
     answer: [
-      'We recommend a write user license for every member of your cyber security organization, leads and managers in the development organization, and senior leaders in marketing, product management, and business management.',
-      'A good rule of thumb: anyone who approves releases should have a write license.',
-      'While this depends heavily on your organizational structure, in practice about 1 in every 15-20 employees across the entire organization needs a write license. For a 1000-person organization, 50-70 write licenses is usually adequate.',
+      'We recommend a user license for every member of your cyber security organization, leads and managers in the development organization, and senior leaders in marketing, product management, and business management.',
+      'A good rule of thumb: anyone who approves releases should have a license.',
+      'While this depends heavily on your organizational structure, in practice about 1 in every 15-20 employees across the entire organization needs a license. For a 1000-person organization, 50-70 licenses is usually adequate.',
     ],
   },
   {

--- a/landing_site/src/pages/pricing.astro
+++ b/landing_site/src/pages/pricing.astro
@@ -1,6 +1,6 @@
 ---
 // Full functional port of the current site's pricing: regional pricing with
-// timezone detection + localStorage persistence, write-user selectors with
+// timezone detection + localStorage persistence, user selectors with
 // live price calculation, real tier features with tooltips. Styled per the
 // 2026 design (clipped buttons, POPULAR badge, square corners).
 import Base from '../layouts/Base.astro';
@@ -99,10 +99,10 @@ const tooltipFor = (b: string) =>
         <h3>ReARM Pro - Starter</h3>
         <div class="price"><span class="amount" id="starter-price">$195</span><span class="unit">Per Month</span></div>
         <div class="selector">
-          <label for="starter-users">Number of write users (1-14):</label>
+          <label for="starter-users">1-14 users:</label>
           <div class="selector-row">
             <input type="number" id="starter-users" min="1" max="14" value="1" />
-            <input type="range" id="starter-range" min="1" max="14" value="1" aria-label="Starter write users" />
+            <input type="range" id="starter-range" min="1" max="14" value="1" aria-label="Starter users" />
           </div>
         </div>
         <ul>
@@ -122,10 +122,10 @@ const tooltipFor = (b: string) =>
         <h3>ReARM Pro - Standard</h3>
         <div class="price"><span class="amount" id="standard-price">$1,350</span><span class="unit">Per Month</span></div>
         <div class="selector">
-          <label for="standard-users">Number of write users (15-39):</label>
+          <label for="standard-users">15-39 users:</label>
           <div class="selector-row">
             <input type="number" id="standard-users" min="15" max="39" value="15" />
-            <input type="range" id="standard-range" min="15" max="39" value="15" aria-label="Standard write users" />
+            <input type="range" id="standard-range" min="15" max="39" value="15" aria-label="Standard users" />
           </div>
         </div>
         <ul>
@@ -142,8 +142,8 @@ const tooltipFor = (b: string) =>
       <!-- Enterprise -->
       <div class="tier">
         <h3>ReARM Pro - Enterprise</h3>
-        <div class="price"><span class="amount" id="enterprise-price">$75</span><span class="unit">per write user per month</span></div>
-        <div class="selector"><span class="selector-note">40+ write users</span></div>
+        <div class="price"><span class="amount" id="enterprise-price">$75</span><span class="unit">per user per month</span></div>
+        <div class="selector"><span class="selector-note">40+ users</span></div>
         <ul>
           {enterpriseBullets.map((b) => (
             <li>
@@ -158,8 +158,8 @@ const tooltipFor = (b: string) =>
 
     <div class="container">
       <p class="tiers-note">
-        Each paid seat is one write user. Read-only users are included at no extra cost (1 per 3 write
-        users on Starter; 1 per 2 on Standard and Enterprise). Details in the <a href="/pricing-faq/">Pricing FAQ</a>.
+        Each paid seat is one user. On Standard and Enterprise, one additional read-only user is included
+        at no extra cost for every 2 users. Details in the <a href="/pricing-faq/">Pricing FAQ</a>.
       </p>
     </div>
   </section>

--- a/landing_site/src/pages/pricing.astro
+++ b/landing_site/src/pages/pricing.astro
@@ -113,7 +113,7 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--navy" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--navy" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
 
       <!-- Standard -->
@@ -136,7 +136,7 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--orange" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--orange" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
 
       <!-- Enterprise -->
@@ -152,7 +152,7 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--navy" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--navy" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
     </div>
 

--- a/landing_site/src/pages/use-cases/[slug].astro
+++ b/landing_site/src/pages/use-cases/[slug].astro
@@ -34,7 +34,7 @@ const { page } = Astro.props;
 
   <section class="steps">
     <div class="container">
-      <div class="eyebrow eyebrow--muted steps-label">HOW TEAMS USE ReARM FOR THIS</div>
+      <div class="eyebrow eyebrow--muted steps-label">{page.stepsLabel ?? 'HOW TEAMS USE ReARM FOR THIS'}</div>
       <div class="steps-grid">
         {page.steps.map((s) => (
           <div class="step-card">

--- a/landing_site/src/pages/use-cases/[slug].astro
+++ b/landing_site/src/pages/use-cases/[slug].astro
@@ -34,7 +34,7 @@ const { page } = Astro.props;
 
   <section class="steps">
     <div class="container">
-      <div class="eyebrow eyebrow--muted steps-label">{page.stepsLabel ?? 'HOW TEAMS USE ReARM FOR THIS'}</div>
+      <div class="eyebrow eyebrow--muted steps-label">HOW TEAMS USE ReARM FOR THIS</div>
       <div class="steps-grid">
         {page.steps.map((s) => (
           <div class="step-card">


### PR DESCRIPTION
## Five changes to the landing site, deployed to the sandbox for review (https://landing.psclaude.rearmhq.com, image `local-37`)

### 1. Pricing: seats are just users; read-only grant only on Standard and Enterprise
- Selectors read `1-14 users` / `15-39 users`; Enterprise reads `per user per month` for `40+ users`; the note under the tiers says each paid seat is one user and that Standard and Enterprise include one additional read-only user for every 2 users.
- Pricing FAQ: no read-only grant on Starter; 1-per-2 on Standard and Enterprise only, example kept (20 users -> up to 10 read-only, 30 total); "How many user licenses do I need?" loses the write qualifier.
- `design.json` Enterprise unit `/user/mo`.

### 2. Pricing call to action
All three tier buttons read **Book Demo** and open https://calendly.com/pavel-reliza/30min in a new tab instead of a sales mailto.

### 3. Use case renamed to "Deployment Governance, DevOps, BYOC" with new copy
URL `/use-cases/deployment-governance/` and the instance-page screenshot unchanged; label updated in the nav, homepage tile, question row and `pageHrefs` (old key kept). New headline "DevOps, BYOC, Air-Gap at Scale." and seven steps: instances as first-class targets; ship by pointing at a feature set, nothing pushed from CI; ReARM CD pulling outbound and reporting back, sensitive configuration encrypted for the target cluster; promotion per environment following approvals, configurable; plan versus actual per instance or per customer; evidence following the deployment; air-gapped sites via CLI-resolved release, packaged bundle carried across the gap, transfer recorded against a distribution target or placeholder instance. Note states the DevOps surface is ReARM Pro.


### 4. New use case: SBOM Aggregation (first in the menu)
`/use-cases/sbom-aggregation/`, no screenshot. Component releases with SBOMs arrive from CI; products are assembled by feature-set rules; every product release is pinned to exact component releases; an aggregated SBOM is produced on demand per product version; aggregated SBOMs are ready to be served downstream; findings are evaluated against every pinned component in every shipped version. Added first in the use-case navigation and the homepage tiles.


### 5. New use case: VEX Exploitability eXchange (second in the menu)
`/use-cases/vex-exploitability-exchange/`, no screenshot, based on the Importing VEX workflow doc: VEX as a regular artifact matched against the release SBOM inventory; issuer-class trust gate; scoped decisions with the broader-scope conflict guard (verified in `VexVerdictResolver`); conditional mitigations deferred until attested; review next to the verbatim statement; VEX export as CycloneDX-VEX or OpenVEX. Added second in the navigation and homepage tiles.

## Verified
`astro build` clean (51 pages); generated pricing, FAQ and use-case pages checked for the new strings and absence of the old ones; live sandbox pages checked the same way after each hot-swap.

The June release-notes post still says "write user"; left as historical.

