### PR TITLE
Document what support attestations put in an export (7g PR B docs)

### DIFF
--- a/documentation_site/docs/workflows/exporting-compliance-artifacts.md
+++ b/documentation_site/docs/workflows/exporting-compliance-artifacts.md
@@ -67,12 +67,24 @@ Two layers, both emitted together and both governed by that single setting.
 | `reliza:support:source:<milestone>` | Where each milestone date came from |
 | `cdx:lifecycle:milestone:endOfSupport` (and `endOfLife`, `endOfGuaranteedSupport`) | Standard CycloneDX milestone dates |
 
-**A `declarations` block** at the document level, in CycloneDX's own attestation vocabulary --
-`claims[]` naming what was attested about which component, `evidence[]` carrying the value, the
-assessment instant and the person who recorded it, and `assessors[]` naming the organization.
+**A `declarations` block** at the document level, in CycloneDX's own attestation vocabulary:
+
+- `claims[]` -- what was attested about which component. A claim targets a component's
+  `bom-ref`; where a component arrived without one, ReARM assigns a namespaced
+  `reliza:bomref:` identifier so the claim has something to point at, and removes it again on
+  any export that does not carry the claim.
+- `evidence[]` -- the attested value, the assessment instant, and the person who recorded it.
+  Milestone dates appear here too, each with its own assessment instant.
+- `assessors[]` -- the assessing organization and whether the assessment is third-party.
+- `attestations[]` -- the join between an assessor and the claims it made, so a reader can tell
+  who asserted what.
+
 This requires CycloneDX 1.6; a BOM served at an earlier spec version carries the properties only.
 
-The two layers describe the same facts under the same names, so a consumer can reconcile them.
+The two layers describe the same facts under the same names **and the same values**, so a
+consumer can reconcile them: `reliza:support:party` reads `FIRST_PARTY`/`THIRD_PARTY` in both.
+The CycloneDX party role (`manufacturer`/`supplier`) appears only where it belongs, on the
+assessor.
 
 ### The disclosure marker
 

--- a/documentation_site/docs/workflows/exporting-compliance-artifacts.md
+++ b/documentation_site/docs/workflows/exporting-compliance-artifacts.md
@@ -33,6 +33,78 @@ Exports the merged SBOM for the release. Options:
 
 Click **Export** to download the file.
 
+## Support Attestations in Exports
+
+Releases can carry per-component **support attestations** -- the manufacturer's statement of
+how long a component is supported, and at what level. Where an attestation exists, ReARM can
+weave it into the SBOM it serves, so a reviewer reads the support position out of the artifact
+itself rather than out of the UI.
+
+This affects the **merged SBOM export**, the **single-artifact CycloneDX download** and the
+**SPDX-augmented download**. It is controlled by one organization setting, and it is **off by
+default**.
+
+### Turning it on
+
+**Organization Settings -> Carry support attestations in BOM exports.** While it is off, exports
+carry no support facts at all, whatever the coverage gauge on the release page says. The gauge
+states the setting beside the coverage figure for exactly this reason: full attestation coverage
+and an export that carries none of it are not a contradiction, they are the default.
+
+### What a consumer sees
+
+Two layers, both emitted together and both governed by that single setting.
+
+**Component properties**, on each attested component:
+
+| Property | Meaning |
+|---|---|
+| `reliza:support:levelOfSupport` | The attested level. Never emitted without `reliza:support:assessedAt` beside it |
+| `reliza:support:assessedAt` | When the assessment was made (not when the row was written) |
+| `reliza:support:status` | Derived from the milestone dates and the current date |
+| `reliza:support:justification` | The stated basis for the claim |
+| `reliza:support:party` | Whether the manufacturer is a first or third party to the component |
+| `reliza:support:source:<milestone>` | Where each milestone date came from |
+| `cdx:lifecycle:milestone:endOfSupport` (and `endOfLife`, `endOfGuaranteedSupport`) | Standard CycloneDX milestone dates |
+
+**A `declarations` block** at the document level, in CycloneDX's own attestation vocabulary --
+`claims[]` naming what was attested about which component, `evidence[]` carrying the value, the
+assessment instant and the person who recorded it, and `assessors[]` naming the organization.
+This requires CycloneDX 1.6; a BOM served at an earlier spec version carries the properties only.
+
+The two layers describe the same facts under the same names, so a consumer can reconcile them.
+
+### The disclosure marker
+
+Every JSON BOM ReARM serves carries `reliza:support:disclosure` on `metadata`, with one of two
+values. **Read it before drawing a conclusion from an absent property:**
+
+| Value | Meaning |
+|---|---|
+| `derived-non-attested-current-state` | Support facts were injected. A component with no support property has no attestation on file |
+| `provenance-stripped-no-disclosure` | **Nothing was asserted.** The document says nothing about support -- including about components that DO have an end-of-support date recorded |
+
+Reading the second as the first is how a reviewer concludes a device has no out-of-support parts
+when it does. The values are deliberately distinct so that absence and silence cannot be confused.
+
+Support facts are **derived current state, not a frozen attestation**: they are computed when the
+document is served, so the same release exported on two dates can report different
+`reliza:support:status` values from unchanged underlying dates.
+
+### Uploaded BOMs cannot forge these
+
+The `reliza:support:*` and `reliza:device:*` property namespaces and the `declarations` block are
+**server-owned**. On every egress above -- and on the raw artifact download, and whether or not
+the setting is on -- ReARM strips any of them found in an uploaded BOM before serving it. Their
+presence in a document ReARM served therefore means ReARM put them there.
+
+The strip is deliberately not tied to the setting: it is a security control, while injection is a
+content choice. An organization that has never turned injection on is still protected from an
+uploaded BOM carrying a forged attestation under its name.
+
+The CSV and Excel media types of the SBOM export do not carry component properties at all, so no
+support facts appear in them.
+
 ## VDR Export
 
 Exports vulnerability disclosure data as a [CycloneDX 1.6 VDR](https://cyclonedx.org/capabilities/vdr/).


### PR DESCRIPTION
Documents what rearm-saas #505 (7g PR B) makes visible in a served SBOM. Companion to
that PR; no code.

## Why

7g changes the export shape a consumer sees -- the `reliza:support:*` properties, the
new document-level `declarations` block, and the disclosure marker saying which of the
two things happened. None of it was documented anywhere.

## Placement -- flagging a deviation

The instruction was `documentation_site/docs/integrations/`. I put it in
`workflows/exporting-compliance-artifacts.md` instead.

`integrations/` is entirely third-party connectors -- Slack, Jenkins, Dtrack, BEAR, ADO,
GitHub -- and follows the rule that every outbound third-party call needs a page there.
An export shape is not an outbound call, and someone asking "what is in the SBOM ReARM
just gave me" opens the export page, which already documents SBOM/VDR/VEX/OBOM/BOV.
**Say the word and it moves.**

## What it covers

The section a reader most needs is the disclosure marker, so it is called out rather
than tabulated away:

- `derived-non-attested-current-state` -- an absent support property means no
  attestation on file.
- `provenance-stripped-no-disclosure` -- **nothing was asserted**, including about
  components that DO have a recorded end-of-support date.

Reading the second as the first is how a reviewer concludes a device has no
out-of-support parts when it does.

Also states two things the UI cannot:

- The setting is **off by default**, so full coverage on the gauge beside an export
  carrying none of it is the default rather than a contradiction.
- The reliza namespaces and the `declarations` block are server-owned and stripped from
  uploads on every egress **whether or not the setting is on**, because a security
  control and a content choice are not the same switch.

Plus the property table, the `declarations` shape and its 1.6 floor, and the note that
CSV/Excel media types carry no component properties at all.
