### PR TITLE
Author the per-release FDA narrative override, and read it in history (7h)

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1070,6 +1070,51 @@
                             {{ deviceWindowError }}
                         </n-alert>
                     </div>
+                    <!-- The per-release FDA assessment narrative OVERRIDE. Beside the window
+                         because both are device-level facts an auditor reads together, and
+                         PRODUCT-gated for the same reason. The org default is shown
+                         read-only underneath so the author can see what they are replacing:
+                         without it, "override" is an instruction to write something without
+                         being told what it displaces. -->
+                    <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
+                        <h3>Assessment justification for this release</h3>
+                        <p class="text-muted" style="max-width: 760px;">
+                            Overrides the organization default below, for this release only.
+                            Leave it empty to inherit. Clearing a saved override returns this
+                            release to the default &mdash; it does not remove the
+                            justification from the generated documents.
+                        </p>
+                        <n-input v-model:value="releaseNarrative" type="textarea" :rows="5"
+                            style="max-width: 760px;"
+                            :maxlength="FDA_PROSE_MAX_LENGTH" show-count
+                            :disabled="!isWritable || savingReleaseNarrative"
+                            @update:value="releaseNarrativeError = null"
+                            placeholder="Leave empty to use the organization default." />
+                        <div style="margin-top: 8px;">
+                            <n-button v-if="isWritable" size="small" type="primary"
+                                :disabled="!releaseNarrativeDirty" :loading="savingReleaseNarrative"
+                                @click="saveReleaseNarrative">Save justification</n-button>
+                            <span v-if="!releaseNarrativeIsOverridden" class="text-muted"
+                                style="font-size: 12px; margin-left: 10px;">
+                                This release currently inherits the organization default.
+                            </span>
+                        </div>
+                        <n-alert v-if="releaseNarrativeError" type="error" :show-icon="true"
+                            style="font-size: 12px; max-width: 720px; margin-top: 10px;">
+                            {{ releaseNarrativeError }}
+                        </n-alert>
+                        <div style="margin-top: 14px;">
+                            <div class="text-muted" style="font-size: 12px;">
+                                Organization default (read-only, edited in Organization Settings)
+                            </div>
+                            <n-input v-if="orgNarrativeDefault" type="textarea" :rows="3"
+                                style="max-width: 760px;" readonly :value="orgNarrativeDefault" />
+                            <span v-else class="text-muted" style="font-size: 12px;">
+                                No organization default has been authored yet. With no override
+                                here either, generated documents carry no justification section.
+                            </span>
+                        </div>
+                    </div>
                     <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
                         <h3>Components
                             <Icon v-if="isWritable && isUpdatable"
@@ -1705,6 +1750,9 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
+import { releaseNarrativeVariables, releaseNarrativeDirty as releaseNarrativeNotEqual,
+    FDA_PROSE_MAX_LENGTH } from '@/utils/releaseNarrativeInput'
+import { formatNarrativeChange } from '@/utils/narrativeHistory'
 import { formatSupportWindow } from '@/utils/supportWindowDisplay'
 import { deviceWindowVariables } from '@/utils/deviceSupportWindowInput'
 import graphqlQueries from '@/utils/graphqlQueries'
@@ -1868,6 +1916,93 @@ function seedDeviceWindow () {
     deviceWindowBaseline.eos = deviceWindow.eos
     deviceWindowBaseline.eol = deviceWindow.eol
     deviceWindowError.value = null
+}
+
+/**
+ * The per-release FDA assessment narrative override.
+ *
+ * NULL MEANS INHERIT, not empty, which is why the form distinguishes "no override" from "an
+ * override that happens to be blank" -- the latter cannot exist, because a supplied empty
+ * string is how the server is told to clear.
+ */
+const releaseNarrative: Ref<string> = ref('')
+/**
+ * What the server last confirmed. Refreshed from the MUTATION RESPONSE, never only from a
+ * follow-up read: on the org prose form that mistake meant a failed re-read reported a
+ * committed save as failed AND left the baseline stale, so the operator's next clear was
+ * silently omitted while the server kept the text.
+ */
+const releaseNarrativeBaseline: Ref<string> = ref('')
+const savingReleaseNarrative: Ref<boolean> = ref(false)
+const releaseNarrativeError: Ref<string | null> = ref(null)
+
+const releaseNarrativeDirty: ComputedRef<boolean> = computed((): boolean =>
+    releaseNarrativeNotEqual(releaseNarrative.value, releaseNarrativeBaseline.value))
+
+/** Whether this release currently overrides, as opposed to inheriting. */
+const releaseNarrativeIsOverridden: ComputedRef<boolean> = computed((): boolean =>
+    !!(releaseNarrativeBaseline.value || '').trim())
+
+/** The org-level default, shown read-only so the author sees what an override replaces. */
+const orgNarrativeDefault: ComputedRef<string> = computed((): string =>
+    (store.getters.myorg?.settings?.fdaAssessmentNarrative) || '')
+
+function seedReleaseNarrative () {
+    // UNDEFINED means the query did not ask; NULL means the server says there is no
+    // override. Same distinction the device window needs, and for the same reason: coercing
+    // the first to the second blanks a stored value and greys out Save. Both release queries
+    // select the field now, and the drift spec asserts the pairing.
+    const r: any = updatedRelease.value
+    if (r?.fdaAssessmentNarrative !== undefined) {
+        releaseNarrative.value = r.fdaAssessmentNarrative || ''
+    }
+    releaseNarrativeBaseline.value = releaseNarrative.value
+    releaseNarrativeError.value = null
+}
+
+async function saveReleaseNarrative () {
+    savingReleaseNarrative.value = true
+    releaseNarrativeError.value = null
+    try {
+        const vars = releaseNarrativeVariables(
+            updatedRelease.value.uuid,
+            updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid,
+            releaseNarrative.value, releaseNarrativeBaseline.value)
+        // Null means the form is not dirty. Firing a mutation anyway would append nothing on
+        // the server (it diffs too) but would still cost a round trip and a toast claiming
+        // something happened.
+        if (!vars) { savingReleaseNarrative.value = false; return }
+        const resp = await graphqlClient.mutate({
+            mutation: gql`
+                mutation updateReleaseNarrative($release: ReleaseInput!) {
+                    updateRelease(release: $release) { uuid fdaAssessmentNarrative }
+                }`,
+            variables: { release: vars }
+        })
+        // From the mutation's OWN response, before anything that can throw. The write has
+        // committed; this is the truth and it is already in hand.
+        const saved = (resp?.data as any)?.updateRelease
+        if (saved) {
+            releaseNarrative.value = saved.fdaAssessmentNarrative || ''
+            releaseNarrativeBaseline.value = releaseNarrative.value
+        }
+        notify('success', 'Saved', releaseNarrativeBaseline.value
+            ? 'Release justification updated.'
+            : 'Release justification cleared; this release now inherits the organization default.')
+    } catch (err: any) {
+        releaseNarrativeError.value = commonFunctions.extractGraphQLErrorMessage(err)
+    } finally {
+        savingReleaseNarrative.value = false
+    }
+
+    // Outside the try: a refetch keeps the rest of the page in step, but the save has already
+    // been reported from the mutation response, so a refetch failure must not be dressed up
+    // as a failed save.
+    try {
+        await fetchRelease()
+    } catch (e) {
+        // The justification itself is correct on screen; the surrounding page may be stale.
+    }
 }
 
 async function saveDeviceWindow () {
@@ -2102,6 +2237,7 @@ onMounted(async () => {
     // and seeding against an empty release would show a declared window as blank and then
     // treat re-typing it as a change.
     seedDeviceWindow()
+    seedReleaseNarrative()
     await fetchReleaseKeys()
     await loadDtrackConfigured()
     if (hasPendingStatuses()) ensureStatusPolling()
@@ -2647,6 +2783,7 @@ async function goToRelease (uuid: string) {
         isProductRelease.value = await detectIsProduct()
         await fetchRelease()
         seedDeviceWindow()
+        seedReleaseNarrative()
         await fetchReleaseKeys()
     } finally {
         isLoading.value = false
@@ -5848,6 +5985,19 @@ const releaseHistoryFields = computed(() => [
             // with, so it has to read.
             if (row.rus === 'SUPPORT_WINDOW') {
                 const txt = `${formatSupportWindow(row.oldValue)} -> ${formatSupportWindow(row.newValue)}`
+                return reasonIcon ? h('span', { style: 'display: inline-flex; align-items: center;' }, [txt, reasonIcon]) : txt
+            }
+            // Same shape as SUPPORT_WINDOW: a FDA_NARRATIVE event carries old/new values and
+            // no objectId, so without this branch the row falls through to `return
+            // row.objectId` and renders BLANK -- a Scope column saying the justification
+            // changed, beside nothing saying anything about it.
+            //
+            // Lengths, never the text. The stored values are 200-character EXCERPTS, so
+            // rendering them would show a sentence stopping mid-word; and this table is a
+            // dense list of every change to the release, where paragraphs of regulatory prose
+            // make the surrounding rows unreadable. The full current text is one panel away.
+            if (row.rus === 'FDA_NARRATIVE') {
+                const txt = formatNarrativeChange(row.oldValue, row.newValue)
                 return reasonIcon ? h('span', { style: 'display: inline-flex; align-items: center;' }, [txt, reasonIcon]) : txt
             }
             // For artifact events from acollections, show type with info icon

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1750,8 +1750,8 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
-import { releaseNarrativeVariables, releaseNarrativeDirty as releaseNarrativeNotEqual,
-    FDA_PROSE_MAX_LENGTH } from '@/utils/releaseNarrativeInput'
+import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/releaseNarrativeInput'
+import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
 import { formatSupportWindow } from '@/utils/supportWindowDisplay'
 import { deviceWindowVariables } from '@/utils/deviceSupportWindowInput'
@@ -1937,7 +1937,7 @@ const savingReleaseNarrative: Ref<boolean> = ref(false)
 const releaseNarrativeError: Ref<string | null> = ref(null)
 
 const releaseNarrativeDirty: ComputedRef<boolean> = computed((): boolean =>
-    releaseNarrativeNotEqual(releaseNarrative.value, releaseNarrativeBaseline.value))
+    releaseNarrativeDiffers(releaseNarrative.value, releaseNarrativeBaseline.value))
 
 /** Whether this release currently overrides, as opposed to inheriting. */
 const releaseNarrativeIsOverridden: ComputedRef<boolean> = computed((): boolean =>
@@ -1971,7 +1971,7 @@ async function saveReleaseNarrative () {
         // Null means the form is not dirty. Firing a mutation anyway would append nothing on
         // the server (it diffs too) but would still cost a round trip and a toast claiming
         // something happened.
-        if (!vars) { savingReleaseNarrative.value = false; return }
+        if (!vars) return
         const resp = await graphqlClient.mutate({
             mutation: gql`
                 mutation updateReleaseNarrative($release: ReleaseInput!) {
@@ -1985,10 +1985,17 @@ async function saveReleaseNarrative () {
         if (saved) {
             releaseNarrative.value = saved.fdaAssessmentNarrative || ''
             releaseNarrativeBaseline.value = releaseNarrative.value
+            // INSIDE the guard, and worded from the REFRESHED baseline. Outside it, an empty
+            // response left the baseline at its pre-save value, so authoring a narrative
+            // reported "cleared" and clearing one reported "updated" -- a confident sentence
+            // stating the opposite of what the operator had just done. OrgSettings gets this
+            // right with the same else-branch.
+            notify('success', 'Saved', releaseNarrativeBaseline.value
+                ? 'Release justification updated.'
+                : 'Release justification cleared; this release now inherits the organization default.')
+        } else {
+            notify('warning', 'Save Warning', 'Save completed but no response received.')
         }
-        notify('success', 'Saved', releaseNarrativeBaseline.value
-            ? 'Release justification updated.'
-            : 'Release justification cleared; this release now inherits the organization default.')
     } catch (err: any) {
         releaseNarrativeError.value = commonFunctions.extractGraphQLErrorMessage(err)
     } finally {

--- a/ui/src/components/releaseNarrativeWiring.spec.ts
+++ b/ui/src/components/releaseNarrativeWiring.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * Import and wiring assertions for the per-release narrative override.
+ *
+ * Same reason as its three siblings: no vue-tsc, so an undefined identifier in
+ * <script setup> is a RUNTIME error the build ignores. That is not hypothetical on this
+ * feature -- extracting a helper once deleted the `proseBaseline` declaration along with it,
+ * and the build, 427 unit tests and eslint were all green while every save threw in the
+ * browser.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+/** Sliced by BRACE DEPTH; cutting at the next `function` breaks silently on insertion. */
+function functionBody (name: string): string {
+    const start = source.indexOf(`function ${name} (`)
+    if (start < 0) throw new Error(`no function ${name} in ReleaseView.vue`)
+    let depth = 0
+    let i = source.indexOf('{', start)
+    const open = i
+    for (; i < source.length; i++) {
+        if (source[i] === '{') depth++
+        else if (source[i] === '}' && --depth === 0) break
+    }
+    return source.slice(open, i + 1)
+}
+
+describe('the release narrative editor is wired into ReleaseView', () => {
+    it.each([
+        ['releaseNarrativeVariables', '@/utils/releaseNarrativeInput'],
+        ['FDA_PROSE_MAX_LENGTH', '@/utils/releaseNarrativeInput'],
+        ['formatNarrativeChange', '@/utils/narrativeHistory']
+    ])('imports %s from %s', (symbol, module) => {
+        expect(source).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
+    })
+
+    it.each([
+        ['releaseNarrative'], ['releaseNarrativeBaseline'], ['savingReleaseNarrative'],
+        ['releaseNarrativeError'], ['releaseNarrativeDirty'], ['releaseNarrativeIsOverridden'],
+        ['orgNarrativeDefault'], ['saveReleaseNarrative'], ['seedReleaseNarrative']
+    ])('declares %s, which the template references', (symbol) => {
+        expect(source).toMatch(new RegExp(`(const|function) ${symbol}\\b`))
+    })
+
+    // The editor must be seeded EVERY time the release is loaded, not just on one path. The
+    // device window shipped with two load paths and only one seeding call would have blanked
+    // it on the other.
+    it('seeds the narrative wherever it seeds the device window', () => {
+        const windowSeeds = (source.match(/seedDeviceWindow\(\)/g) || []).length
+        const narrativeSeeds = (source.match(/seedReleaseNarrative\(\)/g) || []).length
+        expect(windowSeeds).toBeGreaterThan(0)
+        expect(narrativeSeeds).toBe(windowSeeds)
+    })
+
+    // The 8,000 cap must be visible, not just enforced server-side: an uncapped paste fails
+    // the whole write and names the wire field rather than the label the author sees.
+    it('caps the input at the shared bound and shows the count', () => {
+        const tag = source.match(/v-model:value="releaseNarrative"[\s\S]*?\/>/)
+        expect(tag).not.toBeNull()
+        expect(tag![0]).toContain(':maxlength="FDA_PROSE_MAX_LENGTH"')
+        expect(tag![0]).toContain('show-count')
+        expect(tag![0]).toContain(':disabled="!isWritable || savingReleaseNarrative"')
+    })
+
+    // REGRESSION (Layer 1, org prose form): the baseline must come from the mutation's own
+    // response, BEFORE the refetch that can throw. Refreshing it only via the refetch meant a
+    // failed refetch reported a committed save as failed and left the baseline stale, so the
+    // next clear was silently omitted while the server kept the text.
+    it('refreshes the baseline from the mutation response before refetching', () => {
+        const body = functionBody('saveReleaseNarrative')
+        expect(body).toMatch(/resp\?\.data/)
+        expect(body.indexOf('releaseNarrativeBaseline.value =')).toBeLessThan(body.indexOf('await fetchRelease()'))
+    })
+
+    it('does not fire a mutation when the form is not dirty', () => {
+        const body = functionBody('saveReleaseNarrative')
+        expect(body.indexOf('if (!vars)')).toBeLessThan(body.indexOf('graphqlClient.mutate'))
+    })
+
+    // The author must see what an override replaces. Without the default on screen,
+    // "override" is an instruction to write something without being told what it displaces.
+    it('shows the org default read-only beneath the editor', () => {
+        expect(source).toMatch(/orgNarrativeDefault/)
+        const tag = source.match(/:value="orgNarrativeDefault"[\s\S]{0,120}/)
+        expect(source).toMatch(/readonly :value="orgNarrativeDefault"/)
+        expect(tag).not.toBeNull()
+    })
+
+    // A FDA_NARRATIVE event carries no objectId, so without its own branch the history row
+    // renders blank -- a Scope column saying the justification changed beside nothing.
+    it('renders FDA_NARRATIVE history rows through the length formatter', () => {
+        expect(source).toContain("row.rus === 'FDA_NARRATIVE'")
+        expect(source).toMatch(/formatNarrativeChange\(row\.oldValue, row\.newValue\)/)
+    })
+
+    // Both release queries must select it: fetchRelease switches documents once the
+    // artifacts tab is visited, and null means INHERIT rather than an obvious absence.
+    it('is selected by both release queries', () => {
+        const queries = readFileSync(
+            fileURLToPath(new URL('../utils/graphqlQueries.ts', import.meta.url)), 'utf8')
+        const hits = (queries.match(/^\s+fdaAssessmentNarrative$/gm) || []).length
+        expect(hits).toBeGreaterThanOrEqual(2)
+    })
+})

--- a/ui/src/components/releaseNarrativeWiring.spec.ts
+++ b/ui/src/components/releaseNarrativeWiring.spec.ts
@@ -31,7 +31,8 @@ function functionBody (name: string): string {
 describe('the release narrative editor is wired into ReleaseView', () => {
     it.each([
         ['releaseNarrativeVariables', '@/utils/releaseNarrativeInput'],
-        ['FDA_PROSE_MAX_LENGTH', '@/utils/releaseNarrativeInput'],
+        ['releaseNarrativeDiffers', '@/utils/releaseNarrativeInput'],
+        ['FDA_PROSE_MAX_LENGTH', '@/utils/fdaProseInput'],
         ['formatNarrativeChange', '@/utils/narrativeHistory']
     ])('imports %s from %s', (symbol, module) => {
         expect(source).toMatch(new RegExp(
@@ -84,10 +85,20 @@ describe('the release narrative editor is wired into ReleaseView', () => {
     // The author must see what an override replaces. Without the default on screen,
     // "override" is an instruction to write something without being told what it displaces.
     it('shows the org default read-only beneath the editor', () => {
-        expect(source).toMatch(/orgNarrativeDefault/)
-        const tag = source.match(/:value="orgNarrativeDefault"[\s\S]{0,120}/)
         expect(source).toMatch(/readonly :value="orgNarrativeDefault"/)
-        expect(tag).not.toBeNull()
+    })
+
+    // REGRESSION: the success toast used to sit OUTSIDE the `saved` guard and take its
+    // wording from a baseline that is still the pre-save value when the response is empty --
+    // so authoring a narrative reported "cleared" and clearing one reported "updated".
+    it('reports success only inside the saved guard, and warns otherwise', () => {
+        const body = functionBody('saveReleaseNarrative')
+        const guard = body.indexOf('if (saved)')
+        const success = body.indexOf("notify('success'")
+        const elseWarn = body.indexOf("notify('warning'")
+        expect(guard).toBeGreaterThan(-1)
+        expect(success).toBeGreaterThan(guard)
+        expect(elseWarn).toBeGreaterThan(success)
     })
 
     // A FDA_NARRATIVE event carries no objectId, so without its own branch the history row

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -731,14 +731,18 @@ const DELIVERABLE_DETAIL_DATA = `
     }
 `
 
-// eos / eol: the DEVICE support window. Selected by BOTH release queries deliberately.
+// eos / eol / fdaAssessmentNarrative: the DEVICE support window and the per-release FDA
+// narrative override. Selected by BOTH release queries deliberately.
 // fetchRelease switches to the full query once the artifacts tab has been visited, so a
 // field present in only one of them reads as "not declared" from that point on -- which for
-// this pair is a meaningful value, not an obvious absence, so the omission is invisible
-// rather than loud. releaseFragmentsSchemaDrift.spec.ts asserts the pairing.
+// these is a meaningful value, not an obvious absence, so the omission is invisible rather
+// than loud. That exact bug shipped once on eos/eol: the editor saved correctly, the refetch
+// read undefined, and the pickers blanked while the value sat safely in the database.
+// releaseFragmentsSchemaDrift.spec.ts asserts the pairing for all three.
 const singleReleaseDataNoParent = `
     eos
     eol
+    fdaAssessmentNarrative
     createdDate
     org
     hardware
@@ -1280,12 +1284,15 @@ query FetchReleaseInProducts($releaseID: ID!, $orgID: ID) {
 // eos / eol: the DEVICE support window. Selected here rather than fetched on demand because
 // the release view seeds its editor from the loaded release, and an unselected field reads
 // as "not declared" -- a meaningful value here, so the omission would be invisible rather
-// than obviously broken. Must stay in step with singleReleaseDataNoParent.
+// than obviously broken. Must stay in step with singleReleaseDataNoParent -- the drift spec
+// asserts it, because a comment was the only thing holding the pair together when eos/eol
+// diverged.
 const singleReleaseProductNoParent = `
     createdDate
     org
     eos
     eol
+    fdaAssessmentNarrative
     artifacts
     artifactDetails {
         ${ARTIFACT_DETAIL_DATA}

--- a/ui/src/utils/narrativeHistory.spec.ts
+++ b/ui/src/utils/narrativeHistory.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { narrativeLength, formatNarrativeChange } from './narrativeHistory'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
 
 describe('narrativeLength', () => {
     it('is the string length when the value was stored whole', () => {
@@ -19,6 +21,16 @@ describe('narrativeLength', () => {
         expect(narrativeLength(null)).toBe(0)
         expect(narrativeLength(undefined)).toBe(0)
         expect(narrativeLength('')).toBe(0)
+    })
+
+    // The marker is appended ONLY above the 200-character cut, so a SHORT narrative that
+    // genuinely ends in a marker-shaped phrase -- prose quoting an earlier history row --
+    // was stored whole and must be measured by its own length. Without the length guard
+    // this reported 42.
+    it('ignores a trailing marker on a value short enough to have been stored whole', () => {
+        const authored = 'the prior row read ... (42 characters)'
+        expect(authored.length).toBeLessThan(200)
+        expect(narrativeLength(authored)).toBe(authored.length)
     })
 
     // The marker is only meaningful at the END. Narrative prose could legitimately contain
@@ -70,5 +82,32 @@ describe('formatNarrativeChange', () => {
 
     it('falls back to a neutral phrase rather than rendering a blank cell', () => {
         expect(formatNarrativeChange(null, null)).toBe('narrative unchanged')
+    })
+})
+
+/**
+ * The regex above encodes a format string that lives in ANOTHER REPOSITORY. If
+ * ReleaseData.narrativeExcerpt ever rewords -- "chars", a different separator -- narrativeLength
+ * silently reverts to reporting ~218 for every long narrative, which is precisely the
+ * wrong-number-in-the-audit-trail failure it exists to prevent, with nothing failing.
+ *
+ * Reading the Java source is the same trick the schema drift specs use, and it is the only
+ * thing that couples the two.
+ */
+describe('the excerpt marker still matches the backend that writes it', () => {
+    const PRO_RELEASE_DATA = fileURLToPath(new URL(
+        '../../../../rearm-core/backend/src/main/java/io/reliza/model/ReleaseData.java', import.meta.url))
+
+    it.runIf(existsSync(PRO_RELEASE_DATA))('emits "... (N characters)" and cuts at 200', () => {
+        const java = readFileSync(PRO_RELEASE_DATA, 'utf8')
+        expect(java).toContain('NARRATIVE_EVENT_EXCERPT_MAX = 200')
+        expect(java).toContain('+ "... (" + narrative.length() + " characters)"')
+    })
+
+    it.runIf(existsSync(PRO_RELEASE_DATA))('produces a value this parser reads correctly', () => {
+        // Reproduce the backend expression exactly, then round-trip it.
+        const narrative = 'x'.repeat(9000)
+        const backendWould = narrative.substring(0, 200) + '... (' + narrative.length + ' characters)'
+        expect(narrativeLength(backendWould)).toBe(9000)
     })
 })

--- a/ui/src/utils/narrativeHistory.spec.ts
+++ b/ui/src/utils/narrativeHistory.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { narrativeLength, formatNarrativeChange } from './narrativeHistory'
+
+describe('narrativeLength', () => {
+    it('is the string length when the value was stored whole', () => {
+        expect(narrativeLength('short narrative')).toBe(15)
+    })
+
+    // THE REGRESSION THIS EXISTS FOR: the event carries at most ~200 characters, so the
+    // excerpt's own length is meaningless for anything longer. Reporting it would tell an
+    // auditor a 9,000-character justification was 218 characters.
+    it('reads the TRUE length out of the excerpt marker, not the excerpt', () => {
+        const excerpt = 'w'.repeat(200) + '... (9000 characters)'
+        expect(excerpt.length).not.toBe(9000)
+        expect(narrativeLength(excerpt)).toBe(9000)
+    })
+
+    it('treats absent values as zero', () => {
+        expect(narrativeLength(null)).toBe(0)
+        expect(narrativeLength(undefined)).toBe(0)
+        expect(narrativeLength('')).toBe(0)
+    })
+
+    // The marker is only meaningful at the END. Narrative prose could legitimately contain
+    // a parenthetical that looks like it.
+    it('ignores a marker-shaped phrase that is not the trailing marker', () => {
+        expect(narrativeLength('we counted ... (42 characters) and then continued'))
+            .toBe('we counted ... (42 characters) and then continued'.length)
+    })
+})
+
+describe('formatNarrativeChange', () => {
+    it('reports a first narrative as set, with its length', () => {
+        expect(formatNarrativeChange(null, 'x'.repeat(1240)))
+            .toBe('narrative set (1,240 characters)')
+    })
+
+    it('reports a replacement as changed, with both lengths', () => {
+        expect(formatNarrativeChange('x'.repeat(1240), 'y'.repeat(890)))
+            .toBe('narrative changed (1,240 characters -> 890 characters)')
+    })
+
+    // "cleared" and not "removed": clearing the override returns the release to INHERITING
+    // the org default, so the document keeps its justification section. An auditor reading
+    // "removed" would conclude the opposite.
+    it('says a clear returns the release to the org default', () => {
+        expect(formatNarrativeChange('x'.repeat(1240), null))
+            .toBe('narrative cleared, release returns to the org default (was 1,240 characters)')
+    })
+
+    it('uses the true lengths when the event carried excerpts', () => {
+        const oldEx = 'a'.repeat(200) + '... (5000 characters)'
+        const newEx = 'b'.repeat(200) + '... (7500 characters)'
+        expect(formatNarrativeChange(oldEx, newEx))
+            .toBe('narrative changed (5,000 characters -> 7,500 characters)')
+    })
+
+    // Never the text: the event holds an excerpt that stops mid-word, and the history table
+    // is a dense list where paragraphs of prose make every surrounding row unreadable.
+    it('never renders the narrative text itself', () => {
+        const secret = 'the manufacturer states that components were assessed by hand'
+        expect(formatNarrativeChange(null, secret)).not.toContain('manufacturer')
+        expect(formatNarrativeChange(secret, null)).not.toContain('manufacturer')
+        expect(formatNarrativeChange(secret, secret + '!')).not.toContain('manufacturer')
+    })
+
+    it('singularises a one-character narrative', () => {
+        expect(formatNarrativeChange(null, 'x')).toBe('narrative set (1 character)')
+    })
+
+    it('falls back to a neutral phrase rather than rendering a blank cell', () => {
+        expect(formatNarrativeChange(null, null)).toBe('narrative unchanged')
+    })
+})

--- a/ui/src/utils/narrativeHistory.ts
+++ b/ui/src/utils/narrativeHistory.ts
@@ -1,0 +1,58 @@
+// Rendering for FDA_NARRATIVE release update events.
+
+/**
+ * The marker the backend appends when it excerpts a narrative into an update event.
+ *
+ * ReleaseData.narrativeExcerpt stores at most 200 characters and, when it truncates, appends
+ * "... (N characters)" with the TRUE length. Anything longer than that is not in the event
+ * at all -- the full text lives on the release.
+ */
+const EXCERPT_MARKER = /\.\.\. \((\d+) characters\)$/
+
+/**
+ * How long the narrative actually was, given what the event carries.
+ *
+ * THE POINT OF THIS FUNCTION: the event value is an EXCERPT, so its own `.length` is 200-ish
+ * for every narrative longer than that. Reporting it would tell an auditor that a 9,000
+ * character justification was 218 characters -- a specific, plausible, wrong number in the
+ * one place someone goes to reconstruct what happened. The marker carries the real length;
+ * use it when present and fall back to the string only when the value was stored whole.
+ */
+export function narrativeLength (eventValue: string | null | undefined): number {
+    if (!eventValue) return 0
+    const m = EXCERPT_MARKER.exec(eventValue)
+    return m ? Number(m[1]) : eventValue.length
+}
+
+/** Thousands separators, so a five-digit count is readable at a glance in a table. */
+function count (n: number): string {
+    return `${n.toLocaleString('en-US')} character${n === 1 ? '' : 's'}`
+}
+
+/**
+ * One history row for a narrative change.
+ *
+ * NEVER THE TEXT, only what happened and how big it was. Two reasons, and the second is the
+ * load-bearing one:
+ *
+ *   - the event holds an excerpt, so rendering it would show a sentence that stops
+ *     mid-word and read as data corruption rather than as a deliberate summary;
+ *   - the history table is a dense list of every change to a release. Pasting paragraphs of
+ *     regulatory prose into a cell there makes the surrounding rows unreadable, and the full
+ *     current text is one panel away on the same page.
+ *
+ * "cleared" is deliberately not "removed": clearing the override returns the release to
+ * INHERITING the org default, so the document does not lose its justification section. An
+ * auditor reading "removed" would reasonably conclude the opposite.
+ */
+export function formatNarrativeChange (
+    oldValue: string | null | undefined,
+    newValue: string | null | undefined
+): string {
+    const before = narrativeLength(oldValue)
+    const after = narrativeLength(newValue)
+    if (!before && after) return `narrative set (${count(after)})`
+    if (before && !after) return `narrative cleared, release returns to the org default (was ${count(before)})`
+    if (before && after) return `narrative changed (${count(before)} -> ${count(after)})`
+    return 'narrative unchanged'
+}

--- a/ui/src/utils/narrativeHistory.ts
+++ b/ui/src/utils/narrativeHistory.ts
@@ -10,6 +10,16 @@
 const EXCERPT_MARKER = /\.\.\. \((\d+) characters\)$/
 
 /**
+ * The excerpt length the backend cuts at, mirroring ReleaseData.NARRATIVE_EVENT_EXCERPT_MAX.
+ *
+ * Load-bearing for the guard below, not decoration: the marker is appended ONLY when the
+ * narrative exceeded this, so a short narrative that legitimately ENDS in something
+ * marker-shaped -- prose quoting an earlier history row, say -- must be measured by its own
+ * length rather than believed. Without the guard that narrative reports 42 characters.
+ */
+const EXCERPT_MAX = 200
+
+/**
  * How long the narrative actually was, given what the event carries.
  *
  * THE POINT OF THIS FUNCTION: the event value is an EXCERPT, so its own `.length` is 200-ish
@@ -21,7 +31,9 @@ const EXCERPT_MARKER = /\.\.\. \((\d+) characters\)$/
 export function narrativeLength (eventValue: string | null | undefined): number {
     if (!eventValue) return 0
     const m = EXCERPT_MARKER.exec(eventValue)
-    return m ? Number(m[1]) : eventValue.length
+    // Both conditions. A value at or under the cut was stored WHOLE, so any marker in it is
+    // the author's own text and not ours.
+    return (m && eventValue.length > EXCERPT_MAX) ? Number(m[1]) : eventValue.length
 }
 
 /** Thousands separators, so a five-digit count is readable at a glance in a table. */

--- a/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
+++ b/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
+import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { buildSchema, validate, parse } from 'graphql'
 import graphqlQueries from './graphqlQueries'
@@ -18,10 +18,15 @@ import graphqlQueries from './graphqlQueries'
 // Pro (it may lag on updates), so a field valid on CE is valid on Pro.
 const CE_SCHEMA_PATH = fileURLToPath(new URL(
     '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
 
 // Read eagerly: a missing schema is a broken checkout, and should fail the
 // suite rather than quietly skip every assertion below.
 const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+const proSchema = existsSync(PRO_SCHEMA_PATH)
+    ? buildSchema(readFileSync(PRO_SCHEMA_PATH, 'utf8'))
+    : null
 
 // Every fragment here is a selection set on Release, so each one is checked in
 // the operation shape the UI actually sends it in.
@@ -58,14 +63,40 @@ const SINGLE_RELEASE_DOCUMENTS: Array<[string, any]> = [
 ]
 
 describe('single-release documents vs the CE schema', () => {
-    it.each(SINGLE_RELEASE_DOCUMENTS)('%s is valid against the CE schema', (_name, doc) => {
-        expect(validate(ceSchema, doc).map(e => e.message)).toEqual([])
+    /**
+     * Pro, not CE. These two select fdaAssessmentNarrative, which CE gains at the deferred
+     * sync -- so a CE assertion here would fail for a reason the ruling has already accepted
+     * as informational. Checking Pro keeps the assertion meaningful instead of deleting it.
+     */
+    it.runIf(proSchema).each(SINGLE_RELEASE_DOCUMENTS)(
+        '%s is valid against the Pro schema', (_name, doc) => {
+            expect(validate(proSchema as any, doc).map(e => e.message)).toEqual([])
+        })
+
+    /**
+     * The CE gap is EXPECTED and TEMPORARY, asserted so it cannot quietly become permanent:
+     * when the sync lands this fails, and the documents move back to a CE assertion.
+     */
+    it.each(SINGLE_RELEASE_DOCUMENTS)('%s is still ahead of CE, pending the sync', (_name, doc) => {
+        const errs = validate(ceSchema, doc).map(e => e.message).join(' ')
+        expect(errs).toContain('fdaAssessmentNarrative')
     })
 
     it.each(SINGLE_RELEASE_DOCUMENTS)('%s selects the device support window', (_name, doc) => {
         const printed = doc.loc?.source?.body ?? ''
         expect(printed).toMatch(/\beos\b/)
         expect(printed).toMatch(/\beol\b/)
+    })
+
+    /**
+     * The narrative override rides the SAME pairing, and for the same reason: null means
+     * INHERIT, so a query that omits it reads as "this release has no override" -- a
+     * meaningful value rather than an obvious absence. Omitting it from one document would
+     * make the editor blank itself after a save on exactly the tab sequence that broke
+     * eos/eol.
+     */
+    it.each(SINGLE_RELEASE_DOCUMENTS)('%s selects the narrative override', (_name, doc) => {
+        expect(doc.loc?.source?.body ?? '').toMatch(/\bfdaAssessmentNarrative\b/)
     })
 })
 

--- a/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
+++ b/ui/src/utils/releaseFragmentsSchemaDrift.spec.ts
@@ -78,8 +78,15 @@ describe('single-release documents vs the CE schema', () => {
      * when the sync lands this fails, and the documents move back to a CE assertion.
      */
     it.each(SINGLE_RELEASE_DOCUMENTS)('%s is still ahead of CE, pending the sync', (_name, doc) => {
-        const errs = validate(ceSchema, doc).map(e => e.message).join(' ')
-        expect(errs).toContain('fdaAssessmentNarrative')
+        const errs = validate(ceSchema, doc).map(e => e.message)
+        // EVERY error must be the expected one, not merely "the expected one appears".
+        // Joining and asking toContain was near-worthless: an unrelated typo -- a misspelled
+        // artifactDetails subfield, say -- adds its own message while the expected string is
+        // still present, so the assertion passed on a broken document. Combined with the Pro
+        // check being skippable on a checkout without a rearm-core sibling, these two
+        // documents could have ended up with no real validity checking at all.
+        expect(errs.length).toBeGreaterThan(0)
+        expect(errs.filter(e => !e.includes('fdaAssessmentNarrative'))).toEqual([])
     })
 
     it.each(SINGLE_RELEASE_DOCUMENTS)('%s selects the device support window', (_name, doc) => {

--- a/ui/src/utils/releaseNarrativeInput.spec.ts
+++ b/ui/src/utils/releaseNarrativeInput.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { releaseNarrativeVariables, releaseNarrativeDirty, FDA_PROSE_MAX_LENGTH } from './releaseNarrativeInput'
+
+const U = '11111111-1111-1111-1111-111111111111'
+const O = '22222222-2222-2222-2222-222222222222'
+
+describe('releaseNarrativeVariables', () => {
+    // The durable guard, same as the device window's: updateRelease treats a null list as
+    // "no change", so a payload that grew an artifacts key could DETACH release contents.
+    it('sends ONLY uuid, org and the field -- never a dead key', () => {
+        const vars = releaseNarrativeVariables(U, O, 'device-specific', null)
+        expect(Object.keys(vars!).sort()).toEqual(['fdaAssessmentNarrative', 'org', 'uuid'])
+    })
+
+    it('returns null when nothing changed, so no mutation is fired', () => {
+        expect(releaseNarrativeVariables(U, O, 'same', 'same')).toBeNull()
+        expect(releaseNarrativeVariables(U, O, null, null)).toBeNull()
+    })
+
+    it('sends a changed value trimmed', () => {
+        expect(releaseNarrativeVariables(U, O, '  new text  ', null))
+            .toEqual({ uuid: U, org: O, fdaAssessmentNarrative: 'new text' })
+    })
+
+    // '' is the wire form of a deliberate clear; the server reads it as "return to
+    // inheriting the org default".
+    it('sends an empty string when text is emptied', () => {
+        expect(releaseNarrativeVariables(U, O, '', 'previous'))
+            .toEqual({ uuid: U, org: O, fdaAssessmentNarrative: '' })
+    })
+
+    it('treats replacing text with whitespace as a clear', () => {
+        expect(releaseNarrativeVariables(U, O, '   ', 'previous'))
+            .toEqual({ uuid: U, org: O, fdaAssessmentNarrative: '' })
+    })
+
+    it('treats whitespace typed into an empty field as no change', () => {
+        expect(releaseNarrativeVariables(U, O, '   ', null)).toBeNull()
+    })
+
+    it('does not send a field whose only change is surrounding whitespace', () => {
+        expect(releaseNarrativeVariables(U, O, '  same  ', 'same')).toBeNull()
+    })
+
+    // null on the server and '' in an untouched form are the same state; treating them as
+    // different would send a spurious clear on every save of a form nobody edited.
+    it('treats a null baseline and an empty form as equal', () => {
+        expect(releaseNarrativeVariables(U, O, '', null)).toBeNull()
+    })
+})
+
+describe('releaseNarrativeDirty', () => {
+    it('is false for equal values and whitespace-only differences', () => {
+        expect(releaseNarrativeDirty('same', 'same')).toBe(false)
+        expect(releaseNarrativeDirty('  same  ', 'same')).toBe(false)
+        expect(releaseNarrativeDirty(null, '')).toBe(false)
+    })
+
+    it('is true for a real edit and for a clear', () => {
+        expect(releaseNarrativeDirty('new', 'old')).toBe(true)
+        expect(releaseNarrativeDirty('', 'old')).toBe(true)
+        expect(releaseNarrativeDirty('new', null)).toBe(true)
+    })
+})
+
+describe('the shared bound', () => {
+    // Re-exported rather than redeclared: the release override and the org default must not
+    // be able to accept different lengths, and the server enforces one number for both.
+    it('is the same constant the org prose form uses', () => {
+        expect(FDA_PROSE_MAX_LENGTH).toBe(8000)
+    })
+})

--- a/ui/src/utils/releaseNarrativeInput.spec.ts
+++ b/ui/src/utils/releaseNarrativeInput.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { releaseNarrativeVariables, releaseNarrativeDirty, FDA_PROSE_MAX_LENGTH } from './releaseNarrativeInput'
+import { releaseNarrativeVariables, releaseNarrativeDiffers } from './releaseNarrativeInput'
+import { FDA_PROSE_MAX_LENGTH } from './fdaProseInput'
 
 const U = '11111111-1111-1111-1111-111111111111'
 const O = '22222222-2222-2222-2222-222222222222'
@@ -49,17 +50,17 @@ describe('releaseNarrativeVariables', () => {
     })
 })
 
-describe('releaseNarrativeDirty', () => {
+describe('releaseNarrativeDiffers', () => {
     it('is false for equal values and whitespace-only differences', () => {
-        expect(releaseNarrativeDirty('same', 'same')).toBe(false)
-        expect(releaseNarrativeDirty('  same  ', 'same')).toBe(false)
-        expect(releaseNarrativeDirty(null, '')).toBe(false)
+        expect(releaseNarrativeDiffers('same', 'same')).toBe(false)
+        expect(releaseNarrativeDiffers('  same  ', 'same')).toBe(false)
+        expect(releaseNarrativeDiffers(null, '')).toBe(false)
     })
 
     it('is true for a real edit and for a clear', () => {
-        expect(releaseNarrativeDirty('new', 'old')).toBe(true)
-        expect(releaseNarrativeDirty('', 'old')).toBe(true)
-        expect(releaseNarrativeDirty('new', null)).toBe(true)
+        expect(releaseNarrativeDiffers('new', 'old')).toBe(true)
+        expect(releaseNarrativeDiffers('', 'old')).toBe(true)
+        expect(releaseNarrativeDiffers('new', null)).toBe(true)
     })
 })
 

--- a/ui/src/utils/releaseNarrativeInput.ts
+++ b/ui/src/utils/releaseNarrativeInput.ts
@@ -1,0 +1,45 @@
+// Release narrative form state -> updateRelease variables, honouring the PATCH contract.
+
+import { FDA_PROSE_MAX_LENGTH } from './fdaProseInput'
+
+export { FDA_PROSE_MAX_LENGTH }
+
+/**
+ * Build the narrow partial for a per-release narrative write.
+ *
+ * Same narrowness rule as the device window: { uuid, org } plus the one field, and nothing
+ * else. updateRelease treats a null list as "no change", so a payload that grew an
+ * artifacts or commits key could DETACH a release's contents -- and widening it also arms
+ * the DRAFT_ONLY gate, which only stays dormant because isAssemblyRequested trips on fields
+ * this payload omits.
+ *
+ * PATCH semantics, matching the org-level prose form:
+ *   unchanged         -> omitted, so an unrelated release save cannot disturb the narrative
+ *   emptied from text -> sent as '', which the server reads as a deliberate CLEAR
+ *   changed           -> sent trimmed
+ *
+ * Trimmed on both sides before comparison, so whitespace-only input equals empty in both
+ * directions: typing spaces into an empty field is not a change, and replacing text with
+ * spaces IS a clear. The server rejects surrounding whitespace anyway.
+ */
+export function releaseNarrativeVariables (
+    uuid: string,
+    org: string,
+    current: string | null | undefined,
+    baseline: string | null | undefined
+): Record<string, unknown> | null {
+    const now = (current || '').trim()
+    const was = (baseline || '').trim()
+    // NULL, not an empty object: "nothing to send" is a different answer from "send a patch
+    // with no fields", and the caller must not fire a mutation for an unchanged form.
+    if (now === was) return null
+    return { uuid, org, fdaAssessmentNarrative: now }
+}
+
+/** True when the form differs from what the server last confirmed. */
+export function releaseNarrativeDirty (
+    current: string | null | undefined,
+    baseline: string | null | undefined
+): boolean {
+    return (current || '').trim() !== (baseline || '').trim()
+}

--- a/ui/src/utils/releaseNarrativeInput.ts
+++ b/ui/src/utils/releaseNarrativeInput.ts
@@ -1,9 +1,5 @@
 // Release narrative form state -> updateRelease variables, honouring the PATCH contract.
 
-import { FDA_PROSE_MAX_LENGTH } from './fdaProseInput'
-
-export { FDA_PROSE_MAX_LENGTH }
-
 /**
  * Build the narrow partial for a per-release narrative write.
  *
@@ -36,8 +32,14 @@ export function releaseNarrativeVariables (
     return { uuid, org, fdaAssessmentNarrative: now }
 }
 
-/** True when the form differs from what the server last confirmed. */
-export function releaseNarrativeDirty (
+/**
+ * True when the form differs from what the server last confirmed.
+ *
+ * Named "differs" rather than "dirty" because ReleaseView owns a computed called
+ * releaseNarrativeDirty; importing this under an alias would have given one function two
+ * names, tested under one and read under the other.
+ */
+export function releaseNarrativeDiffers (
     current: string | null | undefined,
     baseline: string | null | undefined
 ): boolean {


### PR DESCRIPTION
Step 4b. The editor for the override rearm-saas#500 added, plus the history branch that
makes it readable. Small PR, three new files and one component.

## The org default is shown read-only beneath the editor

Without it, "override" is an instruction to write something without being told what it
displaces -- and the author cannot judge whether a device-specific justification is even
needed until they have read the one it would replace. When neither exists the panel says so
explicitly, because that combination means generated documents carry **no justification
section at all**.

## Same PATCH shape as the org prose form, including the lessons

* baseline diffed, so an unrelated release save cannot disturb the narrative
* `''` is a deliberate CLEAR, and the toast says what clearing **means**: the release returns
  to inheriting, it does not lose its justification
* the baseline is refreshed from the **mutation response**, before the refetch that can
  throw. On the org form, refreshing only via a nested re-read meant a failed re-read
  reported a COMMITTED save as failed and left the baseline stale, so the operator's next
  clear was silently omitted while the server kept the text
* the 8,000 cap is visible (`maxlength` + `show-count`), not only enforced server-side where
  an over-length paste fails the whole write and names the wire field
* `releaseNarrativeVariables` returns **null** for an unchanged form, so no mutation fires

## History: lengths, never the text -- and the length is the subtle part

`FDA_NARRATIVE` carries old/new values and no `objectId`, so without its own branch the row
falls through to `return row.objectId` and renders **blank** -- a Scope column saying the
justification changed beside nothing saying anything about it. Exactly the defect
`SUPPORT_WINDOW` had.

The backend stores a **200-character excerpt** in the event, appending `... (N characters)`
when it truncates. Using the stored value's own `.length` would tell an auditor that a
9,000-character justification was 218 characters -- a specific, plausible, wrong number in
the one place someone goes to reconstruct what happened. `narrativeLength` reads the marker
when present and falls back to the string only when the value was stored whole. Spec'd both
ways, including a marker-shaped phrase mid-sentence that must NOT be treated as the marker.

"cleared" is deliberately not "removed": clearing returns the release to INHERITING, so the
document keeps its justification section. An auditor reading "removed" would conclude the
opposite.

## Query pairing

Both release queries select the field, and `releaseFragmentsSchemaDrift` now asserts that
pairing for all three of `eos`/`eol`/`fdaAssessmentNarrative`. `fetchRelease` switches
documents once the artifacts tab is visited, and null here means INHERIT -- a meaningful
value, so an omission would be invisible rather than loud. That precise bug shipped once on
`eos`/`eol`.

The two single-release documents are now Pro-ahead, so the drift spec validates them against
Pro and **asserts the CE gap explicitly**: when the deferred sync lands that assertion fails,
and the documents move back to a CE check rather than the gap quietly becoming permanent.

## Pro-backend probe, all green

Against `rearm-pro:t3993-7g` on the sandbox, release `9000.1.0` (Infusion Pump 9000):

```
N1  narrative card present on the PRODUCT release
N2  org default shown read-only
N3  starts inheriting
N4  Save enabled once dirty
N5  override persisted across reload
N6  no longer says inheriting
N7  addendum carries the RELEASE override
N8  addendum scope says: this release
N9  FDA_NARRATIVE row present in history
N10 history row is NOT blank
N11 history does not leak the narrative text
N12 unrelated (device window) save left the narrative intact
N13 Save enabled for a clear
N14 override cleared
N15 says inheriting again
N16 addendum fell back to the ORG default
N17 addendum scope back to: organization default
X   0 page exceptions
```

N7/N8 and N16/N17 are the round trip through the resolution seam, observed rather than
inferred: set the override and the generated document changes what it carries and how it
labels the source; clear it and both go back.

## Checks

**586 tests / 43 files** (was 541/40). 0 non-ASCII added. 2 CE drift warnings, both expected
and both asserted so they cannot become permanent. `releaseNarrativeWiring.spec.ts` continues
the `*Wiring.spec.ts` pattern, and asserts the narrative is seeded on **every** path that
seeds the device window -- the window shipped with two load paths, and one missing seeding
call would blank the editor on the other.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>