### PR TITLE
fix(component): show the clone action on product feature sets

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1034,11 +1034,17 @@
                                             v-model:value="cloneBrProps.name"
                                             required
                                             :placeholder="'Enter cloned ' + words.branchFirstUpper + ' name'" />
-                                            <label>Version Pin of new {{ words.branchFirstUpper }} (Defaults to Version Schema: {{ componentData.featureBranchVersioniong }} )"</label>
-                                        <n-input
+                                        <label>Version schema of new {{ words.branchFirstUpper }} (defaults to the {{ words.branchFirstUpper.toLowerCase() }} schema of {{ componentData.name }}: {{ componentData.featureBranchVersioning || 'not set' }})</label>
+                                        <n-select
                                             v-model:value="cloneBrProps.schema"
-                                            required
-                                            placeholder="Enter Version Pin" />
+                                            tag
+                                            filterable
+                                            :placeholder="'Select version schema for ' + words.branchFirstUpper"
+                                            :options="constants.BranchVersionTypes" />
+                                        <n-input
+                                            v-if="cloneBrProps.schema === 'custom_version'"
+                                            v-model:value="customCloneVersionSchema"
+                                            placeholder="Custom Version Schema" />
                                         <label>Type of new {{ words.branchFirstUpper }}</label>
                                         <n-select
                                             placeholder="Please choose type"
@@ -2224,24 +2230,35 @@ const defaultCloneBrProps = {
 }
 
 const cloneBrProps: Ref<any> = ref(commonFunctions.deepCopy(defaultCloneBrProps))
+const customCloneVersionSchema = ref('')
 
 const cloneBranchReset = function () {
     cloneBrProps.value.name = ''
     cloneBrProps.value.type = ''
     cloneBrProps.value.schema = componentData.value.featureBranchVersioning
+    customCloneVersionSchema.value = ''
 }
 
 const cloneBranchSubmit = async function () {
-    let brProps = {
+    if (!cloneBrProps.value.name) { notify('warning', 'Missing', `Name of the new ${words.value.branchFirstUpper} is required`); return }
+    const versionSchema = cloneBrProps.value.schema === 'custom_version' ? customCloneVersionSchema.value : cloneBrProps.value.schema
+    const brProps = {
         name: cloneBrProps.value.name,
         branchUuid: cloneBrProps.value.originalBranch.uuid,
-        versionSchema: cloneBrProps.value.schema,
-        branchType: cloneBrProps.value.type
+        versionSchema,
+        branchType: cloneBrProps.value.type || null
     }
-    const response: any = store.dispatch('cloneBranch', brProps)
-    selectBranch(response.uuid)
-    cloneBranchReset()
-    showCloneBranchModal.value = false
+    try {
+        const response: any = await store.dispatch('cloneBranch', brProps)
+        await store.dispatch('fetchBranches', { componentId: componentUuid, forceRefresh: true })
+        latestRefreshToken.value++
+        cloneBranchReset()
+        showCloneBranchModal.value = false
+        notify('success', 'Cloned', `${words.value.branchFirstUpper} ${response.name} created`)
+        selectBranch(response.uuid)
+    } catch (error: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(error.message))
+    }
 }
 
 const onCreateBranchSubmit = async function() {
@@ -2947,14 +2964,23 @@ async function archiveBranchFromList (row: any) {
     await commonFunctions.swalWrapper(onSwalConfirm, swalData, notify)
 }
 
+// Action cells sit on a row whose click / double-click selects or opens the
+// branch. The whole cell swallows both events so a click near the icon can't
+// switch the selection.
+const actionCell = (children: any) => h('div', {
+    style: 'display: flex; justify-content: center; align-items: center; min-height: 28px;',
+    onClick: (e: Event) => e.stopPropagation(),
+    onDblclick: (e: Event) => e.stopPropagation(),
+}, children)
+
 function archiveActionCell (row: any) {
     if (!isWritable.value || row.type === 'BASE') return null
-    return h(NIcon, {
+    return actionCell(h(NIcon, {
         title: 'Archive ' + words.value.branchFirstUpper,
         class: 'icons clickable',
         size: 22,
         onClick: (e: Event) => { e.stopPropagation(); archiveBranchFromList(row) },
-    }, () => h(Trash))
+    }, () => h(Trash)))
 }
 
 const branchFields: any[] = [
@@ -3020,16 +3046,16 @@ const cloneBranchColumn = {
     key: 'manage',
     width: 50,
     render: (row: any) => {
-        return h(
+        return actionCell(h(
             NIcon,
             {
                 title: 'Clone ' + words.value.branchFirstUpper,
                 class: 'icons clickable',
                 size: 25,
-                onClick: () => { cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; showCloneBranchModal.value = true }
+                onClick: (e: Event) => { e.stopPropagation(); cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; customCloneVersionSchema.value = ''; showCloneBranchModal.value = true }
             },
             () => h(Copy)
-        )
+        ))
     }
 }
 const branchColumns = computed(() => (!isComponent.value && isWritable.value) ? [...branchFields, cloneBranchColumn] : branchFields)

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1067,7 +1067,7 @@
                                 @selectBranch="selectBranchFromLatest" />
                         </n-tab-pane>
                         <n-tab-pane name="branches" :tab="componentData.type === 'COMPONENT' ? 'Branches' : words.branchFirstUpper + 's'">
-                            <n-data-table :data="branches" :columns="branchFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
+                            <n-data-table :data="branches" :columns="branchColumns" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                         </n-tab-pane>
                         <n-tab-pane v-if="componentData.type === 'COMPONENT'" name="tags" tab="Tags">
                             <n-data-table :data="tags" :columns="tagFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
@@ -3012,24 +3012,27 @@ const branchFields: any[] = [
         render: archiveActionCell,
     },]
 
-if (!isComponent.value && isWritable){
-    branchFields.push({
-        title: '',
-        key: 'manage',
-        render: (row: any) => {
-            return h(
-                NIcon, 
-                {
-                    title: 'Clone ' + words.value.branchFirstUpper,
-                    class: 'icons clickable',
-                    size: 25,
-                    onClick: () => {cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; showCloneBranchModal.value = true}
-                }, 
-                () => h(Copy)
-            )
-        }
-    })
+// Clone lives on product feature sets for writers. isComponent / isWritable
+// only settle once the component loads, so the column is attached reactively
+// rather than pushed once at setup (which silently never ran for products).
+const cloneBranchColumn = {
+    title: '',
+    key: 'manage',
+    width: 50,
+    render: (row: any) => {
+        return h(
+            NIcon,
+            {
+                title: 'Clone ' + words.value.branchFirstUpper,
+                class: 'icons clickable',
+                size: 25,
+                onClick: () => { cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; showCloneBranchModal.value = true }
+            },
+            () => h(Copy)
+        )
+    }
 }
+const branchColumns = computed(() => (!isComponent.value && isWritable.value) ? [...branchFields, cloneBranchColumn] : branchFields)
 
 const branchTableRowKey = (row: any) => row.uuid
 


### PR DESCRIPTION
## Summary
- The Feature Sets table on a product is supposed to carry a clone icon per row (the modal, form and store action exist), but the column was pushed once at setup while the product flag still defaulted to *component* and the writable check was a computed ref tested without `.value`. Products therefore never showed the action.
- The column is now attached through a computed column list once the product has loaded and the user has write access. Component branches are unchanged.
- Review follow-ups: the schema label now names the product and its feature branch schema (it read a misspelled property and showed nothing); the version pin is the same schema selector with a custom entry as Create Feature Set; the clone and archive icons sit in a cell that swallows click / double-click so they no longer select or open the row; submit awaits the mutation, refreshes the list, surfaces errors such as a duplicate name, and selects the new feature set.
- Needs the backend `cloneBranch` mutation, restored in the Pro backend.

## Test plan
- [x] `vite build`; eslint error count unchanged from main
- [x] sandbox: product Feature Sets tab shows the clone icon for a writer; cloning "Base Feature Set" through the modal created a feature set with the same 4 dependencies and 1 pattern, auto-integrate kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)


- [x] sandbox (review follow-ups): pressing the clone icon leaves the selected feature set unchanged; the label names the product and its schema; a custom schema entered through the selector is stored; the new feature set is listed and selected; a duplicate name shows an error toast
