### PR TITLE
feat(distribution): software vs hardware shipments; menu for all non-OSS installations

### DIFF
--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -53,15 +53,18 @@
                 <h4>{{ terms.shipments }} <span class="subtle">({{ terms.installedBase }})</span></h4>
                 <n-icon v-if="isWritable" @click="openShipModal()" class="icons clickable" :title="terms.shipAction" size="22"><CirclePlus /></n-icon>
                 <n-tabs v-model:value="shipmentTab" type="segment" size="small" animated data-testid="shipment-tabs">
-                    <n-tab-pane name="software" :tab="`Software (${softwareShipments.length})`">
-                        <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
-                    </n-tab-pane>
                     <n-tab-pane name="hardware" :tab="`Hardware (${hardwareShipments.length})`">
                         <n-data-table :columns="shipmentColumns" :data="hardwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
                     </n-tab-pane>
+                    <n-tab-pane name="samd" :tab="`SaMD (${samdShipments.length})`">
+                        <n-data-table :columns="shipmentColumns" :data="samdShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                    <n-tab-pane name="software" :tab="`Software (${softwareShipments.length})`">
+                        <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
                 </n-tabs>
 
-                <!-- Devices of selected hardware shipment -->
+                <!-- Units of the selected HARDWARE / SAMD shipment -->
                 <template v-if="selectedShipment && selectedShipment.kind !== 'SOFTWARE'">
                     <h4 style="margin-top: 12px;">Devices <span class="subtle">of selected {{ terms.shipment.toLowerCase() }}</span></h4>
                     <n-icon v-if="isWritable" @click="openDeviceModal()" class="icons clickable" title="Add device" size="22"><CirclePlus /></n-icon>
@@ -109,12 +112,13 @@
                     Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust the rest. Fields marked * are required.
                 </div>
                 <div v-if="resolvedIdentity" class="identityBox" data-testid="ship-kind-box">
-                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ isSoftwareShipment ? 'Software shipment' : 'Hardware shipment' }}</n-tag>
+                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ shipmentKindLabel(resolvedIdentity.shipmentKind) }}</n-tag>
                     <template v-if="resolvedIdentity.deviceClass !== 'NONE'">
                         &middot; {{ terms.deviceIdentity }}: <n-tag size="small" type="info">{{ resolvedIdentity.deviceClass }}</n-tag>
                         <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
                     </template>
-                    <span v-if="isSoftwareShipment" class="subtle"> &middot; a software release{{ resolvedIdentity.deviceClass !== 'NONE' ? ' (SaMD)' : '' }}: no quantity or batch facts; optionally applied to devices at this site</span>
+                    <span v-if="isSoftwareShipment" class="subtle"> &middot; plain software: no quantity or batch facts; optionally applied to devices at this site</span>
+                    <span v-else-if="resolvedIdentity.shipmentKind === 'SAMD'" class="subtle"> &middot; software as a medical device: shipped and tracked per unit like hardware</span>
                 </div>
                 <div v-if="!editingShipmentUuid" class="subtle" style="margin-bottom: 6px;">Fields marked * are required.</div>
                 <n-form-item label="Release *">
@@ -309,13 +313,16 @@ const emptyContact = () => ({ address: '', phone: '', email: '' })
 const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contact: emptyContact(), notes: '' })
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
 const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
-// Shipment kind follows the feature set: hardware present -> a physical batch,
-// otherwise (plain software, SaMD) a software release that may be applied to
+// Shipment kind comes from the feature set's component classification (nature +
+// deviceClass): HARDWARE = physical batch, SAMD = software medical device shipped and
+// tracked per unit like hardware, SOFTWARE = plain software that may be applied to
 // devices at the site. The server derives the same value; this only drives the form.
 const isSoftwareShipment = computed(() => resolvedIdentity.value?.shipmentKind === 'SOFTWARE')
-const shipmentTab = ref('software')
+const shipmentKindLabel = (k: string) => k === 'SOFTWARE' ? 'Software shipment' : k === 'SAMD' ? 'SaMD shipment' : 'Hardware shipment'
+const shipmentTab = ref('hardware')
 const softwareShipments = computed(() => shipments.value.filter((s: any) => s.kind === 'SOFTWARE'))
-const hardwareShipments = computed(() => shipments.value.filter((s: any) => s.kind !== 'SOFTWARE'))
+const samdShipments = computed(() => shipments.value.filter((s: any) => s.kind === 'SAMD'))
+const hardwareShipments = computed(() => shipments.value.filter((s: any) => s.kind !== 'SOFTWARE' && s.kind !== 'SAMD'))
 const siteDevices: Ref<any[]> = ref([])
 const siteDeviceOptions = computed(() => siteDevices.value.map((d: any) => ({ label: summarizeIds(d.identifiers) || shortUuid(d.uuid), value: d.uuid })))
 async function loadSiteDevices (siteUuid: string) {
@@ -416,7 +423,7 @@ watch(() => route.params.siteuuid, async (v) => {
     selectedSiteUuid.value = v ? v.toString() : ''
     selectedShipmentUuid.value = ''; devices.value = []
     await Promise.all([loadShipments(selectedSiteUuid.value), loadSiteDevices(selectedSiteUuid.value)])
-    if (!softwareShipments.value.length && hardwareShipments.value.length) shipmentTab.value = 'hardware'
+    shipmentTab.value = hardwareShipments.value.length || !(samdShipments.value.length || softwareShipments.value.length) ? 'hardware' : samdShipments.value.length ? 'samd' : 'software'
 })
 
 // ---- columns ----

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -24,13 +24,6 @@
                     <n-tag size="small" :type="domainTagType" style="margin-left: 6px;">{{ selectedClient.domain || 'GENERIC' }}</n-tag>
                 </h4>
                 <div v-if="selectedClient.contact" class="contactLine">{{ formatContact(selectedClient.contact) }}</div>
-                <n-space size="small" style="margin: 4px 0;">
-                    <n-button v-if="isWritable" size="tiny" @click="openClientModal(selectedClient)">Edit</n-button>
-                    <n-popconfirm v-if="isWritable" @positive-click="deleteClient(selectedClient)">
-                        <template #trigger><n-button size="tiny" type="error">Archive</n-button></template>
-                        Archive client {{ selectedClient.name }} with all its sites, shipments, and devices?
-                    </n-popconfirm>
-                </n-space>
                 <h4>Sites</h4>
                 <n-icon v-if="isWritable" @click="openSiteModal()" class="icons clickable" title="Add Site" size="22"><CirclePlus /></n-icon>
                 <n-data-table :columns="siteColumns" :data="sites" :row-class-name="siteRowClass" :row-props="siteRowProps" size="small" />
@@ -43,26 +36,23 @@
             <template v-if="selectedSite">
                 <h4>{{ selectedSite.name }}</h4>
                 <div v-if="selectedSite.contact" class="contactLine">{{ formatContact(selectedSite.contact) }}</div>
-                <n-space size="small" style="margin: 4px 0;">
-                    <n-button v-if="isWritable" size="tiny" @click="openSiteModal(selectedSite)">Edit</n-button>
-                    <n-popconfirm v-if="isWritable" @positive-click="deleteSite(selectedSite)">
-                        <template #trigger><n-button size="tiny" type="error">Archive</n-button></template>
-                        Archive site {{ selectedSite.name }} with its shipments and devices?
-                    </n-popconfirm>
-                </n-space>
                 <h4>{{ terms.shipments }} <span class="subtle">({{ terms.installedBase }})</span></h4>
                 <n-icon v-if="isWritable" @click="openShipModal()" class="icons clickable" :title="terms.shipAction" size="22"><CirclePlus /></n-icon>
-                <n-tabs v-model:value="shipmentTab" type="segment" size="small" animated data-testid="shipment-tabs">
-                    <n-tab-pane name="hardware" :tab="`Hardware (${hardwareShipments.length})`">
+                <n-tabs v-if="showHardwareTab || showSamdTab" v-model:value="shipmentTab" type="segment" size="small" animated data-testid="shipment-tabs">
+                    <n-tab-pane v-if="showHardwareTab" name="hardware" :tab="`Hardware (${hardwareShipments.length})`">
                         <n-data-table :columns="shipmentColumns" :data="hardwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
                     </n-tab-pane>
-                    <n-tab-pane name="samd" :tab="`SaMD (${samdShipments.length})`">
+                    <n-tab-pane v-if="showSamdTab" name="samd" :tab="`SaMD (${samdShipments.length})`">
                         <n-data-table :columns="shipmentColumns" :data="samdShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
                     </n-tab-pane>
                     <n-tab-pane name="software" :tab="`Software (${softwareShipments.length})`">
                         <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
                     </n-tab-pane>
                 </n-tabs>
+                <!-- software-only organization: no tabs, just the software shipments -->
+                <div v-else data-testid="shipment-tabs" data-software-only="true">
+                    <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                </div>
 
                 <!-- Units of the selected HARDWARE / SAMD shipment -->
                 <template v-if="selectedShipment && !isPlainSoftware(selectedShipment)">
@@ -195,7 +185,7 @@ import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from '
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
-import { CirclePlus, InfoCircle, Edit as EditIcon } from '@vicons/tabler'
+import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -327,6 +317,27 @@ const shipmentTab = ref('hardware')
 const softwareShipments = computed(() => shipments.value.filter(isPlainSoftware))
 const samdShipments = computed(() => shipments.value.filter(isSamd))
 const hardwareShipments = computed(() => shipments.value.filter(isHardware))
+// Which tabs make sense here follows the org's component classification: no hardware
+// components -> software only; SaMD only for MEDICAL-framed clients of an org that has SaMD
+// components. A kind that already has rows stays visible so nothing is hidden by accident.
+const orgHasHardware = ref(false)
+const orgHasSamd = ref(false)
+async function loadOrgClassification () {
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query componentsClassification($o: ID!) { components(orgUuid: $o, componentType: ANY) { uuid nature deviceClass } }`, variables: { o: orguuid.value }, fetchPolicy: 'no-cache' })
+        const comps: any[] = resp.data.components || []
+        orgHasHardware.value = comps.some(isHardware)
+        orgHasSamd.value = comps.some(isSamd)
+    } catch (e) { orgHasHardware.value = false; orgHasSamd.value = false }
+}
+const showHardwareTab = computed(() => orgHasHardware.value || hardwareShipments.value.length > 0)
+const showSamdTab = computed(() => (selectedClient.value?.domain === 'MEDICAL' && orgHasSamd.value) || samdShipments.value.length > 0)
+const pickShipmentTab = () => {
+    const visible = [showHardwareTab.value ? 'hardware' : '', showSamdTab.value ? 'samd' : '', 'software'].filter(Boolean)
+    const counts: Record<string, number> = { hardware: hardwareShipments.value.length, samd: samdShipments.value.length, software: softwareShipments.value.length }
+    shipmentTab.value = visible.find(t => counts[t] > 0) || visible[0]
+}
+watch([showHardwareTab, showSamdTab], () => { if (!['hardware', 'samd', 'software'].includes(shipmentTab.value) || (shipmentTab.value === 'hardware' && !showHardwareTab.value) || (shipmentTab.value === 'samd' && !showSamdTab.value)) pickShipmentTab() })
 const siteDevices: Ref<any[]> = ref([])
 const siteDeviceOptions = computed(() => siteDevices.value.map((d: any) => ({ label: summarizeIds(d.identifiers) || shortUuid(d.uuid), value: d.uuid })))
 async function loadSiteDevices (siteUuid: string) {
@@ -427,15 +438,27 @@ watch(() => route.params.siteuuid, async (v) => {
     selectedSiteUuid.value = v ? v.toString() : ''
     selectedShipmentUuid.value = ''; devices.value = []
     await Promise.all([loadShipments(selectedSiteUuid.value), loadSiteDevices(selectedSiteUuid.value)])
-    shipmentTab.value = hardwareShipments.value.length || !(samdShipments.value.length || softwareShipments.value.length) ? 'hardware' : samdShipments.value.length ? 'samd' : 'software'
+    pickShipmentTab()
 })
 
 // ---- columns ----
+// Edit / archive live inside the list row (no header label); clicks must not select the row.
+const rowActions = (r: any, edit: (x: any) => void, archive: (x: any) => Promise<void>, confirmText: string) => h('span', { style: 'white-space: nowrap;', onClick: (e: Event) => e.stopPropagation() }, [
+    h(NIcon, { size: 18, class: 'icons clickable', title: 'Edit', style: 'margin-right: 8px;', onClick: () => edit(r) }, { default: () => h(EditIcon) }),
+    h(NPopconfirm, { onPositiveClick: () => archive(r) }, {
+        trigger: () => h(NIcon, { size: 18, class: 'icons clickable', title: 'Archive', style: 'color: #d03050;' }, { default: () => h(ArchiveIcon) }),
+        default: () => confirmText
+    })
+])
 const clientColumns = [
     { key: 'name', title: 'Name' },
-    { key: 'domain', title: 'Framing', render: (r: any) => h(NTag, { size: 'small' }, { default: () => r.domain || 'GENERIC' }) }
+    { key: 'domain', title: 'Framing', render: (r: any) => h(NTag, { size: 'small' }, { default: () => r.domain || 'GENERIC' }) },
+    ...(isWritable ? [{ key: 'actions', title: '', width: 70, render: (r: any) => rowActions(r, openClientModal, deleteClient, `Archive client ${r.name} with all its sites, shipments, and devices?`) }] : [])
 ]
-const siteColumns = [{ key: 'name', title: 'Name' }]
+const siteColumns = [
+    { key: 'name', title: 'Name' },
+    ...(isWritable ? [{ key: 'actions', title: '', width: 70, render: (r: any) => rowActions(r, openSiteModal, deleteSite, `Archive site ${r.name} with its shipments and devices?`) }] : [])
+]
 const shipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
     {
@@ -708,6 +731,7 @@ const fleetDriftColumns = [
 const driftRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device.uuid } }) })
 
 onMounted(async () => {
+    loadOrgClassification()
     store.dispatch('fetchProducts', orguuid.value)
     loadFleetDrift()
     await loadClients()

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -65,7 +65,7 @@
                 </n-tabs>
 
                 <!-- Units of the selected HARDWARE / SAMD shipment -->
-                <template v-if="selectedShipment && selectedShipment.kind !== 'SOFTWARE'">
+                <template v-if="selectedShipment && !isPlainSoftware(selectedShipment)">
                     <h4 style="margin-top: 12px;">Devices <span class="subtle">of selected {{ terms.shipment.toLowerCase() }}</span></h4>
                     <n-icon v-if="isWritable" @click="openDeviceModal()" class="icons clickable" title="Add device" size="22"><CirclePlus /></n-icon>
                     <n-data-table :columns="deviceColumns" :data="devices" :row-props="deviceRowProps" size="small" />
@@ -112,13 +112,13 @@
                     Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust the rest. Fields marked * are required.
                 </div>
                 <div v-if="resolvedIdentity" class="identityBox" data-testid="ship-kind-box">
-                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ shipmentKindLabel(resolvedIdentity.shipmentKind) }}</n-tag>
+                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ shipmentKindLabel(resolvedIdentity) }}</n-tag>
                     <template v-if="resolvedIdentity.deviceClass !== 'NONE'">
                         &middot; {{ terms.deviceIdentity }}: <n-tag size="small" type="info">{{ resolvedIdentity.deviceClass }}</n-tag>
                         <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
                     </template>
                     <span v-if="isSoftwareShipment" class="subtle"> &middot; plain software: no quantity or batch facts; optionally applied to devices at this site</span>
-                    <span v-else-if="resolvedIdentity.shipmentKind === 'SAMD'" class="subtle"> &middot; software as a medical device: shipped and tracked per unit like hardware</span>
+                    <span v-else-if="isSamd(resolvedIdentity)" class="subtle"> &middot; software as a medical device: shipped and tracked per unit like hardware</span>
                 </div>
                 <div v-if="!editingShipmentUuid" class="subtle" style="margin-bottom: 6px;">Fields marked * are required.</div>
                 <n-form-item label="Release *">
@@ -313,16 +313,20 @@ const emptyContact = () => ({ address: '', phone: '', email: '' })
 const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contact: emptyContact(), notes: '' })
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
 const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
-// Shipment kind comes from the feature set's component classification (nature +
-// deviceClass): HARDWARE = physical batch, SAMD = software medical device shipped and
-// tracked per unit like hardware, SOFTWARE = plain software that may be applied to
-// devices at the site. The server derives the same value; this only drives the form.
-const isSoftwareShipment = computed(() => resolvedIdentity.value?.shipmentKind === 'SOFTWARE')
-const shipmentKindLabel = (k: string) => k === 'SOFTWARE' ? 'Software shipment' : k === 'SAMD' ? 'SaMD shipment' : 'Hardware shipment'
+// Shipments carry the same two-axis classification as components: nature (HARDWARE /
+// SOFTWARE, hardware if any constituent component is hardware) and deviceClass. HARDWARE =
+// physical batch; SOFTWARE + MEDICAL_* = SaMD, shipped and tracked per unit like hardware;
+// SOFTWARE + NONE = plain software that may be applied to devices at the site. The server
+// derives and stores both; this only drives the form and the tabs.
+const isHardware = (x: any) => x?.nature === 'HARDWARE'
+const isSamd = (x: any) => !isHardware(x) && !!x?.deviceClass && x.deviceClass !== 'NONE'
+const isPlainSoftware = (x: any) => !isHardware(x) && !isSamd(x)
+const isSoftwareShipment = computed(() => !!resolvedIdentity.value && isPlainSoftware(resolvedIdentity.value))
+const shipmentKindLabel = (x: any) => isHardware(x) ? 'Hardware shipment' : isSamd(x) ? 'SaMD shipment' : 'Software shipment'
 const shipmentTab = ref('hardware')
-const softwareShipments = computed(() => shipments.value.filter((s: any) => s.kind === 'SOFTWARE'))
-const samdShipments = computed(() => shipments.value.filter((s: any) => s.kind === 'SAMD'))
-const hardwareShipments = computed(() => shipments.value.filter((s: any) => s.kind !== 'SOFTWARE' && s.kind !== 'SAMD'))
+const softwareShipments = computed(() => shipments.value.filter(isPlainSoftware))
+const samdShipments = computed(() => shipments.value.filter(isSamd))
+const hardwareShipments = computed(() => shipments.value.filter(isHardware))
 const siteDevices: Ref<any[]> = ref([])
 const siteDeviceOptions = computed(() => siteDevices.value.map((d: any) => ({ label: summarizeIds(d.identifiers) || shortUuid(d.uuid), value: d.uuid })))
 async function loadSiteDevices (siteUuid: string) {
@@ -370,7 +374,7 @@ const onCreateUnitId = () => ({ idType: 'SERIAL', idValue: '' })
 // ---- GraphQL ----
 const CLIENT_FIELDS = 'uuid org name domain contact { address phone email } notes'
 const SITE_FIELDS = 'uuid org client name contact { address phone email } notes'
-const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes kind devices identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
+const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes nature deviceClass devices identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
 const DEVICE_FIELDS = 'uuid org shippedProduct site versionDrift notes identifiers { idType idValue } plan { expectedRelease } actual { reportedRelease reportedAt source } tracking { receivedDate patientId disposition dispositionDate }'
 
 async function loadClients () {
@@ -397,7 +401,7 @@ async function resolveIdentity () {
     resolvedIdentity.value = null
     if (!shipForm.featureSet) return
     try {
-        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi hasHardware shipmentKind } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
+        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi nature } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
         resolvedIdentity.value = resp.data.featureSetDeviceIdentity
     } catch (e: any) { /* invalid uuid etc */ }
 }

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -52,10 +52,17 @@
                 </n-space>
                 <h4>{{ terms.shipments }} <span class="subtle">({{ terms.installedBase }})</span></h4>
                 <n-icon v-if="isWritable" @click="openShipModal()" class="icons clickable" :title="terms.shipAction" size="22"><CirclePlus /></n-icon>
-                <n-data-table :columns="shipmentColumns" :data="shipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                <n-tabs v-model:value="shipmentTab" type="segment" size="small" animated data-testid="shipment-tabs">
+                    <n-tab-pane name="software" :tab="`Software (${softwareShipments.length})`">
+                        <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                    <n-tab-pane name="hardware" :tab="`Hardware (${hardwareShipments.length})`">
+                        <n-data-table :columns="shipmentColumns" :data="hardwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                </n-tabs>
 
-                <!-- Devices of selected shipment -->
-                <template v-if="selectedShipment">
+                <!-- Devices of selected hardware shipment -->
+                <template v-if="selectedShipment && selectedShipment.kind !== 'SOFTWARE'">
                     <h4 style="margin-top: 12px;">Devices <span class="subtle">of selected {{ terms.shipment.toLowerCase() }}</span></h4>
                     <n-icon v-if="isWritable" @click="openDeviceModal()" class="icons clickable" title="Add device" size="22"><CirclePlus /></n-icon>
                     <n-data-table :columns="deviceColumns" :data="devices" :row-props="deviceRowProps" size="small" />
@@ -92,21 +99,25 @@
         <!-- Ship modal -->
         <n-modal v-model:show="showShipModal" preset="dialog" :show-icon="false" :title="editingShipmentUuid ? 'Edit Shipment' : terms.shipAction" style="width: 640px;">
             <n-form>
-                <n-form-item v-if="!editingShipmentUuid" label="Product">
+                <n-form-item v-if="!editingShipmentUuid" label="Product *">
                     <n-select v-model:value="shipProductUuid" filterable :options="products" placeholder="Pick a product" @update:value="onShipProductChange" />
                 </n-form-item>
-                <n-form-item v-if="!editingShipmentUuid" label="Feature set">
+                <n-form-item v-if="!editingShipmentUuid" label="Feature set *">
                     <n-select v-model:value="shipForm.featureSet" filterable :options="featureSetOptions" :disabled="!shipProductUuid" placeholder="Pick a feature set" @update:value="onFeatureSetChange" />
                 </n-form-item>
                 <div v-if="editingShipmentUuid" class="identityBox">
-                    Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust release, dates, quantity, identifiers and choices.
+                    Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust the rest. Fields marked * are required.
                 </div>
-                <div v-if="resolvedIdentity" class="identityBox">
-                    {{ terms.deviceIdentity }}:
-                    <n-tag size="small" :type="resolvedIdentity.deviceClass === 'NONE' ? 'default' : 'info'">{{ resolvedIdentity.deviceClass }}</n-tag>
-                    <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
+                <div v-if="resolvedIdentity" class="identityBox" data-testid="ship-kind-box">
+                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ isSoftwareShipment ? 'Software shipment' : 'Hardware shipment' }}</n-tag>
+                    <template v-if="resolvedIdentity.deviceClass !== 'NONE'">
+                        &middot; {{ terms.deviceIdentity }}: <n-tag size="small" type="info">{{ resolvedIdentity.deviceClass }}</n-tag>
+                        <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
+                    </template>
+                    <span v-if="isSoftwareShipment" class="subtle"> &middot; a software release{{ resolvedIdentity.deviceClass !== 'NONE' ? ' (SaMD)' : '' }}: no quantity or batch facts; optionally applied to devices at this site</span>
                 </div>
-                <n-form-item label="Release">
+                <div v-if="!editingShipmentUuid" class="subtle" style="margin-bottom: 6px;">Fields marked * are required.</div>
+                <n-form-item label="Release *">
                     <n-select v-model:value="shipForm.release" filterable :options="shipReleases" :disabled="!shipForm.featureSet" placeholder="Pick a release / version" @update:value="onShipReleaseChange" />
                 </n-form-item>
                 <n-form-item v-if="shipDeliverables.length" label="Deliverable / lot">
@@ -127,8 +138,12 @@
                     </n-form-item>
                 </template>
                 <n-form-item label="Ship date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.shipDate" value-format="yyyy-MM-dd" placeholder="defaults to today" /></n-form-item>
-                <n-form-item label="Quantity"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
-                <n-form-item label="Batch identifiers">
+                <n-form-item v-if="isSoftwareShipment" label="Applies to devices (optional)">
+                    <n-select v-model:value="shipForm.devices" multiple filterable clearable :options="siteDeviceOptions" data-testid="ship-devices"
+                        :placeholder="siteDeviceOptions.length ? 'Pick devices from hardware shipments at this site, or leave empty' : 'No devices at this site yet — leave empty'" />
+                </n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Quantity *"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Batch identifiers">
                     <n-dynamic-input v-model:value="shipForm.identifiers" :on-create="onCreateBatchId">
                         <template #create-button-default>Add identifier</template>
                         <template #default="{ value }">
@@ -137,8 +152,8 @@
                         </template>
                     </n-dynamic-input>
                 </n-form-item>
-                <n-form-item label="Manufacture date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.manufactureDate" value-format="yyyy-MM-dd" /></n-form-item>
-                <n-form-item label="Expiry date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.expiryDate" value-format="yyyy-MM-dd" /></n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Manufacture date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.manufactureDate" value-format="yyyy-MM-dd" /></n-form-item>
+                <n-form-item :label="isSoftwareShipment ? 'Expiry / end of support date (optional)' : 'Expiry date'"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.expiryDate" value-format="yyyy-MM-dd" /></n-form-item>
             </n-form>
             <template #action><n-button type="primary" @click="shipProduct">{{ editingShipmentUuid ? 'Save changes' : terms.shipAction }}</n-button></template>
         </n-modal>
@@ -175,7 +190,7 @@ export default { name: 'DistributionOfOrg' }
 import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
+import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
 import { CirclePlus, InfoCircle, Edit as EditIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
@@ -293,7 +308,24 @@ async function onShipReleaseChange (releaseUuid: string) {
 const emptyContact = () => ({ address: '', phone: '', email: '' })
 const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contact: emptyContact(), notes: '' })
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
-const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null })
+const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
+// Shipment kind follows the feature set: hardware present -> a physical batch,
+// otherwise (plain software, SaMD) a software release that may be applied to
+// devices at the site. The server derives the same value; this only drives the form.
+const isSoftwareShipment = computed(() => resolvedIdentity.value?.shipmentKind === 'SOFTWARE')
+const shipmentTab = ref('software')
+const softwareShipments = computed(() => shipments.value.filter((s: any) => s.kind === 'SOFTWARE'))
+const hardwareShipments = computed(() => shipments.value.filter((s: any) => s.kind !== 'SOFTWARE'))
+const siteDevices: Ref<any[]> = ref([])
+const siteDeviceOptions = computed(() => siteDevices.value.map((d: any) => ({ label: summarizeIds(d.identifiers) || shortUuid(d.uuid), value: d.uuid })))
+async function loadSiteDevices (siteUuid: string) {
+    if (!siteUuid) { siteDevices.value = []; return }
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query devicesOfSite($s: ID!, $o: ID!) { devicesOfSite(siteUuid: $s, orgUuid: $o) { uuid identifiers { idType idValue } shippedProduct } }`, variables: { s: siteUuid, o: orguuid.value }, fetchPolicy: 'no-cache' })
+        siteDevices.value = resp.data.devicesOfSite || []
+    } catch (e) { siteDevices.value = [] }
+}
+const deviceLabel = (uuid: string) => siteDeviceOptions.value.find(o => o.value === uuid)?.label || shortUuid(uuid)
 const editingShipmentUuid: Ref<string> = ref('')
 
 // Resolved display info per release uuid (product / feature set / version)
@@ -331,7 +363,7 @@ const onCreateUnitId = () => ({ idType: 'SERIAL', idValue: '' })
 // ---- GraphQL ----
 const CLIENT_FIELDS = 'uuid org name domain contact { address phone email } notes'
 const SITE_FIELDS = 'uuid org client name contact { address phone email } notes'
-const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
+const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes kind devices identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
 const DEVICE_FIELDS = 'uuid org shippedProduct site versionDrift notes identifiers { idType idValue } plan { expectedRelease } actual { reportedRelease reportedAt source } tracking { receivedDate patientId disposition dispositionDate }'
 
 async function loadClients () {
@@ -358,7 +390,7 @@ async function resolveIdentity () {
     resolvedIdentity.value = null
     if (!shipForm.featureSet) return
     try {
-        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
+        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi hasHardware shipmentKind } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
         resolvedIdentity.value = resp.data.featureSetDeviceIdentity
     } catch (e: any) { /* invalid uuid etc */ }
 }
@@ -383,7 +415,8 @@ watch(() => route.params.clientuuid, async (v) => {
 watch(() => route.params.siteuuid, async (v) => {
     selectedSiteUuid.value = v ? v.toString() : ''
     selectedShipmentUuid.value = ''; devices.value = []
-    await loadShipments(selectedSiteUuid.value)
+    await Promise.all([loadShipments(selectedSiteUuid.value), loadSiteDevices(selectedSiteUuid.value)])
+    if (!softwareShipments.value.length && hardwareShipments.value.length) shipmentTab.value = 'hardware'
 })
 
 // ---- columns ----
@@ -438,6 +471,33 @@ const shipmentColumns = computed(() => [
             onClick: (e: Event) => { e.stopPropagation(); openShipModal(r) }
         }, { default: () => h(EditIcon) })
     }] : [])
+])
+const softwareShipmentColumns = computed(() => [
+    { key: 'shipDate', title: 'Date' },
+    (shipmentColumns.value as any[])[1],
+    { key: 'expiryDate', title: 'Expires', render: (r: any) => r.expiryDate || h('span', { class: 'subtle' }, '—') },
+    {
+        key: 'devices', title: 'Devices',
+        render: (r: any) => {
+            const ids: string[] = r.devices || []
+            if (!ids.length) return h('span', { class: 'subtle', title: 'Shipped without devices' }, 'none')
+            return h(NTooltip, { trigger: 'hover', placement: 'left' }, {
+                trigger: () => h(NTag, { size: 'small', type: 'info' }, { default: () => `${ids.length} device${ids.length === 1 ? '' : 's'}` }),
+                default: () => h('div', ids.map((u: string) => h('div', deviceLabel(u))))
+            })
+        }
+    },
+    {
+        key: 'info', title: '',
+        render: (r: any) => {
+            const facts: [string, any][] = [['Notes', r.notes]].filter(([, v]) => v !== null && v !== undefined && v !== '') as [string, any][]
+            return facts.length ? h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 460px;' }, {
+                trigger: () => h(NIcon, { size: 16, style: 'color: #909399; vertical-align: middle;', onClick: (e: Event) => e.stopPropagation() }, { default: () => h(InfoCircle) }),
+                default: () => h('div', facts.map(([k, v]) => h('div', { style: 'margin: 2px 0;' }, [h('strong', `${k}: `), String(v)])))
+            }) : ''
+        }
+    },
+    ...(isWritable ? [(shipmentColumns.value as any[])[(shipmentColumns.value as any[]).length - 1]] : [])
 ])
 const deviceColumns = computed(() => [
     { key: 'ids', title: 'Unit ids', render: (r: any) => summarizeIds(r.identifiers) || h('span', { class: 'subtle' }, '—') },
@@ -522,8 +582,9 @@ async function deleteSite (s: any) {
 function cleanIds (ids: any[]) { return (ids || []).filter(i => i.idType && i.idValue) }
 async function openShipModal (existing?: any) {
     shipForm.featureSet = ''; shipForm.release = ''; shipForm.deliverable = null; shipForm.shipDate = null; shipForm.quantity = 1
-    shipForm.identifiers = []; shipForm.manufactureDate = null; shipForm.expiryDate = null
+    shipForm.identifiers = []; shipForm.manufactureDate = null; shipForm.expiryDate = null; shipForm.devices = []
     shipProductUuid.value = ''; shipReleases.value = []; shipDeliverables.value = []
+    await loadSiteDevices(selectedSiteUuid.value)
     shipChoices.value = []; Object.keys(shipChoiceSelections).forEach(k => delete shipChoiceSelections[k])
     resolvedIdentity.value = null
     editingShipmentUuid.value = existing?.uuid || ''
@@ -536,6 +597,7 @@ async function openShipModal (existing?: any) {
         shipForm.identifiers = (existing.identifiers || []).map((i: any) => ({ idType: i.idType, idValue: i.idValue }))
         shipForm.manufactureDate = existing.manufactureDate || null
         shipForm.expiryDate = existing.expiryDate || null
+        shipForm.devices = [...(existing.devices || [])]
         shipReleases.value = await loadReleasesForBranch(existing.featureSet)
         await Promise.all([loadShipChoices(existing.release), resolveIdentity()])
         for (const cr of (existing.choiceResolutions || [])) {
@@ -547,7 +609,9 @@ async function openShipModal (existing?: any) {
 }
 async function shipProduct () {
     if (!shipForm.featureSet || !shipForm.release) { notify('warning', 'Missing', 'Feature set and release are required'); return }
-    const input: any = { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: shipForm.quantity, identifiers: cleanIds(shipForm.identifiers) }
+    const input: any = isSoftwareShipment.value
+        ? { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: 1, identifiers: [], devices: shipForm.devices || [] }
+        : { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: shipForm.quantity, identifiers: cleanIds(shipForm.identifiers) }
     if (shipChoices.value.length) {
         const resolutions: any[] = []
         for (const cv of shipChoices.value) {
@@ -566,7 +630,7 @@ async function shipProduct () {
     }
     if (shipForm.deliverable) input.deliverable = shipForm.deliverable
     if (shipForm.shipDate) input.shipDate = shipForm.shipDate
-    if (shipForm.manufactureDate) input.manufactureDate = shipForm.manufactureDate
+    if (shipForm.manufactureDate && !isSoftwareShipment.value) input.manufactureDate = shipForm.manufactureDate
     if (shipForm.expiryDate) input.expiryDate = shipForm.expiryDate
     try {
         if (editingShipmentUuid.value) {

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -144,7 +144,7 @@
                 <n-form-item label="Ship date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.shipDate" value-format="yyyy-MM-dd" placeholder="defaults to today" /></n-form-item>
                 <n-form-item v-if="isSoftwareShipment" label="Applies to devices (optional)">
                     <n-select v-model:value="shipForm.devices" multiple filterable clearable :options="siteDeviceOptions" data-testid="ship-devices"
-                        :placeholder="siteDeviceOptions.length ? 'Pick devices from hardware shipments at this site, or leave empty' : 'No devices at this site yet — leave empty'" />
+                        :placeholder="siteDeviceOptions.length ? 'Pick devices from hardware or SaMD shipments at this site, or leave empty' : 'No devices at this site yet — leave empty'" />
                 </n-form-item>
                 <n-form-item v-if="!isSoftwareShipment" label="Quantity *"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
                 <n-form-item v-if="!isSoftwareShipment" label="Batch identifiers">

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -194,8 +194,8 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
             key: 'instances',
             icon: renderIcon(CloudServerOutlined)
         },
-        // Distribution module is SAAS-only for now.
-        ...(myuser.installationType === 'SAAS' ? [{
+        // Distribution module: every non-OSS installation.
+        ...(myuser.installationType !== 'OSS' ? [{
             label: () =>
                 h(
                     RouterLink,


### PR DESCRIPTION
## Summary
- The Distribution menu is shown on every non-OSS installation, not only SaaS.
- The ship form and the shipment list follow the component classification the backend now stamps on shipments (`nature` + `deviceClass`): **hardware** and **SaMD** (software with a medical device class) keep the device-style form (device identity / UDI, quantity, batch identifiers, manufacture and expiry dates, per-unit device enrolment). **Plain software** (SOFTWARE, class NONE) no longer shows Quantity, Batch identifiers or Manufacture date; expiry is labelled optional. Required fields are marked with `*`; the Device Identity line is only shown when the class is not NONE.
- Plain-software shipments can optionally be applied to devices already at the site (multi-select fed by the site's devices), or shipped with no device at all (air-gapped client).
- The shipment list is split into **Hardware**, **SaMD** and **Software** tabs, shown only where they apply: the Hardware tab needs hardware-nature components in the org, the SaMD tab needs a MEDICAL-framed client and SaMD components in the org, and an org without hardware components gets the plain software table with no tabs. A kind that already has shipments stays visible.
- Edit / archive for clients and sites are icons inside the list rows (Name, Framing, actions; no header label). The archive icon keeps its confirmation. The header buttons are gone.

Needs the backend that exposes `nature` on the identity lookup and `nature` / `deviceClass` / `devices` on shipments.

## Test plan
- [x] `vite build`, eslint clean
- [x] sandbox: hardware, SaMD and plain-software feature sets shipped; devices linked to a software shipment; tabs bucket existing rows
- [x] sandbox: GENERIC client of an org with hardware shows Hardware + Software; MEDICAL client shows Hardware + SaMD + Software; org without hardware components shows the software table only; row action icons render, header buttons removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
