### PR TITLE
The FDA support addendum as PDF, sharing one document definition with the CSV (7i)

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -85,7 +85,7 @@
                          addendum always walks the whole release scope, so an operator who
                          ticked "Top Level Dependencies Only" and got a full-scope document
                          would have no way to tell the control had been dropped on the floor. -->
-                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
+                    <n-form-item v-if="!isAddendumExport">
                         <template #label>
                             <span style="display: inline-flex; align-items: center;">
                                 Select SBOM configuration for export
@@ -123,9 +123,10 @@
                                  below do not apply to it. A checkbox would imply it rides
                                  along with whichever format was picked. -->
                             <n-radio-button value="FDA_ADDENDUM">FDA support addendum (CSV)</n-radio-button>
+                            <n-radio-button value="FDA_ADDENDUM_PDF">FDA support addendum (PDF)</n-radio-button>
                         </n-radio-group>
                     </n-form-item>
-                    <n-alert v-if="selectedSbomMediaType === 'FDA_ADDENDUM'" type="default"
+                    <n-alert v-if="isAddendumExport" type="default"
                         :show-icon="false" style="font-size: 12px; max-width: 620px; margin-bottom: 10px;">
                         Every component in this release with its level of support, the end-of-support
                         date where one is attested and the justification where none is, plus the
@@ -157,7 +158,7 @@
                             />
                         </n-radio-group>
                     </n-form-item>
-                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
+                    <n-form-item v-if="!isAddendumExport">
                         <span style="display: inline-flex; align-items: center;">
                             Top Level Dependencies Only:
                             <n-tooltip trigger="hover">
@@ -171,7 +172,7 @@
                         </span>
                         <n-switch style="margin-left: 5px;" v-model:value="tldOnly"/>
                     </n-form-item>
-                    <n-form-item v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'">
+                    <n-form-item v-if="!isAddendumExport">
                         <span style="display: inline-flex; align-items: center;">
                             Ignore Optional Dependencies:
                             <n-tooltip trigger="hover">
@@ -1750,6 +1751,7 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
+import { renderAddendumPdfBlob, addendumPdfFileName } from '@/utils/addendumPdf'
 import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/releaseNarrativeInput'
 import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
@@ -2825,6 +2827,15 @@ watch(() => props.uuidprop, (newUuid) => {
 
 // Media type for SBOM export
 const selectedSbomMediaType = ref('JSON')
+/**
+ * Both addendum encodings, as one condition.
+ *
+ * The addendum is a different DOCUMENT that happens to share this modal, so the BOM-shaping
+ * options do not apply to either encoding of it. Asking the question once means adding a
+ * third encoding later cannot leave one control wired to the old two-value test.
+ */
+const isAddendumExport: ComputedRef<boolean> = computed((): boolean =>
+    selectedSbomMediaType.value === 'FDA_ADDENDUM' || selectedSbomMediaType.value === 'FDA_ADDENDUM_PDF')
 
 //getAggregatedChangelog
 const showExportSBOMModal: Ref<boolean> = ref(false)
@@ -5123,7 +5134,7 @@ async function uploadNewBomVersion (art: any) {
  * no support attestation, which is the one number a reviewer is looking for. The collector
  * returns no data at all on any refusal, so there is nothing here to accidentally save.
  */
-async function exportFdaAddendum () {
+async function exportFdaAddendum (asPdf: boolean) {
     try {
         bomExportPending.value = true
         const orgUuid = updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
@@ -5142,10 +5153,15 @@ async function exportFdaAddendum () {
             Swal.fire('Addendum not generated', result.error, 'error')
             return
         }
-        const blob = new Blob([renderAddendumCsv(result.data)], { type: 'text/csv;charset=utf-8' })
+        // The collection is identical for both encodings -- only the rendering differs -- so
+        // the branch is here rather than at the top. That keeps ONE refusal path: a partial
+        // document must be impossible in both formats, not in whichever one was written first.
+        const blob = asPdf
+            ? await renderAddendumPdfBlob(result.data)
+            : new Blob([renderAddendumCsv(result.data)], { type: 'text/csv;charset=utf-8' })
         const link = document.createElement('a')
         link.href = window.URL.createObjectURL(blob)
-        link.download = addendumFileName(result.data)
+        link.download = asPdf ? addendumPdfFileName(result.data) : addendumFileName(result.data)
         // append -> click -> remove -> revoke, following utils/bovExport.ts rather than the
         // older exports in this file: revoking the URL of a DETACHED anchor races the
         // browser's own fetch of it in some engines, and a silently empty download is a
@@ -5155,7 +5171,8 @@ async function exportFdaAddendum () {
         document.body.removeChild(link)
         window.URL.revokeObjectURL(link.href)
         notify('success', 'Addendum exported',
-            `${result.data.totalComponents} components, ${result.data.unassessedComponents} with no attestation.`)
+            `${asPdf ? 'PDF' : 'CSV'}: ${result.data.totalComponents} components,`
+            + ` ${result.data.unassessedComponents} with no attestation.`)
     } catch (err: any) {
         // extractGraphQLErrorMessage, not the parseGraphQLError(err.message) its neighbours
         // use: this catch only fires on throws collectAddendumData did NOT convert into a
@@ -5171,7 +5188,8 @@ async function exportFdaAddendum () {
 async function exportReleaseSbom (tldOnly: boolean, ignoreDev: boolean, selectedBomStructureType: string, selectedRebomType: string, mediaType: string) {
     // Routed here rather than from the template so the button keeps one handler and the
     // modal cannot end up with two spinners disagreeing about whether an export is running.
-    if (mediaType === 'FDA_ADDENDUM') return exportFdaAddendum()
+    if (mediaType === 'FDA_ADDENDUM') return exportFdaAddendum(false)
+    if (mediaType === 'FDA_ADDENDUM_PDF') return exportFdaAddendum(true)
     try {
         bomExportPending.value = true
         const excludeCoverageTypes = computedExcludeCoverageTypes.value.length > 0 ? computedExcludeCoverageTypes.value : null

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -193,7 +193,7 @@
                         </span>
                         <n-switch style="margin-left: 5px;" v-model:value="ignoreDev"/>
                     </n-form-item>
-                    <n-form-item>
+                    <n-form-item v-if="!isAddendumExport">
                         <div style="width: 100%;">
                             <div style="display: inline-flex; align-items: center;">
                                 <span style="display: inline-flex; align-items: center;">
@@ -1751,7 +1751,7 @@ import { GET_VEX_PROPOSALS_BY_RELEASE } from '@/graphql/vexImport'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
-import { renderAddendumPdfBlob, addendumPdfFileName } from '@/utils/addendumPdf'
+import { renderAddendumPdfBlob, addendumPdfFileName, findUnrenderableText } from '@/utils/addendumPdf'
 import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/releaseNarrativeInput'
 import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
@@ -5134,7 +5134,7 @@ async function uploadNewBomVersion (art: any) {
  * no support attestation, which is the one number a reviewer is looking for. The collector
  * returns no data at all on any refusal, so there is nothing here to accidentally save.
  */
-async function exportFdaAddendum (asPdf: boolean) {
+async function exportFdaAddendum (mediaType: string) {
     try {
         bomExportPending.value = true
         const orgUuid = updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
@@ -5156,6 +5156,16 @@ async function exportFdaAddendum (asPdf: boolean) {
         // The collection is identical for both encodings -- only the rendering differs -- so
         // the branch is here rather than at the top. That keeps ONE refusal path: a partial
         // document must be impossible in both formats, not in whichever one was written first.
+        const asPdf = mediaType === 'FDA_ADDENDUM_PDF'
+        // Refused BEFORE rendering, in the same voice as every other addendum refusal.
+        // pdfmake ships Roboto only and silently DROPS a character it cannot draw, so a
+        // component named in Japanese would leave a blank cell in a document meant to be
+        // complete -- while the CSV for the same release shows the text.
+        const unrenderable = asPdf ? findUnrenderableText(result.data) : null
+        if (unrenderable) {
+            Swal.fire('Addendum not generated', unrenderable, 'error')
+            return
+        }
         const blob = asPdf
             ? await renderAddendumPdfBlob(result.data)
             : new Blob([renderAddendumCsv(result.data)], { type: 'text/csv;charset=utf-8' })
@@ -5188,8 +5198,7 @@ async function exportFdaAddendum (asPdf: boolean) {
 async function exportReleaseSbom (tldOnly: boolean, ignoreDev: boolean, selectedBomStructureType: string, selectedRebomType: string, mediaType: string) {
     // Routed here rather than from the template so the button keeps one handler and the
     // modal cannot end up with two spinners disagreeing about whether an export is running.
-    if (mediaType === 'FDA_ADDENDUM') return exportFdaAddendum(false)
-    if (mediaType === 'FDA_ADDENDUM_PDF') return exportFdaAddendum(true)
+    if (mediaType === 'FDA_ADDENDUM' || mediaType === 'FDA_ADDENDUM_PDF') return exportFdaAddendum(mediaType)
     try {
         bomExportPending.value = true
         const excludeCoverageTypes = computedExcludeCoverageTypes.value.length > 0 ? computedExcludeCoverageTypes.value : null

--- a/ui/src/components/addendumExportWiring.spec.ts
+++ b/ui/src/components/addendumExportWiring.spec.ts
@@ -40,7 +40,8 @@ describe('the FDA addendum export is wired into the export modal', () => {
         ['renderAddendumCsv', '@/utils/addendumCsv'],
         ['addendumFileName', '@/utils/addendumCsv'],
         ['renderAddendumPdfBlob', '@/utils/addendumPdf'],
-        ['addendumPdfFileName', '@/utils/addendumPdf']
+        ['addendumPdfFileName', '@/utils/addendumPdf'],
+        ['findUnrenderableText', '@/utils/addendumPdf']
     ])('imports %s from %s', (symbol, module) => {
         expect(source).toMatch(new RegExp(
             `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
@@ -76,9 +77,12 @@ describe('the FDA addendum export is wired into the export modal', () => {
 
     // One handler, so the modal cannot end up with two spinners disagreeing about whether
     // an export is running.
-    it('routes both addendum types through the single export button', () => {
-        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM'\) return exportFdaAddendum\(false\)/)
-        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM_PDF'\) return exportFdaAddendum\(true\)/)
+    // The format travels as a VALUE, matching exportReleaseSbom beside it. A boolean here
+    // would be the same two-value test that isAddendumExport exists to avoid in the template.
+    it('routes both addendum types through the single export button, carrying the format', () => {
+        expect(source).toMatch(/return exportFdaAddendum\(mediaType\)/)
+        expect(source).toMatch(/async function exportFdaAddendum \(mediaType: string\)/)
+        expect(source).not.toMatch(/exportFdaAddendum\((true|false)\)/)
     })
 
     // The refusal must reach the operator. A silent failure here means they believe they
@@ -97,9 +101,24 @@ describe('the FDA addendum export is wired into the export modal', () => {
     // The BOM-shaping controls do not apply to the addendum, so they are HIDDEN rather than
     // left enabled and silently ignored -- an operator who ticked "Top Level Dependencies
     // Only" and got a full-scope document would have no way to tell.
-    it('hides the BOM-shaping controls for EITHER addendum encoding', () => {
+    // FOUR, not three. The artifact-coverage-type filter was left ungated when its three
+    // siblings were gated, so it stayed visible and toggleable while exportFdaAddendum
+    // ignored it entirely -- the exact "dropped on the floor" failure the gate exists for.
+    it('hides all four BOM-shaping controls for EITHER addendum encoding', () => {
         const gates = source.match(/v-if="!isAddendumExport"/g) || []
-        expect(gates.length).toBeGreaterThanOrEqual(3)
+        expect(gates.length).toBe(4)
+    })
+
+    // The refusal must come BEFORE any rendering, and must not download anything.
+    it('refuses unrenderable text before building the PDF', () => {
+        const body = handlerBody()
+        expect(body.indexOf('findUnrenderableText')).toBeLessThan(body.indexOf('renderAddendumPdfBlob'))
+        expect(body.indexOf('if (unrenderable)')).toBeLessThan(body.indexOf('new Blob'))
+    })
+
+    // The stuck-spinner class this feature has already hit once, in pdfmake's callback API.
+    it('always clears the export spinner in a finally', () => {
+        expect(handlerBody()).toMatch(/finally \{[\s\S]*?bomExportPending\.value = false/)
     })
 
     it('appends, clicks, removes, then revokes the object URL', () => {

--- a/ui/src/components/addendumExportWiring.spec.ts
+++ b/ui/src/components/addendumExportWiring.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { ADDENDUM_COLUMNS } from '@/utils/addendumCsv'
+import { ADDENDUM_COLUMNS } from '@/utils/addendumDocument'
 
 /**
  * Import and wiring assertions for the FDA addendum export.
@@ -38,7 +38,9 @@ describe('the FDA addendum export is wired into the export modal', () => {
     it.each([
         ['collectAddendumData', '@/utils/addendumData'],
         ['renderAddendumCsv', '@/utils/addendumCsv'],
-        ['addendumFileName', '@/utils/addendumCsv']
+        ['addendumFileName', '@/utils/addendumCsv'],
+        ['renderAddendumPdfBlob', '@/utils/addendumPdf'],
+        ['addendumPdfFileName', '@/utils/addendumPdf']
     ])('imports %s from %s', (symbol, module) => {
         expect(source).toMatch(new RegExp(
             `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'${module.replace(/\//g, '\\/')}'`))
@@ -50,15 +52,33 @@ describe('the FDA addendum export is wired into the export modal', () => {
 
     // Its own export TYPE, not a toggle: the addendum is a different document that happens
     // to share the modal, and the BOM-shaping options do not apply to it.
-    it('offers the addendum as a radio option beside the BOM formats', () => {
+    it('offers BOTH addendum encodings as radio options beside the BOM formats', () => {
         expect(source).toContain('<n-radio-button value="FDA_ADDENDUM">')
+        expect(source).toContain('<n-radio-button value="FDA_ADDENDUM_PDF">')
         expect(source).not.toMatch(/n-switch[^>]*addendum/i)
+    })
+
+    // Declared, not just referenced: the template uses it in four places, and an undefined
+    // identifier in <script setup> is a runtime error this build does not catch.
+    it('declares isAddendumExport, which the template gates four controls on', () => {
+        expect(source).toMatch(/const isAddendumExport\b/)
+        expect((source.match(/isAddendumExport/g) || []).length).toBeGreaterThanOrEqual(5)
+    })
+
+    // One collection, one refusal path, branching only at the render step -- a partial
+    // document must be impossible in BOTH encodings, not in whichever came first.
+    it('routes both encodings through the same collector and refusal', () => {
+        const body = handlerBody()
+        expect((body.match(/collectAddendumData\(/g) || []).length).toBe(1)
+        expect((body.match(/if \(!result\.ok\)/g) || []).length).toBe(1)
+        expect(body.indexOf('if (!result.ok)')).toBeLessThan(body.indexOf('renderAddendumPdfBlob'))
     })
 
     // One handler, so the modal cannot end up with two spinners disagreeing about whether
     // an export is running.
-    it('routes the addendum through the single export button', () => {
-        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM'\) return exportFdaAddendum\(\)/)
+    it('routes both addendum types through the single export button', () => {
+        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM'\) return exportFdaAddendum\(false\)/)
+        expect(source).toMatch(/if \(mediaType === 'FDA_ADDENDUM_PDF'\) return exportFdaAddendum\(true\)/)
     })
 
     // The refusal must reach the operator. A silent failure here means they believe they
@@ -77,8 +97,8 @@ describe('the FDA addendum export is wired into the export modal', () => {
     // The BOM-shaping controls do not apply to the addendum, so they are HIDDEN rather than
     // left enabled and silently ignored -- an operator who ticked "Top Level Dependencies
     // Only" and got a full-scope document would have no way to tell.
-    it('hides the BOM-shaping controls when the addendum is selected', () => {
-        const gates = source.match(/v-if="selectedSbomMediaType !== 'FDA_ADDENDUM'"/g) || []
+    it('hides the BOM-shaping controls for EITHER addendum encoding', () => {
+        const gates = source.match(/v-if="!isAddendumExport"/g) || []
         expect(gates.length).toBeGreaterThanOrEqual(3)
     })
 

--- a/ui/src/utils/addendumCsv.spec.ts
+++ b/ui/src/utils/addendumCsv.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { addendumRow, addendumHeaderRows, renderAddendumCsv, addendumFileName,
-    ADDENDUM_COLUMNS, NOT_ASSESSED, LEVEL_NOT_STATED } from './addendumCsv'
+import { renderAddendumCsv, addendumFileName } from './addendumCsv'
+import { addendumRow, addendumHeaderRows, ADDENDUM_COLUMNS, NOT_ASSESSED,
+    LEVEL_NOT_STATED } from './addendumDocument'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {

--- a/ui/src/utils/addendumCsv.ts
+++ b/ui/src/utils/addendumCsv.ts
@@ -6,7 +6,8 @@
 
 import { csvDocument } from './csv'
 import type { AddendumData } from './addendumData'
-import { ADDENDUM_COLUMNS, addendumRow, addendumHeaderRows, displayOrder } from './addendumDocument'
+import { ADDENDUM_COLUMNS, addendumRow, addendumHeaderRows, displayOrder,
+    addendumFileStem } from './addendumDocument'
 
 /**
  * Header rows padded to the table's width.
@@ -33,6 +34,5 @@ export function renderAddendumCsv (d: AddendumData): string {
 
 /** Stable, sortable, and identifies the release without needing the file to be opened. */
 export function addendumFileName (d: AddendumData): string {
-    const slug = (d.releaseVersion || d.releaseUuid).replace(/[^A-Za-z0-9._-]+/g, '-')
-    return `fda-support-addendum-${slug}.csv`
+    return `${addendumFileStem(d)}.csv`
 }

--- a/ui/src/utils/addendumCsv.ts
+++ b/ui/src/utils/addendumCsv.ts
@@ -1,119 +1,12 @@
-// The FDA support addendum, as CSV.
+// The FDA support addendum, encoded as CSV.
 //
-// One of three renderers over the SAME collected data (addendumData.ts). This file decides
-// only how to SAY the facts; it must not fetch, count or resolve anything, or the PDF and
-// the Device Support Statement will disagree with it about what the release contains.
+// One of three renderers over the SAME collected data (addendumData.ts), and one of two over
+// the same document definition (addendumDocument.ts). This file decides only how to ENCODE
+// the rows -- what the rows say is not its call to make, or the PDF beside it would drift.
 
 import { csvDocument } from './csv'
-import type { AddendumComponent, AddendumData } from './addendumData'
-import { isLiveAttestation } from './addendumData'
-
-export const ADDENDUM_COLUMNS = [
-    'Component', 'Version', 'PURL', 'Level of support', 'End of support',
-    'Justification', 'Attestation state', 'Last assessed'
-]
-
-/**
- * The value stated when a component carries no live attestation.
- *
- * NOT an empty cell, and the distinction is the point of the document. Blank reads as an
- * omission -- something the exporter forgot -- whereas the honest claim is that the
- * manufacturer looked and has nothing recorded. A reviewer counting blanks cannot tell those
- * apart; this way the row says which it is.
- */
-export const NOT_ASSESSED = 'not assessed'
-
-/**
- * The value stated when a component IS attested but the assessor recorded no level.
- *
- * Distinct from NOT_ASSESSED, and the distinction is not cosmetic. A level is optional on an
- * attestation, and a justification-only attestation is precisely the L1021-1022 case this
- * document exists to carry -- the assessor looked, could not determine a level, and said
- * why. The gauge counts those rows as ATTESTED. Printing "not assessed" in the level column
- * for them produced a document whose table contradicted its own header: "10 components with
- * a support attestation" above ten rows each saying not assessed.
- */
-export const LEVEL_NOT_STATED = 'not stated -- see justification'
-
-/** Fully-qualified name: group is part of a component's identity, not decoration. */
-function displayName (c: AddendumComponent): string | null {
-    if (c.group && c.name) return `${c.group}:${c.name}`
-    return c.name || c.group || null
-}
-
-/**
- * One component row.
- *
- * LEVEL AND JUSTIFICATION ARE ALTERNATIVES, per L1021-1022: a component with an attested
- * level states it, and one without states WHY the information cannot be given. Emitting both
- * would suggest the justification qualifies the level, when it exists precisely because
- * there is no level to give.
- *
- * A WITHDRAWN attestation is treated as not assessed -- it keeps its history but is not
- * injected into exports, so counting it here would make the addendum disagree with the BOM
- * it accompanies.
- */
-export function addendumRow (c: AddendumComponent): unknown[] {
-    const live = isLiveAttestation(c)
-    // Two rules at once, and they are separate:
-    //   LEVEL AND JUSTIFICATION ARE ALTERNATIVES (L1021-1022) -- a component with a level
-    //   states it, one without states WHY, and emitting both would suggest the justification
-    //   qualifies the level rather than standing in for it.
-    //   A WITHDRAWN attestation states NOTHING, justification included. It is retracted and
-    //   not injected into exports, and an earlier revision emitted its prose anyway --
-    //   republishing a claim the manufacturer had formally withdrawn, in the one document
-    //   where that matters most.
-    return [
-        displayName(c),
-        c.version,
-        c.purl,
-        live ? (c.levelOfSupport || LEVEL_NOT_STATED) : NOT_ASSESSED,
-        live ? c.endOfSupportDate : null,
-        live && !c.levelOfSupport ? c.justification : null,
-        live ? 'ATTESTED' : (c.attestationState || NOT_ASSESSED),
-        live ? c.assessedAt : null
-    ]
-}
-
-/**
- * The header block: what a reviewer reads before the table.
- *
- * Device EOS and EOL are stated as TWO SEPARATE FACTS. They answer different questions --
- * when patching stops, and when selling stops -- and merging them into one "support window"
- * line forces the reader to guess which a lone date is.
- *
- * The assessed / unassessed counts live HERE rather than being counted from the rows below.
- * They come from the same resolver as the on-screen gauge, so the document cannot state a
- * number the page disagrees with; addendumData refuses outright if the two ever diverge.
- */
-export function addendumHeaderRows (d: AddendumData): unknown[][] {
-    const rows: unknown[][] = [
-        ['FDA software support addendum'],
-        ['Organization', d.orgName],
-        ['Device', d.componentName],
-        ['Release', d.releaseVersion],
-        ['Release UUID', d.releaseUuid],
-        ['Generated', d.generatedAt],
-        [],
-        ['Device end of support (EOS)', d.deviceEos || 'not declared'],
-        ['Device end of sale / end of life (EOL)', d.deviceEol || 'not declared'],
-        [],
-        ['Components in this release', d.totalComponents],
-        ['Components with a support attestation', d.attestedComponents],
-        ['Components with no support attestation', d.unassessedComponents],
-        []
-    ]
-    if (d.narrative) {
-        rows.push(['Assessment justification', d.narrative])
-        rows.push(['Justification scope', d.narrativeIsPerRelease ? 'this release' : 'organization default'])
-        rows.push([])
-    }
-    if (d.patchesMayCeaseStatement) rows.push(['Patches may cease at end of support', d.patchesMayCeaseStatement])
-    if (d.riskTransferProcessRef) rows.push(['Risk-transfer process reference', d.riskTransferProcessRef])
-    if (d.riskIncreasesNotice) rows.push(['Risk increases over time', d.riskIncreasesNotice])
-    if (d.patchesMayCeaseStatement || d.riskTransferProcessRef || d.riskIncreasesNotice) rows.push([])
-    return rows
-}
+import type { AddendumData } from './addendumData'
+import { ADDENDUM_COLUMNS, addendumRow, addendumHeaderRows, displayOrder } from './addendumDocument'
 
 /**
  * Header rows padded to the table's width.
@@ -127,22 +20,6 @@ function padded (row: unknown[]): unknown[] {
     return row.length >= ADDENDUM_COLUMNS.length
         ? row
         : [...row, ...Array(ADDENDUM_COLUMNS.length - row.length).fill(null)]
-}
-
-/**
- * Stable display order, applied HERE rather than in the collector.
- *
- * The walk returns cursor (uuid) order, which is effectively random to a reviewer. Sorting
- * in the renderer keeps the collector free of presentation decisions -- the PDF may well
- * want a different order (by risk, say) and must not have to undo one imposed upstream.
- */
-function displayOrder (components: AddendumComponent[]): AddendumComponent[] {
-    return [...components].sort((a, b) => {
-        const an = (displayName(a) || '').toLowerCase()
-        const bn = (displayName(b) || '').toLowerCase()
-        if (an !== bn) return an < bn ? -1 : 1
-        return (a.version || '').localeCompare(b.version || '')
-    })
 }
 
 /** The whole document. */

--- a/ui/src/utils/addendumDocument.ts
+++ b/ui/src/utils/addendumDocument.ts
@@ -16,6 +16,15 @@
 import type { AddendumComponent, AddendumData } from './addendumData'
 import { isLiveAttestation } from './addendumData'
 
+/**
+ * The document's own title, owned here because every renderer needs it and one of them also
+ * needs to RECOGNISE it: the PDF prints it as a heading and must then drop the matching row
+ * from its facts table. When that comparison was against a copy of the literal, renaming the
+ * title printed it twice -- once as a heading, once as a fact row with an empty value -- and
+ * the guard test kept passing, because it asserted the absence of the OLD string.
+ */
+export const ADDENDUM_TITLE = 'FDA software support addendum'
+
 export const ADDENDUM_COLUMNS = [
     'Component', 'Version', 'PURL', 'Level of support', 'End of support',
     'Justification', 'Attestation state', 'Last assessed'
@@ -44,7 +53,7 @@ export const NOT_ASSESSED = 'not assessed'
 export const LEVEL_NOT_STATED = 'not stated -- see justification'
 
 /** Fully-qualified name: group is part of a component's identity, not decoration. */
-export function displayName (c: AddendumComponent): string | null {
+function displayName (c: AddendumComponent): string | null {
     if (c.group && c.name) return `${c.group}:${c.name}`
     return c.name || c.group || null
 }
@@ -96,7 +105,7 @@ export function addendumRow (c: AddendumComponent): unknown[] {
  */
 export function addendumHeaderRows (d: AddendumData): unknown[][] {
     const rows: unknown[][] = [
-        ['FDA software support addendum'],
+        [ADDENDUM_TITLE],
         ['Organization', d.orgName],
         ['Device', d.componentName],
         ['Release', d.releaseVersion],
@@ -137,4 +146,22 @@ export function displayOrder (components: AddendumComponent[]): AddendumComponen
         if (an !== bn) return an < bn ? -1 : 1
         return (a.version || '').localeCompare(b.version || '')
     })
+}
+
+/**
+ * The filename stem both renderers share, so the CSV and the PDF for one release sort
+ * together in a downloads folder.
+ *
+ * Shared rather than duplicated: each renderer had its own copy of this expression, and each
+ * spec hardcoded its own expected filename, so changing the sanitising rule in one and not
+ * the other would have passed every test while breaking the stated contract.
+ *
+ * Falls back through version, then uuid, then a fixed stem. The last step matters: both
+ * copies threw a TypeError when version AND uuid were absent, turning a nameless release
+ * into a failed export rather than an awkwardly named file.
+ */
+export function addendumFileStem (d: AddendumData): string {
+    const raw = d.releaseVersion || d.releaseUuid || 'release'
+    const slug = String(raw).replace(/[^A-Za-z0-9._-]+/g, '-')
+    return `fda-support-addendum-${slug || 'release'}`
 }

--- a/ui/src/utils/addendumDocument.ts
+++ b/ui/src/utils/addendumDocument.ts
@@ -1,0 +1,140 @@
+// The FDA support addendum as a DOCUMENT: its columns, its rows and its header block.
+//
+// RENDERER-AGNOSTIC ON PURPOSE. The CSV and the PDF have to be comparable line for line,
+// which they cannot be if each decides for itself what a component's Level of support cell
+// says -- and those decisions are regulatory rather than typographic: level and
+// justification are ALTERNATIVES under L1021-1022, a WITHDRAWN attestation states nothing at
+// all, an absent fact reads "not assessed" rather than leaving a blank a reviewer would
+// count as an omission. One implementation and two renderers makes parity STRUCTURAL, so
+// the parity spec proves what the code already guarantees instead of comparing two
+// hand-maintained copies.
+//
+// These lived in addendumCsv.ts for one PR. A module named "csv" exporting a PDF's row
+// semantics is the kind of thing a reviewer rightly stops, so they moved before the second
+// renderer arrived rather than after.
+
+import type { AddendumComponent, AddendumData } from './addendumData'
+import { isLiveAttestation } from './addendumData'
+
+export const ADDENDUM_COLUMNS = [
+    'Component', 'Version', 'PURL', 'Level of support', 'End of support',
+    'Justification', 'Attestation state', 'Last assessed'
+]
+
+/**
+ * The value stated when a component carries no live attestation.
+ *
+ * NOT an empty cell, and the distinction is the point of the document. Blank reads as an
+ * omission -- something the exporter forgot -- whereas the honest claim is that the
+ * manufacturer looked and has nothing recorded. A reviewer counting blanks cannot tell those
+ * apart; this way the row says which it is.
+ */
+export const NOT_ASSESSED = 'not assessed'
+
+/**
+ * The value stated when a component IS attested but the assessor recorded no level.
+ *
+ * Distinct from NOT_ASSESSED, and the distinction is not cosmetic. A level is optional on an
+ * attestation, and a justification-only attestation is precisely the L1021-1022 case this
+ * document exists to carry -- the assessor looked, could not determine a level, and said
+ * why. The gauge counts those rows as ATTESTED. Printing "not assessed" in the level column
+ * for them produced a document whose table contradicted its own header: "10 components with
+ * a support attestation" above ten rows each saying not assessed.
+ */
+export const LEVEL_NOT_STATED = 'not stated -- see justification'
+
+/** Fully-qualified name: group is part of a component's identity, not decoration. */
+export function displayName (c: AddendumComponent): string | null {
+    if (c.group && c.name) return `${c.group}:${c.name}`
+    return c.name || c.group || null
+}
+
+/**
+ * One component row.
+ *
+ * LEVEL AND JUSTIFICATION ARE ALTERNATIVES, per L1021-1022: a component with an attested
+ * level states it, and one without states WHY the information cannot be given. Emitting both
+ * would suggest the justification qualifies the level, when it exists precisely because
+ * there is no level to give.
+ *
+ * A WITHDRAWN attestation is treated as not assessed -- it keeps its history but is not
+ * injected into exports, so counting it here would make the addendum disagree with the BOM
+ * it accompanies.
+ */
+export function addendumRow (c: AddendumComponent): unknown[] {
+    const live = isLiveAttestation(c)
+    // Two rules at once, and they are separate:
+    //   LEVEL AND JUSTIFICATION ARE ALTERNATIVES (L1021-1022) -- a component with a level
+    //   states it, one without states WHY, and emitting both would suggest the justification
+    //   qualifies the level rather than standing in for it.
+    //   A WITHDRAWN attestation states NOTHING, justification included. It is retracted and
+    //   not injected into exports, and an earlier revision emitted its prose anyway --
+    //   republishing a claim the manufacturer had formally withdrawn, in the one document
+    //   where that matters most.
+    return [
+        displayName(c),
+        c.version,
+        c.purl,
+        live ? (c.levelOfSupport || LEVEL_NOT_STATED) : NOT_ASSESSED,
+        live ? c.endOfSupportDate : null,
+        live && !c.levelOfSupport ? c.justification : null,
+        live ? 'ATTESTED' : (c.attestationState || NOT_ASSESSED),
+        live ? c.assessedAt : null
+    ]
+}
+
+/**
+ * The header block: what a reviewer reads before the table.
+ *
+ * Device EOS and EOL are stated as TWO SEPARATE FACTS. They answer different questions --
+ * when patching stops, and when selling stops -- and merging them into one "support window"
+ * line forces the reader to guess which a lone date is.
+ *
+ * The assessed / unassessed counts live HERE rather than being counted from the rows below.
+ * They come from the same resolver as the on-screen gauge, so the document cannot state a
+ * number the page disagrees with; addendumData refuses outright if the two ever diverge.
+ */
+export function addendumHeaderRows (d: AddendumData): unknown[][] {
+    const rows: unknown[][] = [
+        ['FDA software support addendum'],
+        ['Organization', d.orgName],
+        ['Device', d.componentName],
+        ['Release', d.releaseVersion],
+        ['Release UUID', d.releaseUuid],
+        ['Generated', d.generatedAt],
+        [],
+        ['Device end of support (EOS)', d.deviceEos || 'not declared'],
+        ['Device end of sale / end of life (EOL)', d.deviceEol || 'not declared'],
+        [],
+        ['Components in this release', d.totalComponents],
+        ['Components with a support attestation', d.attestedComponents],
+        ['Components with no support attestation', d.unassessedComponents],
+        []
+    ]
+    if (d.narrative) {
+        rows.push(['Assessment justification', d.narrative])
+        rows.push(['Justification scope', d.narrativeIsPerRelease ? 'this release' : 'organization default'])
+        rows.push([])
+    }
+    if (d.patchesMayCeaseStatement) rows.push(['Patches may cease at end of support', d.patchesMayCeaseStatement])
+    if (d.riskTransferProcessRef) rows.push(['Risk-transfer process reference', d.riskTransferProcessRef])
+    if (d.riskIncreasesNotice) rows.push(['Risk increases over time', d.riskIncreasesNotice])
+    if (d.patchesMayCeaseStatement || d.riskTransferProcessRef || d.riskIncreasesNotice) rows.push([])
+    return rows
+}
+
+/**
+ * Stable display order, applied HERE rather than in the collector.
+ *
+ * The walk returns cursor (uuid) order, which is effectively random to a reviewer. Sorting
+ * in the renderer keeps the collector free of presentation decisions -- the PDF may well
+ * want a different order (by risk, say) and must not have to undo one imposed upstream.
+ */
+export function displayOrder (components: AddendumComponent[]): AddendumComponent[] {
+    return [...components].sort((a, b) => {
+        const an = (displayName(a) || '').toLowerCase()
+        const bn = (displayName(b) || '').toLowerCase()
+        if (an !== bn) return an < bn ? -1 : 1
+        return (a.version || '').localeCompare(b.version || '')
+    })
+}

--- a/ui/src/utils/addendumParity.spec.ts
+++ b/ui/src/utils/addendumParity.spec.ts
@@ -5,7 +5,7 @@ vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
 import { renderAddendumCsv } from './addendumCsv'
 import { buildAddendumDocDefinition } from './addendumPdf'
-import { ADDENDUM_COLUMNS } from './addendumDocument'
+import { ADDENDUM_COLUMNS, ADDENDUM_TITLE } from './addendumDocument'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 /**
@@ -118,15 +118,33 @@ describe('CSV and PDF are the same document in two encodings', () => {
         expect(pdfDataRows).toEqual(csvDataRows.map(r => r.map(deneutralise)))
     })
 
-    it('agree on the header block facts', () => {
+    it('agree on the header block facts, in both directions', () => {
         const factsTable = (doc.content as any[]).filter(c => c && c.table)[0].table
         const pdfFacts = new Map<string, string>(
             factsTable.body.map((r: any) => [String(r[0].text), String(r[1].text)]))
-        for (const row of csvRows.slice(0, csvHeaderIdx)) {
-            const label = row[0]
-            if (!label || label === 'FDA software support addendum') continue
-            expect(pdfFacts.get(label), `header fact "${label}"`).toBe(row[1])
+        const csvFacts = csvRows.slice(0, csvHeaderIdx)
+            .filter(r => r[0] && r[0] !== ADDENDUM_TITLE && r.some(c => c.length))
+        for (const row of csvFacts) {
+            expect(pdfFacts.get(row[0]), `header fact "${row[0]}"`).toBe(row[1])
         }
+        // BOTH directions: a fact the PDF invents, or one it drops, is a divergence too.
+        expect([...pdfFacts.keys()].sort()).toEqual(csvFacts.map(r => r[0]).sort())
+        // The PDF renders a header row as exactly two cells, so a future three-element row
+        // would be silently truncated. Fail here instead.
+        expect(csvFacts.every(r => r.filter(c => c.length).length <= 2)).toBe(true)
+    })
+
+    // Deliberate, and previously unasserted: the CSV emits no data rows for an empty release
+    // while the PDF emits an explanatory note row, so the counts differ BY DESIGN.
+    it('handle a release with no components in their own documented ways', () => {
+        const empty = { ...DATA, components: [], totalComponents: 0, attestedComponents: 0,
+            unassessedComponents: 0 }
+        const csv = parseCsv(renderAddendumCsv(empty))
+        const hdr = csv.findIndex(r => r[0] === ADDENDUM_COLUMNS[0])
+        expect(csv.slice(hdr + 1).filter(r => r.some(c => c.length))).toHaveLength(0)
+        const t = (buildAddendumDocDefinition(empty).content as any[]).filter(c => c && c.table)[1].table
+        expect(t.body).toHaveLength(2)
+        expect(JSON.stringify(t.body[1])).toContain('no SBOM components')
     })
 
     // Encoding differences are allowed and expected -- the CSV quotes, the PDF does not --
@@ -138,6 +156,13 @@ describe('CSV and PDF are the same document in two encodings', () => {
         expect(csvRow.join(' ')).toContain('said "yes", then\nleft')
     })
 
+    /**
+     * KNOWN SECOND DIVERGENCE, recorded so it is a decision rather than a surprise: a TAB
+     * inside operator prose is preserved by the CSV (quoted) and collapsed to a single space
+     * by the PDF, because that is what a PDF text run does with whitespace. The fixture below
+     * deliberately contains no tabs, so the "only differing cell" claim holds for it; a tab
+     * would add a second, and this note is where a future reader finds out why.
+     */
     // The CSV neutralises a leading = against spreadsheet evaluation; the PDF has no such
     // risk. Asserted so the difference is a decision on record rather than a surprise, and
     // so the CELL TEXT is otherwise identical.
@@ -152,8 +177,11 @@ describe('CSV and PDF are the same document in two encodings', () => {
         // searching rather than by a fixed index: displayOrder sorts alphabetically, so the
         // formula row is not where it was declared.
         const formulaIdx = csvDataRows.findIndex(r => r[0].endsWith(':formula'))
+        // Guarded: an unguarded index turned a row-count divergence into a TypeError rather
+        // than a readable assertion failure, which is the harder bug to diagnose.
+        expect(pdfDataRows).toHaveLength(csvDataRows.length)
         const differing = csvDataRows.flatMap((r, i) =>
-            r.map((c, j) => (c === pdfDataRows[i][j] ? null : `${i}:${j}`)).filter(Boolean))
+            r.map((c, j) => (c === (pdfDataRows[i] || [])[j] ? null : `${i}:${j}`)).filter(Boolean))
         expect(differing).toEqual([`${formulaIdx}:5`])
     })
 })

--- a/ui/src/utils/addendumParity.spec.ts
+++ b/ui/src/utils/addendumParity.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, createPdf: vi.fn() } }))
+vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
+
+import { renderAddendumCsv } from './addendumCsv'
+import { buildAddendumDocDefinition } from './addendumPdf'
+import { ADDENDUM_COLUMNS } from './addendumDocument'
+import type { AddendumComponent, AddendumData } from './addendumData'
+
+/**
+ * CSV / PDF parity.
+ *
+ * A reviewer holding both documents for one release must never have to work out which is
+ * right. Parity is structural -- both renderers call addendumRow and displayOrder from
+ * addendumDocument.ts -- so these assertions prove the structure is actually wired that way
+ * rather than comparing two hand-maintained copies. If someone reimplements a rule in one
+ * renderer, this fails.
+ */
+function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
+    return {
+        sbomComponentUuid: 'sc-x', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+        purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+        levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+        endOfSupportDate: '2030-01-01', justification: null,
+        assessedAt: '2026-09-01T00:00:00Z', ...over
+    }
+}
+
+/** Deliberately awkward: every branch of addendumRow, plus CSV-hostile characters. */
+const COMPONENTS: AddendumComponent[] = [
+    comp({ sbomComponentUuid: 'a', name: 'zeta', group: null }),
+    comp({ sbomComponentUuid: 'b', name: 'alpha', group: 'org.example',
+        levelOfSupport: null, justification: 'no upstream date published, and we asked' }),
+    comp({ sbomComponentUuid: 'c', name: 'withdrawn-one', attestationState: 'WITHDRAWN',
+        justification: 'retracted reasoning' }),
+    comp({ sbomComponentUuid: 'd', name: 'unassessed', attestationState: null,
+        levelOfSupport: null, endOfSupportDate: null, assessedAt: null }),
+    comp({ sbomComponentUuid: 'e', name: 'quote"comma,newline',
+        justification: 'said "yes", then\nleft', levelOfSupport: null }),
+    comp({ sbomComponentUuid: 'f', name: 'formula', levelOfSupport: null,
+        justification: '=HYPERLINK("http://x","ok")' })
+]
+
+const DATA: AddendumData = {
+    releaseUuid: 'r-parity', releaseVersion: '9000.1.0', componentName: 'Infusion Pump 9000',
+    deviceEos: '2030-06-30', deviceEol: null,
+    narrative: 'Assessed per DHF-PROC-9001, "rev D", including a comma.',
+    narrativeIsPerRelease: true, orgName: 'Acme, Inc.',
+    patchesMayCeaseStatement: 'Patches may cease.', riskTransferProcessRef: 'DHF-4471',
+    riskIncreasesNotice: 'Risk increases.',
+    totalComponents: COMPONENTS.length, attestedComponents: 2,
+    unassessedComponents: COMPONENTS.length - 2,
+    components: COMPONENTS, generatedAt: '2026-09-08T12:00:00Z'
+}
+
+/** Parse the CSV back into rows, so the comparison is against what a READER sees. */
+function parseCsv (csv: string): string[][] {
+    const rows: string[][] = []
+    let row: string[] = [], cur = '', q = false
+    const body = csv.charCodeAt(0) === 0xfeff ? csv.slice(1) : csv
+    for (let i = 0; i < body.length; i++) {
+        const c = body[i]
+        if (q) {
+            if (c === '"') { if (body[i + 1] === '"') { cur += '"'; i++ } else q = false }
+            else cur += c
+        } else if (c === '"') q = true
+        else if (c === ',') { row.push(cur); cur = '' }
+        else if (c === '\r' && body[i + 1] === '\n') { row.push(cur); cur = ''; rows.push(row); row = []; i++ }
+        else cur += c
+    }
+    if (cur.length || row.length) { row.push(cur); rows.push(row) }
+    return rows
+}
+
+const csvRows = parseCsv(renderAddendumCsv(DATA))
+const csvHeaderIdx = csvRows.findIndex(r => r[0] === ADDENDUM_COLUMNS[0] && r[1] === ADDENDUM_COLUMNS[1])
+const csvDataRows = csvRows.slice(csvHeaderIdx + 1).filter(r => r.some(c => c.length))
+
+/**
+ * Undo the ONE permitted divergence.
+ *
+ * csvCell prefixes an apostrophe when a cell begins with =, +, -, @, tab or CR, because
+ * several spreadsheets evaluate such a cell on open -- a justification rendering as a
+ * hyperlink means the exported evidence does not say what the record says. A PDF has no
+ * evaluation risk, so it carries the operator's text verbatim. That is an ENCODING
+ * difference, and this strips it so the comparison below is about what the cell SAYS.
+ */
+const FORMULA_LEADERS = ['=', '+', '-', '@', '\t', '\r']
+function deneutralise (cell: string): string {
+    return cell.length > 1 && cell[0] === "'" && FORMULA_LEADERS.includes(cell[1])
+        ? cell.slice(1)
+        : cell
+}
+
+const doc: any = buildAddendumDocDefinition(DATA)
+const pdfTable = (doc.content as any[]).filter(c => c && c.table)[1].table
+const pdfDataRows: string[][] = pdfTable.body.slice(1)
+
+describe('CSV and PDF are the same document in two encodings', () => {
+    it('agree on the column set and its order', () => {
+        expect(csvRows[csvHeaderIdx]).toEqual(ADDENDUM_COLUMNS)
+        expect(pdfTable.body[0].map((c: any) => c.text)).toEqual(ADDENDUM_COLUMNS)
+    })
+
+    it('emit the same number of data rows', () => {
+        expect(csvDataRows).toHaveLength(COMPONENTS.length)
+        expect(pdfDataRows).toHaveLength(COMPONENTS.length)
+    })
+
+    it('emit the rows in the same order', () => {
+        expect(pdfDataRows.map(r => r[0])).toEqual(csvDataRows.map(r => r[0]))
+    })
+
+    // The assertion that actually matters: every cell, both documents, same value. A rule
+    // reimplemented in one renderer shows up here as a mismatched cell.
+    it('agree on every cell value', () => {
+        expect(pdfDataRows).toEqual(csvDataRows.map(r => r.map(deneutralise)))
+    })
+
+    it('agree on the header block facts', () => {
+        const factsTable = (doc.content as any[]).filter(c => c && c.table)[0].table
+        const pdfFacts = new Map<string, string>(
+            factsTable.body.map((r: any) => [String(r[0].text), String(r[1].text)]))
+        for (const row of csvRows.slice(0, csvHeaderIdx)) {
+            const label = row[0]
+            if (!label || label === 'FDA software support addendum') continue
+            expect(pdfFacts.get(label), `header fact "${label}"`).toBe(row[1])
+        }
+    })
+
+    // Encoding differences are allowed and expected -- the CSV quotes, the PDF does not --
+    // but they must not change what the cell SAYS.
+    it('agree on a cell containing a quote, a comma and a newline', () => {
+        const csvRow = csvDataRows.find(r => r[0].includes('quote'))!
+        const pdfRow = pdfDataRows.find(r => r[0].includes('quote'))!
+        expect(pdfRow).toEqual(csvRow)
+        expect(csvRow.join(' ')).toContain('said "yes", then\nleft')
+    })
+
+    // The CSV neutralises a leading = against spreadsheet evaluation; the PDF has no such
+    // risk. Asserted so the difference is a decision on record rather than a surprise, and
+    // so the CELL TEXT is otherwise identical.
+    it('differ only in formula neutralisation, which is CSV-specific', () => {
+        const raw = renderAddendumCsv(DATA)
+        expect(raw).toContain("'=HYPERLINK")
+        const pdfRow = pdfDataRows.find(r => r[0].endsWith(':formula'))!
+        const csvRow = csvDataRows.find(r => r[0].endsWith(':formula'))!
+        expect(pdfRow[5]).toBe('=HYPERLINK("http://x","ok")')
+        expect(csvRow[5]).toBe("'=HYPERLINK(\"http://x\",\"ok\")")
+        // ...and that is the ONLY cell in the whole document where they differ. Located by
+        // searching rather than by a fixed index: displayOrder sorts alphabetically, so the
+        // formula row is not where it was declared.
+        const formulaIdx = csvDataRows.findIndex(r => r[0].endsWith(':formula'))
+        const differing = csvDataRows.flatMap((r, i) =>
+            r.map((c, j) => (c === pdfDataRows[i][j] ? null : `${i}:${j}`)).filter(Boolean))
+        expect(differing).toEqual([`${formulaIdx}:5`])
+    })
+})

--- a/ui/src/utils/addendumPdf.spec.ts
+++ b/ui/src/utils/addendumPdf.spec.ts
@@ -7,8 +7,9 @@ const createPdf = vi.fn()
 vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, get createPdf () { return createPdf } } }))
 vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
-import { buildAddendumDocDefinition, addendumPdfFileName, renderAddendumPdfBlob } from './addendumPdf'
-import { ADDENDUM_COLUMNS } from './addendumDocument'
+import { buildAddendumDocDefinition, addendumPdfFileName, renderAddendumPdfBlob,
+    findUnrenderableText } from './addendumPdf'
+import { ADDENDUM_COLUMNS, ADDENDUM_TITLE } from './addendumDocument'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
@@ -108,9 +109,21 @@ describe('buildAddendumDocDefinition', () => {
         expect(rows.every((r: any) => String(r[0].text).trim().length > 0)).toBe(true)
     })
 
+    // Asserted against the shared CONSTANT, not a copy of the literal. When this compared a
+    // hardcoded string, renaming the title made the PDF print it twice -- once as the
+    // heading, once as a fact row -- and this test stayed green, because it was asserting the
+    // absence of a string that no longer existed anywhere.
     it('does not repeat the title inside the facts table', () => {
         const labels = factsTable(buildAddendumDocDefinition(data())).body.map((r: any) => r[0].text)
-        expect(labels).not.toContain('FDA software support addendum')
+        expect(labels).not.toContain(ADDENDUM_TITLE)
+        expect((buildAddendumDocDefinition(data()).content as any[])[0].text).toBe(ADDENDUM_TITLE)
+    })
+
+    it('pads the empty-state colSpan row to the column count', () => {
+        const doc = buildAddendumDocDefinition(data({ components: [], totalComponents: 0, attestedComponents: 0, unassessedComponents: 0 }))
+        const row = dataTable(doc).body[1]
+        expect(row).toHaveLength(ADDENDUM_COLUMNS.length)
+        expect(row[0].colSpan).toBe(ADDENDUM_COLUMNS.length)
     })
 
     it('renders an explicit note for a release with no components', () => {
@@ -184,5 +197,71 @@ describe('renderAddendumPdfBlob', () => {
         await renderAddendumPdfBlob(data())
         expect(getBlob).toHaveBeenCalledTimes(1)
         expect(getBlob.mock.calls[0]).toHaveLength(0)
+    })
+})
+
+/**
+ * FONT COVERAGE.
+ *
+ * pdfmake bundles Roboto only and SILENTLY DROPS a character it cannot draw -- no error, no
+ * placeholder, no warning. A component named in Japanese produced an empty Component cell in
+ * a regulatory document, while the CSV for the same release showed the text. Blank is the one
+ * thing this document must never be ambiguous about, so the export refuses instead.
+ *
+ * Non-Latin samples are written as \u escapes: this repo is plain-ASCII by rule, and the CI
+ * invisible-character check runs before the build.
+ */
+describe('findUnrenderableText', () => {
+    it('passes a document that is entirely Latin', () => {
+        expect(findUnrenderableText(data())).toBeNull()
+    })
+
+    it.each([
+        ['accented Latin', '\u0047\u0072\u00fcnwald caf\u00e9'],
+        ['Vietnamese', 'Ti\u1ebfng Vi\u1ec7t'],
+        ['Cyrillic', '\u041f\u0440\u043e\u0432\u0435\u0440\u043a\u0430'],
+        ['Greek', '\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac'],
+        ['em dash and curly quotes', '\u2014 \u201cq\u201d']
+    ])('passes %s, which Roboto draws', (_n, text) => {
+        expect(findUnrenderableText(data({ narrative: text }))).toBeNull()
+    })
+
+    it.each([
+        ['CJK', '\u652f\u63f4\u7d42\u4e86'],
+        ['Hangul', '\ud55c\uad6d\uc5b4'],
+        ['Arabic', '\u0627\u0644\u0639\u0631\u0628\u064a\u0629'],
+        ['Hebrew', '\u05e2\u05d1\u05e8\u05d9\u05ea'],
+        ['Thai', '\u0e44\u0e17\u0e22'],
+        ['Devanagari', '\u0939\u093f\u0928\u094d\u0926\u0940'],
+        ['an emoji', '\u26a0']
+    ])('refuses %s, which Roboto silently drops', (_n, text) => {
+        const msg = findUnrenderableText(data({ narrative: text }))
+        expect(msg).not.toBeNull()
+        expect(msg).toContain('CSV')
+    })
+
+    // Every cell is scanned, not just the narrative -- the first report of this was a
+    // component NAME, which lives in the table rather than the header block.
+    it('scans component cells, not only the header block', () => {
+        const msg = findUnrenderableText(data({
+            components: [comp({ name: '\u65e5\u672c\u8a9e\u30e9\u30a4\u30d6\u30e9\u30ea' })]
+        }))
+        expect(msg).not.toBeNull()
+    })
+
+    it('scans justification text', () => {
+        const msg = findUnrenderableText(data({
+            components: [comp({ levelOfSupport: null, justification: '\u4e2d\u6587' })]
+        }))
+        expect(msg).not.toBeNull()
+    })
+
+    // The message has to be actionable: an operator who cannot export the PDF needs to know
+    // which characters and what to do instead.
+    it('names the offending characters and points at the CSV', () => {
+        const msg = findUnrenderableText(data({ narrative: '\u652f' })) as string
+        expect(msg).toContain('\u652f')
+        expect(msg).toMatch(/CSV/)
+        expect(msg).toMatch(/silently dropped|blank/)
     })
 })

--- a/ui/src/utils/addendumPdf.spec.ts
+++ b/ui/src/utils/addendumPdf.spec.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi } from 'vitest'
 // pdfmake pulls its font VFS in at import time, which is a megabyte of base64 and needs a
 // browser-ish global. Stubbed because nothing here renders: the whole point of returning a
 // plain doc definition is that the document can be asserted without pdfmake at all.
-vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, createPdf: vi.fn() } }))
+const createPdf = vi.fn()
+vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, get createPdf () { return createPdf } } }))
 vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
-import { buildAddendumDocDefinition, addendumPdfFileName } from './addendumPdf'
+import { buildAddendumDocDefinition, addendumPdfFileName, renderAddendumPdfBlob } from './addendumPdf'
 import { ADDENDUM_COLUMNS } from './addendumDocument'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
@@ -155,5 +156,33 @@ describe('addendumPdfFileName', () => {
     it('falls back to the uuid and strips anything path-unsafe', () => {
         expect(addendumPdfFileName(data({ releaseVersion: null }))).toBe('fda-support-addendum-r-1.pdf')
         expect(addendumPdfFileName(data({ releaseVersion: 'feature/x y' }))).toBe('fda-support-addendum-feature-x-y.pdf')
+    })
+})
+
+/**
+ * The pdfmake SEAM, which the doc-definition tests deliberately cannot cover.
+ *
+ * Mocking pdfmake is right for asserting the document -- but it means the integration with
+ * pdfmake itself has no unit coverage at all, and that is exactly where this shipped a bug:
+ * getBlob() is PROMISE-BASED in 0.3, an earlier revision passed it a 0.2-style callback, the
+ * callback was never invoked, and the export spinner span forever with no error. The live
+ * probe was the only thing that caught it.
+ *
+ * These two assertions close that specific hole: the promise must actually settle, and the
+ * callback form must not come back.
+ */
+describe('renderAddendumPdfBlob', () => {
+    it('resolves the blob getBlob() returns, rather than waiting on a callback', async () => {
+        const fake = new Blob(['%PDF-'], { type: 'application/pdf' })
+        createPdf.mockReturnValue({ getBlob: () => Promise.resolve(fake) })
+        await expect(renderAddendumPdfBlob(data())).resolves.toBe(fake)
+    })
+
+    it('calls getBlob with NO arguments -- the callback form never settles in 0.3', async () => {
+        const getBlob = vi.fn(() => Promise.resolve(new Blob(['%PDF-'])))
+        createPdf.mockReturnValue({ getBlob })
+        await renderAddendumPdfBlob(data())
+        expect(getBlob).toHaveBeenCalledTimes(1)
+        expect(getBlob.mock.calls[0]).toHaveLength(0)
     })
 })

--- a/ui/src/utils/addendumPdf.spec.ts
+++ b/ui/src/utils/addendumPdf.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// pdfmake pulls its font VFS in at import time, which is a megabyte of base64 and needs a
+// browser-ish global. Stubbed because nothing here renders: the whole point of returning a
+// plain doc definition is that the document can be asserted without pdfmake at all.
+vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, createPdf: vi.fn() } }))
+vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
+
+import { buildAddendumDocDefinition, addendumPdfFileName } from './addendumPdf'
+import { ADDENDUM_COLUMNS } from './addendumDocument'
+import type { AddendumComponent, AddendumData } from './addendumData'
+
+function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
+    return {
+        sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+        purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+        levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+        endOfSupportDate: '2030-01-01', justification: null,
+        assessedAt: '2026-09-01T00:00:00Z', ...over
+    }
+}
+
+function data (over: Partial<AddendumData> = {}): AddendumData {
+    return {
+        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump',
+        deviceEos: '2030-06-30', deviceEol: '2033-01-01',
+        narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
+        patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null,
+        totalComponents: 1, attestedComponents: 1, unassessedComponents: 0,
+        components: [comp()], generatedAt: '2026-09-08T12:00:00Z', ...over
+    }
+}
+
+const tables = (doc: any) => (doc.content as any[]).filter(c => c && c.table)
+const dataTable = (doc: any) => tables(doc)[1].table
+const factsTable = (doc: any) => tables(doc)[0].table
+
+describe('buildAddendumDocDefinition', () => {
+    it('returns a plain object, not a rendered document', () => {
+        const doc = buildAddendumDocDefinition(data())
+        expect(typeof doc).toBe('object')
+        expect(Array.isArray(doc.content)).toBe(true)
+    })
+
+    it('carries the column row, in the documented order', () => {
+        const header = dataTable(buildAddendumDocDefinition(data())).body[0]
+        expect(header.map((c: any) => c.text)).toEqual(ADDENDUM_COLUMNS)
+    })
+
+    it('gives one width per column, so no cell is unallocated', () => {
+        const t = dataTable(buildAddendumDocDefinition(data()))
+        expect(t.widths).toHaveLength(ADDENDUM_COLUMNS.length)
+    })
+
+    it('repeats the column row across pages', () => {
+        expect(dataTable(buildAddendumDocDefinition(data())).headerRows).toBe(1)
+    })
+
+    it('emits one body row per component plus the header', () => {
+        const d = data({ components: [comp(), comp({ name: 'other' }), comp({ name: 'third' })],
+            totalComponents: 3, attestedComponents: 3, unassessedComponents: 0 })
+        expect(dataTable(buildAddendumDocDefinition(d)).body).toHaveLength(4)
+    })
+
+    // The most important property of this document. A justification cut short at a page
+    // boundary is a regulatory statement the manufacturer did not make, and it would look
+    // deliberate. pdfmake wraps by default; nothing here may turn that off.
+    it('never truncates: no noWrap and no ellipsis anywhere', () => {
+        const long = 'x'.repeat(9000)
+        const doc = buildAddendumDocDefinition(data({
+            narrative: long,
+            components: [comp({ levelOfSupport: null, justification: long })]
+        }))
+        const json = JSON.stringify(doc)
+        expect(json).not.toContain('noWrap')
+        expect(json).not.toContain('ellipsis')
+        // and the full text is present, not a shortened copy
+        expect(json).toContain(long)
+    })
+
+    it('states the device EOS and EOL as two separate labelled facts', () => {
+        const labels = factsTable(buildAddendumDocDefinition(data())).body.map((r: any) => r[0].text)
+        expect(labels).toContain('Device end of support (EOS)')
+        expect(labels).toContain('Device end of sale / end of life (EOL)')
+    })
+
+    it('carries the assessed and unassessed counts', () => {
+        const doc = buildAddendumDocDefinition(data({ totalComponents: 10, attestedComponents: 4, unassessedComponents: 6 }))
+        const rows = factsTable(doc).body
+        const find = (l: string) => rows.find((r: any) => r[0].text === l)?.[1].text
+        expect(find('Components with no support attestation')).toBe('6')
+        expect(find('Components with a support attestation')).toBe('4')
+    })
+
+    it('labels the narrative source', () => {
+        const org = factsTable(buildAddendumDocDefinition(data())).body
+        expect(org.find((r: any) => r[0].text === 'Justification scope')?.[1].text).toBe('organization default')
+        const rel = factsTable(buildAddendumDocDefinition(data({ narrativeIsPerRelease: true }))).body
+        expect(rel.find((r: any) => r[0].text === 'Justification scope')?.[1].text).toBe('this release')
+    })
+
+    // The CSV emits blank spacer rows between header groups. Rendered as label/value pairs
+    // those would be empty lines in a table with no borders -- visible gaps that read as
+    // missing data.
+    it('drops the CSV spacer rows rather than rendering empty lines', () => {
+        const rows = factsTable(buildAddendumDocDefinition(data())).body
+        expect(rows.every((r: any) => String(r[0].text).trim().length > 0)).toBe(true)
+    })
+
+    it('does not repeat the title inside the facts table', () => {
+        const labels = factsTable(buildAddendumDocDefinition(data())).body.map((r: any) => r[0].text)
+        expect(labels).not.toContain('FDA software support addendum')
+    })
+
+    it('renders an explicit note for a release with no components', () => {
+        const doc = buildAddendumDocDefinition(data({ components: [], totalComponents: 0, attestedComponents: 0, unassessedComponents: 0 }))
+        expect(JSON.stringify(doc)).toContain('no SBOM components')
+    })
+
+    describe('the footer', () => {
+        const footer = (d = data()) => (buildAddendumDocDefinition(d).footer as any)(2, 7)
+
+        // A page separated from the document must still say which release it describes;
+        // these get printed and passed around.
+        it('carries release identity on every page', () => {
+            const texts = footer().columns.map((c: any) => c.text).join(' | ')
+            expect(texts).toContain('Pump')
+            expect(texts).toContain('1.4.5')
+            expect(texts).toContain('r-1')
+        })
+
+        it('carries the generation timestamp as a UTC RFC-3339 instant', () => {
+            const t = footer().columns.map((c: any) => c.text).join(' ')
+            expect(t).toContain('2026-09-08T12:00:00Z')
+            expect(t).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z/)
+        })
+
+        it('numbers pages as N of M', () => {
+            expect(footer().columns.map((c: any) => c.text).join(' ')).toContain('Page 2 of 7')
+        })
+
+        it('survives a release with no name or version', () => {
+            const t = footer(data({ componentName: null, releaseVersion: null }))
+            expect(() => JSON.stringify(t)).not.toThrow()
+            expect(t.columns[0].text).toContain('r-1')
+        })
+    })
+})
+
+describe('addendumPdfFileName', () => {
+    it('shares the CSV stem so the pair sorts together', () => {
+        expect(addendumPdfFileName(data())).toBe('fda-support-addendum-1.4.5.pdf')
+    })
+
+    it('falls back to the uuid and strips anything path-unsafe', () => {
+        expect(addendumPdfFileName(data({ releaseVersion: null }))).toBe('fda-support-addendum-r-1.pdf')
+        expect(addendumPdfFileName(data({ releaseVersion: 'feature/x y' }))).toBe('fda-support-addendum-feature-x-y.pdf')
+    })
+})

--- a/ui/src/utils/addendumPdf.ts
+++ b/ui/src/utils/addendumPdf.ts
@@ -1,0 +1,126 @@
+// The FDA support addendum, rendered as PDF.
+//
+// The second renderer over addendumDocument.ts. It shares the columns, the rows, the header
+// block and the ordering with the CSV, so the two documents are comparable line for line --
+// a reviewer holding both must not have to wonder which one is right about a component.
+//
+// DELIBERATELY NOT AN EXTENSION OF pdfExport.ts. That module renders findings: it filters by
+// severity and analysis state, sorts by a vulnerability type order, and colours cells by
+// CVSS band. None of that has meaning here, and threading a second document through its
+// options object would couple a regulatory export to a vulnerability report's shape.
+
+import pdfMake from 'pdfmake/build/pdfmake'
+import pdfFonts from 'pdfmake/build/vfs_fonts'
+import type { AddendumData } from './addendumData'
+import { ADDENDUM_COLUMNS, addendumRow, addendumHeaderRows, displayOrder } from './addendumDocument'
+
+pdfMake.vfs = pdfFonts.vfs
+
+/**
+ * Column widths, in pdfmake units, one per ADDENDUM_COLUMNS entry.
+ *
+ * '*' means "share the remaining space". Justification and PURL get the stars because they
+ * are the two unbounded fields -- a justification is up to 8,000 characters of operator
+ * prose. Everything else is a date, a short token or a name, and giving those fixed widths
+ * is what stops the two wide columns from being squeezed into a ribbon.
+ */
+const COLUMN_WIDTHS = [110, 55, '*', 85, 62, '*', 62, 92]
+
+/** A cell that must never be blank in a regulatory table. */
+function cell (value: unknown): string {
+    if (null === value || undefined === value) return ''
+    return String(value)
+}
+
+/**
+ * The document definition: PLAIN JSON, no rendering.
+ *
+ * Returned rather than rendered so the spec can assert on the structure directly. Asserting
+ * against a rendered PDF would mean parsing a binary to find out whether a cell said "not
+ * assessed", which tests the parser as much as the document.
+ *
+ * LONG TEXT WRAPS, NEVER TRUNCATES. pdfmake wraps by default inside a table cell, and
+ * nothing here sets noWrap or an ellipsis. That is the single most important property of
+ * this document: a justification cut short at a page boundary is a regulatory statement the
+ * manufacturer did not make, and it would look deliberate.
+ */
+export function buildAddendumDocDefinition (d: AddendumData): Record<string, unknown> {
+    const headerRows = addendumHeaderRows(d)
+    const body = [
+        ADDENDUM_COLUMNS.map(h => ({ text: h, style: 'tableHeader' })),
+        ...displayOrder(d.components).map(c => addendumRow(c).map(v => cell(v)))
+    ]
+
+    return {
+        pageSize: 'A4',
+        pageOrientation: 'landscape',
+        pageMargins: [28, 34, 28, 46],
+        content: [
+            { text: 'FDA software support addendum', style: 'title' },
+            // The header block, rendered as label/value pairs from the SAME source the CSV
+            // header uses. Rows the CSV emits as spacers come through with no label, so they
+            // are dropped rather than rendered as empty lines.
+            {
+                style: 'facts',
+                table: {
+                    widths: [190, '*'],
+                    body: headerRows
+                        .filter(r => r.length && null !== r[0] && undefined !== r[0] && '' !== String(r[0]))
+                        .filter(r => String(r[0]) !== 'FDA software support addendum')
+                        .map(r => [{ text: cell(r[0]), bold: true }, { text: cell(r[1]) }])
+                },
+                layout: 'noBorders',
+                margin: [0, 0, 0, 12]
+            },
+            {
+                table: {
+                    headerRows: 1,
+                    widths: COLUMN_WIDTHS,
+                    body: body.length > 1 ? body : [...body, [{
+                        text: 'This release contains no SBOM components.',
+                        colSpan: ADDENDUM_COLUMNS.length, alignment: 'center', italics: true
+                    }, {}, {}, {}, {}, {}, {}, {}]]
+                },
+                layout: 'lightHorizontalLines'
+            }
+        ],
+        /**
+         * Release identity on every page, because a page separated from the document must
+         * still say which release it describes -- these get printed and passed around.
+         */
+        footer: (currentPage: number, pageCount: number) => ({
+            style: 'footer',
+            margin: [28, 8, 28, 0],
+            columns: [
+                { text: `${d.componentName || '(unnamed device)'} ${d.releaseVersion || ''} (${d.releaseUuid})`, alignment: 'left' },
+                { text: `Generated ${d.generatedAt}`, alignment: 'center' },
+                { text: `Page ${currentPage} of ${pageCount}`, alignment: 'right' }
+            ]
+        }),
+        styles: {
+            title: { fontSize: 15, bold: true, margin: [0, 0, 0, 8] },
+            facts: { fontSize: 9 },
+            tableHeader: { bold: true, fontSize: 8, color: '#333333' },
+            footer: { fontSize: 7, color: '#666666' }
+        },
+        defaultStyle: { fontSize: 8 }
+    }
+}
+
+/** Same stem as the CSV, so the pair sorts together in a downloads folder. */
+export function addendumPdfFileName (d: AddendumData): string {
+    const slug = (d.releaseVersion || d.releaseUuid).replace(/[^A-Za-z0-9._-]+/g, '-')
+    return `fda-support-addendum-${slug}.pdf`
+}
+
+/**
+ * Render to a Blob rather than calling pdfmake's own .download().
+ *
+ * The addendum's CSV path already builds a Blob and drives an anchor; using the same idiom
+ * keeps one download path to reason about, and it is the one that revokes its object URL.
+ */
+export function renderAddendumPdfBlob (d: AddendumData): Promise<Blob> {
+    return new Promise((resolve) => {
+        pdfMake.createPdf(buildAddendumDocDefinition(d) as any).getBlob((blob: Blob) => resolve(blob))
+    })
+}

--- a/ui/src/utils/addendumPdf.ts
+++ b/ui/src/utils/addendumPdf.ts
@@ -119,8 +119,10 @@ export function addendumPdfFileName (d: AddendumData): string {
  * The addendum's CSV path already builds a Blob and drives an anchor; using the same idiom
  * keeps one download path to reason about, and it is the one that revokes its object URL.
  */
-export function renderAddendumPdfBlob (d: AddendumData): Promise<Blob> {
-    return new Promise((resolve) => {
-        pdfMake.createPdf(buildAddendumDocDefinition(d) as any).getBlob((blob: Blob) => resolve(blob))
-    })
+export async function renderAddendumPdfBlob (d: AddendumData): Promise<Blob> {
+    // getBlob() is PROMISE-BASED in pdfmake 0.3 (`async getBlob()`, typed
+    // `getBlob(): Promise<Blob>`). An earlier revision passed it a callback, as 0.2 took --
+    // the callback was simply never invoked, so the promise never settled and the export
+    // spinner span forever with no error anywhere. Awaiting it is the whole fix.
+    return pdfMake.createPdf(buildAddendumDocDefinition(d) as any).getBlob()
 }

--- a/ui/src/utils/addendumPdf.ts
+++ b/ui/src/utils/addendumPdf.ts
@@ -12,7 +12,8 @@
 import pdfMake from 'pdfmake/build/pdfmake'
 import pdfFonts from 'pdfmake/build/vfs_fonts'
 import type { AddendumData } from './addendumData'
-import { ADDENDUM_COLUMNS, addendumRow, addendumHeaderRows, displayOrder } from './addendumDocument'
+import { ADDENDUM_COLUMNS, ADDENDUM_TITLE, addendumRow, addendumHeaderRows, displayOrder,
+    addendumFileStem } from './addendumDocument'
 
 pdfMake.vfs = pdfFonts.vfs
 
@@ -26,10 +27,71 @@ pdfMake.vfs = pdfFonts.vfs
  */
 const COLUMN_WIDTHS = [110, 55, '*', 85, 62, '*', 62, 92]
 
-/** A cell that must never be blank in a regulatory table. */
+/**
+ * Coerce a value for a table cell.
+ *
+ * Empty for null/undefined -- and that is NOT the same as a blank meaning "nothing recorded".
+ * Whether a cell says "not assessed" or stands empty was decided upstream in addendumRow;
+ * this only turns an absent value into an empty string rather than the text "null".
+ */
 function cell (value: unknown): string {
     if (null === value || undefined === value) return ''
     return String(value)
+}
+
+/**
+ * The codepoint ranges the bundled Roboto can actually draw.
+ *
+ * pdfmake ships ROBOTO ONLY. A character it has no glyph for is not flagged, substituted or
+ * warned about -- it is silently DROPPED, so a component named in Japanese produces an EMPTY
+ * cell in a regulatory document while the CSV for the same release shows the text. Blank is
+ * the one thing this document must never be ambiguous about.
+ *
+ * Determined by RENDERING and extracting, not by reading a spec: Latin (including Extended-A,
+ * Turkish and Vietnamese), Greek, Cyrillic, punctuation and currency draw; Latin Extended-B,
+ * arrows, emoji, Hebrew, Arabic, Hangul, Thai, Devanagari and CJK do not.
+ *
+ * DELIBERATELY CONSERVATIVE. It is a whitelist, so an unlisted script is refused rather than
+ * rendered blank, and it will refuse some characters Roboto could in fact draw. That trade is
+ * the point: a false refusal is visible, explained and recoverable via the CSV, while a false
+ * render is an invisible hole in a document someone files.
+ */
+const RENDERABLE = [
+    [0x09, 0x0a], [0x0d, 0x0d],
+    [0x20, 0x17f],      // Basic Latin, Latin-1 Supplement, Latin Extended-A
+    [0x370, 0x3ff],     // Greek
+    [0x400, 0x4ff],     // Cyrillic
+    [0x1e00, 0x1eff],   // Latin Extended Additional (Vietnamese)
+    [0x2010, 0x201f],   // dashes and quotation marks
+    [0x2020, 0x2027], [0x2030, 0x203a],
+    [0x20a0, 0x20bf],   // currency
+    [0x2122, 0x2122]    // trade mark
+]
+
+function isRenderable (code: number): boolean {
+    return RENDERABLE.some(([lo, hi]) => code >= lo && code <= hi)
+}
+
+/**
+ * The characters in this document that the PDF font cannot draw, or null if there are none.
+ *
+ * Returned rather than thrown so the caller refuses in the same voice as every other addendum
+ * refusal -- no document at all, with a reason, instead of one that quietly omits words the
+ * manufacturer wrote.
+ */
+export function findUnrenderableText (d: AddendumData): string | null {
+    const offenders = new Set<string>()
+    const scan = (v: unknown) => {
+        const t = cell(v)
+        for (const ch of t) if (!isRenderable(ch.codePointAt(0) as number)) offenders.add(ch)
+    }
+    for (const row of addendumHeaderRows(d)) row.forEach(scan)
+    for (const c of d.components) addendumRow(c).forEach(scan)
+    if (!offenders.size) return null
+    const sample = [...offenders].slice(0, 12).join(' ')
+    return 'This release contains characters the PDF font cannot draw (' + sample + ').'
+        + ' They would be silently dropped, leaving blank cells in a document that is meant to'
+        + ' be complete. Export the CSV instead -- it carries every character.'
 }
 
 /**
@@ -56,7 +118,7 @@ export function buildAddendumDocDefinition (d: AddendumData): Record<string, unk
         pageOrientation: 'landscape',
         pageMargins: [28, 34, 28, 46],
         content: [
-            { text: 'FDA software support addendum', style: 'title' },
+            { text: ADDENDUM_TITLE, style: 'title' },
             // The header block, rendered as label/value pairs from the SAME source the CSV
             // header uses. Rows the CSV emits as spacers come through with no label, so they
             // are dropped rather than rendered as empty lines.
@@ -66,7 +128,7 @@ export function buildAddendumDocDefinition (d: AddendumData): Record<string, unk
                     widths: [190, '*'],
                     body: headerRows
                         .filter(r => r.length && null !== r[0] && undefined !== r[0] && '' !== String(r[0]))
-                        .filter(r => String(r[0]) !== 'FDA software support addendum')
+                        .filter(r => String(r[0]) !== ADDENDUM_TITLE)
                         .map(r => [{ text: cell(r[0]), bold: true }, { text: cell(r[1]) }])
                 },
                 layout: 'noBorders',
@@ -79,7 +141,7 @@ export function buildAddendumDocDefinition (d: AddendumData): Record<string, unk
                     body: body.length > 1 ? body : [...body, [{
                         text: 'This release contains no SBOM components.',
                         colSpan: ADDENDUM_COLUMNS.length, alignment: 'center', italics: true
-                    }, {}, {}, {}, {}, {}, {}, {}]]
+                    }, ...Array(ADDENDUM_COLUMNS.length - 1).fill({})]]
                 },
                 layout: 'lightHorizontalLines'
             }
@@ -109,8 +171,7 @@ export function buildAddendumDocDefinition (d: AddendumData): Record<string, unk
 
 /** Same stem as the CSV, so the pair sorts together in a downloads folder. */
 export function addendumPdfFileName (d: AddendumData): string {
-    const slug = (d.releaseVersion || d.releaseUuid).replace(/[^A-Za-z0-9._-]+/g, '-')
-    return `fda-support-addendum-${slug}.pdf`
+    return `${addendumFileStem(d)}.pdf`
 }
 
 /**


### PR DESCRIPTION
Step 5. Extraction first, then the second renderer.

## addendumDocument.ts

The columns, the rows, the header block and the display order moved out of `addendumCsv.ts`.
Both renderers import from it and decide only how to **encode** what it says.

Those decisions are regulatory rather than typographic -- level and justification are
ALTERNATIVES under L1021-1022, a WITHDRAWN attestation states nothing at all, an absent fact
reads "not assessed" rather than leaving a blank a reviewer would count as an omission. A
module named "csv" exporting them to a PDF is a finding waiting to happen. Behaviour-neutral:
the 53 existing CSV and collector tests pass unchanged.

## Parity is structural, and the spec proves the wiring

The two documents cannot disagree about a cell because one function produces the rows.
`addendumParity.spec.ts` parses the CSV back with its own RFC-4180 reader and compares
against the PDF's table body: same columns, same order, same count, **same cell values**.

It earned its place immediately by finding the one real divergence: `csvCell` prefixes an
apostrophe on a cell starting with `=`/`+`/`-`/`@`, because spreadsheets evaluate those on
open and a justification rendering as a hyperlink means the exported evidence does not say
what the record says. A PDF has no such risk and carries the text verbatim. That is an
encoding difference, so the spec strips it and then asserts it is the **only** differing cell
in the document -- located by search, because `displayOrder` sorts alphabetically and the row
is not where it was declared.

**Revert-probed twice**: reimplementing the WITHDRAWN rule in the PDF alone fails "agree on
every cell value"; dropping the shared ordering fails "emit the rows in the same order".

## The renderer

`buildAddendumDocDefinition` returns **plain JSON and renders nothing**, so the spec asserts
structure directly instead of parsing a binary to learn whether a cell said "not assessed" --
which would test the parser as much as the document. 20 assertions, including the one that
matters most: no `noWrap`, no `ellipsis`, and a 9,000-character justification present in
full. A justification cut short at a page boundary is a regulatory statement the manufacturer
did not make, and it would look deliberate.

Not an extension of `pdfExport.ts`, deliberately: that module filters by severity and
analysis state, sorts by vulnerability type and colours by CVSS band. None of that means
anything here.

Footer on every page: release identity, the UTC RFC-3339 generation instant, page N of M.
Identity repeats because a page separated from the document must still say which release it
describes, and these get printed.

## A bug the unit specs could not have caught

`getBlob()` is promise-based in pdfmake 0.3 (`async getBlob()`). I passed a 0.2-style
callback; it was never invoked, so the promise never settled and **the export spinner span
forever with no error** -- the worst shape a failure can take, because it looks like
slowness.

The specs mock pdfmake, correctly, so the document can be asserted without rendering. That
leaves the pdfmake *seam* with no coverage, and that is precisely where the bug was. Two
assertions now close it: the promise must settle, and `getBlob` must be called with no
arguments. Revert-probed -- the callback form fails both by timeout, the same hang a user
would see.

## Pro probe, both encodings from one release

```
P4/P5   CSV data rows 10 == gauge total 10
P6      PDF is a real PDF
P7/P8   every CSV component and purl appears in the PDF
P9      10 of 10 rows carried
P9b     longest name intact, wrapped not cut
P10-P11 header facts present; PDF states the same total as the CSV
P12-P14 footer: page N of M, release uuid, UTC RFC-3339 instant
X       0 page exceptions
```

Two probe corrections worth recording, because **both made a correct document look broken**:

`pdftotext -layout` interleaves a wrapped cell's continuation with the other columns', so a
long purl is not contiguous even after stripping whitespace. Flowed mode reassembles cleanly.

Flowed mode then **de-hyphenates** -- it treats a hyphen at a line break as hyphenation and
drops it, and pdfmake wraps long identifiers at their hyphens, so `commons-collections` came
back as `commonscollections`. The comparison is hyphen-insensitive now, but it still reports
the strict count and separately proves from `-layout` that the hyphens are in the document.
Normalising a difference away without checking what it was is how a probe stops being
evidence.

## Checks

**620 tests / 46 files** (was 591/43). 0 non-ASCII added. Build clean. 2 CE drift warnings,
unchanged and expected.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>