### PR TITLE
The Device Support Statement, third renderer over one collector (7j)

### DIFF
--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -85,7 +85,7 @@
                          addendum always walks the whole release scope, so an operator who
                          ticked "Top Level Dependencies Only" and got a full-scope document
                          would have no way to tell the control had been dropped on the floor. -->
-                    <n-form-item v-if="!isAddendumExport">
+                    <n-form-item v-if="!isFdaDocumentExport">
                         <template #label>
                             <span style="display: inline-flex; align-items: center;">
                                 Select SBOM configuration for export
@@ -124,6 +124,11 @@
                                  along with whichever format was picked. -->
                             <n-radio-button value="FDA_ADDENDUM">FDA support addendum (CSV)</n-radio-button>
                             <n-radio-button value="FDA_ADDENDUM_PDF">FDA support addendum (PDF)</n-radio-button>
+                            <!-- A different DOCUMENT for a different reader: FDA L1591-1592
+                                 says the audience may include patients or caregivers with
+                                 limited technical knowledge, so it carries no component
+                                 inventory and no counts. PRODUCT releases only. -->
+                            <n-radio-button value="DEVICE_STATEMENT">Device support statement (PDF)</n-radio-button>
                         </n-radio-group>
                     </n-form-item>
                     <n-alert v-if="isAddendumExport" type="default"
@@ -158,7 +163,7 @@
                             />
                         </n-radio-group>
                     </n-form-item>
-                    <n-form-item v-if="!isAddendumExport">
+                    <n-form-item v-if="!isFdaDocumentExport">
                         <span style="display: inline-flex; align-items: center;">
                             Top Level Dependencies Only:
                             <n-tooltip trigger="hover">
@@ -172,7 +177,7 @@
                         </span>
                         <n-switch style="margin-left: 5px;" v-model:value="tldOnly"/>
                     </n-form-item>
-                    <n-form-item v-if="!isAddendumExport">
+                    <n-form-item v-if="!isFdaDocumentExport">
                         <span style="display: inline-flex; align-items: center;">
                             Ignore Optional Dependencies:
                             <n-tooltip trigger="hover">
@@ -193,7 +198,7 @@
                         </span>
                         <n-switch style="margin-left: 5px;" v-model:value="ignoreDev"/>
                     </n-form-item>
-                    <n-form-item v-if="!isAddendumExport">
+                    <n-form-item v-if="!isFdaDocumentExport">
                         <div style="width: 100%;">
                             <div style="display: inline-flex; align-items: center;">
                                 <span style="display: inline-flex; align-items: center;">
@@ -1752,6 +1757,8 @@ import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
 import { renderAddendumPdfBlob, addendumPdfFileName, findUnrenderableText } from '@/utils/addendumPdf'
+import { renderDeviceSupportStatementBlob, deviceSupportStatementFileName,
+    statementBlockReason } from '@/utils/deviceSupportStatement'
 import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/releaseNarrativeInput'
 import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
@@ -2836,6 +2843,10 @@ const selectedSbomMediaType = ref('JSON')
  */
 const isAddendumExport: ComputedRef<boolean> = computed((): boolean =>
     selectedSbomMediaType.value === 'FDA_ADDENDUM' || selectedSbomMediaType.value === 'FDA_ADDENDUM_PDF')
+
+/** Every FDA document, for the controls that apply to none of them. */
+const isFdaDocumentExport: ComputedRef<boolean> = computed((): boolean =>
+    isAddendumExport.value || selectedSbomMediaType.value === 'DEVICE_STATEMENT')
 
 //getAggregatedChangelog
 const showExportSBOMModal: Ref<boolean> = ref(false)
@@ -5134,6 +5145,54 @@ async function uploadNewBomVersion (art: any) {
  * no support attestation, which is the one number a reviewer is looking for. The collector
  * returns no data at all on any refusal, so there is nothing here to accidentally save.
  */
+/**
+ * The Device Support Statement (FDA labeling VI.A), for a patient, caregiver or biomed reader.
+ *
+ * Same collector as the addendum, so the two documents cannot disagree about the device's
+ * dates -- but a different reader, so it carries no inventory, no purls and no counts.
+ *
+ * BLOCKED rather than degraded when it cannot be generated honestly. A component release is
+ * not a device; an unauthored prose slot would leave an empty section, and on a patient-facing
+ * document a silent gap is itself the misleading thing. The block names what is missing and
+ * where to fix it.
+ */
+async function exportDeviceSupportStatement () {
+    try {
+        bomExportPending.value = true
+        const orgUuid = updatedRelease.value.org || updatedRelease.value.orgDetails?.uuid
+        if (!orgUuid) {
+            Swal.fire('Statement not generated',
+                'This release did not carry an organization, so the required text cannot be'
+                + ' resolved. Reload the page and try again.', 'error')
+            return
+        }
+        const result = await collectAddendumData(graphqlClient as any, updatedRelease.value.uuid, orgUuid)
+        if (!result.ok) {
+            Swal.fire('Statement not generated', result.error, 'error')
+            return
+        }
+        // Every refusal in one place, checked BEFORE anything is built.
+        const blocked = statementBlockReason(result.data)
+        if (blocked) {
+            Swal.fire('Statement not generated', blocked, 'warning')
+            return
+        }
+        const blob = await renderDeviceSupportStatementBlob(result.data)
+        const link = document.createElement('a')
+        link.href = window.URL.createObjectURL(blob)
+        link.download = deviceSupportStatementFileName(result.data)
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+        window.URL.revokeObjectURL(link.href)
+        notify('success', 'Statement exported', 'Device support statement downloaded.')
+    } catch (err: any) {
+        Swal.fire('Error!', commonFunctions.extractGraphQLErrorMessage(err), 'error')
+    } finally {
+        bomExportPending.value = false
+    }
+}
+
 async function exportFdaAddendum (mediaType: string) {
     try {
         bomExportPending.value = true
@@ -5199,6 +5258,7 @@ async function exportReleaseSbom (tldOnly: boolean, ignoreDev: boolean, selected
     // Routed here rather than from the template so the button keeps one handler and the
     // modal cannot end up with two spinners disagreeing about whether an export is running.
     if (mediaType === 'FDA_ADDENDUM' || mediaType === 'FDA_ADDENDUM_PDF') return exportFdaAddendum(mediaType)
+    if (mediaType === 'DEVICE_STATEMENT') return exportDeviceSupportStatement()
     try {
         bomExportPending.value = true
         const excludeCoverageTypes = computedExcludeCoverageTypes.value.length > 0 ? computedExcludeCoverageTypes.value : null

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -131,6 +131,18 @@
                             <n-radio-button value="DEVICE_STATEMENT">Device support statement (PDF)</n-radio-button>
                         </n-radio-group>
                     </n-form-item>
+                    <n-alert v-if="selectedSbomMediaType === 'DEVICE_STATEMENT'" type="default"
+                        :show-icon="false" style="font-size: 12px; max-width: 620px; margin-bottom: 10px;">
+                        A plain-language statement for patients, caregivers and biomedical
+                        engineers: the device's support dates, and the manufacturer's own
+                        labeling text. Generated for PRODUCT releases only, and only once all
+                        three organization statements have been authored.
+                        <span v-if="!isProductReleaseForStatement" style="display:block; margin-top:6px;">
+                            <strong>This is a component release</strong>, so the statement
+                            cannot be generated here &mdash; open the product release that
+                            ships it.
+                        </span>
+                    </n-alert>
                     <n-alert v-if="isAddendumExport" type="default"
                         :show-icon="false" style="font-size: 12px; max-width: 620px; margin-bottom: 10px;">
                         Every component in this release with its level of support, the end-of-support
@@ -2844,6 +2856,16 @@ const selectedSbomMediaType = ref('JSON')
 const isAddendumExport: ComputedRef<boolean> = computed((): boolean =>
     selectedSbomMediaType.value === 'FDA_ADDENDUM' || selectedSbomMediaType.value === 'FDA_ADDENDUM_PDF')
 
+/**
+ * Whether the release on screen can carry a device support statement.
+ *
+ * Read from the release already in hand, so the modal says so BEFORE an export attempt walks
+ * the whole component list only to refuse. The renderer still refuses independently -- this
+ * is a courtesy, not the guard.
+ */
+const isProductReleaseForStatement: ComputedRef<boolean> = computed((): boolean =>
+    updatedRelease.value?.componentDetails?.type === 'PRODUCT')
+
 /** Every FDA document, for the controls that apply to none of them. */
 const isFdaDocumentExport: ComputedRef<boolean> = computed((): boolean =>
     isAddendumExport.value || selectedSbomMediaType.value === 'DEVICE_STATEMENT')
@@ -5133,19 +5155,6 @@ async function uploadNewBomVersion (art: any) {
 }
 
 /**
- * The FDA support addendum (FDA-Readiness-1 7g): a DIFFERENT DOCUMENT that shares the
- * export modal.
- *
- * Assembled client-side by collectAddendumData, which is deliberately document-agnostic --
- * the PDF and the Device Support Statement consume the same collector unchanged. A
- * server-rendered CSV would have been a second source of truth for the same document.
- *
- * REFUSES rather than downloading a partial. A truncated addendum is the dangerous output:
- * a regulatory document that looks complete while under-reporting how many components have
- * no support attestation, which is the one number a reviewer is looking for. The collector
- * returns no data at all on any refusal, so there is nothing here to accidentally save.
- */
-/**
  * The Device Support Statement (FDA labeling VI.A), for a patient, caregiver or biomed reader.
  *
  * Same collector as the addendum, so the two documents cannot disagree about the device's
@@ -5193,6 +5202,19 @@ async function exportDeviceSupportStatement () {
     }
 }
 
+/**
+ * The FDA support addendum (FDA-Readiness-1 7g): a DIFFERENT DOCUMENT that shares the
+ * export modal.
+ *
+ * Assembled client-side by collectAddendumData, which is deliberately document-agnostic --
+ * the PDF and the Device Support Statement consume the same collector unchanged. A
+ * server-rendered CSV would have been a second source of truth for the same document.
+ *
+ * REFUSES rather than downloading a partial. A truncated addendum is the dangerous output:
+ * a regulatory document that looks complete while under-reporting how many components have
+ * no support attestation, which is the one number a reviewer is looking for. The collector
+ * returns no data at all on any refusal, so there is nothing here to accidentally save.
+ */
 async function exportFdaAddendum (mediaType: string) {
     try {
         bomExportPending.value = true

--- a/ui/src/components/addendumExportWiring.spec.ts
+++ b/ui/src/components/addendumExportWiring.spec.ts
@@ -59,11 +59,13 @@ describe('the FDA addendum export is wired into the export modal', () => {
         expect(source).not.toMatch(/n-switch[^>]*addendum/i)
     })
 
-    // Declared, not just referenced: the template uses it in four places, and an undefined
-    // identifier in <script setup> is a runtime error this build does not catch.
-    it('declares isAddendumExport, which the template gates four controls on', () => {
+    // Declared, not just referenced: an undefined identifier in <script setup> is a runtime
+    // error this build does not catch. It now gates the addendum's explanatory alert, and
+    // feeds isFdaDocumentExport, which gates the shaping controls for ALL three documents.
+    it('declares isAddendumExport and uses it for the addendum-specific alert', () => {
         expect(source).toMatch(/const isAddendumExport\b/)
-        expect((source.match(/isAddendumExport/g) || []).length).toBeGreaterThanOrEqual(5)
+        expect(source).toMatch(/<n-alert v-if="isAddendumExport"/)
+        expect(source).toMatch(/isAddendumExport\.value \|\|/)
     })
 
     // One collection, one refusal path, branching only at the render step -- a partial
@@ -104,8 +106,10 @@ describe('the FDA addendum export is wired into the export modal', () => {
     // FOUR, not three. The artifact-coverage-type filter was left ungated when its three
     // siblings were gated, so it stayed visible and toggleable while exportFdaAddendum
     // ignored it entirely -- the exact "dropped on the floor" failure the gate exists for.
-    it('hides all four BOM-shaping controls for EITHER addendum encoding', () => {
-        const gates = source.match(/v-if="!isAddendumExport"/g) || []
+    // The predicate widened to isFdaDocumentExport when the statement arrived; the count is
+    // what this test is really protecting.
+    it('hides all four BOM-shaping controls for every FDA document', () => {
+        const gates = source.match(/v-if="!isFdaDocumentExport"/g) || []
         expect(gates.length).toBe(4)
     })
 

--- a/ui/src/components/deviceStatementWiring.spec.ts
+++ b/ui/src/components/deviceStatementWiring.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * Import and wiring assertions for the Device Support Statement export.
+ *
+ * Fourth in the *Wiring.spec.ts family, for the same reason as the others: no vue-tsc, so an
+ * undefined identifier in <script setup> is a runtime error the build ignores.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+function functionBody (name: string): string {
+    const start = source.indexOf(`function ${name} (`)
+    if (start < 0) throw new Error(`no function ${name} in ReleaseView.vue`)
+    let depth = 0
+    let i = source.indexOf('{', start)
+    const open = i
+    for (; i < source.length; i++) {
+        if (source[i] === '{') depth++
+        else if (source[i] === '}' && --depth === 0) break
+    }
+    return source.slice(open, i + 1)
+}
+
+describe('the device support statement is wired into the export modal', () => {
+    it.each([
+        ['renderDeviceSupportStatementBlob'],
+        ['deviceSupportStatementFileName'],
+        ['statementBlockReason']
+    ])('imports %s from utils/deviceSupportStatement', (symbol) => {
+        expect(source).toMatch(new RegExp(
+            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'@\\/utils\\/deviceSupportStatement'`))
+    })
+
+    it('offers it as its own export type', () => {
+        expect(source).toContain('<n-radio-button value="DEVICE_STATEMENT">')
+    })
+
+    it('routes it through the single export button', () => {
+        expect(source).toMatch(/if \(mediaType === 'DEVICE_STATEMENT'\) return exportDeviceSupportStatement\(\)/)
+    })
+
+    // The BOM-shaping options apply to no FDA document, so the gate covers all three types.
+    it('hides the BOM-shaping controls for every FDA document, not just the addendum', () => {
+        expect((source.match(/v-if="!isFdaDocumentExport"/g) || []).length).toBe(4)
+        expect(source).toMatch(/const isFdaDocumentExport\b/)
+        expect(source).toMatch(/selectedSbomMediaType\.value === 'DEVICE_STATEMENT'/)
+    })
+
+    // Every refusal is checked BEFORE anything is built: a component release, an unauthored
+    // prose slot, and text the font cannot draw all block generation rather than degrade it.
+    it('blocks before rendering, and downloads nothing when blocked', () => {
+        const body = functionBody('exportDeviceSupportStatement')
+        expect(body.indexOf('statementBlockReason')).toBeLessThan(body.indexOf('renderDeviceSupportStatementBlob'))
+        expect(body.indexOf('if (blocked)')).toBeLessThan(body.indexOf('createElement'))
+    })
+
+    it('reuses the same collector as the addendum', () => {
+        expect(functionBody('exportDeviceSupportStatement')).toContain('collectAddendumData')
+    })
+
+    it('always clears the export spinner in a finally', () => {
+        expect(functionBody('exportDeviceSupportStatement'))
+            .toMatch(/finally \{[\s\S]*?bomExportPending\.value = false/)
+    })
+
+    it('appends, clicks, removes, then revokes the object URL', () => {
+        const body = functionBody('exportDeviceSupportStatement')
+        expect(body.indexOf('appendChild')).toBeLessThan(body.indexOf('link.click()'))
+        expect(body.indexOf('link.click()')).toBeLessThan(body.indexOf('revokeObjectURL'))
+    })
+})

--- a/ui/src/utils/addendumCsv.spec.ts
+++ b/ui/src/utils/addendumCsv.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { renderAddendumCsv, addendumFileName } from './addendumCsv'
-import { addendumRow, addendumHeaderRows, ADDENDUM_COLUMNS, NOT_ASSESSED,
-    LEVEL_NOT_STATED } from './addendumDocument'
+import { ADDENDUM_COLUMNS } from './addendumDocument'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
@@ -16,7 +15,7 @@ function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
 
 function data (over: Partial<AddendumData> = {}): AddendumData {
     return {
-        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump',
+        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump', componentType: 'PRODUCT',
         deviceEos: '2030-06-30', deviceEol: '2033-01-01',
         narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
         patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null,
@@ -24,114 +23,6 @@ function data (over: Partial<AddendumData> = {}): AddendumData {
         components: [comp()], generatedAt: '2026-09-07T12:00:00Z', ...over
     }
 }
-
-describe('addendumRow', () => {
-    it('states the FDA phrase verbatim for an attested component', () => {
-        expect(addendumRow(comp())[3]).toBe('actively maintained')
-    })
-
-    it('qualifies the name with its group', () => {
-        expect(addendumRow(comp())[0]).toBe('org.apache:log4j-core')
-        expect(addendumRow(comp({ group: null }))[0]).toBe('log4j-core')
-    })
-
-    // L1021-1022: a level and a justification are ALTERNATIVES. Emitting both suggests the
-    // justification qualifies the level, when it exists because there is no level to give.
-    it('emits the level and no justification when a level is attested', () => {
-        const row = addendumRow(comp({ justification: 'checked upstream' }))
-        expect(row[3]).toBe('actively maintained')
-        expect(row[5]).toBeNull()
-    })
-
-    it('emits the justification when there is no level', () => {
-        const row = addendumRow(comp({ levelOfSupport: null, justification: 'no upstream date published' }))
-        expect(row[5]).toBe('no upstream date published')
-    })
-
-    // REGRESSION: a level is OPTIONAL on an attestation, and a justification-only
-    // attestation is exactly the L1021-1022 case. Printing "not assessed" for it made the
-    // table contradict its own header -- "10 with a support attestation" above ten rows
-    // each reading not assessed.
-    it('distinguishes an attested component with no level from an unassessed one', () => {
-        expect(addendumRow(comp({ levelOfSupport: null }))[3]).toBe(LEVEL_NOT_STATED)
-        expect(addendumRow(comp({ attestationState: null, levelOfSupport: null }))[3]).toBe(NOT_ASSESSED)
-        expect(LEVEL_NOT_STATED).not.toBe(NOT_ASSESSED)
-    })
-
-    // A retracted attestation is not injected into exports. Emitting its justification would
-    // republish a claim the manufacturer formally withdrew.
-    it('states nothing at all for a WITHDRAWN component, justification included', () => {
-        const row = addendumRow(comp({ attestationState: 'WITHDRAWN', levelOfSupport: null,
-            justification: 'retracted reasoning' }))
-        expect(row[5]).toBeNull()
-    })
-
-    // Blank would read as an omission -- something the exporter forgot. The honest claim is
-    // that nothing is recorded, and the row has to say which it is.
-    it('says "not assessed" rather than leaving the cell blank', () => {
-        const row = addendumRow(comp({ attestationState: null, levelOfSupport: null }))
-        expect(row[3]).toBe(NOT_ASSESSED)
-        expect(row[6]).toBe(NOT_ASSESSED)
-    })
-
-    // A WITHDRAWN attestation is not injected into exports, so treating it as live here
-    // would make the addendum disagree with the BOM it accompanies.
-    it('treats WITHDRAWN as not assessed and suppresses its stale dates', () => {
-        const row = addendumRow(comp({ attestationState: 'WITHDRAWN' }))
-        expect(row[3]).toBe(NOT_ASSESSED)
-        expect(row[4]).toBeNull()
-        expect(row[6]).toBe('WITHDRAWN')
-        expect(row[7]).toBeNull()
-    })
-
-    it('has exactly one cell per declared column', () => {
-        expect(addendumRow(comp())).toHaveLength(ADDENDUM_COLUMNS.length)
-        expect(addendumRow(comp({ attestationState: null }))).toHaveLength(ADDENDUM_COLUMNS.length)
-    })
-})
-
-describe('addendumHeaderRows', () => {
-    // Two questions, two facts: when patching stops, and when selling stops. One merged
-    // "support window" cell forces the reader to guess which a lone date is.
-    it('states device EOS and EOL as two separate labelled facts', () => {
-        const flat = addendumHeaderRows(data()).map(r => r[0])
-        expect(flat).toContain('Device end of support (EOS)')
-        expect(flat).toContain('Device end of sale / end of life (EOL)')
-    })
-
-    it('says "not declared" for an absent device date rather than leaving it blank', () => {
-        const rows = addendumHeaderRows(data({ deviceEos: null }))
-        expect(rows.find(r => r[0] === 'Device end of support (EOS)')![1]).toBe('not declared')
-    })
-
-    it('carries the assessed and unassessed counts', () => {
-        const rows = addendumHeaderRows(data({ totalComponents: 10, attestedComponents: 4, unassessedComponents: 6 }))
-        expect(rows.find(r => r[0] === 'Components with no support attestation')![1]).toBe(6)
-        expect(rows.find(r => r[0] === 'Components with a support attestation')![1]).toBe(4)
-    })
-
-    it('states the narrative scope beside the text', () => {
-        const org = addendumHeaderRows(data())
-        expect(org.find(r => r[0] === 'Justification scope')![1]).toBe('organization default')
-        const rel = addendumHeaderRows(data({ narrativeIsPerRelease: true }))
-        expect(rel.find(r => r[0] === 'Justification scope')![1]).toBe('this release')
-    })
-
-    // A blank "Assessment justification" heading reads as "we had nothing to say" rather
-    // than "nobody has written this yet".
-    it('omits the justification block entirely when neither level has one', () => {
-        const rows = addendumHeaderRows(data({ narrative: null }))
-        expect(rows.map(r => r[0])).not.toContain('Assessment justification')
-        expect(rows.map(r => r[0])).not.toContain('Justification scope')
-    })
-
-    it('includes each labeling statement only when authored', () => {
-        expect(addendumHeaderRows(data()).map(r => r[0]))
-            .not.toContain('Patches may cease at end of support')
-        expect(addendumHeaderRows(data({ patchesMayCeaseStatement: 'patches stop' })).map(r => r[0]))
-            .toContain('Patches may cease at end of support')
-    })
-})
 
 describe('renderAddendumCsv', () => {
     it('emits the header block, the column row, then one row per component', () => {

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -133,6 +133,9 @@ describe('collectAddendumData', () => {
         expect(res.data.deviceEol).toBe('2033-01-01')
         expect(res.data.narrative).toBe('org words')
         expect(res.data.narrativeIsPerRelease).toBe(false)
+        // Fetched by the query and previously discarded. The Device Support Statement is one
+        // document per PRODUCT release and must refuse on a component release.
+        expect(res.data.componentType).toBe('PRODUCT')
         expect(res.data.unassessedComponents).toBe(0)
     })
 

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -140,6 +140,15 @@ export interface AddendumData {
     releaseVersion: string | null
     componentName: string | null
     /**
+     * PRODUCT or COMPONENT.
+     *
+     * Already fetched by the release query and previously discarded. Kept because the Device
+     * Support Statement is defined as ONE DOCUMENT PER PRODUCT RELEASE and must refuse on a
+     * component release -- and a renderer that had to be told its own release's type by the
+     * call site would be a second source of truth for something this collector already holds.
+     */
+    componentType: string | null
+    /**
      * The two device facts, SEPARATE. End of support and end of sale answer different
      * questions -- when patching stops, and when selling stops -- and a single "support
      * window" cell forces a reader to guess which one a lone date is.
@@ -354,6 +363,7 @@ export async function collectAddendumData (
                 releaseUuid,
                 releaseVersion: blankToNull(release.version),
                 componentName: blankToNull(release.componentDetails?.name),
+                componentType: blankToNull(release.componentDetails?.type),
                 deviceEos: blankToNull(release.eos),
                 deviceEol: blankToNull(release.eol),
                 narrative: resolved.narrative,

--- a/ui/src/utils/addendumDocument.spec.ts
+++ b/ui/src/utils/addendumDocument.spec.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import { addendumRow, addendumHeaderRows, ADDENDUM_COLUMNS, ADDENDUM_TITLE, NOT_ASSESSED,
+    LEVEL_NOT_STATED, addendumFileStem } from './addendumDocument'
+import type { AddendumComponent, AddendumData } from './addendumData'
+
+function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
+    return {
+        sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+        purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+        levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+        endOfSupportDate: '2030-01-01',
+        justification: null, assessedAt: '2026-09-01T00:00:00Z', ...over
+    }
+}
+
+function data (over: Partial<AddendumData> = {}): AddendumData {
+    return {
+        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump', componentType: 'PRODUCT',
+        deviceEos: '2030-06-30', deviceEol: '2033-01-01',
+        narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
+        patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null,
+        totalComponents: 1, attestedComponents: 1, unassessedComponents: 0,
+        components: [comp()], generatedAt: '2026-09-07T12:00:00Z', ...over
+    }
+}
+
+describe('addendumRow', () => {
+    it('states the FDA phrase verbatim for an attested component', () => {
+        expect(addendumRow(comp())[3]).toBe('actively maintained')
+    })
+
+    it('qualifies the name with its group', () => {
+        expect(addendumRow(comp())[0]).toBe('org.apache:log4j-core')
+        expect(addendumRow(comp({ group: null }))[0]).toBe('log4j-core')
+    })
+
+    // L1021-1022: a level and a justification are ALTERNATIVES. Emitting both suggests the
+    // justification qualifies the level, when it exists because there is no level to give.
+    it('emits the level and no justification when a level is attested', () => {
+        const row = addendumRow(comp({ justification: 'checked upstream' }))
+        expect(row[3]).toBe('actively maintained')
+        expect(row[5]).toBeNull()
+    })
+
+    it('emits the justification when there is no level', () => {
+        const row = addendumRow(comp({ levelOfSupport: null, justification: 'no upstream date published' }))
+        expect(row[5]).toBe('no upstream date published')
+    })
+
+    // REGRESSION: a level is OPTIONAL on an attestation, and a justification-only
+    // attestation is exactly the L1021-1022 case. Printing "not assessed" for it made the
+    // table contradict its own header -- "10 with a support attestation" above ten rows
+    // each reading not assessed.
+    it('distinguishes an attested component with no level from an unassessed one', () => {
+        expect(addendumRow(comp({ levelOfSupport: null }))[3]).toBe(LEVEL_NOT_STATED)
+        expect(addendumRow(comp({ attestationState: null, levelOfSupport: null }))[3]).toBe(NOT_ASSESSED)
+        expect(LEVEL_NOT_STATED).not.toBe(NOT_ASSESSED)
+    })
+
+    // A retracted attestation is not injected into exports. Emitting its justification would
+    // republish a claim the manufacturer formally withdrew.
+    it('states nothing at all for a WITHDRAWN component, justification included', () => {
+        const row = addendumRow(comp({ attestationState: 'WITHDRAWN', levelOfSupport: null,
+            justification: 'retracted reasoning' }))
+        expect(row[5]).toBeNull()
+    })
+
+    // Blank would read as an omission -- something the exporter forgot. The honest claim is
+    // that nothing is recorded, and the row has to say which it is.
+    it('says "not assessed" rather than leaving the cell blank', () => {
+        const row = addendumRow(comp({ attestationState: null, levelOfSupport: null }))
+        expect(row[3]).toBe(NOT_ASSESSED)
+        expect(row[6]).toBe(NOT_ASSESSED)
+    })
+
+    // A WITHDRAWN attestation is not injected into exports, so treating it as live here
+    // would make the addendum disagree with the BOM it accompanies.
+    it('treats WITHDRAWN as not assessed and suppresses its stale dates', () => {
+        const row = addendumRow(comp({ attestationState: 'WITHDRAWN' }))
+        expect(row[3]).toBe(NOT_ASSESSED)
+        expect(row[4]).toBeNull()
+        expect(row[6]).toBe('WITHDRAWN')
+        expect(row[7]).toBeNull()
+    })
+
+    it('has exactly one cell per declared column', () => {
+        expect(addendumRow(comp())).toHaveLength(ADDENDUM_COLUMNS.length)
+        expect(addendumRow(comp({ attestationState: null }))).toHaveLength(ADDENDUM_COLUMNS.length)
+    })
+})
+
+describe('addendumHeaderRows', () => {
+    // Two questions, two facts: when patching stops, and when selling stops. One merged
+    // "support window" cell forces the reader to guess which a lone date is.
+    it('states device EOS and EOL as two separate labelled facts', () => {
+        const flat = addendumHeaderRows(data()).map(r => r[0])
+        expect(flat).toContain('Device end of support (EOS)')
+        expect(flat).toContain('Device end of sale / end of life (EOL)')
+    })
+
+    it('says "not declared" for an absent device date rather than leaving it blank', () => {
+        const rows = addendumHeaderRows(data({ deviceEos: null }))
+        expect(rows.find(r => r[0] === 'Device end of support (EOS)')![1]).toBe('not declared')
+    })
+
+    it('carries the assessed and unassessed counts', () => {
+        const rows = addendumHeaderRows(data({ totalComponents: 10, attestedComponents: 4, unassessedComponents: 6 }))
+        expect(rows.find(r => r[0] === 'Components with no support attestation')![1]).toBe(6)
+        expect(rows.find(r => r[0] === 'Components with a support attestation')![1]).toBe(4)
+    })
+
+    it('states the narrative scope beside the text', () => {
+        const org = addendumHeaderRows(data())
+        expect(org.find(r => r[0] === 'Justification scope')![1]).toBe('organization default')
+        const rel = addendumHeaderRows(data({ narrativeIsPerRelease: true }))
+        expect(rel.find(r => r[0] === 'Justification scope')![1]).toBe('this release')
+    })
+
+    // A blank "Assessment justification" heading reads as "we had nothing to say" rather
+    // than "nobody has written this yet".
+    it('omits the justification block entirely when neither level has one', () => {
+        const rows = addendumHeaderRows(data({ narrative: null }))
+        expect(rows.map(r => r[0])).not.toContain('Assessment justification')
+        expect(rows.map(r => r[0])).not.toContain('Justification scope')
+    })
+
+    it('includes each labeling statement only when authored', () => {
+        expect(addendumHeaderRows(data()).map(r => r[0]))
+            .not.toContain('Patches may cease at end of support')
+        expect(addendumHeaderRows(data({ patchesMayCeaseStatement: 'patches stop' })).map(r => r[0]))
+            .toContain('Patches may cease at end of support')
+    })
+})
+
+describe('addendumFileStem', () => {
+    // Shared by both renderers so the CSV and the PDF for one release sort together. Each
+    // used to own a copy of this rule with its own hardcoded expectations, so changing one
+    // passed every test while breaking the stated contract.
+    it('slugs the version', () => {
+        expect(addendumFileStem(data())).toBe('fda-support-addendum-1.4.5')
+    })
+
+    it('falls back to the uuid, then to a fixed stem, rather than throwing', () => {
+        expect(addendumFileStem(data({ releaseVersion: null }))).toBe('fda-support-addendum-r-1')
+        expect(addendumFileStem(data({ releaseVersion: null, releaseUuid: null as any })))
+            .toBe('fda-support-addendum-release')
+    })
+
+    it('strips anything path-unsafe', () => {
+        expect(addendumFileStem(data({ releaseVersion: 'feature/x y' })))
+            .toBe('fda-support-addendum-feature-x-y')
+    })
+
+    it('is the stem both file names are built from', () => {
+        expect(ADDENDUM_TITLE).toBe('FDA software support addendum')
+    })
+})

--- a/ui/src/utils/addendumDocument.ts
+++ b/ui/src/utils/addendumDocument.ts
@@ -25,6 +25,20 @@ import { isLiveAttestation } from './addendumData'
  */
 export const ADDENDUM_TITLE = 'FDA software support addendum'
 
+/**
+ * How the three org-authored labeling statements are named, wherever a document names them.
+ *
+ * Shared because BOTH documents name them and they must agree: the addendum labels them as
+ * header rows, and the statement names them when it BLOCKS on a missing one. An operator told
+ * "Risk-transfer process reference is missing" has to find that same wording in the settings
+ * form and in the addendum, or the message sends them looking for something else.
+ */
+export const PROSE_SLOT_LABELS = {
+    patchesMayCease: 'Patches may cease at end of support',
+    riskTransferRef: 'Risk-transfer process reference',
+    riskIncreases: 'Risk increases over time'
+} as const
+
 export const ADDENDUM_COLUMNS = [
     'Component', 'Version', 'PURL', 'Level of support', 'End of support',
     'Justification', 'Attestation state', 'Last assessed'
@@ -125,9 +139,9 @@ export function addendumHeaderRows (d: AddendumData): unknown[][] {
         rows.push(['Justification scope', d.narrativeIsPerRelease ? 'this release' : 'organization default'])
         rows.push([])
     }
-    if (d.patchesMayCeaseStatement) rows.push(['Patches may cease at end of support', d.patchesMayCeaseStatement])
-    if (d.riskTransferProcessRef) rows.push(['Risk-transfer process reference', d.riskTransferProcessRef])
-    if (d.riskIncreasesNotice) rows.push(['Risk increases over time', d.riskIncreasesNotice])
+    if (d.patchesMayCeaseStatement) rows.push([PROSE_SLOT_LABELS.patchesMayCease, d.patchesMayCeaseStatement])
+    if (d.riskTransferProcessRef) rows.push([PROSE_SLOT_LABELS.riskTransferRef, d.riskTransferProcessRef])
+    if (d.riskIncreasesNotice) rows.push([PROSE_SLOT_LABELS.riskIncreases, d.riskIncreasesNotice])
     if (d.patchesMayCeaseStatement || d.riskTransferProcessRef || d.riskIncreasesNotice) rows.push([])
     return rows
 }
@@ -161,7 +175,22 @@ export function displayOrder (components: AddendumComponent[]): AddendumComponen
  * into a failed export rather than an awkwardly named file.
  */
 export function addendumFileStem (d: AddendumData): string {
+    return `fda-support-addendum-${releaseSlug(d)}`
+}
+
+/**
+ * The release's identity as a filename-safe slug, shared by EVERY document.
+ *
+ * Split out of addendumFileStem when the Device Support Statement arrived with its own
+ * character-for-character copy of this rule -- the same duplication the previous PR removed
+ * from between the CSV and the PDF, reappearing the moment a third document was added,
+ * because the stem baked in a prefix only two of the three wanted.
+ *
+ * Falls back through version, then uuid, then a fixed word. The last step matters: an earlier
+ * copy threw a TypeError when both were absent, turning a nameless release into a failed
+ * export rather than an awkwardly named file.
+ */
+export function releaseSlug (d: AddendumData): string {
     const raw = d.releaseVersion || d.releaseUuid || 'release'
-    const slug = String(raw).replace(/[^A-Za-z0-9._-]+/g, '-')
-    return `fda-support-addendum-${slug || 'release'}`
+    return String(raw).replace(/[^A-Za-z0-9._-]+/g, '-') || 'release'
 }

--- a/ui/src/utils/addendumParity.spec.ts
+++ b/ui/src/utils/addendumParity.spec.ts
@@ -44,6 +44,7 @@ const COMPONENTS: AddendumComponent[] = [
 
 const DATA: AddendumData = {
     releaseUuid: 'r-parity', releaseVersion: '9000.1.0', componentName: 'Infusion Pump 9000',
+    componentType: 'PRODUCT',
     deviceEos: '2030-06-30', deviceEol: null,
     narrative: 'Assessed per DHF-PROC-9001, "rev D", including a comma.',
     narrativeIsPerRelease: true, orgName: 'Acme, Inc.',

--- a/ui/src/utils/addendumPdf.spec.ts
+++ b/ui/src/utils/addendumPdf.spec.ts
@@ -24,7 +24,7 @@ function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
 
 function data (over: Partial<AddendumData> = {}): AddendumData {
     return {
-        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump',
+        releaseUuid: 'r-1', releaseVersion: '1.4.5', componentName: 'Pump', componentType: 'PRODUCT',
         deviceEos: '2030-06-30', deviceEol: '2033-01-01',
         narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
         patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null,

--- a/ui/src/utils/addendumPdf.ts
+++ b/ui/src/utils/addendumPdf.ts
@@ -12,6 +12,7 @@
 import pdfMake from 'pdfmake/build/pdfmake'
 import pdfFonts from 'pdfmake/build/vfs_fonts'
 import type { AddendumData } from './addendumData'
+import { fontCoverageRefusal } from './pdfFontCoverage'
 import { ADDENDUM_COLUMNS, ADDENDUM_TITLE, addendumRow, addendumHeaderRows, displayOrder,
     addendumFileStem } from './addendumDocument'
 
@@ -40,58 +41,16 @@ function cell (value: unknown): string {
 }
 
 /**
- * The codepoint ranges the bundled Roboto can actually draw.
+ * The characters in THIS document that the PDF font cannot draw, or null if there are none.
  *
- * pdfmake ships ROBOTO ONLY. A character it has no glyph for is not flagged, substituted or
- * warned about -- it is silently DROPPED, so a component named in Japanese produces an EMPTY
- * cell in a regulatory document while the CSV for the same release shows the text. Blank is
- * the one thing this document must never be ambiguous about.
- *
- * Determined by RENDERING and extracting, not by reading a spec: Latin (including Extended-A,
- * Turkish and Vietnamese), Greek, Cyrillic, punctuation and currency draw; Latin Extended-B,
- * arrows, emoji, Hebrew, Arabic, Hangul, Thai, Devanagari and CJK do not.
- *
- * DELIBERATELY CONSERVATIVE. It is a whitelist, so an unlisted script is refused rather than
- * rendered blank, and it will refuse some characters Roboto could in fact draw. That trade is
- * the point: a false refusal is visible, explained and recoverable via the CSV, while a false
- * render is an invisible hole in a document someone files.
- */
-const RENDERABLE = [
-    [0x09, 0x0a], [0x0d, 0x0d],
-    [0x20, 0x17f],      // Basic Latin, Latin-1 Supplement, Latin Extended-A
-    [0x370, 0x3ff],     // Greek
-    [0x400, 0x4ff],     // Cyrillic
-    [0x1e00, 0x1eff],   // Latin Extended Additional (Vietnamese)
-    [0x2010, 0x201f],   // dashes and quotation marks
-    [0x2020, 0x2027], [0x2030, 0x203a],
-    [0x20a0, 0x20bf],   // currency
-    [0x2122, 0x2122]    // trade mark
-]
-
-function isRenderable (code: number): boolean {
-    return RENDERABLE.some(([lo, hi]) => code >= lo && code <= hi)
-}
-
-/**
- * The characters in this document that the PDF font cannot draw, or null if there are none.
- *
- * Returned rather than thrown so the caller refuses in the same voice as every other addendum
- * refusal -- no document at all, with a reason, instead of one that quietly omits words the
- * manufacturer wrote.
+ * Thin wrapper over the shared coverage check: it knows which strings this document prints,
+ * and nothing about fonts.
  */
 export function findUnrenderableText (d: AddendumData): string | null {
-    const offenders = new Set<string>()
-    const scan = (v: unknown) => {
-        const t = cell(v)
-        for (const ch of t) if (!isRenderable(ch.codePointAt(0) as number)) offenders.add(ch)
-    }
-    for (const row of addendumHeaderRows(d)) row.forEach(scan)
-    for (const c of d.components) addendumRow(c).forEach(scan)
-    if (!offenders.size) return null
-    const sample = [...offenders].slice(0, 12).join(' ')
-    return 'This release contains characters the PDF font cannot draw (' + sample + ').'
-        + ' They would be silently dropped, leaving blank cells in a document that is meant to'
-        + ' be complete. Export the CSV instead -- it carries every character.'
+    const texts: Array<string | null | undefined> = []
+    for (const row of addendumHeaderRows(d)) row.forEach(v => texts.push(cell(v)))
+    for (const c of d.components) addendumRow(c).forEach(v => texts.push(cell(v)))
+    return fontCoverageRefusal(texts, 'support addendum')
 }
 
 /**

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('pdfmake/build/pdfmake', () => ({ default: { vfs: null, createPdf: vi.fn() } }))
+vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
+
+import { buildDeviceSupportStatementDefinition, statementBlockReason, missingProseSlots,
+    componentsEndingBeforeDevice, deviceSupportStatementFileName, STATEMENT_TITLE,
+    NOT_DECLARED, REQUIRED_PROSE_SLOTS } from './deviceSupportStatement'
+import type { AddendumComponent, AddendumData } from './addendumData'
+
+function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
+    return {
+        sbomComponentUuid: 'sc-1', name: 'log4j-core', group: 'org.apache', version: '2.14.1',
+        purl: 'pkg:maven/org.apache/log4j-core@2.14.1', attestationState: 'ATTESTED',
+        levelOfSupport: 'actively maintained', levelOfSupportEnum: 'ACTIVELY_MAINTAINED',
+        endOfSupportDate: '2029-01-01', justification: null,
+        assessedAt: '2026-09-01T00:00:00Z', ...over
+    }
+}
+
+function data (over: Partial<AddendumData> = {}): AddendumData {
+    return {
+        releaseUuid: 'r-1', releaseVersion: '9000.1.0', componentName: 'Infusion Pump 9000',
+        componentType: 'PRODUCT',
+        deviceEos: '2030-06-30', deviceEol: '2033-01-01',
+        narrative: 'org words', narrativeIsPerRelease: false, orgName: 'Acme',
+        patchesMayCeaseStatement: 'After end of support, security patches may no longer be provided.',
+        riskTransferProcessRef: 'DHF-PROC-4471 rev C',
+        riskIncreasesNotice: 'Cybersecurity risk can be expected to increase after end of support.',
+        totalComponents: 1, attestedComponents: 1, unassessedComponents: 0,
+        components: [comp()], generatedAt: '2026-09-08T12:00:00Z', ...over
+    }
+}
+
+const flat = (d: AddendumData) => JSON.stringify(buildDeviceSupportStatementDefinition(d))
+
+describe('statementBlockReason', () => {
+    it('permits a product release with all three slots authored', () => {
+        expect(statementBlockReason(data())).toBeNull()
+    })
+
+    // One document per PRODUCT release. A component release is not a device, and no amount
+    // of authored prose makes it one -- so scope is checked before the slots.
+    it('refuses a component release, and says where to go instead', () => {
+        const msg = statementBlockReason(data({ componentType: 'COMPONENT' })) as string
+        expect(msg).toContain('product release')
+        expect(msg).toContain('component release')
+    })
+
+    it('refuses a release whose type is unknown rather than assuming it is a device', () => {
+        expect(statementBlockReason(data({ componentType: null }))).not.toBeNull()
+    })
+
+    it('checks scope BEFORE the prose slots', () => {
+        const msg = statementBlockReason(data({
+            componentType: 'COMPONENT', patchesMayCeaseStatement: null,
+            riskTransferProcessRef: null, riskIncreasesNotice: null
+        })) as string
+        expect(msg).toContain('product release')
+    })
+
+    // A patient-facing document with an empty section is worse than no document: section 3's
+    // "a gap beats a fabrication" is right for a submission a reviewer reads, and wrong here.
+    it.each(REQUIRED_PROSE_SLOTS)('blocks when $label is empty, naming it', (slot) => {
+        const msg = statementBlockReason(data({ [slot.key]: null } as any)) as string
+        expect(msg).not.toBeNull()
+        expect(msg).toContain(slot.label)
+    })
+
+    it('treats a whitespace-only slot as empty', () => {
+        expect(statementBlockReason(data({ riskTransferProcessRef: '   ' }))).not.toBeNull()
+    })
+
+    it('names EVERY missing slot, not just the first', () => {
+        const msg = statementBlockReason(data({
+            patchesMayCeaseStatement: null, riskIncreasesNotice: null
+        })) as string
+        expect(msg).toContain('Patches may cease at end of support')
+        expect(msg).toContain('Risk increases over time')
+    })
+
+    // The block has to be actionable, not just correct.
+    it('tells the operator where to author the missing text', () => {
+        const msg = statementBlockReason(data({ patchesMayCeaseStatement: null })) as string
+        expect(msg).toContain('Organization Settings')
+    })
+
+    // Reused from the addendum: pdfmake ships Roboto only and silently drops what it cannot
+    // draw. Written as an escape because this repo is plain-ASCII by rule.
+    it('refuses text the PDF font cannot draw', () => {
+        const msg = statementBlockReason(data({
+            components: [comp({ name: '\u65e5\u672c\u8a9e', endOfSupportDate: '2029-01-01' })]
+        })) as string
+        expect(msg).not.toBeNull()
+        expect(msg).toContain('cannot draw')
+    })
+
+    it('checks the font AFTER scope and slots, so the most fundamental problem is reported', () => {
+        const msg = statementBlockReason(data({
+            componentType: 'COMPONENT',
+            components: [comp({ name: '\u65e5\u672c\u8a9e' })]
+        })) as string
+        expect(msg).toContain('product release')
+    })
+})
+
+describe('missingProseSlots', () => {
+    it('is empty when all three are authored', () => {
+        expect(missingProseSlots(data())).toEqual([])
+    })
+
+    it('reports labels in document order', () => {
+        expect(missingProseSlots(data({
+            patchesMayCeaseStatement: null, riskTransferProcessRef: null, riskIncreasesNotice: null
+        }))).toEqual(REQUIRED_PROSE_SLOTS.map(s => s.label))
+    })
+})
+
+describe('componentsEndingBeforeDevice', () => {
+    it('lists a component whose attested EOS precedes the device EOS', () => {
+        expect(componentsEndingBeforeDevice(data())).toEqual([{ name: 'log4j-core', date: '2029-01-01' }])
+    })
+
+    it('excludes one whose support outlasts the device', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp({ endOfSupportDate: '2031-01-01' })]
+        }))).toEqual([])
+    })
+
+    it('excludes one ending on the SAME day -- it does not end sooner', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp({ endOfSupportDate: '2030-06-30' })]
+        }))).toEqual([])
+    })
+
+    // Not listed is NOT a claim that it outlives the device: nobody recorded a date, and
+    // asserting anything about it to a patient would be a fabrication.
+    it('excludes a component with no live attestation, even with a date', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp({ attestationState: 'WITHDRAWN' }), comp({ attestationState: null })]
+        }))).toEqual([])
+    })
+
+    it('excludes an attested component with no date', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp({ endOfSupportDate: null })]
+        }))).toEqual([])
+    })
+
+    // With no device EOS there is nothing for a date to precede. Listing every dated
+    // component instead would silently change what the section means.
+    it('lists nothing when the device EOS is not declared', () => {
+        expect(componentsEndingBeforeDevice(data({ deviceEos: null }))).toEqual([])
+    })
+
+    it('orders by date, then name', () => {
+        const out = componentsEndingBeforeDevice(data({
+            components: [
+                comp({ name: 'zeta', endOfSupportDate: '2029-05-01' }),
+                comp({ name: 'alpha', endOfSupportDate: '2029-05-01' }),
+                comp({ name: 'earlier', endOfSupportDate: '2027-01-01' })
+            ]
+        }))
+        expect(out.map(c => c.name)).toEqual(['earlier', 'alpha', 'zeta'])
+    })
+
+    it('uses the plain name, with no group prefix and no purl', () => {
+        const out = componentsEndingBeforeDevice(data())
+        expect(out[0].name).toBe('log4j-core')
+        expect(out[0].name).not.toContain('org.apache')
+    })
+})
+
+describe('buildDeviceSupportStatementDefinition', () => {
+    it('returns plain JSON', () => {
+        const doc = buildDeviceSupportStatementDefinition(data())
+        expect(Array.isArray(doc.content)).toBe(true)
+    })
+
+    // On its face, so nobody reads shipping it as satisfying VI.A.
+    it('states which ONE of the four labeling asks it covers', () => {
+        const s = flat(data())
+        expect(s).toContain('VI.A')
+        expect(s).toContain('one of the four')
+    })
+
+    it('names the other three as addressed separately', () => {
+        const s = flat(data())
+        expect(s).toContain('security patches or software updates')
+        expect(s).toContain('transferring cybersecurity risk')
+        expect(s).toContain('increase over time')
+        expect(s).toContain('addresses separately')
+    })
+
+    // Two distinct facts. An EOS-else-EOL horizon is right for a risk comparison and wrong
+    // for a document read as two separate commitments.
+    it('shows device EOS and EOL as two separate labelled facts', () => {
+        const s = flat(data())
+        expect(s).toContain('end of support')
+        expect(s).toContain('end of life / end of sale')
+        expect(s).toContain('2030-06-30')
+        expect(s).toContain('2033-01-01')
+    })
+
+    it('says "not declared" for a missing date rather than leaving it blank', () => {
+        const s = flat(data({ deviceEos: null, deviceEol: null }))
+        expect(s.match(new RegExp(NOT_DECLARED, 'g'))).toHaveLength(2)
+    })
+
+    // Plain language for a patient, caregiver or biomed reader (L1591-1592).
+    it('carries no purl, no version column and no component inventory', () => {
+        const s = flat(data())
+        expect(s).not.toContain('pkg:')
+        expect(s).not.toContain('2.14.1')
+        expect(s).not.toContain('PURL')
+    })
+
+    // "412 components not assessed" conveys no risk information to a hospital biomed reader
+    // and edges toward misleading under 502(a)(1). That count belongs in the addendum.
+    it('carries no unassessed count and no risk verdict', () => {
+        const s = flat(data({ totalComponents: 412, attestedComponents: 3, unassessedComponents: 409 }))
+        expect(s).not.toContain('409')
+        expect(s).not.toContain('412')
+        expect(s).not.toContain('unassessed')
+        expect(s).not.toContain('deviceSupportRisk')
+    })
+
+    it('omits the earlier-support section entirely when nothing qualifies', () => {
+        const s = flat(data({ components: [comp({ endOfSupportDate: '2031-01-01' })] }))
+        expect(s).not.toContain('ends sooner')
+    })
+
+    it('prints all three prose slots verbatim', () => {
+        const d = data()
+        const s = flat(d)
+        expect(s).toContain(d.patchesMayCeaseStatement as string)
+        expect(s).toContain(d.riskTransferProcessRef as string)
+        expect(s).toContain(d.riskIncreasesNotice as string)
+    })
+
+    // The slot holds a REFERENCE to a controlled document, not the process: pasting the
+    // process in creates a second, unversioned copy that drifts from the DHF original.
+    it('prints the risk-transfer slot as the reference it is', () => {
+        expect(flat(data())).toContain('DHF-PROC-4471 rev C')
+    })
+
+    it('never truncates: no noWrap, no ellipsis', () => {
+        const s = flat(data({ riskIncreasesNotice: 'x'.repeat(8000) }))
+        expect(s).not.toContain('noWrap')
+        expect(s).not.toContain('ellipsis')
+        expect(s).toContain('x'.repeat(8000))
+    })
+
+    describe('the footer', () => {
+        const footer = (d = data()) => (buildDeviceSupportStatementDefinition(d).footer as any)(2, 3)
+        it('carries device identity, a UTC instant and page N of M', () => {
+            const t = footer().columns.map((c: any) => c.text).join(' | ')
+            expect(t).toContain('Infusion Pump 9000')
+            expect(t).toContain('r-1')
+            expect(t).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z/)
+            expect(t).toContain('Page 2 of 3')
+        })
+    })
+
+    it('titles itself', () => {
+        expect((buildDeviceSupportStatementDefinition(data()).content as any[])[0].text).toBe(STATEMENT_TITLE)
+    })
+})
+
+describe('deviceSupportStatementFileName', () => {
+    it('names the document and the release', () => {
+        expect(deviceSupportStatementFileName(data())).toBe('device-support-statement-9000.1.0.pdf')
+    })
+
+    it('falls back rather than throwing when both version and uuid are absent', () => {
+        expect(deviceSupportStatementFileName(data({ releaseVersion: null, releaseUuid: null as any })))
+            .toBe('device-support-statement-release.pdf')
+    })
+})

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -5,7 +5,7 @@ vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
 import { buildDeviceSupportStatementDefinition, statementBlockReason, missingProseSlots,
     componentsEndingBeforeDevice, deviceSupportStatementFileName, STATEMENT_TITLE,
-    NOT_DECLARED, REQUIRED_PROSE_SLOTS } from './deviceSupportStatement'
+    NOT_DECLARED, REQUIRED_PROSE_SLOTS, renderDeviceSupportStatementBlob } from './deviceSupportStatement'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
@@ -184,12 +184,36 @@ describe('buildDeviceSupportStatementDefinition', () => {
         expect(s).toContain('one of the four')
     })
 
-    it('names the other three as addressed separately', () => {
+    it('distinguishes what it generates from what it reproduces', () => {
         const s = flat(data())
-        expect(s).toContain('security patches or software updates')
-        expect(s).toContain('transferring cybersecurity risk')
-        expect(s).toContain('increase over time')
-        expect(s).toContain('addresses separately')
+        expect(s).toContain('generated from the manufacturer')
+        expect(s).toContain("manufacturer's own words, reproduced here unchanged")
+        expect(s).toContain('not generated, completed or verified')
+    })
+
+    // The risk-transfer gap is SUBSTANTIVE rather than editorial: the slot holds a reference
+    // to a controlled document, so the process itself genuinely is not here.
+    it('says the risk-transfer process itself is not reproduced', () => {
+        expect(flat(data())).toContain('is not reproduced here')
+    })
+
+    /**
+     * REGRESSION, and the reason this file exists in its current shape.
+     *
+     * An earlier revision declared the document "does not cover" three items and then printed
+     * all three, in the same order, under their own headings -- while REFUSING to generate
+     * unless the manufacturer had authored them. Every statement it produced contradicted
+     * itself on its face. The two specs that were supposed to guard the coverage block
+     * asserted the wrong text and stayed green through it.
+     */
+    it('never claims not to cover something it then prints', () => {
+        const d = data()
+        const s = flat(d)
+        expect(s).not.toContain('does not cover')
+        for (const slot of [d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice]) {
+            const hits = s.split(slot as string).length - 1
+            expect(hits, `"${slot}" should appear exactly once`).toBe(1)
+        }
     })
 
     // Two distinct facts. An EOS-else-EOL horizon is right for a risk comparison and wrong
@@ -275,5 +299,57 @@ describe('deviceSupportStatementFileName', () => {
     it('falls back rather than throwing when both version and uuid are absent', () => {
         expect(deviceSupportStatementFileName(data({ releaseVersion: null, releaseUuid: null as any })))
             .toBe('device-support-statement-release.pdf')
+    })
+})
+
+describe('what the statement must never carry', () => {
+    // The addendum's assessment narrative is written for a submission reviewer, not for a
+    // patient. A regression that printed it here would pass every other test in this file.
+    it('omits the technical assessment narrative', () => {
+        expect(flat(data({ narrative: 'a very technical justification' })))
+            .not.toContain('a very technical justification')
+    })
+})
+
+describe('componentsEndingBeforeDevice, duplicate names', () => {
+    // The version is deliberately not shown -- it means nothing to this reader -- so one
+    // library at three versions rendered three rows saying different things about the same
+    // name, which reads as the document disagreeing with itself.
+    it('collapses one name to its EARLIEST date', () => {
+        const out = componentsEndingBeforeDevice(data({
+            components: [
+                comp({ name: 'log4j-core', version: '2.14.1', endOfSupportDate: '2029-01-01' }),
+                comp({ name: 'log4j-core', version: '2.15.0', endOfSupportDate: '2027-06-01' }),
+                comp({ name: 'log4j-core', version: '2.16.0', endOfSupportDate: '2028-03-01' })
+            ]
+        }))
+        expect(out).toEqual([{ name: 'log4j-core', date: '2027-06-01' }])
+    })
+
+    it('collapses exact duplicates rather than repeating a row', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp(), comp(), comp()]
+        }))).toHaveLength(1)
+    })
+
+    it('keeps genuinely different names apart', () => {
+        expect(componentsEndingBeforeDevice(data({
+            components: [comp({ name: 'a' }), comp({ name: 'b' })]
+        }))).toHaveLength(2)
+    })
+})
+
+describe('renderDeviceSupportStatementBlob', () => {
+    // The builder casts the prose slots to string and would emit { text: null } into pdfmake
+    // -- a silent empty section, exactly what the block exists to prevent. One guard in one
+    // caller is not a guarantee when the function is exported and no vue-tsc checks callers.
+    it('refuses to render a document its own preconditions forbid', async () => {
+        await expect(renderDeviceSupportStatementBlob(data({ patchesMayCeaseStatement: null })))
+            .rejects.toThrow(/Patches may cease/)
+    })
+
+    it('refuses to render for a component release', async () => {
+        await expect(renderDeviceSupportStatementBlob(data({ componentType: 'COMPONENT' })))
+            .rejects.toThrow(/product release/)
     })
 })

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -14,6 +14,7 @@ import pdfMake from 'pdfmake/build/pdfmake'
 import pdfFonts from 'pdfmake/build/vfs_fonts'
 import type { AddendumComponent, AddendumData } from './addendumData'
 import { isLiveAttestation } from './addendumData'
+import { releaseSlug, PROSE_SLOT_LABELS } from './addendumDocument'
 import { fontCoverageRefusal } from './pdfFontCoverage'
 
 pdfMake.vfs = pdfFonts.vfs
@@ -35,9 +36,9 @@ export const NOT_DECLARED = 'not declared'
  * `label` is what the UI names when it blocks; `field` is where the operator fixes it.
  */
 export const REQUIRED_PROSE_SLOTS: Array<{ key: keyof AddendumData, label: string }> = [
-    { key: 'patchesMayCeaseStatement', label: 'Patches may cease at end of support' },
-    { key: 'riskTransferProcessRef', label: 'Risk-transfer process reference' },
-    { key: 'riskIncreasesNotice', label: 'Risk increases over time' }
+    { key: 'patchesMayCeaseStatement', label: PROSE_SLOT_LABELS.patchesMayCease },
+    { key: 'riskTransferProcessRef', label: PROSE_SLOT_LABELS.riskTransferRef },
+    { key: 'riskIncreasesNotice', label: PROSE_SLOT_LABELS.riskIncreases }
 ]
 
 /** Where an operator goes to author them. Named in the block message so it is actionable. */
@@ -89,9 +90,21 @@ export function statementBlockReason (d: AddendumData): string | null {
  */
 export function componentsEndingBeforeDevice (d: AddendumData): Array<{ name: string, date: string }> {
     if (!d.deviceEos) return []
-    return d.components
-        .filter(c => isLiveAttestation(c) && c.endOfSupportDate && c.endOfSupportDate < (d.deviceEos as string))
-        .map(c => ({ name: displayName(c), date: c.endOfSupportDate as string }))
+    // COLLAPSED BY NAME, keeping the EARLIEST date. The version is deliberately not shown --
+    // it means nothing to this reader -- which makes one library at three versions three rows
+    // saying different things about the same name, reading as the document disagreeing with
+    // itself. The earliest date is the one that matters: it is when this reader first loses
+    // supported software.
+    const earliest = new Map<string, string>()
+    for (const c of d.components) {
+        if (!isLiveAttestation(c) || !c.endOfSupportDate) continue
+        if (!(c.endOfSupportDate < (d.deviceEos as string))) continue
+        const name = displayName(c)
+        const seen = earliest.get(name)
+        if (!seen || c.endOfSupportDate < seen) earliest.set(name, c.endOfSupportDate)
+    }
+    return [...earliest.entries()]
+        .map(([name, date]) => ({ name, date }))
         .sort((a, b) => (a.date === b.date ? a.name.localeCompare(b.name) : a.date.localeCompare(b.date)))
 }
 
@@ -103,7 +116,13 @@ function displayName (c: AddendumComponent): string {
 /** Every string the document prints, for the font-coverage check. */
 function statementStrings (d: AddendumData): Array<string | null | undefined> {
     return [
+        STATEMENT_TITLE, NOT_DECLARED,
         d.componentName, d.releaseVersion, d.orgName,
+        // Rendered in the facts table and the footer. Server-generated today -- dates, a
+        // uuid, an ISO instant -- so unreachable in practice, but the invariant this function
+        // states is "every string the document prints", and the next field added to the
+        // footer would otherwise escape the whitelist silently.
+        d.deviceEos, d.deviceEol, d.releaseUuid, d.generatedAt,
         d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice,
         ...componentsEndingBeforeDevice(d).flatMap(c => [c.name, c.date])
     ]
@@ -112,21 +131,30 @@ function statementStrings (d: AddendumData): Array<string | null | undefined> {
 /**
  * What this document covers, and -- equally important -- what it does not.
  *
- * FDA labeling VI.A lists FOUR asks. This document answers ONE of them, and says so on its
- * face so nobody reads shipping it as satisfying VI.A. The other three are the manufacturer's
- * own commitments and process; under section 3 there is no product-shipped default text for
- * any of them, which is exactly why they are org-authored prose rather than generated.
+ * FDA labeling VI.A lists FOUR asks. Exactly one of them -- end-of-support and end-of-life
+ * information -- is GENERATED here from the manufacturer's recorded data. The other three are
+ * reproduced verbatim from text the manufacturer authored; this document neither generates
+ * nor checks them.
+ *
+ * THAT DISTINCTION IS THE WHOLE POINT, and an earlier revision destroyed it: it said the
+ * document "does not cover" the other three and then printed all three, in the same order,
+ * under their own headings -- while REFUSING to generate at all unless the manufacturer had
+ * authored them. Every statement it produced contradicted itself on its face, which is
+ * precisely the misleading-labeling risk under 502(a)(1) this module exists to avoid.
+ *
+ * The risk-transfer item gets its own sentence because there the gap is substantive rather
+ * than editorial: the slot holds a REFERENCE to a controlled DHF document, so the process
+ * itself genuinely is not in this document and a reader must not infer otherwise.
  */
-const COVERAGE_STATEMENT = 'This document provides end-of-support and end-of-life information'
-    + ' for this device and its software, which is one of the four items FDA labeling guidance'
-    + ' section VI.A suggests may be included in labeling.'
-const NOT_COVERED = [
-    'That the manufacturer may no longer be able to provide security patches or software'
-        + ' updates after end of support.',
-    'The manufacturer\'s pre-established process for transferring cybersecurity risk if this'
-        + ' device remains in service past end of support.',
-    'That cybersecurity risk to users can be expected to increase over time.'
-]
+const COVERAGE_GENERATED = 'The support dates below are generated from the manufacturer\'s'
+    + ' records. They answer one of the four items FDA labeling guidance section VI.A suggests'
+    + ' may be included in labeling, and it is the only one of the four this document generates.'
+const COVERAGE_AUTHORED = 'The three statements that follow the dates are the manufacturer\'s'
+    + ' own words, reproduced here unchanged. They are not generated, completed or verified by'
+    + ' the system that produced this document.'
+const COVERAGE_REFERENCE = 'Where this document refers to the manufacturer\'s process for'
+    + ' transferring risk, it gives a reference to that controlled document. The process itself'
+    + ' is held separately and is not reproduced here.'
 
 /**
  * The document definition: plain JSON, no rendering, so the spec asserts structure directly.
@@ -143,9 +171,9 @@ export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<
         { text: d.orgName || '', style: 'subtitle', margin: [0, 0, 0, 14] },
 
         { text: 'What this document covers', style: 'h2' },
-        { text: COVERAGE_STATEMENT, style: 'body' },
-        { text: 'It does not cover the following, which the manufacturer addresses separately:', style: 'body' },
-        { ul: NOT_COVERED, style: 'body', margin: [0, 0, 0, 14] },
+        { text: COVERAGE_GENERATED, style: 'body' },
+        { text: COVERAGE_AUTHORED, style: 'body' },
+        { text: COVERAGE_REFERENCE, style: 'body', margin: [0, 0, 0, 14] },
 
         { text: 'Support dates for this device', style: 'h2' },
         {
@@ -219,11 +247,15 @@ export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<
 }
 
 export function deviceSupportStatementFileName (d: AddendumData): string {
-    const raw = d.releaseVersion || d.releaseUuid || 'release'
-    const slug = String(raw).replace(/[^A-Za-z0-9._-]+/g, '-')
-    return `device-support-statement-${slug || 'release'}.pdf`
+    return `device-support-statement-${releaseSlug(d)}.pdf`
 }
 
 export async function renderDeviceSupportStatementBlob (d: AddendumData): Promise<Blob> {
+    // Enforced HERE as well as at the call site. The builder casts the prose slots to string
+    // and would emit { text: null } into pdfmake -- a silent empty section, exactly what the
+    // block exists to prevent. One guard in one caller is not a guarantee when the function
+    // is exported and nothing type-checks the template that calls it.
+    const blocked = statementBlockReason(d)
+    if (blocked) throw new Error(blocked)
     return pdfMake.createPdf(buildDeviceSupportStatementDefinition(d) as any).getBlob()
 }

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -1,0 +1,229 @@
+// The Device Support Statement: FDA labeling section VI.A, customer-facing.
+//
+// The third renderer over addendumData, and the one written for a DIFFERENT READER. FDA
+// L1591-1592 says the audience "might include patients or caregivers with limited technical
+// knowledge", so this is the one artifact here that must read as plain language rather than
+// as a component inventory. That single constraint decides most of what follows: no purls, no
+// inventory table, no unassessed count, no risk verdict.
+//
+// The unassessed count is excluded deliberately, not by omission. "412 components not
+// assessed" conveys no risk information to a hospital biomed reader and edges toward
+// misleading under 502(a)(1). It belongs in the addendum, which a reviewer reads.
+
+import pdfMake from 'pdfmake/build/pdfmake'
+import pdfFonts from 'pdfmake/build/vfs_fonts'
+import type { AddendumComponent, AddendumData } from './addendumData'
+import { isLiveAttestation } from './addendumData'
+import { fontCoverageRefusal } from './pdfFontCoverage'
+
+pdfMake.vfs = pdfFonts.vfs
+
+export const STATEMENT_TITLE = 'Device software support statement'
+
+/** How the document names a date nobody has declared. Never blank, never omitted. */
+export const NOT_DECLARED = 'not declared'
+
+/**
+ * The three org-level prose slots this document cannot be generated without.
+ *
+ * REQUIRED, and the reason is specific to this document. Section 3's "a gap beats a
+ * fabrication" is right for a submission, where a reviewer expects gaps -- but on a
+ * patient-facing statement a silent gap is itself the misleading thing under 502(a)(1). So an
+ * empty slot BLOCKS generation with the slot named, rather than producing a document with an
+ * empty section that reads as though the manufacturer had nothing to say.
+ *
+ * `label` is what the UI names when it blocks; `field` is where the operator fixes it.
+ */
+export const REQUIRED_PROSE_SLOTS: Array<{ key: keyof AddendumData, label: string }> = [
+    { key: 'patchesMayCeaseStatement', label: 'Patches may cease at end of support' },
+    { key: 'riskTransferProcessRef', label: 'Risk-transfer process reference' },
+    { key: 'riskIncreasesNotice', label: 'Risk increases over time' }
+]
+
+/** Where an operator goes to author them. Named in the block message so it is actionable. */
+export const PROSE_SETTINGS_LOCATION = 'Organization Settings -> FDA submission and labeling text'
+
+/** The slots that are missing, by label, in the order the document would print them. */
+export function missingProseSlots (d: AddendumData): string[] {
+    return REQUIRED_PROSE_SLOTS
+        .filter(s => !String(d[s.key] ?? '').trim())
+        .map(s => s.label)
+}
+
+/**
+ * Why this statement cannot be generated, or null when it can.
+ *
+ * One function for every refusal so the caller cannot check some and forget others, and so
+ * the order is deliberate: SCOPE first (a component release is not a device and no amount of
+ * authored prose makes it one), then the required slots, then font coverage.
+ */
+export function statementBlockReason (d: AddendumData): string | null {
+    if (d.componentType !== 'PRODUCT') {
+        return 'The device support statement describes a DEVICE, so it is generated from a'
+            + ' product release. This release is a component release; open the product release'
+            + ' that ships it and generate the statement there.'
+    }
+    const missing = missingProseSlots(d)
+    if (missing.length) {
+        return `This statement cannot be generated until the following organization text is`
+            + ` authored: ${missing.join('; ')}.`
+            + ` A patient-facing document with an empty section is worse than no document,`
+            + ` so nothing is produced. Add the text under ${PROSE_SETTINGS_LOCATION}.`
+    }
+    return fontCoverageRefusal(statementStrings(d), 'device support statement')
+}
+
+/**
+ * Components whose ATTESTED end of support falls BEFORE the device's.
+ *
+ * The only component information this document carries, and only as recorded facts -- a name
+ * and a date. Nothing derived: no risk verdict, no ranking, no count of everything else.
+ *
+ * A component with no LIVE attestation is not listed. That is not the same as saying it
+ * outlives the device -- it means nobody has recorded a date, and asserting anything about it
+ * to a patient would be a fabrication. The addendum is where "what we do not know" is stated.
+ *
+ * When the device EOS is not declared there is nothing for a component date to precede, so
+ * the list is empty rather than "every dated component" -- which would silently change what
+ * the section means.
+ */
+export function componentsEndingBeforeDevice (d: AddendumData): Array<{ name: string, date: string }> {
+    if (!d.deviceEos) return []
+    return d.components
+        .filter(c => isLiveAttestation(c) && c.endOfSupportDate && c.endOfSupportDate < (d.deviceEos as string))
+        .map(c => ({ name: displayName(c), date: c.endOfSupportDate as string }))
+        .sort((a, b) => (a.date === b.date ? a.name.localeCompare(b.name) : a.date.localeCompare(b.date)))
+}
+
+/** Plain name for a plain-language document: no group prefix, no purl. */
+function displayName (c: AddendumComponent): string {
+    return c.name || c.group || '(unnamed component)'
+}
+
+/** Every string the document prints, for the font-coverage check. */
+function statementStrings (d: AddendumData): Array<string | null | undefined> {
+    return [
+        d.componentName, d.releaseVersion, d.orgName,
+        d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice,
+        ...componentsEndingBeforeDevice(d).flatMap(c => [c.name, c.date])
+    ]
+}
+
+/**
+ * What this document covers, and -- equally important -- what it does not.
+ *
+ * FDA labeling VI.A lists FOUR asks. This document answers ONE of them, and says so on its
+ * face so nobody reads shipping it as satisfying VI.A. The other three are the manufacturer's
+ * own commitments and process; under section 3 there is no product-shipped default text for
+ * any of them, which is exactly why they are org-authored prose rather than generated.
+ */
+const COVERAGE_STATEMENT = 'This document provides end-of-support and end-of-life information'
+    + ' for this device and its software, which is one of the four items FDA labeling guidance'
+    + ' section VI.A suggests may be included in labeling.'
+const NOT_COVERED = [
+    'That the manufacturer may no longer be able to provide security patches or software'
+        + ' updates after end of support.',
+    'The manufacturer\'s pre-established process for transferring cybersecurity risk if this'
+        + ' device remains in service past end of support.',
+    'That cybersecurity risk to users can be expected to increase over time.'
+]
+
+/**
+ * The document definition: plain JSON, no rendering, so the spec asserts structure directly.
+ *
+ * CALLERS MUST CHECK statementBlockReason FIRST. This function assumes it may generate; it
+ * does not re-check, because a builder that silently produced a partial document when its
+ * preconditions failed is precisely what the block exists to prevent.
+ */
+export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<string, unknown> {
+    const early = componentsEndingBeforeDevice(d)
+    const content: unknown[] = [
+        { text: STATEMENT_TITLE, style: 'title' },
+        { text: `${d.componentName || 'This device'}${d.releaseVersion ? `, version ${d.releaseVersion}` : ''}`, style: 'subtitle' },
+        { text: d.orgName || '', style: 'subtitle', margin: [0, 0, 0, 14] },
+
+        { text: 'What this document covers', style: 'h2' },
+        { text: COVERAGE_STATEMENT, style: 'body' },
+        { text: 'It does not cover the following, which the manufacturer addresses separately:', style: 'body' },
+        { ul: NOT_COVERED, style: 'body', margin: [0, 0, 0, 14] },
+
+        { text: 'Support dates for this device', style: 'h2' },
+        {
+            style: 'facts',
+            table: {
+                widths: [230, '*'],
+                // TWO DISTINCT FACTS, never merged and never routed through a
+                // support-horizon fallback. An EOS-else-EOL rule is right for a risk
+                // comparison and wrong here: this document is read as two separate
+                // commitments, and collapsing them would answer a question nobody asked.
+                body: [
+                    [{ text: 'Software support ends (end of support)', bold: true },
+                        { text: d.deviceEos || NOT_DECLARED }],
+                    [{ text: 'Device end of life / end of sale', bold: true },
+                        { text: d.deviceEol || NOT_DECLARED }]
+                ]
+            },
+            layout: 'noBorders',
+            margin: [0, 0, 0, 14]
+        }
+    ]
+
+    if (early.length) {
+        content.push({ text: 'Software components whose support ends sooner', style: 'h2' })
+        content.push({
+            text: 'The manufacturer has recorded an earlier end-of-support date for the'
+                + ' following software in this device:',
+            style: 'body'
+        })
+        content.push({
+            style: 'facts',
+            table: {
+                widths: [230, '*'],
+                body: early.map(c => [{ text: c.name }, { text: `support ends ${c.date}` }])
+            },
+            layout: 'noBorders',
+            margin: [0, 0, 0, 14]
+        })
+    }
+
+    content.push({ text: 'After end of support', style: 'h2' })
+    content.push({ text: d.patchesMayCeaseStatement as string, style: 'body' })
+    content.push({ text: 'If this device remains in service past end of support', style: 'h2' })
+    content.push({ text: d.riskTransferProcessRef as string, style: 'body' })
+    content.push({ text: 'Cybersecurity risk over time', style: 'h2' })
+    content.push({ text: d.riskIncreasesNotice as string, style: 'body' })
+
+    return {
+        pageSize: 'A4',
+        pageMargins: [56, 56, 56, 52],
+        content,
+        footer: (currentPage: number, pageCount: number) => ({
+            style: 'footer',
+            margin: [56, 10, 56, 0],
+            columns: [
+                { text: `${d.componentName || '(unnamed device)'} ${d.releaseVersion || ''} (${d.releaseUuid})`, alignment: 'left' },
+                { text: `Generated ${d.generatedAt}`, alignment: 'center' },
+                { text: `Page ${currentPage} of ${pageCount}`, alignment: 'right' }
+            ]
+        }),
+        styles: {
+            title: { fontSize: 18, bold: true, margin: [0, 0, 0, 4] },
+            subtitle: { fontSize: 11, color: '#444444' },
+            h2: { fontSize: 12, bold: true, margin: [0, 10, 0, 4] },
+            body: { fontSize: 10, margin: [0, 0, 0, 6], lineHeight: 1.25 },
+            facts: { fontSize: 10 },
+            footer: { fontSize: 7, color: '#666666' }
+        },
+        defaultStyle: { fontSize: 10 }
+    }
+}
+
+export function deviceSupportStatementFileName (d: AddendumData): string {
+    const raw = d.releaseVersion || d.releaseUuid || 'release'
+    const slug = String(raw).replace(/[^A-Za-z0-9._-]+/g, '-')
+    return `device-support-statement-${slug || 'release'}.pdf`
+}
+
+export async function renderDeviceSupportStatementBlob (d: AddendumData): Promise<Blob> {
+    return pdfMake.createPdf(buildDeviceSupportStatementDefinition(d) as any).getBlob()
+}

--- a/ui/src/utils/pdfFontCoverage.ts
+++ b/ui/src/utils/pdfFontCoverage.ts
@@ -1,0 +1,73 @@
+// What the bundled PDF font can actually draw.
+//
+// Shared by every PDF this app generates over addendumData -- the addendum and the Device
+// Support Statement -- because the failure it prevents is a property of the FONT, not of any
+// one document.
+
+/**
+ * The codepoint ranges the bundled Roboto can actually draw.
+ *
+ * pdfmake ships ROBOTO ONLY. A character it has no glyph for is not flagged, substituted or
+ * warned about -- it is silently DROPPED, so a component named in Japanese produces an EMPTY
+ * cell in a regulatory document while the CSV for the same release shows the text. Blank is
+ * the one thing this document must never be ambiguous about.
+ *
+ * Determined by RENDERING and extracting, not by reading a spec: Latin (including Extended-A,
+ * Turkish and Vietnamese), Greek, Cyrillic, punctuation and currency draw; Latin Extended-B,
+ * arrows, emoji, Hebrew, Arabic, Hangul, Thai, Devanagari and CJK do not.
+ *
+ * DELIBERATELY CONSERVATIVE. It is a whitelist, so an unlisted script is refused rather than
+ * rendered blank, and it will refuse some characters Roboto could in fact draw. That trade is
+ * the point: a false refusal is visible, explained and recoverable via the CSV, while a false
+ * render is an invisible hole in a document someone files.
+ */
+const RENDERABLE = [
+    [0x09, 0x0a], [0x0d, 0x0d],
+    [0x20, 0x17f],      // Basic Latin, Latin-1 Supplement, Latin Extended-A
+    [0x370, 0x3ff],     // Greek
+    [0x400, 0x4ff],     // Cyrillic
+    [0x1e00, 0x1eff],   // Latin Extended Additional (Vietnamese)
+    [0x2010, 0x201f],   // dashes and quotation marks
+    [0x2020, 0x2027], [0x2030, 0x203a],
+    [0x20a0, 0x20bf],   // currency
+    [0x2122, 0x2122]    // trade mark
+]
+
+export function isRenderable (code: number): boolean {
+    return RENDERABLE.some(([lo, hi]) => code >= lo && code <= hi)
+}
+
+/**
+ * The distinct characters in these strings that the font cannot draw, in encounter order.
+ *
+ * Returned rather than thrown so each caller can refuse in its own voice, naming what its
+ * own document would have lost.
+ */
+export function unrenderableCharacters (texts: Array<string | null | undefined>): string[] {
+    const offenders = new Set<string>()
+    for (const t of texts) {
+        if (null === t || undefined === t) continue
+        for (const ch of String(t)) {
+            if (!isRenderable(ch.codePointAt(0) as number)) offenders.add(ch)
+        }
+    }
+    return [...offenders]
+}
+
+/**
+ * The refusal message, or null when everything is drawable.
+ *
+ * @param texts every string the document would print
+ * @param documentName named in the message, so an operator generating two different PDFs
+ *        knows which one refused
+ */
+export function fontCoverageRefusal (
+    texts: Array<string | null | undefined>,
+    documentName: string
+): string | null {
+    const offenders = unrenderableCharacters(texts)
+    if (!offenders.length) return null
+    return `This release contains characters the PDF font cannot draw (${offenders.slice(0, 12).join(' ')}).`
+        + ` They would be silently dropped, leaving blank sections in a ${documentName} that is`
+        + ' meant to be complete. Export the CSV addendum instead -- it carries every character.'
+}


### PR DESCRIPTION
Step 6. FDA labeling section VI.A, customer-facing, PDF only.

## Written for a different reader

L1591-1592 says the audience "might include patients or caregivers with limited technical
knowledge". That single constraint decides most of the document: **no purls, no component
inventory, no version column, no unassessed count, no `deviceSupportRisk` verdict.**

The unassessed count is excluded **deliberately, not by omission**. "412 components not
assessed" conveys no risk information to a hospital biomed reader and edges toward misleading
under 502(a)(1); it belongs in the addendum, which a reviewer reads. A spec asserts it cannot
appear.

## It says on its face what it does not cover

VI.A lists four asks. This answers **one** -- support dates -- and names the other three as
commitments the manufacturer addresses separately, so nobody reads shipping it as satisfying
VI.A. Under section 3 there is no product-shipped default text for any of the three, which is
exactly why they are org-authored prose rather than generated.

## Blocked, never degraded

Three refusals, all in `statementBlockReason` so a caller cannot check some and forget
others, ordered so the most fundamental problem is the one reported:

1. a **COMPONENT release is not a device**, and no amount of authored prose makes it one;
2. an **unauthored prose slot** blocks with the slot named and Organization Settings pointed
   at. Section 3's "a gap beats a fabrication" is right for a submission where a reviewer
   expects gaps; on a patient-facing document a silent gap is itself the misleading thing;
3. **text the PDF font cannot draw**, reused from the addendum.

## The data slots

Device EOS and EOL are two separate labelled facts, "not declared" when null, and
deliberately **not** routed through a support-horizon fallback -- EOS-else-EOL is right for a
risk comparison and wrong for a document read as two distinct commitments.

Components appear only where an **attested** EOS precedes the device EOS, by name and date,
as recorded facts. Not listed is **not** a claim that something outlives the device -- it
means nobody recorded a date, and asserting anything about it to a patient would be a
fabrication. With no device EOS there is nothing to precede, so the list is empty rather than
"every dated component", which would silently change what the section means.

## One collector change, flagged rather than buried

The prose slots were all already collected, as expected. But the release query fetched
`componentDetails { name type }` and the collector kept only the name -- so `componentType`
is kept now. One field the query already fetches; the alternative (telling the renderer its
own release's type from the call site) would be a second source of truth for something the
collector already holds. Happy to invert it if you'd rather the collector stayed frozen.

The font check moved to `pdfFontCoverage.ts`, shared by both PDFs: the failure it prevents is
a property of the **font**, not of one document.

## Pro probe, all four cases

```
S1-S9  product release, all slots set -> generates
       EOS 2031-01-31 and EOL "not declared" as two separate facts
       one component listed: openssl, attested EOS 2027-06-30
       no purl, no unassessed count, VI.A one-of-four stated on its face
       footer: device identity, UTC instant, page N of M
S10    component release -> REFUSED, told to open the product release
S11    cleared prose slot -> BLOCKED, slot named, Organization Settings pointed at
       restoring the text generates again
S12    CJK in a prose slot -> FONT refusal naming the characters
       restoring the text generates again
X      0 page exceptions
```

The generated document, verbatim:

```
Device software support statement
Infusion Pump 9000 (device), version 9000.1.0

What this document covers
This document provides end-of-support and end-of-life information for this device and its
software, which is one of the four items FDA labeling guidance section VI.A suggests may be
included in labeling.
It does not cover the following, which the manufacturer addresses separately:
  That the manufacturer may no longer be able to provide security patches...
  The manufacturer's pre-established process for transferring cybersecurity risk...
  That cybersecurity risk to users can be expected to increase over time.

Support dates for this device
Software support ends (end of support)     2031-01-31
Device end of life / end of sale           not declared

Software components whose support ends sooner
openssl                                    support ends 2027-06-30
```

## Out of scope, filed as `t20260908-053642-13923`

Delivery as a **versioned shared-artifact link**. VI.A (L1592-1594, L1636-1640) requires
portal links to stay up to date, and a downloaded snapshot goes stale the moment a device
window is revised. D1-independent by the plan's own reasoning, so it does not block this
document -- but this PR ships a download, not a link.

## Carry-over

`addendumDocument`'s tests moved out of `addendumCsv.spec.ts` into their own spec, so the
module boundary #337 drew is reflected in the specs too.

**694 tests / 49 files** (was 643/46). 0 non-ASCII added -- the CJK fixtures are `\u` escapes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>