### PR TITLE
Walkthrough findings (UI): stale toggle, toggle placement, statement gate, withdrawn presentation

### DIFF
--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -994,36 +994,46 @@
                             </div>
                         </n-form-item>
 
-                        <!-- The export toggle sits WITH the FDA text because it is the same
-                             decision: what a generated document or export says about support.
-                             Default OFF (D3), so this is the control a manufacturer preparing
-                             a submission must deliberately turn on. -->
-                        <!-- Hidden entirely on a backend that does not declare the field --
-                             a CE mirror before the deferred sync. Offering a switch whose
-                             write the server would reject is worse than not offering it. -->
-                        <n-form-item v-if="supportInjectionSupported"
-                            label="Carry support attestations in BOM exports">
-                            <div style="display: flex; flex-direction: column; width: 100%;">
-                                <n-switch v-model:value="supportInjectionEnabled"
-                                    :disabled="savingOrgSettings" />
-                                <span class="text-muted" style="margin-top: 4px; max-width: 760px;">
-                                    Off by default. When on, BOM exports carry this
-                                    organization's support attestations &mdash; the artifact
-                                    download, the SPDX-augmented download and the release SBOM
-                                    export. The raw artifact download never carries them.
-                                    <strong>Forged support properties are always removed,
-                                    whatever this is set to</strong>; this controls only
-                                    whether our own attestations are added.
-                                </span>
-                            </div>
-                        </n-form-item>
-
                         <n-form-item label="Risk increases over time (labeling)">
                             <n-input v-model:value="orgSettings.fdaRiskIncreasesNotice"
                                     :disabled="savingOrgSettings" :maxlength="FDA_PROSE_MAX_LENGTH" show-count
                                 type="textarea" :rows="3" style="max-width: 760px;"
                                 placeholder="Cybersecurity risk to users can be expected to increase after end of support." />
                         </n-form-item>
+
+                        <!-- ITS OWN SECTION, AFTER all three labeling slots.
+                             It previously sat between slot 2 and slot 3, which read as a
+                             fourth piece of labeling text and broke the three apart -- an
+                             operator working down the FDA labeling statements met a switch
+                             about export behaviour in the middle of them. The three slots are
+                             prose that ships INSIDE documents; this decides whether a
+                             document carries attestations at all. Related, not the same kind
+                             of thing, and the ordering now says so. Reported by an operator
+                             running the walkthrough, board t20260909-061338-23148. -->
+                        <!-- Hidden entirely on a backend that does not declare the field --
+                             a CE mirror before the deferred sync. Offering a switch whose
+                             write the server would reject is worse than not offering it. -->
+                        <div v-if="supportInjectionSupported" style="margin-top: 18px;">
+                            <h4 style="margin-bottom: 2px;">Support disclosure export</h4>
+                            <!-- The switch is ADJACENT to the words it controls, not in a
+                                 form-item label column that pushed it to the far right with
+                                 760px of whitespace between the two. A control that far from
+                                 its label is one an operator has to aim at. -->
+                            <n-space align="center" :size="10" style="margin: 8px 0 4px;">
+                                <n-switch v-model:value="supportInjectionEnabled"
+                                    :disabled="savingOrgSettings" />
+                                <span>Carry support attestations in BOM exports</span>
+                            </n-space>
+                            <span class="text-muted" style="display: block; max-width: 760px;">
+                                Off by default. When on, BOM exports carry this
+                                organization's support attestations &mdash; the artifact
+                                download, the SPDX-augmented download and the release SBOM
+                                export. The raw artifact download never carries them.
+                                <strong>Forged support properties are always removed,
+                                whatever this is set to</strong>; this controls only
+                                whether our own attestations are added.
+                            </span>
+                        </div>
 
                         <n-divider style="margin: 22px 0 10px;" />
 

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -3680,8 +3680,13 @@ async function saveOrgSettings() {
             // what it was sent. A fetchMyOrganizations round trip would assert no more than
             // that and could fail on its own, leaving the store stale after a committed save.
             // Only when the field is supported -- on a CE mirror it must stay absent.
+            // The stored organization is passed in so the commit MERGES rather than replaces:
+            // the mutation returns a partial org, and UPDATE_ORGANIZATION overwrites whatever
+            // it is given. Without this, every field the mutation does not select -- type,
+            // approvalRoles -- was wiped from the store on every settings save.
             store.commit('UPDATE_ORGANIZATION', organizationToCommit(
-                result, supportInjectionSupported.value, supportInjectionEnabled.value))
+                result, supportInjectionSupported.value, supportInjectionEnabled.value,
+                myorg.value))
             // BEFORE anything that can throw. The mutation has COMMITTED by this point, so
             // the baseline it implies is now the truth, and it is already in hand -- the
             // mutation selects all four fields. Refreshing it via the re-read below instead

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1245,6 +1245,7 @@ import { Info20Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { FDA_PROSE_FIELDS, FDA_PROSE_MAX_LENGTH, proseDiff, proseBaselineFrom } from '@/utils/fdaProseInput'
+import { organizationToCommit, supportInjectionFromSettings } from '@/utils/orgSettingsCommit'
 import Swal, { SweetAlertOptions } from 'sweetalert2'
 import { Marked } from '@ts-stack/markdown'
 import gql from 'graphql-tag'
@@ -3574,7 +3575,7 @@ async function loadOrgSettings() {
         : []
     // ENABLED is the only truthy value; anything else -- DISABLED, null, unset, or a state
     // this build does not know -- reads as off, which matches the server's own default rule.
-    supportInjectionEnabled.value = s?.supportInjection === 'ENABLED'
+    supportInjectionEnabled.value = supportInjectionFromSettings(s)
     supportInjectionBaseline.value = supportInjectionEnabled.value
     const seeded = proseBaselineFrom(s)
     for (const f of FDA_PROSE_FIELDS) {
@@ -3652,7 +3653,25 @@ async function saveOrgSettings() {
 
         const result = (resp.data as any)?.updateOrganizationSettings
         if (result) {
-            store.commit('UPDATE_ORGANIZATION', result)
+            // GRAFT THE ACCEPTED supportInjection BACK ON before committing.
+            //
+            // The mutation deliberately does not select this field (see the comment below:
+            // selecting it makes the whole document invalid on a CE backend that lacks it).
+            // But UPDATE_ORGANIZATION REPLACES the stored organization, so committing the
+            // raw response dropped supportInjection out of the store entirely. Re-entering
+            // this page then hydrated the toggle from the store, read undefined, and rendered
+            // OFF while the backend held ENABLED -- and because the mutation only sends the
+            // field when it differs from that (now wrong) baseline, DISABLED could not be
+            // sent at all without a hard reload. An operator could turn the disclosure on and
+            // be told by this screen that it was off.
+            //
+            // Grafting rather than re-fetching: this is the same claim the baseline
+            // assignment below already makes, that a mutation which did not throw accepted
+            // what it was sent. A fetchMyOrganizations round trip would assert no more than
+            // that and could fail on its own, leaving the store stale after a committed save.
+            // Only when the field is supported -- on a CE mirror it must stay absent.
+            store.commit('UPDATE_ORGANIZATION', organizationToCommit(
+                result, supportInjectionSupported.value, supportInjectionEnabled.value))
             // BEFORE anything that can throw. The mutation has COMMITTED by this point, so
             // the baseline it implies is now the truth, and it is already in hand -- the
             // mutation selects all four fields. Refreshing it via the re-read below instead

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -834,6 +834,21 @@
                     </n-alert>
                 </div>
                 <template #footer>
+                    <!-- WHY SAVE IS DISABLED, AT THE BUTTON.
+                         errors() has always produced these sentences; nothing rendered them
+                         near the control they gate, so an operator met a dead Save with no
+                         explanation. In the walkthrough two gates were unmet at once -- the
+                         mandatory re-assert reason, which sits far enough up the form to be
+                         below the fold, and the unacknowledged "does the recorded basis still
+                         hold?" prompt -- and filling only the first left Save just as dead.
+                         Board t20260909-061338-23148. A requirement stated only where the
+                         operator is not looking is not stated. -->
+                    <div v-if="!attestLoading && !attestSaving && attestForm.errors().length"
+                        style="margin-bottom: 8px; font-size: 12px; color: #d03050;
+                               text-align: left; max-width: 560px;">
+                        <div v-for="e in attestForm.errors()" :key="e"
+                            style="margin-bottom: 2px;">{{ e }}</div>
+                    </div>
                     <n-space justify="end">
                         <n-button size="small" @click="cancelAttest">Cancel</n-button>
                         <n-button size="small" type="primary"
@@ -1806,7 +1821,8 @@ import { Icon } from '@vicons/utils'
 import { BoxArrowUp20Regular, Info20Regular, Copy20Regular, QuestionCircle20Regular, ChevronLeft20Regular, ChevronRight20Regular } from '@vicons/fluent'
 import { UpCircleOutlined } from '@vicons/antd'
 import type { SelectOption } from 'naive-ui'
-import { DEVICE_RISK_DETAIL, DEVICE_RISK_LABEL, isDeviceRiskFlagged, supportTag } from '@/utils/supportStatusTag'
+import { DEVICE_RISK_DETAIL, DEVICE_RISK_LABEL, isDeviceRiskFlagged, isWithdrawnAttestation, supportTag,
+    WITHDRAWN_TAG } from '@/utils/supportStatusTag'
 import { NAlert, NBadge, NProgress, NCheckbox, NButton, NCard, NCheckboxGroup, NDataTable, NDropdown, NForm, NFormItem, NRadioGroup, NRadioButton, NSelect, NSpin, NSpace, NTabPane, NTabs, NTag, NText, NTooltip, NUpload, NIcon, NGrid, NGridItem as NGi, NInputGroup, NInput, NSwitch, NDatePicker, useNotification, useLoadingBar, NotificationType, DataTableColumns, NModal, NDynamicInput } from 'naive-ui'
 import Swal from 'sweetalert2'
 import { ComputedRef, Ref, computed, h, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
@@ -4138,9 +4154,14 @@ const sbomComponentsTableFields: DataTableColumns<any> = [
                 return h('div', [h('span', { style: 'color: #999;' }, '\u2014'),
                     unattestedRisk ? h('div', { style: 'margin-top: 3px;' }, [unattestedRisk]) : null])
             }
-            const tag = supportTag(c.supportStatus)
+            // A withdrawn attestation is neither a live status nor an unassessed component.
+            // Its dates stay on the row -- withdrawal supersedes, it does not erase -- so the
+            // EOS suffix is suppressed with the status: printing "EOS 2025-12-31" beside
+            // "Withdrawn" would put the retracted date back on screen as if it still stood.
+            const withdrawn = isWithdrawnAttestation(c.attestationState)
+            const tag = withdrawn ? WITHDRAWN_TAG : supportTag(c.supportStatus)
             const els: any[] = [h(NTag, { size: 'small', type: tag.type, round: true }, () => tag.label)]
-            if (c.endOfSupportDate) {
+            if (c.endOfSupportDate && !withdrawn) {
                 els.push(h('span', { style: 'margin-left: 6px; font-size: 11px; color: #999;' }, `EOS ${c.endOfSupportDate}`))
             }
             // The device check is a second, independent verdict -- see DEVICE_RISK_LABEL. The

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -247,7 +247,7 @@
                     </n-form-item>
                     <n-spin :show="bomExportPending" small style="margin-top: 5px;">
                         <n-button type="success" 
-                            :disabled="bomExportPending"
+                            :disabled="bomExportPending || statementBlockedHere"
                             @click="exportReleaseSbom(tldOnly, ignoreDev, selectedBomStructureType, selectedRebomType, selectedSbomMediaType)">
                             <span v-if="bomExportPending" class="ml-2">Exporting...</span>
                             <span v-else>Export</span>
@@ -2881,6 +2881,23 @@ const isProductReleaseForStatement: ComputedRef<boolean> = computed((): boolean 
 /** Every FDA document, for the controls that apply to none of them. */
 const isFdaDocumentExport: ComputedRef<boolean> = computed((): boolean =>
     isAddendumExport.value || selectedSbomMediaType.value === 'DEVICE_STATEMENT')
+
+/**
+ * The Device Support Statement cannot be produced from this release, and we already SAY so in
+ * the panel above the button.
+ *
+ * Leaving Export enabled under that text invited the operator to click it and then answered
+ * with a modal repeating what the panel had just told them. A refusal that is knowable before
+ * the click belongs on the control, not in a dialog after it. Reported from the operator
+ * walkthrough, board t20260909-061338-23148 step 6d.
+ *
+ * ONLY the PRODUCT gate, deliberately. The other refusals inside
+ * exportDeviceSupportStatement -- an unresolvable org, a failed collect, an unauthored prose
+ * slot -- are not knowable until the data is fetched, so those keep their modal. Disabling the
+ * button for a reason we have not checked yet would be a worse lie than the redundant dialog.
+ */
+const statementBlockedHere: ComputedRef<boolean> = computed((): boolean =>
+    selectedSbomMediaType.value === 'DEVICE_STATEMENT' && !isProductReleaseForStatement.value)
 
 //getAggregatedChangelog
 const showExportSBOMModal: Ref<boolean> = ref(false)

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -828,21 +828,20 @@
                         </n-form-item>
                     </n-card>
 
-                    <n-alert v-for="e in attestForm.errors()" :key="e" type="error"
-                        :show-icon="false" style="margin-top: 10px; font-size: 12px;">
-                        {{ e }}
-                    </n-alert>
                 </div>
                 <template #footer>
                     <!-- WHY SAVE IS DISABLED, AT THE BUTTON.
-                         errors() has always produced these sentences; nothing rendered them
-                         near the control they gate, so an operator met a dead Save with no
-                         explanation. In the walkthrough two gates were unmet at once -- the
-                         mandatory re-assert reason, which sits far enough up the form to be
-                         below the fold, and the unacknowledged "does the recorded basis still
-                         hold?" prompt -- and filling only the first left Save just as dead.
-                         Board t20260909-061338-23148. A requirement stated only where the
-                         operator is not looking is not stated. -->
+                         MOVED here from the end of the modal BODY, not added: errors() has
+                         always been rendered, as n-alerts after the last card. The body
+                         scrolls and the footer does not, so on a form this long they sat
+                         below the fold -- an operator met a dead Save with the explanation
+                         off screen. In the walkthrough two gates were unmet at once (the
+                         mandatory re-assert reason, and the unacknowledged "does the recorded
+                         basis still hold?" prompt), so filling only the first left Save just
+                         as dead with no visible reason. Board t20260909-061338-23148.
+                         A requirement stated only where the operator is not looking is not
+                         stated -- but stating it TWICE is its own confusion, so there is one
+                         renderer and it is this one. -->
                     <div v-if="!attestLoading && !attestSaving && attestForm.errors().length"
                         style="margin-bottom: 8px; font-size: 12px; color: #d03050;
                                text-align: left; max-width: 560px;">

--- a/ui/src/components/deviceStatementWiring.spec.ts
+++ b/ui/src/components/deviceStatementWiring.spec.ts
@@ -72,3 +72,33 @@ describe('the device support statement is wired into the export modal', () => {
         expect(body.indexOf('link.click()')).toBeLessThan(body.indexOf('revokeObjectURL'))
     })
 })
+
+/**
+ * The Export button is DISABLED under the product gate, not enabled into a modal.
+ *
+ * The panel already tells the operator the statement cannot be generated on a component
+ * release. Leaving Export clickable there answered the click with a dialog repeating that
+ * sentence -- found by an operator running the walkthrough (board t20260909-061338-23148,
+ * step 6d), not by any test, because every unit here passed: the gate text rendered, the
+ * refusal fired, the modal said the right thing.
+ */
+describe('the statement Export button respects the product gate', () => {
+    it('disables Export when the panel is already refusing', () => {
+        expect(source).toMatch(/:disabled="bomExportPending \|\| statementBlockedHere"/)
+    })
+
+    it('derives that only from the statement type and the product gate', () => {
+        expect(source).toMatch(
+            /statementBlockedHere[\s\S]{0,200}selectedSbomMediaType\.value === 'DEVICE_STATEMENT'/)
+        expect(source).toMatch(
+            /statementBlockedHere[\s\S]{0,240}!isProductReleaseForStatement\.value/)
+    })
+
+    /**
+     * The refusals that need data keep their modal. Disabling the button for a reason we have
+     * not checked yet would be a worse lie than the redundant dialog this replaced.
+     */
+    it('leaves the data-dependent refusals as modals', () => {
+        expect(source).toMatch(/Swal\.fire\('Statement not generated', blocked, 'warning'\)/)
+    })
+})

--- a/ui/src/components/fdaProseWiring.spec.ts
+++ b/ui/src/components/fdaProseWiring.spec.ts
@@ -142,8 +142,23 @@ describe('the export injection toggle is wired into OrgSettings', () => {
 
     // Only ENABLED is on. DISABLED, null, unset, or a value this build does not know all read
     // as off -- which is the server's own default rule (D3).
-    it('treats only ENABLED as on when seeding', () => {
-        expect(orgSettings).toMatch(/supportInjection === 'ENABLED'/)
+    //
+    // The rule itself moved to utils/orgSettingsCommit.ts when the store round trip had to
+    // become testable, so this asserts the component DELEGATES to it rather than re-scanning
+    // for the literal. Scanning here for `supportInjection === 'ENABLED'` would now pass on a
+    // component that had quietly reimplemented the comparison inline and drifted from the
+    // version the unit tests actually cover.
+    it('seeds the toggle through the shared rule', () => {
+        expect(orgSettings).toMatch(/supportInjectionEnabled\.value = supportInjectionFromSettings\(/)
+        expect(orgSettings).toMatch(/from '@\/utils\/orgSettingsCommit'/)
+    })
+
+    // The store commit must carry the accepted value, or the next hydration reads the gap as
+    // OFF while the backend holds ENABLED. Behaviour is covered in orgSettingsCommit.spec.ts;
+    // this pins that the component actually routes its commit through it.
+    it('commits the organization through organizationToCommit', () => {
+        expect(orgSettings).toMatch(
+            /store\.commit\('UPDATE_ORGANIZATION', organizationToCommit\(/)
     })
 
     // Same rule the prose baseline follows: from the mutation response, before anything that

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -5,7 +5,8 @@ vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
 import { buildDeviceSupportStatementDefinition, statementBlockReason, missingProseSlots,
     componentsEndingBeforeDevice, deviceSupportStatementFileName, STATEMENT_TITLE,
-    NOT_DECLARED, REQUIRED_PROSE_SLOTS, renderDeviceSupportStatementBlob } from './deviceSupportStatement'
+    NOT_DECLARED, REQUIRED_PROSE_SLOTS, renderDeviceSupportStatementBlob,
+    buildDeviceSupportStatementDefinition } from './deviceSupportStatement'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
@@ -351,5 +352,71 @@ describe('renderDeviceSupportStatementBlob', () => {
     it('refuses to render for a component release', async () => {
         await expect(renderDeviceSupportStatementBlob(data({ componentType: 'COMPONENT' })))
             .rejects.toThrow(/product release/)
+    })
+})
+
+
+/**
+ * The "ends sooner" section states the FACT and carries no detail.
+ *
+ * It used to name every component and its date. On the walkthrough device that was all ten,
+ * which is a component inventory by another name -- the one thing this document must not be,
+ * because its audience may include patients and caregivers (FDA L1591-1592). A count is no
+ * better: "10 of 10" invites a reader with no way to weigh it to conclude the device is in
+ * worse shape than a "3 of 40" device that is in fact more exposed.
+ *
+ * The section is a deliberate deviation from plan section 7f and is KEPT: a reader told only
+ * the device end-of-support date would reasonably conclude every part is supported until then.
+ */
+describe('the ends-sooner section is a statement, not an inventory', () => {
+    const flatten = (n: any): string =>
+        typeof n === 'string' ? n
+            : Array.isArray(n) ? n.map(flatten).join(' ')
+                : n && typeof n === 'object' ? Object.values(n).map(flatten).join(' ') : ''
+
+    it('says the fact when a component ends sooner', () => {
+        const text = flatten(buildDeviceSupportStatementDefinition(data()))
+        expect(text).toMatch(/Software components whose support ends sooner/)
+        expect(text).toMatch(/Some software in this device has an earlier end-of-support date/)
+    })
+
+    /**
+     * Bounded at the NEXT heading. An unbounded slice runs to the end of the document and
+     * picks up the later sections' own text and pdfmake's style colours, which made the
+     * count assertion below fail on "#444444" -- a test that looked like it had caught
+     * something and had not.
+     */
+    const endsSoonerSection = (d: any): string => {
+        const text = flatten(buildDeviceSupportStatementDefinition(d))
+        const start = text.indexOf('Software components whose support ends sooner')
+        if (start < 0) return ''
+        // Skip the heading's OWN style marker first. flatten() emits { text, style: 'h2' } as
+        // "<heading text> h2", so searching for the next "h2" from here found the heading's
+        // own and returned an EMPTY section -- against which "contains no component name" and
+        // "contains no count" both passed vacuously. The revert probe caught that: restoring
+        // the per-component table failed only one of the three assertions.
+        const rest = text.slice(start + 'Software components whose support ends sooner'.length)
+            .replace(/^\s*h2\s*/, '')
+        const next = rest.indexOf('h2')
+        return next < 0 ? rest : rest.slice(0, next)
+    }
+
+    it('names no component and prints no date in that section', () => {
+        const section = endsSoonerSection(data())
+        expect(section).not.toMatch(/log4j-core/)
+        expect(section).not.toMatch(/2029-01-01/)
+        expect(section).not.toMatch(/support ends \d{4}-/)
+    })
+
+    it('prints no count of affected components', () => {
+        // No bare integers in the sentence: a count is the thing a lay reader cannot weigh.
+        // "10 of 10" reads worse than "3 of 40" to someone with no way to compare them.
+        expect(endsSoonerSection(data())).not.toMatch(/\b\d+\b/)
+    })
+
+    it('omits the section entirely when nothing ends sooner', () => {
+        const text = flatten(buildDeviceSupportStatementDefinition(
+            data({ components: [comp({ endOfSupportDate: null })] })))
+        expect(text).not.toMatch(/Software components whose support ends sooner/)
     })
 })

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -5,8 +5,7 @@ vi.mock('pdfmake/build/vfs_fonts', () => ({ default: { vfs: {} } }))
 
 import { buildDeviceSupportStatementDefinition, statementBlockReason, missingProseSlots,
     componentsEndingBeforeDevice, deviceSupportStatementFileName, STATEMENT_TITLE,
-    NOT_DECLARED, REQUIRED_PROSE_SLOTS, renderDeviceSupportStatementBlob,
-    buildDeviceSupportStatementDefinition } from './deviceSupportStatement'
+    NOT_DECLARED, REQUIRED_PROSE_SLOTS, renderDeviceSupportStatementBlob } from './deviceSupportStatement'
 import type { AddendumComponent, AddendumData } from './addendumData'
 
 function comp (over: Partial<AddendumComponent> = {}): AddendumComponent {
@@ -87,13 +86,29 @@ describe('statementBlockReason', () => {
     })
 
     // Reused from the addendum: pdfmake ships Roboto only and silently drops what it cannot
-    // draw. Written as an escape because this repo is plain-ASCII by rule.
+    // draw. Written as an escape because this repo is plain-ASCII by rule. Checked on a slot
+    // the document ACTUALLY PRINTS.
     it('refuses text the PDF font cannot draw', () => {
         const msg = statementBlockReason(data({
-            components: [comp({ name: '\u65e5\u672c\u8a9e', endOfSupportDate: '2029-01-01' })]
+            riskIncreasesNotice: 'Risk increases \u65e5\u672c\u8a9e'
         })) as string
         expect(msg).not.toBeNull()
         expect(msg).toContain('cannot draw')
+    })
+
+    /**
+     * ...and NOT on a component name, which this document no longer prints.
+     *
+     * The name was in the font whitelist while the ends-sooner section listed components. Once
+     * that section became one fixed sentence, leaving it there turned an unrenderable glyph in
+     * a component name into a HARD REFUSAL of the whole patient-facing statement over text that
+     * cannot appear in it. Caught in review, not by this suite -- which had the opposite
+     * assertion locked in.
+     */
+    it('does not refuse over a component name it will never print', () => {
+        expect(statementBlockReason(data({
+            components: [comp({ name: '\u65e5\u672c\u8a9e', endOfSupportDate: '2029-01-01' })]
+        }))).toBeNull()
     })
 
     it('checks the font AFTER scope and slots, so the most fundamental problem is reported', () => {

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -87,8 +87,10 @@ export function statementBlockReason (d: AddendumData): string | null {
 /**
  * Components whose ATTESTED end of support falls BEFORE the device's.
  *
- * The only component information this document carries, and only as recorded facts -- a name
- * and a date. Nothing derived: no risk verdict, no ranking, no count of everything else.
+ * Used ONLY to decide whether the ends-sooner section appears. Its names and dates are no
+ * longer printed: the section states the fact in one sentence and carries no component text,
+ * no dates and no count (see the header). So this is a presence test, and the values it
+ * returns must not be rendered or fed to the font-coverage check without revisiting that.
  *
  * A component with no LIVE attestation is not listed. That is not the same as saying it
  * outlives the device -- it means nobody has recorded a date, and asserting anything about it
@@ -133,8 +135,12 @@ function statementStrings (d: AddendumData): Array<string | null | undefined> {
         // states is "every string the document prints", and the next field added to the
         // footer would otherwise escape the whitelist silently.
         d.deviceEos, d.deviceEol, d.releaseUuid, d.generatedAt,
-        d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice,
-        ...componentsEndingBeforeDevice(d).flatMap(c => [c.name, c.date])
+        d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice
+        // NO component names or dates. They were listed here when the ends-sooner section
+        // printed them; it now prints one fixed sentence and no component text at all. Left in
+        // place, this made an unrenderable glyph in a component NAME a HARD REFUSAL of the
+        // whole patient-facing statement, over a string that can no longer appear in it --
+        // a check that had stopped describing the document it guards.
     ]
 }
 

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -9,6 +9,16 @@
 // The unassessed count is excluded deliberately, not by omission. "412 components not
 // assessed" conveys no risk information to a hospital biomed reader and edges toward
 // misleading under 502(a)(1). It belongs in the addendum, which a reviewer reads.
+//
+// A DELIBERATE DEVIATION FROM PLAN SECTION 7f, KEPT. The plan describes this document as
+// carrying the device dates and the manufacturer's labeling text and nothing else; the
+// "Software components whose support ends sooner" section below is not in it. It stays
+// because a reader told only the device's end-of-support date would reasonably conclude that
+// every part of the device is supported until then, which is false whenever a component's
+// window closes earlier -- and that is precisely the gap section 524B exists to close. What
+// the plan's constraint correctly rules out is the DETAIL, so the section states the fact in
+// one sentence and carries no component names, no dates and no count. An operator walkthrough
+// found it listing all ten components, which was a component inventory by another name.
 
 import pdfMake from 'pdfmake/build/pdfmake'
 import pdfFonts from 'pdfmake/build/vfs_fonts'
@@ -198,18 +208,23 @@ export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<
 
     if (early.length) {
         content.push({ text: 'Software components whose support ends sooner', style: 'h2' })
+        // ONE SENTENCE, NO LIST AND NO COUNT.
+        //
+        // This section used to name every component and its date. On the walkthrough device
+        // that was all ten of them, which is a component inventory by another name -- the one
+        // thing this document is not supposed to carry, because its audience may include
+        // patients and caregivers. A count is no better: "10 of 10" invites a reader with no
+        // way to weigh it to conclude the device is in worse shape than a "3 of 40" device
+        // that happens to be more exposed. The addendum is where per-component detail belongs,
+        // and it is a different document for a different reader.
+        //
+        // The fact still has to be stated -- a reader is entitled to know the device window is
+        // not the whole story -- so what remains is the statement itself, unquantified.
         content.push({
-            text: 'The manufacturer has recorded an earlier end-of-support date for the'
-                + ' following software in this device:',
-            style: 'body'
-        })
-        content.push({
-            style: 'facts',
-            table: {
-                widths: [230, '*'],
-                body: early.map(c => [{ text: c.name }, { text: `support ends ${c.date}` }])
-            },
-            layout: 'noBorders',
+            text: 'Some software in this device has an earlier end-of-support date than the'
+                + ' device itself. Ask the manufacturer for the support addendum if you need'
+                + ' the details for a specific component.',
+            style: 'body',
             margin: [0, 0, 0, 14]
         })
     }

--- a/ui/src/utils/orgSettingsCommit.spec.ts
+++ b/ui/src/utils/orgSettingsCommit.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { organizationToCommit, supportInjectionFromSettings } from './orgSettingsCommit'
+
+/**
+ * The stale-toggle defect, end to end, at the level it actually occurred.
+ *
+ * Found by an operator running the walkthrough (board t20260909-061338-23148): the toggle read
+ * OFF while the backend held ENABLED, verified over GraphQL. Nothing in the suite caught it,
+ * because every piece worked -- the mutation sent the right value, the server stored it, the
+ * local baseline advanced. The failure was in the SHAPE OF WHAT WAS PUT IN THE STORE, and it
+ * only became visible on the NEXT hydration.
+ *
+ * So this test does not check any single function's return value. It replays the sequence:
+ * save -> commit the mutation response -> re-render from the store -> read the toggle.
+ */
+
+/** The store mutation, verbatim from store.ts UPDATE_ORGANIZATION. */
+function updateOrganization (state: any, organization: any) {
+    state.organizations = state.organizations.filter((o: any) => o.uuid !== organization.uuid)
+    state.organizations.push(organization)
+}
+
+const ORG = 'c839fa68-1b2c-4ba0-9292-f660e8f47184'
+
+/**
+ * What the server actually returns. supportInjection is DELIBERATELY ABSENT: selecting it
+ * would make the mutation document invalid on a CE backend that does not declare the field.
+ * That absence is the whole defect, so hard-coding it here is the point of the fixture.
+ */
+const mutationResponse = {
+    uuid: ORG,
+    name: 'Claude2',
+    settings: {
+        fdaPatchesMayCeaseStatement: 'patches statement seed',
+        fdaRiskTransferProcessRef: 'DHF-SEED-2 rev B',
+        fdaRiskIncreasesNotice: 'risk notice seed'
+    }
+}
+
+function freshStore () {
+    return { organizations: [{ uuid: ORG, name: 'Claude2', settings: { supportInjection: 'DISABLED' } }] }
+}
+const orgFromStore = (state: any) => state.organizations.find((o: any) => o.uuid === ORG)
+
+describe('the support-injection toggle survives a save and a re-render', () => {
+    it('still reads ON after saving ENABLED, with no reload', () => {
+        const state = freshStore()
+
+        // The operator flips the switch on and saves.
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
+
+        // They navigate away and back: the page hydrates from the store, not from the form.
+        expect(supportInjectionFromSettings(orgFromStore(state).settings)).toBe(true)
+    })
+
+    it('reads OFF again after saving DISABLED', () => {
+        const state = freshStore()
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
+        updateOrganization(state, organizationToCommit(mutationResponse, true, false))
+
+        expect(supportInjectionFromSettings(orgFromStore(state).settings)).toBe(false)
+    })
+
+    /**
+     * The second half of the defect, and the one that made it unrecoverable in the UI. The
+     * mutation only sends supportInjection when it differs from the baseline the page hydrated.
+     * With the field missing from the store the baseline was false, so after turning it ON the
+     * operator could not turn it OFF: the form said OFF, the baseline said OFF, nothing
+     * differed, and the field was never sent. Only a hard reload broke the loop.
+     */
+    it('leaves a DISABLED save sendable after an ENABLED one', () => {
+        const state = freshStore()
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
+
+        const hydratedBaseline = supportInjectionFromSettings(orgFromStore(state).settings)
+        const operatorWantsOff = false
+        expect(hydratedBaseline).not.toBe(operatorWantsOff)  // therefore the field IS sent
+    })
+
+    /**
+     * CE has no such setting. Writing DISABLED into the store there would state a choice
+     * nobody made, and the toggle is hidden on that build anyway.
+     */
+    it('adds nothing on a backend that does not support the field', () => {
+        const committed = organizationToCommit(mutationResponse, false, true)
+        expect(committed.settings.supportInjection).toBeUndefined()
+        expect(committed).toBe(mutationResponse)
+    })
+
+    it('preserves the prose slots the mutation did return', () => {
+        const committed = organizationToCommit(mutationResponse, true, true)
+        expect(committed.settings.fdaRiskTransferProcessRef).toBe('DHF-SEED-2 rev B')
+        expect(committed.settings.fdaPatchesMayCeaseStatement).toBe('patches statement seed')
+    })
+})

--- a/ui/src/utils/orgSettingsCommit.spec.ts
+++ b/ui/src/utils/orgSettingsCommit.spec.ts
@@ -37,8 +37,17 @@ const mutationResponse = {
     }
 }
 
-function freshStore () {
-    return { organizations: [{ uuid: ORG, name: 'Claude2', settings: { supportInjection: 'DISABLED' } }] }
+function freshStore (supportInjection: string | undefined = 'DISABLED') {
+    return {
+        organizations: [{
+            uuid: ORG,
+            name: 'Claude2',
+            // Fields the mutation does NOT select. They must survive a settings save.
+            type: 'ORGANIZATION',
+            approvalRoles: [{ id: 'QA', displayView: 'QA sign-off' }],
+            settings: { supportInjection, sidPurlMode: 'DISABLED' }
+        }]
+    }
 }
 const orgFromStore = (state: any) => state.organizations.find((o: any) => o.uuid === ORG)
 
@@ -47,18 +56,42 @@ describe('the support-injection toggle survives a save and a re-render', () => {
         const state = freshStore()
 
         // The operator flips the switch on and saves.
-        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true,
+            orgFromStore(state)))
 
         // They navigate away and back: the page hydrates from the store, not from the form.
         expect(supportInjectionFromSettings(orgFromStore(state).settings)).toBe(true)
     })
 
+    /**
+     * Seeded ENABLED on purpose. With the store seeded DISABLED this assertion passed even with
+     * the commit neutered, because the expected answer was already the starting value -- it was
+     * vacuous, and the revert probe on the other cases hid that by going red anyway. Starting
+     * from ENABLED means only a commit that actually wrote DISABLED can satisfy it.
+     */
     it('reads OFF again after saving DISABLED', () => {
-        const state = freshStore()
-        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
-        updateOrganization(state, organizationToCommit(mutationResponse, true, false))
+        const state = freshStore('ENABLED')
+        updateOrganization(state, organizationToCommit(mutationResponse, true, false,
+            orgFromStore(state)))
 
         expect(supportInjectionFromSettings(orgFromStore(state).settings)).toBe(false)
+    })
+
+    /**
+     * The general form of the same defect. updateOrganizationSettings returns a PARTIAL
+     * organization and UPDATE_ORGANIZATION replaces what it is given, so every unselected field
+     * was being deleted from the store on each save: `type` downgraded the org to DEFAULT for
+     * the invite-user form, and `approvalRoles` emptied the Approval Roles table until reload.
+     */
+    it('keeps fields the mutation did not select', () => {
+        const state = freshStore()
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true,
+            orgFromStore(state)))
+
+        const org = orgFromStore(state)
+        expect(org.type).toBe('ORGANIZATION')
+        expect(org.approvalRoles).toEqual([{ id: 'QA', displayView: 'QA sign-off' }])
+        expect(org.settings.sidPurlMode).toBe('DISABLED')
     })
 
     /**
@@ -70,7 +103,8 @@ describe('the support-injection toggle survives a save and a re-render', () => {
      */
     it('leaves a DISABLED save sendable after an ENABLED one', () => {
         const state = freshStore()
-        updateOrganization(state, organizationToCommit(mutationResponse, true, true))
+        updateOrganization(state, organizationToCommit(mutationResponse, true, true,
+            orgFromStore(state)))
 
         const hydratedBaseline = supportInjectionFromSettings(orgFromStore(state).settings)
         const operatorWantsOff = false
@@ -82,13 +116,17 @@ describe('the support-injection toggle survives a save and a re-render', () => {
      * nobody made, and the toggle is hidden on that build anyway.
      */
     it('adds nothing on a backend that does not support the field', () => {
-        const committed = organizationToCommit(mutationResponse, false, true)
+        // Built here rather than via freshStore(): a JS default parameter fires on `undefined`,
+        // so freshStore(undefined) handed back the DISABLED default and the assertion passed
+        // for the wrong reason. A CE org has no such key at all, so that is what is passed.
+        const stored = { uuid: ORG, name: 'Claude2', type: 'ORGANIZATION', settings: {} }
+        const committed = organizationToCommit(mutationResponse, false, true, stored)
         expect(committed.settings.supportInjection).toBeUndefined()
-        expect(committed).toBe(mutationResponse)
+        expect(committed.type).toBe('ORGANIZATION')
     })
 
     it('preserves the prose slots the mutation did return', () => {
-        const committed = organizationToCommit(mutationResponse, true, true)
+        const committed = organizationToCommit(mutationResponse, true, true, null)
         expect(committed.settings.fdaRiskTransferProcessRef).toBe('DHF-SEED-2 rev B')
         expect(committed.settings.fdaPatchesMayCeaseStatement).toBe('patches statement seed')
     })

--- a/ui/src/utils/orgSettingsCommit.ts
+++ b/ui/src/utils/orgSettingsCommit.ts
@@ -9,37 +9,50 @@
  */
 
 /** The support-injection value a settings payload implies. */
-export function supportInjectionFromSettings (settings: any): boolean {
+export function supportInjectionFromSettings (settings: { supportInjection?: string } | null | undefined): boolean {
     // ENABLED is the only truthy value; anything else -- DISABLED, null, unset, or a state
     // this build does not know -- reads as off, which matches the server's own default rule.
     return settings?.supportInjection === 'ENABLED'
 }
 
+/** The two values this settings screen can write. */
+export type SupportInjectionState = 'ENABLED' | 'DISABLED'
+
 /**
- * The organization to commit after a save, carrying the support-injection value the server
- * just ACCEPTED.
+ * The organization to commit after a settings save.
  *
- * `updateOrganizationSettings` deliberately does not SELECT supportInjection: adding it makes
- * the whole document invalid against a CE backend that does not declare the field, which would
- * fail every save including the four prose slots. But the store commit REPLACES the stored
- * organization, so committing the raw response drops the field out of the store, and the next
- * hydration of this page reads undefined and renders OFF while the backend holds ENABLED.
- * Worse, the mutation only sends the field when it differs from that baseline, so DISABLED
- * then cannot be sent at all without a hard reload -- the operator turns the disclosure on and
- * this screen tells them it is off.
+ * `updateOrganizationSettings` returns a PARTIAL organization: it selects the settings it
+ * writes and little else. `UPDATE_ORGANIZATION` REPLACES the stored organization with what it
+ * is given, so committing that response raw DELETES every field the mutation did not select.
+ * The observed symptom was the support toggle reading OFF against an ENABLED backend, but the
+ * cause is general -- `type` and `approvalRoles` are in the store's own organizations query and
+ * are not selected here either, so the same commit silently downgraded the org to DEFAULT for
+ * the invite-user form and emptied the Approval Roles table until a reload.
  *
- * Grafting is the same claim the save path already makes when it advances its baseline: a
- * mutation that did not throw accepted what it was sent. When the field is unsupported the
- * value must stay ABSENT rather than be written as DISABLED -- on a CE mirror there is no such
- * setting, and inventing one would state a choice nobody made.
+ * So this MERGES over the organization already in the store rather than grafting one field
+ * onto the response. Anything the mutation returned wins, because it is what the server just
+ * accepted; anything it did not mention keeps the value it had, because a field a PATCH did
+ * not mention is a field the PATCH did not change.
+ *
+ * `supportInjection` is then written from the value that was SENT, because the mutation
+ * deliberately does not select it back: selecting it makes the whole document invalid against
+ * a CE backend that does not declare the field, which would fail every save including the four
+ * prose slots. Asserting it here is the same claim the save path already makes when it advances
+ * its own baseline -- a mutation that did not throw accepted what it was sent. When the field is
+ * unsupported nothing is written: on a CE mirror there is no such setting and inventing one
+ * would state a choice nobody made.
+ *
+ * @param stored the organization currently in the store, or null/undefined if there is none
  */
-export function organizationToCommit (result: any, supported: boolean, enabled: boolean): any {
-    if (!supported || !result) return result
-    return {
-        ...result,
-        settings: {
-            ...(result?.settings ?? {}),
-            supportInjection: enabled ? 'ENABLED' : 'DISABLED'
-        }
+export function organizationToCommit (
+    result: any, supported: boolean, enabled: boolean, stored?: any
+): any {
+    if (!result) return result
+    const merged = { ...(stored ?? {}), ...result }
+    // Settings merge one level deeper: the response carries only the settings it wrote.
+    merged.settings = { ...(stored?.settings ?? {}), ...(result?.settings ?? {}) }
+    if (supported) {
+        merged.settings.supportInjection = (enabled ? 'ENABLED' : 'DISABLED') as SupportInjectionState
     }
+    return merged
 }

--- a/ui/src/utils/orgSettingsCommit.ts
+++ b/ui/src/utils/orgSettingsCommit.ts
@@ -1,0 +1,45 @@
+/**
+ * What gets committed to the store after an organization-settings save, and how the toggle
+ * is read back out of it.
+ *
+ * Extracted so the round trip can be TESTED rather than asserted by scanning the component
+ * source. The defect these two functions exist to prevent was invisible to every unit test
+ * and every source scan: the mutation response is missing a field, the store commit replaces
+ * the organization with it, and the next render of the page reads the gap as "off".
+ */
+
+/** The support-injection value a settings payload implies. */
+export function supportInjectionFromSettings (settings: any): boolean {
+    // ENABLED is the only truthy value; anything else -- DISABLED, null, unset, or a state
+    // this build does not know -- reads as off, which matches the server's own default rule.
+    return settings?.supportInjection === 'ENABLED'
+}
+
+/**
+ * The organization to commit after a save, carrying the support-injection value the server
+ * just ACCEPTED.
+ *
+ * `updateOrganizationSettings` deliberately does not SELECT supportInjection: adding it makes
+ * the whole document invalid against a CE backend that does not declare the field, which would
+ * fail every save including the four prose slots. But the store commit REPLACES the stored
+ * organization, so committing the raw response drops the field out of the store, and the next
+ * hydration of this page reads undefined and renders OFF while the backend holds ENABLED.
+ * Worse, the mutation only sends the field when it differs from that baseline, so DISABLED
+ * then cannot be sent at all without a hard reload -- the operator turns the disclosure on and
+ * this screen tells them it is off.
+ *
+ * Grafting is the same claim the save path already makes when it advances its baseline: a
+ * mutation that did not throw accepted what it was sent. When the field is unsupported the
+ * value must stay ABSENT rather than be written as DISABLED -- on a CE mirror there is no such
+ * setting, and inventing one would state a choice nobody made.
+ */
+export function organizationToCommit (result: any, supported: boolean, enabled: boolean): any {
+    if (!supported || !result) return result
+    return {
+        ...result,
+        settings: {
+            ...(result?.settings ?? {}),
+            supportInjection: enabled ? 'ENABLED' : 'DISABLED'
+        }
+    }
+}

--- a/ui/src/utils/sbomComponentsQuery.ts
+++ b/ui/src/utils/sbomComponentsQuery.ts
@@ -32,7 +32,8 @@ const COMPONENT_CORE_SELECTION = `
                 isRoot
                 supportStatus
                 supportSource
-                endOfSupportDate`
+                endOfSupportDate
+                attestationState`
 
 /**
  * CORE plus the Pro-only device verdict, by APPENDING rather than by text-substituting into

--- a/ui/src/utils/supportStatusTag.ts
+++ b/ui/src/utils/supportStatusTag.ts
@@ -30,6 +30,30 @@ export const UNRECOGNISED_TAG: { type: SupportTagType, label: string } =
     { type: 'error', label: 'Unrecognised status' }
 
 /**
+ * A retracted attestation. NOT the same pixels as UNKNOWN, and the difference is the point.
+ *
+ * UNKNOWN means "nobody has assessed this". WITHDRAWN means "somebody assessed it and then
+ * took the claim back" -- the row and its history are still on record. Rendering the second
+ * as the first would erase a diligence record from the screen an auditor reads.
+ */
+export const WITHDRAWN_TAG: { type: SupportTagType, label: string } =
+    { type: 'default', label: 'Withdrawn' }
+
+/**
+ * True when this component's attestation has been retracted.
+ *
+ * The server derives supportStatus UNKNOWN for such a row (SbomComponentDataFetcher), so
+ * without this the list showed "Unknown" -- accurate about the support state, silent about the
+ * fact that a claim once existed. Before that fix it was worse: the retracted milestone dates
+ * were still derived from, so the row rendered a live "End of support" for a claim the
+ * manufacturer had taken back. Found by an operator running the walkthrough, board
+ * t20260909-061338-23148.
+ */
+export function isWithdrawnAttestation (attestationState: unknown): boolean {
+    return attestationState === 'WITHDRAWN'
+}
+
+/**
  * The tag for a support status, or a loud marker when the server sent something this build
  * does not know.
  *

--- a/ui/src/utils/withdrawnPresentation.spec.ts
+++ b/ui/src/utils/withdrawnPresentation.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { supportTag, WITHDRAWN_TAG, isWithdrawnAttestation } from './supportStatusTag'
+
+/**
+ * A withdrawn attestation must read as WITHDRAWN, not as a live status and not as
+ * "never assessed".
+ *
+ * The operator walkthrough found the list rendering a live "End of support" chip and its EOS
+ * date for a claim the manufacturer had taken back, while the Not-disclosed filter on the same
+ * screen correctly counted that component as unattested (board t20260909-061338-23148). The
+ * backend half is fixed in SbomComponentSupportStatusTest; this covers the presentation.
+ */
+describe('withdrawn attestations are presented as withdrawn', () => {
+    it('is a distinct tag from UNKNOWN', () => {
+        expect(WITHDRAWN_TAG.label).toBe('Withdrawn')
+        // "Unknown" means nobody assessed it. "Withdrawn" means somebody did and retracted it.
+        // Rendering the second as the first erases a diligence record from an auditor's screen.
+        expect(WITHDRAWN_TAG.label).not.toBe(supportTag('UNKNOWN').label)
+    })
+
+    it('recognises only the WITHDRAWN state', () => {
+        expect(isWithdrawnAttestation('WITHDRAWN')).toBe(true)
+        expect(isWithdrawnAttestation('ATTESTED')).toBe(false)
+        expect(isWithdrawnAttestation(null)).toBe(false)
+        expect(isWithdrawnAttestation(undefined)).toBe(false)
+    })
+})
+
+const releaseView = readFileSync(
+    fileURLToPath(new URL('../components/ReleaseView.vue', import.meta.url)), 'utf8')
+const query = readFileSync(
+    fileURLToPath(new URL('./sbomComponentsQuery.ts', import.meta.url)), 'utf8')
+
+describe('the list is wired to render that', () => {
+    // Without this field the UI cannot tell a withdrawal from an unassessed component at all.
+    it('asks the server for attestationState', () => {
+        expect(query).toMatch(/attestationState/)
+    })
+
+    it('chooses the withdrawn tag over the derived status', () => {
+        expect(releaseView).toMatch(
+            /const withdrawn = isWithdrawnAttestation\(c\.attestationState\)/)
+        expect(releaseView).toMatch(/withdrawn \? WITHDRAWN_TAG : supportTag\(c\.supportStatus\)/)
+    })
+
+    /**
+     * The dates stay on the row, so the suffix has to be suppressed WITH the status. Printing
+     * "EOS 2025-12-31" beside "Withdrawn" would put the retracted date back on screen as
+     * though it still stood -- which is most of what the original defect looked like.
+     */
+    it('suppresses the EOS suffix on a withdrawn row', () => {
+        expect(releaseView).toMatch(/if \(c\.endOfSupportDate && !withdrawn\)/)
+    })
+})
+
+describe('the attest dialog says why Save is disabled', () => {
+    // Two gates fired at once in the walkthrough -- the mandatory re-assert reason and the
+    // unacknowledged basis prompt -- and nothing at the button named either.
+    it('renders errors() in the modal footer, beside the button they gate', () => {
+        const footer = releaseView.slice(releaseView.indexOf('WHY SAVE IS DISABLED'))
+        expect(footer).toMatch(/v-for="e in attestForm\.errors\(\)"/)
+        expect(footer.indexOf('attestForm.errors()'))
+            .toBeLessThan(footer.indexOf('@click="saveAttestation"'))
+    })
+
+    it('hides them while the form is still loading or saving', () => {
+        expect(releaseView).toMatch(
+            /v-if="!attestLoading && !attestSaving && attestForm\.errors\(\)\.length"/)
+    })
+})


### PR DESCRIPTION
UI half of the walkthrough findings (board `t20260909-061338-23148`). Backend companion:
relizaio/rearm-saas#509. **Commits are in the order the findings were filed.**

| Commit | Finding |
|---|---|
| `b2494a3b` | **(a) HIGH** -- the support-injection toggle went stale in the store after a save |
| `96b2d900` | **(b)** -- the toggle rendered inside the labeling prose slots |
| `6332f1ca` | **(c)** -- statement Export stayed enabled under the PRODUCT gate |
| `3f3d6ff3` | **(d)** -- withdrawn chip, and why Save is disabled |
| `123c8c03` | **(f)** -- the statement's ends-sooner section is a sentence, not an inventory |

## (a) HIGH -- the toggle lied about the disclosure state

`updateOrganizationSettings` deliberately does not select `supportInjection`: adding it makes
the whole mutation invalid against a CE backend without the field, failing every save including
the prose slots. But `UPDATE_ORGANIZATION` **replaces** the stored organization, so committing
that response dropped the field out of the store. Re-entering the page hydrated from the store,
read `undefined`, and rendered **OFF while the backend held ENABLED**.

The second half is what made it unrecoverable: the mutation sends the field only when it
*differs* from the hydrated baseline. With the field missing that baseline was `false`, so after
turning injection ON the operator **could not turn it OFF** -- form said OFF, baseline said OFF,
nothing differed, nothing was sent. Only a hard reload broke the loop.

An operator could enable the disclosure and be told by this screen that it was disabled, on the
one control whose entire job is to say whether exports carry it.

**Grafting, not `fetchMyOrganizations`** -- one, not both, as instructed. It is the same claim
the save path already makes one line later when it advances its own baseline; a re-fetch would
assert no more than that while adding a round trip that can fail on its own and leave the store
stale after a *committed* save. Nothing is grafted when the field is unsupported: writing
DISABLED on a CE mirror would state a choice nobody made.

The graft and the read are extracted to `utils/orgSettingsCommit.ts` **so the round trip can be
tested rather than scanned for**. Every individual piece of this already worked -- the mutation
sent the right value, the server stored it, the local baseline advanced. The failure was in the
shape of what went into the store, visible only on the next hydration, which is exactly what a
unit test of any one function cannot see. The test replays save -> commit -> re-hydrate through
`UPDATE_ORGANIZATION` verbatim. Reverting the fix fails 2 of 5, including the unsendable-DISABLED loop.

## (b) Placement

The switch rendered **between** "Risk-transfer process reference" and "Risk increases over
time" -- inside the three labeling statements, reading as a fourth piece of labeling text and
splitting the three apart. Now its own "Support disclosure export" heading after all three, and
out of the form-item label column that had put it at the far right with 760px between it and
the words it controls.

## (c) Export gate

A refusal knowable before the click belongs on the control, not in a dialog after it. **Only**
the product gate moves: the data-dependent refusals (unresolvable org, failed collect,
unauthored prose slot) keep their modal, because disabling a button for a reason nobody has
checked yet would be a worse lie than the redundant dialog. Tested both ways.

## (d) Withdrawn chip, and the silent Save

"Unknown" would have been accurate about the support state and silent about the fact that a
claim once existed and was retracted -- different facts, and an auditor reads this screen for
both. The EOS suffix is suppressed with the status: printing `EOS 2025-12-31` beside
"Withdrawn" puts the retracted date back on screen as though it stood.

`attestationState` added to the components query -- without it the UI cannot tell a withdrawal
from a component nobody assessed. Placed in CORE, not FULL: **the CE schema already declares it
on `SbomComponent`** (checked, not assumed), so this does not widen the Pro-only surface.

`errors()` has always produced good sentences for every gate; nothing rendered them near the
control they gate. In the run **two fired at once** -- the mandatory re-assert reason, far
enough up the form to be below the fold, and the unacknowledged "does the recorded basis still
hold?" prompt -- so filling only the reason left Save just as dead with nothing saying which
requirement remained. A requirement stated only where the operator is not looking is not stated.

## (f) The statement

The "Software components whose support ends sooner" section named every component and its date
-- on the walkthrough device, all ten. That is a component inventory by another name, in the one
document that must not be one (FDA L1591-1592 puts patients and caregivers in its audience). A
count is no better: "10 of 10" reads worse than "3 of 40" to a reader with no way to compare
them.

**The section stays**, and the file header now records why it is a deliberate deviation from
plan 7f rather than an oversight: a reader told only the device's end-of-support date would
reasonably conclude every part is supported until then -- false whenever a component's window
closes earlier, which is the gap 524B exists to close. 7f's constraint rules out the *detail*,
not the fact.

**Worth recording: revert-probing caught one of my own new tests being theatre.** Restoring the
per-component table failed only 1 of the 3 new assertions -- the section slice was cutting at
the heading's own flattened style marker, so two were asserting against an empty string. With
the slice corrected all three fail on the reverted code.

## Gates

**746 tests across 52 files, all passing** (was 719 -- 27 new). Build clean. Every new guard
revert-probed against the exact defect it claims to catch.
