### PR TITLE
fix(permissions): DevOps functions and instance grants on every non-OSS installation

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1926,9 +1926,9 @@ const allComponents = computed(() => [...orgComponents.value, ...orgProducts.val
 // Instance + cluster lists used by the ScopedPermissions component to
 // expose per-instance and per-cluster permission sections (replaces
 // the old UI's userInstancePermissionColumns / userClusterPermissionColumns
-// data tables). DevOps Read/Write grants are only honored on SAAS, so we
-// short-circuit the lists to empty on other installation types — that hides
-// the corresponding sections everywhere ScopedPermissions is rendered
+// data tables). Instances and clusters exist on every non-OSS installation;
+// on OSS we short-circuit the lists to empty, which hides the corresponding
+// sections everywhere ScopedPermissions is rendered
 // (users, user groups, programmatic access, free-form keys).
 const orgInstancesAndClusters = computed(() => {
     if (myUser.value?.installationType === 'OSS') return []

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1214,7 +1214,7 @@ async function loadTabSpecificData (tabName: string) {
             loadPerspectives(),
             store.dispatch('fetchComponents', orgResolved.value),
             store.dispatch('fetchProducts', orgResolved.value),
-            ...(myUser.value.installationType === 'SAAS' ? [store.dispatch('fetchInstances', orgResolved.value)] : [])
+            ...(myUser.value.installationType !== 'OSS' ? [store.dispatch('fetchInstances', orgResolved.value)] : [])
         ])
         loadInvitedUsers(true)
     } else if (tabName === "userGroups") {
@@ -1222,11 +1222,11 @@ async function loadTabSpecificData (tabName: string) {
         // type, so a PRODUCT/ANY rule would otherwise preview "matches 0".
         store.dispatch('fetchProducts', orgResolved.value)
         await loadUsers() // Load users for the user selection dropdown
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadUserGroups()
     } else if (tabName === "programmaticAccess") {
         await loadUsers()
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "freeFormKeys") {
         // Same as programmaticAccess — formatValuesForApiKeys() resolves
@@ -1236,7 +1236,7 @@ async function loadTabSpecificData (tabName: string) {
         // only formats when both lists are non-empty) and the column
         // ends up blank for FREEFORM rows.
         await loadUsers()
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "policies") {
         fetchApprovalEntries()
@@ -1931,7 +1931,7 @@ const allComponents = computed(() => [...orgComponents.value, ...orgProducts.val
 // the corresponding sections everywhere ScopedPermissions is rendered
 // (users, user groups, programmatic access, free-form keys).
 const orgInstancesAndClusters = computed(() => {
-    if (myUser.value?.installationType !== 'SAAS') return []
+    if (myUser.value?.installationType === 'OSS') return []
     const all = (store.getters.instancesOfOrg(orgResolved.value) || [])
     return all.filter((x: any) => x.revision === -1 && (x.status === 'ACTIVE' || !x.status))
 })

--- a/ui/src/components/ScopedPermissions.vue
+++ b/ui/src/components/ScopedPermissions.vue
@@ -208,14 +208,14 @@
         </div>
 
         <!-- Per-Cluster Permissions (scope=INSTANCE on a CLUSTER row). SAAS-only. -->
-        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="isSaas && orgPermission.type !== 'ADMIN' && clusters.length">
+        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="hasDevOps && orgPermission.type !== 'ADMIN' && clusters.length">
             <n-h5>
                 <n-text depth="1">
                     Per-Cluster Permissions:
                 </n-text>
             </n-h5>
         </n-space>
-        <div v-if="isSaas && orgPermission.type !== 'ADMIN' && clusters.length">
+        <div v-if="hasDevOps && orgPermission.type !== 'ADMIN' && clusters.length">
             <n-space vertical>
                 <n-card v-for="sp in scopedClusterPermissions" :key="sp.objectId" size="small" style="margin-bottom: 8px;">
                     <n-space align="center" justify="space-between" style="width: 100%;">
@@ -252,14 +252,14 @@
         </div>
 
         <!-- Per-Instance Permissions (scope=INSTANCE on a STANDALONE_INSTANCE / CLUSTER_INSTANCE row). SAAS-only. -->
-        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="isSaas && orgPermission.type !== 'ADMIN' && instances.length">
+        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="hasDevOps && orgPermission.type !== 'ADMIN' && instances.length">
             <n-h5>
                 <n-text depth="1">
                     Per-Instance Permissions:
                 </n-text>
             </n-h5>
         </n-space>
-        <div v-if="isSaas && orgPermission.type !== 'ADMIN' && instances.length">
+        <div v-if="hasDevOps && orgPermission.type !== 'ADMIN' && instances.length">
             <n-space vertical>
                 <n-card v-for="sp in scopedInstancePermissions" :key="sp.objectId" size="small" style="margin-bottom: 8px;">
                     <n-space align="center" justify="space-between" style="width: 100%;">
@@ -370,7 +370,7 @@ const permissionTypesWithAdmin: string[] = constants.PermissionTypesWithAdmin
 const permissionTypes: string[] = constants.PermissionTypes
 const permissionFunctions: string[] = constants.PermissionFunctions
 const essentialReadPermissionFunctions: string[] = constants.EssentialReadPermissionFunctions
-const isSaas = computed(() => installationType.value === 'SAAS')
+const hasDevOps = computed(() => installationType.value !== 'OSS')
 
 const orgPermission = ref<OrgPermission>({
     type: 'NONE',
@@ -378,15 +378,15 @@ const orgPermission = ref<OrgPermission>({
     approvals: []
 })
 
-// DevOps Read/Write only make sense (and are only honored by the backend) for
-// SAAS installations; everywhere else they're hidden. At ESSENTIAL_READ we
+// DevOps Read/Write gate the instance / cluster surface, which exists on every
+// non-OSS installation (SaaS, managed service, on-prem Pro); OSS hides them. At ESSENTIAL_READ we
 // only expose the functions that explicitly support it (currently AGENT) —
 // most org-wide functions are paired with READ_ONLY / READ_WRITE.
 const orgPermissionFunctions = computed(() => permissionFunctions.filter(f =>
     f !== 'RESOURCE' &&
     (props.showSbomProbing || f !== 'SBOM_PROBING') &&
     (!props.showSbomProbing || f !== 'LIFECYCLE_UPDATE') &&
-    (isSaas.value || (f !== 'DEVOPS_READ' && f !== 'DEVOPS_WRITE')) &&
+    (hasDevOps.value || (f !== 'DEVOPS_READ' && f !== 'DEVOPS_WRITE')) &&
     (orgPermission.value.type !== 'ESSENTIAL_READ' || essentialReadPermissionFunctions.includes(f))
 ))
 


### PR DESCRIPTION
## Summary
- The permissions editor only exposed **DevOps Read / DevOps Write** and the cluster / instance grant sections when the installation type was `SAAS`. On a `MANAGED_SERVICE` or on-prem Pro install this made it impossible to give an org-wide read-only user access to the instances page, which is gated on the DevOps Read function.
- The backend has no installation-type gate on these functions, so the UI now hides them on `OSS` only. Org settings fetches the org's instances for the editor on the same condition.

## Test plan
- [x] `vite build`; eslint error count unchanged from main
- [ ] on a non-SaaS Pro install: org-wide Read Only shows DevOps Read / DevOps Write; granting DevOps Read lets the user open the instances page

🤖 Generated with [Claude Code](https://claude.com/claude-code)