### PR TITLE
The export injection toggle, and the state stated beside the gauge (7g A-ui)

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -994,6 +994,26 @@
                             </div>
                         </n-form-item>
 
+                        <!-- The export toggle sits WITH the FDA text because it is the same
+                             decision: what a generated document or export says about support.
+                             Default OFF (D3), so this is the control a manufacturer preparing
+                             a submission must deliberately turn on. -->
+                        <n-form-item label="Carry support attestations in BOM exports">
+                            <div style="display: flex; flex-direction: column; width: 100%;">
+                                <n-switch v-model:value="supportInjectionEnabled"
+                                    :disabled="savingOrgSettings" />
+                                <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
+                                    Off by default. When on, BOM exports carry this
+                                    organization's support attestations &mdash; the artifact
+                                    download, the SPDX-augmented download and the release SBOM
+                                    export. The raw artifact download never carries them.
+                                    <strong>Forged support properties are always removed,
+                                    whatever this is set to</strong>; this controls only
+                                    whether our own attestations are added.
+                                </span>
+                            </div>
+                        </n-form-item>
+
                         <n-form-item label="Risk increases over time (labeling)">
                             <n-input v-model:value="orgSettings.fdaRiskIncreasesNotice"
                                     :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
@@ -3516,6 +3536,17 @@ async function saveOrgDefaultView() {
  */
 const proseBaseline: Record<string, string> = {}
 
+/**
+ * The export toggle as a Boolean for n-switch, mapped to the two-member enum on save.
+ *
+ * A Boolean in the FORM and an enum on the WIRE: the schema deliberately uses an enum so the
+ * field can grow a third state without breaking published clients, but there are two states
+ * to choose between today and a switch is what an operator expects for that. The mapping
+ * lives in one place, here, so the form cannot invent a value the schema does not declare.
+ */
+const supportInjectionEnabled: Ref<boolean> = ref(false)
+const supportInjectionBaseline: Ref<boolean> = ref(false)
+
 async function loadOrgSettings() {
     await loadOrgDefaultView()
     const s = myorg.value?.settings
@@ -3527,6 +3558,10 @@ async function loadOrgSettings() {
     orgSettings.sidAuthoritySegments = Array.isArray(s?.sidAuthoritySegments)
         ? [...s.sidAuthoritySegments]
         : []
+    // ENABLED is the only truthy value; anything else -- DISABLED, null, unset, or a state
+    // this build does not know -- reads as off, which matches the server's own default rule.
+    supportInjectionEnabled.value = s?.supportInjection === 'ENABLED'
+    supportInjectionBaseline.value = supportInjectionEnabled.value
     const seeded = proseBaselineFrom(s)
     for (const f of FDA_PROSE_FIELDS) {
         orgSettings[f] = seeded[f]
@@ -3573,6 +3608,7 @@ async function saveOrgSettings() {
                             fdaPatchesMayCeaseStatement
                             fdaRiskTransferProcessRef
                             fdaRiskIncreasesNotice
+                            supportInjection
                         }
                     }
                 }`,
@@ -3589,7 +3625,12 @@ async function saveOrgSettings() {
                     // Diffed, not dumped: untouched fields are omitted so an unrelated
                     // toggle cannot disturb prose, and a field the user emptied goes as ''
                     // which the server reads as a deliberate clear.
-                    ...proseDiff(orgSettings, proseBaseline)
+                    ...proseDiff(orgSettings, proseBaseline),
+                    // Sent only when actually changed, for the same reason: the mutation is a
+                    // PATCH, and an unchanged field has no business in it.
+                    ...(supportInjectionEnabled.value !== supportInjectionBaseline.value
+                        ? { supportInjection: supportInjectionEnabled.value ? 'ENABLED' : 'DISABLED' }
+                        : {})
                 }
             },
             fetchPolicy: 'no-cache'
@@ -3607,6 +3648,11 @@ async function saveOrgSettings() {
             // the text. That is fabricated prose reaching a patient-facing document, which
             // is the exact failure this feature exists to prevent.
             const savedSettings = (result as any)?.settings
+            // From the mutation's own response, before anything that can throw -- the same
+            // rule the prose baseline follows, and for the same reason: a failed re-read must
+            // not leave the form believing an unsaved state was saved.
+            supportInjectionEnabled.value = savedSettings?.supportInjection === 'ENABLED'
+            supportInjectionBaseline.value = supportInjectionEnabled.value
             const refreshed = proseBaselineFrom(savedSettings)
             for (const f of FDA_PROSE_FIELDS) {
                 orgSettings[f] = refreshed[f]

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -998,7 +998,11 @@
                              decision: what a generated document or export says about support.
                              Default OFF (D3), so this is the control a manufacturer preparing
                              a submission must deliberately turn on. -->
-                        <n-form-item label="Carry support attestations in BOM exports">
+                        <!-- Hidden entirely on a backend that does not declare the field --
+                             a CE mirror before the deferred sync. Offering a switch whose
+                             write the server would reject is worse than not offering it. -->
+                        <n-form-item v-if="supportInjectionSupported"
+                            label="Carry support attestations in BOM exports">
                             <div style="display: flex; flex-direction: column; width: 100%;">
                                 <n-switch v-model:value="supportInjectionEnabled"
                                     :disabled="savingOrgSettings" />
@@ -3544,6 +3548,16 @@ const proseBaseline: Record<string, string> = {}
  * to choose between today and a switch is what an operator expects for that. The mapping
  * lives in one place, here, so the form cannot invent a value the schema does not declare.
  */
+/**
+ * Whether this backend declares the field at all.
+ *
+ * The store sets it false when the organizations query had to fall back to its core document,
+ * which is how a CE mirror predating the deferred sync behaves. The toggle is hidden then,
+ * and the field is never sent -- so the shared settings mutation stays valid.
+ */
+const supportInjectionSupported: ComputedRef<boolean> = computed((): boolean =>
+    store.state.supportInjectionSupported !== false)
+
 const supportInjectionEnabled: Ref<boolean> = ref(false)
 const supportInjectionBaseline: Ref<boolean> = ref(false)
 
@@ -3608,7 +3622,6 @@ async function saveOrgSettings() {
                             fdaPatchesMayCeaseStatement
                             fdaRiskTransferProcessRef
                             fdaRiskIncreasesNotice
-                            supportInjection
                         }
                     }
                 }`,
@@ -3628,7 +3641,8 @@ async function saveOrgSettings() {
                     ...proseDiff(orgSettings, proseBaseline),
                     // Sent only when actually changed, for the same reason: the mutation is a
                     // PATCH, and an unchanged field has no business in it.
-                    ...(supportInjectionEnabled.value !== supportInjectionBaseline.value
+                    ...(supportInjectionSupported.value
+                        && supportInjectionEnabled.value !== supportInjectionBaseline.value
                         ? { supportInjection: supportInjectionEnabled.value ? 'ENABLED' : 'DISABLED' }
                         : {})
                 }
@@ -3648,10 +3662,13 @@ async function saveOrgSettings() {
             // the text. That is fabricated prose reaching a patient-facing document, which
             // is the exact failure this feature exists to prevent.
             const savedSettings = (result as any)?.settings
-            // From the mutation's own response, before anything that can throw -- the same
-            // rule the prose baseline follows, and for the same reason: a failed re-read must
-            // not leave the form believing an unsaved state was saved.
-            supportInjectionEnabled.value = savedSettings?.supportInjection === 'ENABLED'
+            // NOT selected back from the mutation. Adding supportInjection to the response
+            // selection makes the WHOLE updateOrganizationSettings document invalid on a
+            // backend without the field -- so every save, including the four prose slots and
+            // sid PURL, would fail on a CE mirror. The baseline advances to what the server
+            // just ACCEPTED instead, which it did accept: the field is only ever sent when
+            // the toggle is supported, and a rejected mutation lands in the catch below with
+            // the baseline untouched.
             supportInjectionBaseline.value = supportInjectionEnabled.value
             const refreshed = proseBaselineFrom(savedSettings)
             for (const f of FDA_PROSE_FIELDS) {

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1353,7 +1353,19 @@
                             :type="sbomCoverageDisplay.tone"
                             :show-icon="sbomCoverageDisplay.warn"
                             style="margin-bottom: 10px;">
-                            <div style="font-size: 13px;">{{ sbomCoverageDisplay.headline }}</div>
+                            <div style="font-size: 13px;">
+                                {{ sbomCoverageDisplay.headline }}
+                                <!-- The export state, ALWAYS stated when known, beside the
+                                     coverage number rather than inferred from whether a
+                                     warning happens to be showing. Decision D3 makes this a
+                                     build requirement: with injection defaulting off, a full
+                                     coverage figure next to an export carrying nothing is a
+                                     lie by omission. UNKNOWN renders as "could not be read",
+                                     never as OFF -- that would state a choice nobody made. -->
+                                <strong v-if="sbomCoverageDisplay.stateLabel">
+                                    &mdash; {{ sbomCoverageDisplay.stateLabel }}
+                                </strong>
+                            </div>
                             <div v-if="sbomCoverageDisplay.exportNote"
                                 style="font-size: 12px; margin-top: 4px;">
                                 {{ sbomCoverageDisplay.exportNote }}

--- a/ui/src/components/fdaProseWiring.spec.ts
+++ b/ui/src/components/fdaProseWiring.spec.ts
@@ -20,6 +20,31 @@ const orgSettings = readFileSync(
 const releaseView = readFileSync(
     fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
 
+
+/**
+ * The function body, sliced by BRACE DEPTH.
+ *
+ * Cutting at the next `\nasync function` is the idiom this family retired twice: it silently
+ * yields the wrong text -- or an empty string -- the moment a helper is inserted between two
+ * functions.
+ */
+function functionBody (name: string): string {
+    // Both spacings: this file writes `saveOrgSettings()` and `loadOrgSettings()` without a
+    // space, and other functions with one. Throwing on a miss rather than returning '' is the
+    // point -- a rename must fail loudly, not silently assert against an empty string.
+    const start = [`function ${name} (`, `function ${name}(`]
+        .map(sig => orgSettings.indexOf(sig)).filter(i => i >= 0).sort((a, b) => a - b)[0]
+    if (start === undefined) throw new Error(`no function ${name} in OrgSettings.vue`)
+    let depth = 0
+    let i = orgSettings.indexOf('{', start)
+    const open = i
+    for (; i < orgSettings.length; i++) {
+        if (orgSettings[i] === '{') depth++
+        else if (orgSettings[i] === '}' && --depth === 0) break
+    }
+    return orgSettings.slice(open, i + 1)
+}
+
 describe('the FDA prose form is wired into OrgSettings', () => {
     it.each([
         ['FDA_PROSE_FIELDS'], ['FDA_PROSE_MAX_LENGTH'], ['proseDiff'], ['proseBaselineFrom']
@@ -123,16 +148,40 @@ describe('the export injection toggle is wired into OrgSettings', () => {
 
     // Same rule the prose baseline follows: from the mutation response, before anything that
     // can throw, so a failed re-read cannot leave the form claiming an unsaved state.
-    it('refreshes the baseline from the mutation response', () => {
-        const save = orgSettings.slice(orgSettings.indexOf('async function saveOrgSettings'))
-        const body = save.slice(0, save.indexOf('\nasync function', 1))
-        expect(body.indexOf('savedSettings?.supportInjection')).toBeLessThan(body.indexOf('await loadOrgSettings()'))
+    // PRESENCE FIRST, then ordering. The ordering assertion alone passed when the line was
+    // ABSENT, because indexOf returns -1 and -1 is less than every real index -- so deleting
+    // the baseline refresh entirely left this file green. A spec that reads as protection and
+    // checks nothing is worse than no spec.
+    it('advances the baseline before the follow-up re-read', () => {
+        const body = functionBody('saveOrgSettings')
+        expect(body).toContain('supportInjectionBaseline.value = supportInjectionEnabled.value')
+        expect(body.indexOf('supportInjectionBaseline.value = supportInjectionEnabled.value'))
+            .toBeLessThan(body.indexOf('await loadOrgSettings()'))
     })
 
-    it('selects the field in the mutation response and in the store query', () => {
-        expect(orgSettings).toMatch(/^\s+supportInjection$/m)
-        const store = readFileSync(
-            fileURLToPath(new URL('../store.ts', import.meta.url)), 'utf8')
-        expect(store).toMatch(/^\s+supportInjection$/m)
+    // The field must NOT be selected back from the mutation: adding it to the response
+    // selection makes the whole document invalid on a backend without it, so every settings
+    // save fails -- prose slots and sid PURL included.
+    it('does not select supportInjection in the mutation response', () => {
+        const mutation = orgSettings.slice(orgSettings.indexOf('updateOrganizationSettings'))
+        const doc = mutation.slice(0, mutation.indexOf('`,'))
+        expect(doc).not.toMatch(/^\s+supportInjection$/m)
+    })
+
+    // And it is never SENT to a backend that cannot store it.
+    it('sends the field only when the backend supports it', () => {
+        expect(orgSettings).toMatch(/supportInjectionSupported\.value\s*\n?\s*&&/)
+        expect(orgSettings).toMatch(/v-if="supportInjectionSupported"/)
+    })
+
+    // The store's FULL document carries it; CORE deliberately does not, so a backend without
+    // the field still answers. supportInjectionSchemaDrift.spec.ts validates both documents
+    // against both schemas, which is the assertion that actually protects this.
+    it('is carried by the store FULL document only', () => {
+        const q = readFileSync(
+            fileURLToPath(new URL('../utils/organizationsQuery.ts', import.meta.url)), 'utf8')
+        expect(q).toContain('supportInjection')
+        expect(q).toContain('ORGANIZATIONS_CORE')
+        expect(q).toContain('ORGANIZATIONS_FULL')
     })
 })

--- a/ui/src/components/fdaProseWiring.spec.ts
+++ b/ui/src/components/fdaProseWiring.spec.ts
@@ -89,3 +89,50 @@ describe('the device support window is wired into ReleaseView', () => {
         expect(body.indexOf('deviceWindowBaseline.eos =')).toBeLessThan(body.indexOf('await fetchRelease()'))
     })
 })
+
+describe('the export injection toggle is wired into OrgSettings', () => {
+    it('declares the switch state and its baseline', () => {
+        expect(orgSettings).toMatch(/const supportInjectionEnabled\b/)
+        expect(orgSettings).toMatch(/const supportInjectionBaseline\b/)
+    })
+
+    it('binds a switch, disabled while saving', () => {
+        const tag = orgSettings.match(/<n-switch v-model:value="supportInjectionEnabled"[\s\S]*?\/>/)
+        expect(tag).not.toBeNull()
+        expect(tag![0]).toContain(':disabled="savingOrgSettings"')
+    })
+
+    // A Boolean in the form, the ENUM on the wire. The schema uses an enum so the field can
+    // grow a third state without breaking published clients, so the form must never send a
+    // bare true/false.
+    it('maps the switch to the enum, never to a boolean', () => {
+        expect(orgSettings).toMatch(/supportInjection: supportInjectionEnabled\.value \? 'ENABLED' : 'DISABLED'/)
+        expect(orgSettings).not.toMatch(/supportInjection: supportInjectionEnabled\.value\s*[,}]/)
+    })
+
+    // PATCH: an unchanged toggle has no business in the mutation, exactly as for the prose.
+    it('sends the field only when it changed', () => {
+        expect(orgSettings).toMatch(/supportInjectionEnabled\.value !== supportInjectionBaseline\.value/)
+    })
+
+    // Only ENABLED is on. DISABLED, null, unset, or a value this build does not know all read
+    // as off -- which is the server's own default rule (D3).
+    it('treats only ENABLED as on when seeding', () => {
+        expect(orgSettings).toMatch(/supportInjection === 'ENABLED'/)
+    })
+
+    // Same rule the prose baseline follows: from the mutation response, before anything that
+    // can throw, so a failed re-read cannot leave the form claiming an unsaved state.
+    it('refreshes the baseline from the mutation response', () => {
+        const save = orgSettings.slice(orgSettings.indexOf('async function saveOrgSettings'))
+        const body = save.slice(0, save.indexOf('\nasync function', 1))
+        expect(body.indexOf('savedSettings?.supportInjection')).toBeLessThan(body.indexOf('await loadOrgSettings()'))
+    })
+
+    it('selects the field in the mutation response and in the store query', () => {
+        expect(orgSettings).toMatch(/^\s+supportInjection$/m)
+        const store = readFileSync(
+            fileURLToPath(new URL('../store.ts', import.meta.url)), 'utf8')
+        expect(store).toMatch(/^\s+supportInjection$/m)
+    })
+})

--- a/ui/src/components/injectionGaugeWiring.spec.ts
+++ b/ui/src/components/injectionGaugeWiring.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * The export state is actually RENDERED beside the gauge.
+ *
+ * Layer 1 deleted the entire `<strong v-if="sbomCoverageDisplay.stateLabel">` block from
+ * ReleaseView and the full suite stayed green, 719/719 -- the only user-visible half of this
+ * feature shipped unguarded. The display function was thoroughly tested; nothing asserted the
+ * template used it.
+ *
+ * That is the same failure `useReleaseSupportCoverage.ts` records about source-scan guards
+ * being "theatre", so this file is deliberately narrow: it asserts the binding exists, is
+ * conditioned on the label, and sits inside the coverage alert -- the things whose absence
+ * makes the feature invisible while every unit test passes.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+describe('the export state is rendered beside the coverage gauge', () => {
+    it('binds stateLabel in the template', () => {
+        expect(source).toMatch(/\{\{\s*sbomCoverageDisplay\.stateLabel\s*\}\}/)
+    })
+
+    // v-if, not v-show and not unconditional: the label is null before data and after an
+    // error, and rendering a bare dash there would be a claim about a state nobody read.
+    it('renders it only when there is a state to name', () => {
+        expect(source).toMatch(/v-if="sbomCoverageDisplay\.stateLabel"/)
+    })
+
+    /**
+     * Inside the coverage alert, beside the headline.
+     *
+     * Decision D3 is specifically that the state must appear WITH the coverage number -- a
+     * gauge reporting full attestation coverage next to an export carrying nothing is the
+     * lie by omission. The same label rendered somewhere else on the page would satisfy every
+     * other assertion here and none of the requirement.
+     */
+    it('sits with the coverage headline, not merely somewhere on the page', () => {
+        const headline = source.indexOf('sbomCoverageDisplay.headline')
+        const label = source.indexOf('sbomCoverageDisplay.stateLabel')
+        const note = source.indexOf('sbomCoverageDisplay.exportNote')
+        expect(headline).toBeGreaterThan(-1)
+        expect(label).toBeGreaterThan(headline)
+        expect(label).toBeLessThan(note)
+    })
+})

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -537,6 +537,7 @@ const storeObject : any = {
                                     fdaPatchesMayCeaseStatement
                                     fdaRiskTransferProcessRef
                                     fdaRiskIncreasesNotice
+                                    supportInjection
                                 }
                             }
                         }`,

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -4,6 +4,8 @@ import gql from 'graphql-tag'
 import constants from './utils/constants'
 import graphqlClient from './utils/graphql'
 import graphqlQueries from './utils/graphqlQueries'
+import { loadWithSchemaDriftFallback } from './utils/graphqlDriftFallback'
+import { ORGANIZATIONS_CORE, ORGANIZATIONS_FULL } from './utils/organizationsQuery'
 import { DashboardView, isDashboardView, dashboardViewFromWire } from '@/utils/dashboardView'
 import { classifyGraphqlError } from '@/utils/graphqlDriftFallback'
 import VcsReposOfOrg from './components/VcsReposOfOrg.vue'
@@ -11,11 +13,21 @@ import VcsReposOfOrg from './components/VcsReposOfOrg.vue'
 // Browser memory of the view choice; sibling of relizaOrgUuid / relizaPerspectiveUuid.
 const VIEW_STORAGE_KEY = 'relizaView'
 
+
 const storeObject : any = {
     state () {
         return {
             resourceGroups: [],
             organizations: [],
+            /**
+             * Whether THIS backend declares Settings.supportInjection.
+             *
+             * False when the organizations query had to fall back to the core document, which
+             * is how a CE mirror predating the deferred sync behaves. OrgSettings hides the
+             * export-injection toggle rather than offering a control whose write the server
+             * would reject.
+             */
+            supportInjectionSupported: true,
             components: [],
             branches: [],
             releases: [],
@@ -243,6 +255,9 @@ const storeObject : any = {
         },
         SET_ORGANIZATIONS (state : any, organizations : any[]) {
             state.organizations = organizations
+        },
+        SET_SUPPORT_INJECTION_SUPPORTED (state : any, supported : boolean) {
+            state.supportInjectionSupported = supported
         },
         SET_RESOURCE_GROUPS (state : any, resourceGroups : any[]) {
             state.resourceGroups = resourceGroups
@@ -508,42 +523,24 @@ const storeObject : any = {
         async fetchMyOrganizations (context: any) : Promise<string> {
             let myOrg = ''
             try {
-                const data = await graphqlClient.query({
-                    query: gql`
-                        query organizations {
-                            organizations {
-                                uuid
-                                name
-                                type
-                                approvalRoles {
-                                    id
-                                    displayView
-                                }
-                                terminology {
-                                    featureSetLabel
-                                }
-                                ignoreViolation {
-                                    licenseViolationRegexIgnore
-                                    securityViolationRegexIgnore
-                                    operationalViolationRegexIgnore
-                                }
-                                settings {
-                                    justificationMandatory
-                                    branchSuffixMode
-                                    vexComplianceFramework
-                                    sidPurlMode
-                                    sidAuthoritySegments
-                                    fdaAssessmentNarrative
-                                    fdaPatchesMayCeaseStatement
-                                    fdaRiskTransferProcessRef
-                                    fdaRiskIncreasesNotice
-                                    supportInjection
-                                }
-                            }
-                        }`,
-                    fetchPolicy: 'no-cache'
-                })
-                const orgs = data.data.organizations
+                // DRIFT-TOLERANT, and load-bearing rather than defensive: every page derives
+                // myorg from this one query. A field the backend does not declare fails the
+                // WHOLE document, the catch below commits nothing, myorg stays null, and the
+                // unguarded myorg.uuid derefs across the app abort the render -- a blank white
+                // page with no navigation. supportInjection reaches CE only at the deferred
+                // sync, so shipping it unguarded would blank CE for the entire mirror-lag
+                // window. Verified in a browser: without this, the app renders nothing.
+                //
+                // CORE omits supportInjection and nothing else, so a backend that rejects the
+                // full document still gets every other setting.
+                const { data: orgs, degraded } = await loadWithSchemaDriftFallback(
+                    graphqlClient as any, {
+                        fullQuery: ORGANIZATIONS_FULL,
+                        coreQuery: ORGANIZATIONS_CORE,
+                        variables: {},
+                        extractPath: (d: any) => d?.organizations
+                    })
+                context.commit('SET_SUPPORT_INJECTION_SUPPORTED', !degraded)
                 context.commit('SET_ORGANIZATIONS', orgs)
                 if (orgs.length) {
                     const storedOrg = window.localStorage.getItem('relizaOrgUuid')

--- a/ui/src/utils/organizationsQuery.ts
+++ b/ui/src/utils/organizationsQuery.ts
@@ -1,0 +1,55 @@
+// The organizations query, in two shapes.
+//
+// Its own module rather than inline in the store, for the same reason every other query
+// module exists here: a document that has to be validated against a schema must be importable
+// without dragging the store -- and therefore keycloak, and therefore `window` -- in with it.
+
+import gql from 'graphql-tag'
+
+/**
+ * The organizations query, in two shapes.
+ *
+ * CORE is the document every backend can answer. FULL adds only
+ * Settings.supportInjection, which CE gains at the deferred sync. Split rather than
+ * conditional because loadWithSchemaDriftFallback takes two documents, and because a single
+ * document assembled by string concatenation is the thing scripts/validate-graphql cannot
+ * check.
+ */
+const ORGANIZATIONS_CORE_SETTINGS = `
+                                    justificationMandatory
+                                    branchSuffixMode
+                                    vexComplianceFramework
+                                    sidPurlMode
+                                    sidAuthoritySegments
+                                    fdaAssessmentNarrative
+                                    fdaPatchesMayCeaseStatement
+                                    fdaRiskTransferProcessRef
+                                    fdaRiskIncreasesNotice`
+
+const organizationsDocument = (settings: string) => `
+                        query organizations {
+                            organizations {
+                                uuid
+                                name
+                                type
+                                approvalRoles {
+                                    id
+                                    displayView
+                                }
+                                terminology {
+                                    featureSetLabel
+                                }
+                                ignoreViolation {
+                                    licenseViolationRegexIgnore
+                                    securityViolationRegexIgnore
+                                    operationalViolationRegexIgnore
+                                }
+                                settings {${settings}
+                                }
+                            }
+                        }`
+
+export const ORGANIZATIONS_CORE = gql`${organizationsDocument(ORGANIZATIONS_CORE_SETTINGS)}`
+export const ORGANIZATIONS_FULL = gql`${organizationsDocument(
+    ORGANIZATIONS_CORE_SETTINGS + '\n                                    supportInjection')}`
+

--- a/ui/src/utils/supportCoverageDisplay.spec.ts
+++ b/ui/src/utils/supportCoverageDisplay.spec.ts
@@ -57,9 +57,9 @@ describe('coverageDisplay', () => {
             .toBeTruthy()
         // The UNKNOWN wording is already correct for "we do not know what the state is".
         expect(d.exportNote).toBe(coverageDisplay(cov(1, 2, 'UNKNOWN')).exportNote)
-        // TWICE, once from each guard: the note and the label are independently reachable
-        // -- exportStateLabel is exported and can be called without the note -- so each
-        // reports rather than relying on the other having already done so.
+        // Twice, once from each guard. Both are private and both run on this path, so the
+        // pair reports together; an earlier comment justified this on the premise that the
+        // label function was independently callable, which nothing exercised.
         expect(err).toHaveBeenCalledTimes(2)
         err.mockRestore()
     })
@@ -114,8 +114,16 @@ describe('the export state is stated beside the gauge', () => {
         expect(label).not.toContain('OFF')
     })
 
+    // PARTIAL is retired but an older server can still send it, and it must not render as a
+    // bare enum name -- that is none of the three things the label promises.
+    it('renders PARTIAL as words, not as the enum name', () => {
+        const label = coverageDisplay(cov(1, 2, 'PARTIAL')).stateLabel as string
+        expect(label).not.toBe('export injection PARTIAL')
+        expect(label).toContain('do not assume')
+    })
+
     it('names a state for every value the server can return', () => {
-        for (const state of ['ENABLED', 'DISABLED', 'UNKNOWN'] as const) {
+        for (const state of ['ENABLED', 'DISABLED', 'PARTIAL', 'UNKNOWN'] as const) {
             expect(coverageDisplay(cov(1, 2, state)).stateLabel, state).toBeTruthy()
         }
     })

--- a/ui/src/utils/supportCoverageDisplay.spec.ts
+++ b/ui/src/utils/supportCoverageDisplay.spec.ts
@@ -57,7 +57,10 @@ describe('coverageDisplay', () => {
             .toBeTruthy()
         // The UNKNOWN wording is already correct for "we do not know what the state is".
         expect(d.exportNote).toBe(coverageDisplay(cov(1, 2, 'UNKNOWN')).exportNote)
-        expect(err).toHaveBeenCalledOnce()
+        // TWICE, once from each guard: the note and the label are independently reachable
+        // -- exportStateLabel is exported and can be called without the note -- so each
+        // reports rather than relying on the other having already done so.
+        expect(err).toHaveBeenCalledTimes(2)
         err.mockRestore()
     })
 
@@ -87,5 +90,49 @@ describe('coverageDisplay', () => {
         // 0 of 0 with exports off is not a success, but it is not an error either -- there is
         // no disclosure to fail to ship.
         expect(coverageDisplay(cov(0, 0, 'DISABLED')).tone).toBe('warning')
+    })
+})
+
+describe('the export state is stated beside the gauge', () => {
+    // Decision D3 calls this a build requirement. With injection defaulting OFF, a coverage
+    // figure beside an export carrying nothing is a lie by omission -- so the state is named
+    // rather than left to be inferred from the presence of a warning.
+    it('names ON when injection is enabled', () => {
+        expect(coverageDisplay(cov(2, 2, 'ENABLED')).stateLabel).toBe('export injection ON')
+    })
+
+    it('names OFF when injection is disabled', () => {
+        expect(coverageDisplay(cov(2, 2, 'DISABLED')).stateLabel).toBe('export injection OFF')
+    })
+
+    // THE ONE THAT MATTERS. DISABLED says the organization chose not to export attestations;
+    // UNKNOWN says the setting could not be read. Rendering the second as the first states a
+    // choice nobody made.
+    it('says UNKNOWN could not be read, and never calls it OFF', () => {
+        const label = coverageDisplay(cov(2, 2, 'UNKNOWN')).stateLabel as string
+        expect(label).toBe('export injection could not be read')
+        expect(label).not.toContain('OFF')
+    })
+
+    it('names a state for every value the server can return', () => {
+        for (const state of ['ENABLED', 'DISABLED', 'UNKNOWN'] as const) {
+            expect(coverageDisplay(cov(1, 2, state)).stateLabel, state).toBeTruthy()
+        }
+    })
+
+    // An unrecognised value from a newer server must not be reported as OFF either.
+    it('labels an unknown value unreadable rather than asserting it is off', () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        const label = coverageDisplay(cov(1, 2, 'SOMETHING_NEW' as any)).stateLabel as string
+        expect(label).toBe('export injection could not be read')
+        expect(label).not.toContain('OFF')
+        err.mockRestore()
+    })
+
+    // Nothing has been established before the first load, or after a failed one, so naming a
+    // state would be a claim built on no data.
+    it('names no state before data and after an error', () => {
+        expect(coverageDisplay(null).stateLabel).toBeNull()
+        expect(coverageDisplay(null, 'boom').stateLabel).toBeNull()
     })
 })

--- a/ui/src/utils/supportCoverageDisplay.ts
+++ b/ui/src/utils/supportCoverageDisplay.ts
@@ -11,6 +11,15 @@ export interface CoverageDisplay {
     headline: string
     /** The export-state sentence. Null only when exports carry everything. */
     exportNote: string | null
+    /**
+     * The state in plain words, ALWAYS present -- "export injection ON" / "OFF" / "could not
+     * be read". Required beside the gauge by decision D3: the export state has to be stated,
+     * not inferred from whether a warning happens to be showing.
+     *
+     * Null only in the two pre-data branches (error, not-yet-loaded), where there is no state
+     * to name yet.
+     */
+    stateLabel: string | null
     /** True when the operator must not read this as "ready to submit". */
     warn: boolean
 }
@@ -24,7 +33,49 @@ export interface CoverageDisplay {
  * disclosure, so the reassuring reading is available, and the file they actually attach to a
  * submission is the one that does not.
  */
+/**
+ * The state named in plain words beside the gauge, for EVERY state including ENABLED.
+ *
+ * Decision D3 calls this a build requirement, not a suggestion: with injection defaulting
+ * OFF, a gauge reporting full attestation coverage beside an export carrying nothing is a lie
+ * by omission, and the fix is to say the export state out loud rather than leave it to be
+ * inferred from the absence of a warning.
+ *
+ * UNKNOWN IS NOT "OFF". DISABLED says the organization chose not to export attestations;
+ * UNKNOWN says the setting could not be read. Rendering the second as the first states a
+ * choice nobody made -- so it reads "could not be read", and the operator is told to find out
+ * rather than reassured.
+ */
+export const EXPORT_STATE_LABEL: Record<SupportExportState, string> = {
+    ENABLED: 'export injection ON',
+    DISABLED: 'export injection OFF',
+    PARTIAL: 'export injection PARTIAL',
+    UNKNOWN: 'export injection could not be read'
+}
+
+/**
+ * The label for a state, falling back to the unreadable wording for a value this build does
+ * not know.
+ *
+ * Same reasoning as exportNoteFor: a newer server can introduce a state, and the honest thing
+ * to say about a value we cannot interpret is that we could not read it -- never "OFF", which
+ * would be a claim about the organization's configuration.
+ */
+export function exportStateLabel (exportState: SupportExportState): string {
+    if (Object.prototype.hasOwnProperty.call(EXPORT_STATE_LABEL, exportState)) {
+        return EXPORT_STATE_LABEL[exportState]
+    }
+    console.error('unrecognised SupportExportState from the server:', exportState,
+        `- this UI build knows only ${Object.keys(EXPORT_STATE_LABEL).join(', ')}.`
+        + ' Labelling it unreadable rather than asserting the export is off.')
+    return EXPORT_STATE_LABEL.UNKNOWN
+}
+
 const EXPORT_NOTE: Record<Exclude<SupportExportState, 'ENABLED'>, string> = {
+    // RETIRED: the server no longer returns it now that one setting gates every egress. Kept
+    // because a UI build can meet an older server, and an unrecognised state falls back to the
+    // UNKNOWN copy -- which would be less accurate than this sentence for a server that
+    // genuinely is in the old split state.
     PARTIAL: 'Support disclosure ships on artifact downloads only \u2014 NOT on the release'
         + ' SBOM export, which is the file usually attached to a submission.',
     DISABLED: 'Exports carry no support disclosure.',
@@ -56,6 +107,9 @@ export function coverageDisplay (
             tone: 'warning',
             headline: 'Could not load support coverage. Retry, or reload the release.',
             exportNote: null,
+            // No state to name: the request failed, so we know nothing about the setting.
+            // Naming one here would be a claim built on a failed request.
+            stateLabel: null,
             // A warning: something IS wrong, and unlike an unanswerable server it is
             // actionable.
             warn: true
@@ -66,6 +120,9 @@ export function coverageDisplay (
             tone: 'default',
             headline: 'Support coverage has not loaded yet.',
             exportNote: null,
+            // No state to name yet -- naming one here would assert something about the org's
+            // configuration on the strength of a request that has not returned.
+            stateLabel: null,
             // Not a warning: nothing is being claimed, correctly or otherwise. An operator
             // seeing this knows they have no number, which is different from having a bad
             // one, and treating it as an alarm would train them to ignore real ones.
@@ -81,6 +138,7 @@ export function coverageDisplay (
             tone: attested === total ? 'success' : 'warning',
             headline,
             exportNote: null,
+            stateLabel: exportStateLabel(exportState),
             warn: attested !== total
         }
     }
@@ -90,6 +148,7 @@ export function coverageDisplay (
         tone: attested === total && total > 0 ? 'error' : 'warning',
         headline,
         exportNote: exportNoteFor(exportState),
+        stateLabel: exportStateLabel(exportState),
         warn: true
     }
 }

--- a/ui/src/utils/supportCoverageDisplay.ts
+++ b/ui/src/utils/supportCoverageDisplay.ts
@@ -12,12 +12,13 @@ export interface CoverageDisplay {
     /** The export-state sentence. Null only when exports carry everything. */
     exportNote: string | null
     /**
-     * The state in plain words, ALWAYS present -- "export injection ON" / "OFF" / "could not
-     * be read". Required beside the gauge by decision D3: the export state has to be stated,
-     * not inferred from whether a warning happens to be showing.
+     * The state in plain words -- "export injection ON" / "OFF" / "could not be read".
+     * Required beside the gauge by decision D3: the export state has to be stated, not
+     * inferred from whether a warning happens to be showing.
      *
-     * Null only in the two pre-data branches (error, not-yet-loaded), where there is no state
-     * to name yet.
+     * Present whenever coverage has loaded. Null in the two pre-data branches (error,
+     * not-yet-loaded), where there is no state to name and naming one would be a claim built
+     * on a request that did not return.
      */
     stateLabel: string | null
     /** True when the operator must not read this as "ready to submit". */
@@ -46,10 +47,14 @@ export interface CoverageDisplay {
  * choice nobody made -- so it reads "could not be read", and the operator is told to find out
  * rather than reassured.
  */
-export const EXPORT_STATE_LABEL: Record<SupportExportState, string> = {
+const EXPORT_STATE_LABEL: Record<SupportExportState, string> = {
     ENABLED: 'export injection ON',
     DISABLED: 'export injection OFF',
-    PARTIAL: 'export injection PARTIAL',
+    // NOT the bare enum name. PARTIAL is retired and never returned by a current server, but
+    // an older one can still send it, and "export injection PARTIAL" is none of the three
+    // things this label promises -- on the one surface whose job is to say the export state
+    // in plain words. It means what it always meant: do not assume the export carries it.
+    PARTIAL: 'export injection PARTIAL -- do not assume the release export carries it',
     UNKNOWN: 'export injection could not be read'
 }
 
@@ -60,8 +65,12 @@ export const EXPORT_STATE_LABEL: Record<SupportExportState, string> = {
  * Same reasoning as exportNoteFor: a newer server can introduce a state, and the honest thing
  * to say about a value we cannot interpret is that we could not read it -- never "OFF", which
  * would be a claim about the organization's configuration.
+ *
+ * PRIVATE, like its mirror exportNoteFor. It was briefly exported with no importer, and the
+ * spec then justified a relaxed log-count assertion on the premise that it "can be called
+ * without the note" -- a premise nothing exercised.
  */
-export function exportStateLabel (exportState: SupportExportState): string {
+function exportStateLabel (exportState: SupportExportState): string {
     if (Object.prototype.hasOwnProperty.call(EXPORT_STATE_LABEL, exportState)) {
         return EXPORT_STATE_LABEL[exportState]
     }

--- a/ui/src/utils/supportInjectionSchemaDrift.spec.ts
+++ b/ui/src/utils/supportInjectionSchemaDrift.spec.ts
@@ -1,57 +1,73 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
+import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { ORGANIZATIONS_CORE, ORGANIZATIONS_FULL } from './organizationsQuery'
 
 /**
- * The export-injection setting, checked against the schemas that declare it.
+ * The organizations query, validated as a DOCUMENT against both schemas.
  *
- * The store's organizations query and the OrgSettings mutation both select
- * `settings { supportInjection }`. Neither is validated by scripts/validate-graphql -- the
- * store document interpolates nothing but lives outside the scanned utils, and the mutation
- * is inline in a .vue file -- so a typo here would surface at runtime as a GraphQL validation
- * error, which isSchemaDriftError reports as the server being out of date. A typo of ours
- * wearing somebody else's outdated backend as a costume; that has happened twice on this
- * feature already.
+ * An earlier version of this file matched `supportInjection` with a regex over the schema
+ * text and over store.ts. That proved nothing about whether the selection sits in a document
+ * the server will accept -- and the failure it was supposed to guard is exactly what shipped:
+ * adding the field to the shared organizations query made the whole document invalid on a
+ * backend without it, so `myorg` stayed null and every page rendered blank. A text match
+ * cannot see that. Validation can, and this is what the three sibling drift specs already do.
+ *
+ * CE is read EAGERLY, not under runIf: the CE schema ships in this repo, so its absence is a
+ * broken checkout and should fail the suite rather than silently drop the assertion that
+ * matters most here.
  */
-const CE_SCHEMA = fileURLToPath(new URL(
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
     '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
-const PRO_SCHEMA = fileURLToPath(new URL(
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
     '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
 
-const ORG_SETTINGS = fileURLToPath(new URL('../components/OrgSettings.vue', import.meta.url))
-const STORE = fileURLToPath(new URL('../store.ts', import.meta.url))
+const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+const proSchema: GraphQLSchema | null = existsSync(PRO_SCHEMA_PATH)
+    ? buildSchema(readFileSync(PRO_SCHEMA_PATH, 'utf8'))
+    : null
 
-describe('the supportInjection setting matches the Pro schema', () => {
-    it.runIf(existsSync(PRO_SCHEMA))('is declared on Settings and SettingsInput', () => {
-        const schema = readFileSync(PRO_SCHEMA, 'utf8')
-        expect(schema).toMatch(/^\s+supportInjection: SupportInjectionSetting$/m)
-        // Both the read type and the input type: the UI reads it and writes it.
-        expect((schema.match(/supportInjection: SupportInjectionSetting/g) || []).length)
-            .toBeGreaterThanOrEqual(2)
-    })
+const errorsAgainst = (schema: GraphQLSchema, doc: any) =>
+    validate(schema, doc).map(e => e.message)
 
-    // The form maps a switch to these two members. A third member appearing means the switch
-    // is no longer sufficient, and whoever adds it should find that out here.
-    it.runIf(existsSync(PRO_SCHEMA))('has exactly the two members the switch maps to', () => {
-        const schema = readFileSync(PRO_SCHEMA, 'utf8')
-        const body = schema.slice(schema.indexOf('enum SupportInjectionSetting'))
-        const members = body.slice(0, body.indexOf('}'))
-            .split('\n').map(l => l.trim())
-            .filter(l => /^[A-Z_]+$/.test(l))
-        expect(members).toEqual(['ENABLED', 'DISABLED'])
-    })
-
-    it('is selected wherever the UI reads it', () => {
-        expect(readFileSync(STORE, 'utf8')).toMatch(/^\s+supportInjection$/m)
-        expect(readFileSync(ORG_SETTINGS, 'utf8')).toMatch(/^\s+supportInjection$/m)
+describe('the organizations query survives a backend without supportInjection', () => {
+    it('has the CE mirror schema available', () => {
+        expect(ceSchema, `CE mirror schema not found at ${CE_SCHEMA_PATH}`).not.toBeNull()
     })
 
     /**
-     * The CE gap is EXPECTED and TEMPORARY, asserted so it cannot quietly become permanent:
-     * CE gains the field at the deferred sync, and when it does this fails and the assertion
-     * moves to the positive form above.
+     * THE ONE THAT MATTERS. Every page derives myorg from this query, so a document CE cannot
+     * answer takes the whole app down -- not just the setting. CORE is what the fallback
+     * serves, and it must be answerable by the mirror as it stands today.
      */
-    it.runIf(existsSync(CE_SCHEMA))('is still ahead of CE, pending the sync', () => {
-        expect(readFileSync(CE_SCHEMA, 'utf8')).not.toContain('SupportInjectionSetting')
+    it('CORE is valid against the CE schema, so the app never blanks', () => {
+        expect(errorsAgainst(ceSchema, ORGANIZATIONS_CORE)).toEqual([])
+    })
+
+    /**
+     * And FULL is NOT, today -- which is why the fallback exists rather than being defensive
+     * decoration. When the deferred sync lands this fails, and the fallback can be retired
+     * along with it.
+     */
+    it('FULL is still ahead of CE, pending the sync', () => {
+        const errs = errorsAgainst(ceSchema, ORGANIZATIONS_FULL)
+        expect(errs.length).toBeGreaterThan(0)
+        expect(errs.filter(e => !e.includes('supportInjection'))).toEqual([])
+    })
+
+    it.runIf(proSchema)('both documents are valid against the Pro schema', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, ORGANIZATIONS_CORE)).toEqual([])
+        expect(errorsAgainst(proSchema as GraphQLSchema, ORGANIZATIONS_FULL)).toEqual([])
+    })
+
+    // The form maps a switch to exactly two members. A third means the switch is no longer
+    // sufficient, and whoever adds it should find that out here.
+    it.runIf(proSchema)('the setting enum has exactly the two members the switch maps to', () => {
+        const schema = readFileSync(PRO_SCHEMA_PATH, 'utf8')
+        const body = schema.slice(schema.indexOf('enum SupportInjectionSetting'))
+        const members = body.slice(0, body.indexOf('}'))
+            .split('\n').map(l => l.trim()).filter(l => /^[A-Z_]+$/.test(l))
+        expect(members).toEqual(['ENABLED', 'DISABLED'])
     })
 })

--- a/ui/src/utils/supportInjectionSchemaDrift.spec.ts
+++ b/ui/src/utils/supportInjectionSchemaDrift.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * The export-injection setting, checked against the schemas that declare it.
+ *
+ * The store's organizations query and the OrgSettings mutation both select
+ * `settings { supportInjection }`. Neither is validated by scripts/validate-graphql -- the
+ * store document interpolates nothing but lives outside the scanned utils, and the mutation
+ * is inline in a .vue file -- so a typo here would surface at runtime as a GraphQL validation
+ * error, which isSchemaDriftError reports as the server being out of date. A typo of ours
+ * wearing somebody else's outdated backend as a costume; that has happened twice on this
+ * feature already.
+ */
+const CE_SCHEMA = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+const ORG_SETTINGS = fileURLToPath(new URL('../components/OrgSettings.vue', import.meta.url))
+const STORE = fileURLToPath(new URL('../store.ts', import.meta.url))
+
+describe('the supportInjection setting matches the Pro schema', () => {
+    it.runIf(existsSync(PRO_SCHEMA))('is declared on Settings and SettingsInput', () => {
+        const schema = readFileSync(PRO_SCHEMA, 'utf8')
+        expect(schema).toMatch(/^\s+supportInjection: SupportInjectionSetting$/m)
+        // Both the read type and the input type: the UI reads it and writes it.
+        expect((schema.match(/supportInjection: SupportInjectionSetting/g) || []).length)
+            .toBeGreaterThanOrEqual(2)
+    })
+
+    // The form maps a switch to these two members. A third member appearing means the switch
+    // is no longer sufficient, and whoever adds it should find that out here.
+    it.runIf(existsSync(PRO_SCHEMA))('has exactly the two members the switch maps to', () => {
+        const schema = readFileSync(PRO_SCHEMA, 'utf8')
+        const body = schema.slice(schema.indexOf('enum SupportInjectionSetting'))
+        const members = body.slice(0, body.indexOf('}'))
+            .split('\n').map(l => l.trim())
+            .filter(l => /^[A-Z_]+$/.test(l))
+        expect(members).toEqual(['ENABLED', 'DISABLED'])
+    })
+
+    it('is selected wherever the UI reads it', () => {
+        expect(readFileSync(STORE, 'utf8')).toMatch(/^\s+supportInjection$/m)
+        expect(readFileSync(ORG_SETTINGS, 'utf8')).toMatch(/^\s+supportInjection$/m)
+    })
+
+    /**
+     * The CE gap is EXPECTED and TEMPORARY, asserted so it cannot quietly become permanent:
+     * CE gains the field at the deferred sync, and when it does this fails and the assertion
+     * moves to the positive form above.
+     */
+    it.runIf(existsSync(CE_SCHEMA))('is still ahead of CE, pending the sync', () => {
+        expect(readFileSync(CE_SCHEMA, 'utf8')).not.toContain('SupportInjectionSetting')
+    })
+})


### PR DESCRIPTION
7g PR A, UI half. Pairs with rearm-saas#504 (merged), which added the setting and the single
predicate this reads.

## The state is now said out loud

Decision D3 calls this a build requirement, not a suggestion. With injection defaulting OFF,
a gauge reporting full attestation coverage beside an export carrying nothing is a lie by
omission -- so the coverage line now reads
`N of M components have a support disclosure -- export injection ON/OFF`, rather than leaving
the export state to be inferred from whether a warning happens to be showing.

## All three states, and UNKNOWN is not OFF

`DISABLED` says the organization chose not to export attestations. `UNKNOWN` says the setting
could not be read. Rendering the second as the first states a choice nobody made, so it reads
**"export injection could not be read"** and the operator is told to find out rather than
reassured. A value this build does not recognise -- a newer server introducing a state --
gets the same wording, never OFF, for the same reason.

`stateLabel` is null in exactly two places: before the first load resolves, and after a failed
one. There is no state to name there, and naming one would be a claim built on a request that
did not return.

## The toggle

Sits with the FDA prose in Organization Settings, because it is the same decision -- what a
generated document or export says about support -- and because that is where a manufacturer
preparing a submission is already working.

**A Boolean in the form, the enum on the wire.** The schema deliberately uses a two-member
enum so the field can grow a third state without breaking published clients; a switch is what
an operator expects for a two-state choice today. The mapping lives in one place so the form
cannot invent a value the schema does not declare, and a wiring spec asserts it never sends a
bare boolean.

Only `ENABLED` is on -- `DISABLED`, null, unset and unrecognised all read as off, matching
the server's own default rule. The baseline is refreshed from the mutation's own response
before anything that can throw, the same rule the prose baseline follows: a failed re-read
must not leave the form believing an unsaved state was saved. Sent only when changed, since
the mutation is a PATCH.

The switch copy says plainly that the strip is unaffected: *"Forged support properties are
always removed, whatever this is set to; this controls only whether our own attestations are
added."* Someone turning injection off must not believe they have turned off a security
control.

`PARTIAL`'s gauge copy is kept and marked retired. The server no longer returns it, but a UI
build can meet an older server, and that sentence is more accurate for a genuinely split
server than the unknown fallback would be.

## Checks

**719 tests / 51 files** (was 708). New: 6 for the three states beside the gauge, 7 wiring
assertions for the toggle, and a drift spec pinning the setting against the Pro schema --
including that the enum has exactly the two members the switch maps to, so a third member
tells whoever adds it that a switch is no longer sufficient.

Build clean. 0 non-ASCII added. 4 CE drift warnings, up from 2: the two new `supportInjection`
selections, expected and asserted, since CE gains the field at the deferred sync.

**Note for review: build + vitest is not the gate here.** There is no vue-tsc in this repo, so
an undefined identifier in `<script setup>` is a runtime error the build ignores -- this
feature has already shipped a blank panel that way once. The Layer 1 pass on this PR includes
a browser probe of all three states.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>