### PR TITLE
Merge main into fda-readiness-1-dev

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ReARM Build And Submit Documentation Release
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RelizaHub Build And Submit Documentation Helm metadata action
-        uses: relizaio/rearm-helm-action@9261ed4cd8235eeae69d75589f17ebcb5fe457b5 # v1.10.2
+        uses: relizaio/rearm-helm-action@a1959e591cbcc0c56f79acbf34eb42b2e5ae3127 # v1.11.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RelizaHub Build And Submit ReARM Landing Helm metadata action
-        uses: relizaio/rearm-helm-action@9261ed4cd8235eeae69d75589f17ebcb5fe457b5 # v1.10.2
+        uses: relizaio/rearm-helm-action@a1959e591cbcc0c56f79acbf34eb42b2e5ae3127 # v1.11.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build And Submit ReARM Helm to ReARM
-        uses: relizaio/rearm-helm-action@9261ed4cd8235eeae69d75589f17ebcb5fe457b5 # v1.10.2
+        uses: relizaio/rearm-helm-action@a1959e591cbcc0c56f79acbf34eb42b2e5ae3127 # v1.11.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build And Submit ReARM Helm to ReARM
-        uses: relizaio/rearm-helm-action@9261ed4cd8235eeae69d75589f17ebcb5fe457b5 # v1.10.2
+        uses: relizaio/rearm-helm-action@a1959e591cbcc0c56f79acbf34eb42b2e5ae3127 # v1.11.0
         with:
           registry_username: ${{ secrets.REARM_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.REARM_REGISTRY_TOKEN }}
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ReARM Build And Submit UI Release
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build And Submit Backend Release to ReARM
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -225,7 +225,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ReARM Build And Submit ReARM OCI Service Release
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -254,7 +254,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build And Submit ReARM Keycloak Release to ReARM
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ReARM Build And Submit ReARM Landing Release
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}
@@ -306,7 +306,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ReARM Build And Submit Rebom Backend Release
-        uses: relizaio/rearm-docker-action@975e8b3d96b53d56d9c21a34b927b6d7b2a52720 # v1.13.4
+        uses: relizaio/rearm-docker-action@8c011b4568c9a96d74e00402280af7a619ea4e1c # v1.14.0
         with:
           registry_username: ${{ secrets.DOCKER_LOGIN }}
           registry_password: ${{ secrets.DOCKER_TOKEN }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,13 @@ RUN apk add postgresql postgresql-contrib
 # FROM relizaio/maven-postgresql AS build-stage
 ARG VERSION=not_versioned
 ARG TARGETARCH
+# Test phase control. SKIP_TESTS=true|false forces it; the default "auto" runs the
+# tests when GIT_BRANCH is main or master, or when no branch is given (local builds),
+# and skips them (Maven -DskipTests, tests still compile) for every other branch, so
+# PR and feature builds do not pay for the suite while main stays fully tested.
+# GIT_BRANCH is already passed by rearm-docker-action; SKIP_TESTS needs no workflow change.
+ARG SKIP_TESTS=auto
+ARG GIT_BRANCH=git_branch_undefined
 RUN mkdir /run/postgresql && chown postgres:postgres /run/postgresql/ && su - postgres -c "mkdir /var/lib/postgresql/data && chmod 0700 /var/lib/postgresql/data && initdb -D /var/lib/postgresql/data && echo \"port = 5440\" > /var/lib/postgresql/data/postgresql.conf && sed -i \"s#/run/postgresql#/tmp#g\" /var/lib/postgresql/data/postgresql.conf" && su - postgres -c "pg_ctl -D /var/lib/postgresql/data start" && su - postgres -c "psql -p 5440 -c \"alter role postgres with encrypted password 'relizaPass'\"" && su - postgres -c "pg_ctl -D /var/lib/postgresql/data stop"
 RUN mkdir /workdir
 WORKDIR /workdir
@@ -38,7 +45,9 @@ COPY ./ .
 RUN VERSION_SAFE="$(echo $VERSION | tr '/' '-')" && \
     sed -i "s,Version_Managed_By_CI_AND_Reliza,$VERSION_SAFE," pom.xml
 
-RUN su - postgres -c "pg_ctl -D /var/lib/postgresql/data start" && mvn -B -T1C clean package spring-boot:repackage && cp target/*.jar application.jar && java -Djarmode=tools -jar application.jar extract --layers --launcher --destination extracted
+RUN SKIP="$SKIP_TESTS" && if [ "$SKIP" = "auto" ]; then case "$GIT_BRANCH" in main|master|git_branch_undefined) SKIP=false ;; *) SKIP=true ;; esac; fi && \
+    echo "SKIP_TESTS=$SKIP_TESTS GIT_BRANCH=$GIT_BRANCH -> skipTests=$SKIP" && \
+    su - postgres -c "pg_ctl -D /var/lib/postgresql/data start" && mvn -B -T1C clean package spring-boot:repackage -DskipTests=$SKIP && cp target/*.jar application.jar && java -Djarmode=tools -jar application.jar extract --layers --launcher --destination extracted
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b  AS artifact-stage
 ENV JAVA_HOME=/opt/java/openjdk

--- a/landing_site/src/data/design.json
+++ b/landing_site/src/data/design.json
@@ -65,6 +65,18 @@
   ],
   "useCasePanels": [
     {
+      "q": "Shipping products made of many components?",
+      "name": "SBOM Aggregation",
+      "c1": "#7B6CF6",
+      "c2": "#5EEBC3"
+    },
+    {
+      "q": "Drowning in CVEs that don't apply?",
+      "name": "VEX Exploitability eXchange",
+      "c1": "#C86CD8",
+      "c2": "#5B7CFA"
+    },
+    {
       "q": "Shipping a regulated medical device?",
       "name": "Medical Devices",
       "c1": "#5EEBC3",
@@ -78,7 +90,7 @@
     },
     {
       "q": "Need to know what's actually running?",
-      "name": "Deployment Governance",
+      "name": "Deployment Governance, DevOps, BYOC",
       "c1": "#F08A4B",
       "c2": "#F4B04B"
     },
@@ -104,7 +116,7 @@
     },
     {
       "q": "What exactly is deployed in production right now?",
-      "page": "Deployment Governance"
+      "page": "Deployment Governance, DevOps, BYOC"
     },
     {
       "q": "Which of our code did agents write, and under what approval?",
@@ -422,6 +434,122 @@
   ],
   "ucPages": [
     {
+      "label": "SBOM Aggregation",
+      "path": "/use-cases/sbom-aggregation",
+      "persona": "FOR PRODUCT SECURITY + ENGINEERING TEAMS SHIPPING MULTI-COMPONENT PRODUCTS",
+      "h1": "One SBOM per product version, assembled from what actually shipped.",
+      "pain": "A product is dozens of components, each with its own repository, pipeline and SBOM. The customer asks for one SBOM for the version they received. Stitching it together by hand means guessing which component versions went into that release.",
+      "steps": [
+        {
+          "num": "01",
+          "title": "Component releases arrive from CI",
+          "cap": "SBOM/XBOM Management",
+          "body": "Every pipeline run creates a component release in ReARM and attaches the SBOMs it produced. Nothing to collect later: the SBOMs are recorded at build time, against the exact version they describe."
+        },
+        {
+          "num": "02",
+          "title": "Products are assembled by rules",
+          "cap": "Feature Sets",
+          "body": "A product's feature set defines which component branches belong to it. Rules decide when a new component release rolls into a new product release, automatically or after approval. No one maintains a version matrix by hand."
+        },
+        {
+          "num": "03",
+          "title": "Every product release is pinned",
+          "cap": "Feature Sets",
+          "body": "Each product release records the exact component releases it contains. Ask ReARM what went into product version 3.2.1 and the answer is a list of pinned versions, not a best guess from dates."
+        },
+        {
+          "num": "04",
+          "title": "Aggregated SBOM on demand",
+          "cap": "SBOM/XBOM Management",
+          "body": "For any product release, ReARM merges the component SBOMs into one product SBOM: one document that covers everything shipped in that version, ready to hand to a customer, a regulator or a scanner."
+        },
+        {
+          "num": "05",
+          "title": "Delivered with the product",
+          "cap": "Distribution",
+          "body": "Aggregated SBOMs are ready to be served downstream, so each customer can receive the SBOM for each version they run."
+        },
+        {
+          "num": "06",
+          "title": "Findings follow the aggregate",
+          "cap": "Findings Aggregation",
+          "body": "New vulnerabilities are evaluated against every component pinned in every shipped product version, so a finding in one library maps straight to the product versions and customers it affects."
+        }
+      ],
+      "note": false,
+      "shot": false,
+      "a1": "rgba(123,108,246,0.10)",
+      "a2": "rgba(94,235,195,0.10)",
+      "id": "3e",
+      "href": "#3e",
+      "publicDemo": true,
+      "stripLabel": "EVIDENCE",
+      "strip": [
+        "Pinned Composition",
+        "Aggregated SBOM"
+      ],
+      "evidence": "COMPONENT SBOMS · FEATURE SETS · PINNED PRODUCT RELEASES · AGGREGATED SBOM · FINDINGS"
+    },
+    {
+      "label": "VEX Exploitability eXchange",
+      "path": "/use-cases/vex-exploitability-exchange",
+      "persona": "FOR PRODUCT SECURITY TEAMS RECEIVING AND ISSUING VEX",
+      "h1": "Vendor said \"not affected\". Prove it, apply it, and pass it on.",
+      "pain": "Scanners flag thousands of CVEs; most do not apply to how the code is actually used. Vendors send VEX documents saying so, your own reviews produce more, and the decisions end up in tickets and spreadsheets where nobody can trace who decided what, for which version, on what evidence.",
+      "steps": [
+        {
+          "num": "01",
+          "title": "VEX is just another artifact",
+          "cap": "SBOM/XBOM Management",
+          "body": "Attach a CycloneDX-VEX or OpenVEX document to a release from the UI, the CLI or your pipeline. ReARM matches every statement against the release's SBOM inventory, so a claim only lands where the affected component actually is."
+        },
+        {
+          "num": "02",
+          "title": "Trust depends on who is talking",
+          "cap": "Findings Aggregation",
+          "body": "A vendor's \"exploitable\" is accepted at once; a vendor's \"not affected\" is staged for your review, because that is where downplaying happens. Your own analyses auto-accept; third-party claims always wait. Import mode and issuer trust compose, and the least permissive wins."
+        },
+        {
+          "num": "03",
+          "title": "One decision, the right scope",
+          "cap": "Findings Aggregation",
+          "body": "A claim can apply to one release, a branch, a whole component, or the entire portfolio. ReARM records it once at the scope you choose, and stages any claim that contradicts an existing broader decision for review instead of silently overriding it."
+        },
+        {
+          "num": "04",
+          "title": "Conditional claims wait for evidence",
+          "cap": "Release Policies",
+          "body": "\"Not affected, protected at perimeter\" is only true while the perimeter holds. ReARM defers such decisions until someone attests the mitigation is in place, with the evidence recorded; waive it and the decision is never written."
+        },
+        {
+          "num": "05",
+          "title": "Review with the original in view",
+          "cap": "Audit Evidence",
+          "body": "Every staged statement is reviewed next to the verbatim VEX it came from and any existing analysis it would touch. Accept, modify, or reject with a required comment; who decided what, and when, stays on record."
+        },
+        {
+          "num": "06",
+          "title": "Export VEX for your customers",
+          "cap": "Distribution",
+          "body": "Your decisions re-emit as CycloneDX-VEX or OpenVEX per release, so the VEX you ship downstream carries the same provenance you demanded upstream, and survives a round trip."
+        }
+      ],
+      "note": false,
+      "shot": false,
+      "a1": "rgba(200,108,216,0.10)",
+      "a2": "rgba(91,124,250,0.10)",
+      "id": "3d",
+      "href": "#3d",
+      "publicDemo": true,
+      "stripLabel": "EVIDENCE",
+      "strip": [
+        "CycloneDX-VEX · OpenVEX",
+        "Trust Gate"
+      ],
+      "evidence": "VEX IMPORT · TRUST GATE · SCOPED ANALYSIS · MITIGATION ATTESTATIONS · VEX EXPORT"
+    },
+    {
       "id": "3f",
       "href": "#3f",
       "path": "/use-cases/medical-devices",
@@ -524,10 +652,10 @@
       "id": "3h",
       "href": "#3h",
       "path": "/use-cases/deployment-governance",
-      "label": "Deployment Governance",
-      "persona": "FOR PLATFORM + DEVOPS LEADS",
-      "h1": "What should be running, what is actually running, and the delta.",
-      "pain": "Release records say what was approved. Nobody can prove what is deployed where right now. ReARM closes the loop between plan and actual.",
+      "label": "Deployment Governance, DevOps, BYOC",
+      "persona": "FOR PLATFORM + DEVOPS TEAMS, AND VENDORS SHIPPING INTO CUSTOMER CLOUDS",
+      "h1": "DevOps, BYOC, Air-Gap at Scale.",
+      "pain": "Bring Your Own Cloud means your product runs on infrastructure you do not operate: a customer's VPC, a partner's cluster, an air-gapped site. CI cannot push there, and once it ships nobody can say which version is live. ReARM holds the plan; ReARM CD inside each cluster pulls it, applies it, and reports back.",
       "a1": "rgba(240,138,75,0.10)",
       "a2": "rgba(244,176,75,0.10)",
       "stripLabel": "EVIDENCE",
@@ -538,43 +666,49 @@
       "evidence": "INSTANCES · ENVIRONMENTS · FEATURE-SET TARGETING · RUNTIME EVIDENCE",
       "publicDemo": true,
       "shot": "[ SCREENSHOT 8: instances page, plan vs actual side by side ]",
-      "note": false,
+      "note": "Instances, secrets, feature-set deploys and ReARM CD control are part of ReARM Pro.",
       "steps": [
         {
           "num": "01",
-          "title": "Instances and environments registered",
-          "body": "Every instance and environment is a first-class object in ReARM, not a spreadsheet row.",
-          "cap": "Deployment Model"
+          "title": "Each target is an instance",
+          "cap": "Deployment Model",
+          "body": "Every cluster, namespace or site you deploy into is registered as an instance in ReARM, grouped into clusters, with its own secrets and configuration. Customer infrastructure becomes a first-class object in ReARM."
         },
         {
           "num": "02",
-          "title": "Plan vs actual, continuously reconciled",
-          "body": "Approved and expected state vs observed state, resolved side by side and kept current.",
-          "cap": "Reconciliation"
+          "title": "Ship by pointing, not pushing",
+          "cap": "Feature Sets",
+          "body": "A feature set pins the exact component and product releases that ship together. Point an instance at it and ReARM records the target. Nothing is pushed from CI, and no CI credentials ever reach the customer's cloud."
         },
         {
           "num": "03",
-          "title": "Drift surfaced immediately",
-          "body": "The moment actual diverges from plan, it is visible. No quarterly audits to find out.",
-          "cap": "Drift Detection"
+          "title": "ReARM CD pulls it in",
+          "cap": "ReARM CD",
+          "body": "A small open-source agent installed in the customer's cluster connects outbound to ReARM, watches the instance's target, reconciles the running workloads to match, and reports what actually landed. Sensitive configuration is transmitted securely: encrypted for that cluster alone, so only it can open it."
         },
         {
           "num": "04",
-          "title": "Feature-set targeting",
-          "body": "Point an instance at a feature set; ReARM reconciles what should land there. Your CI/CD queries ReARM for the latest release that passed all required approval gates and promotes only that version. No approved status in ReARM, no deployment.",
-          "cap": "Feature Sets"
+          "title": "Promotion follows approvals",
+          "cap": "Release Policies",
+          "body": "Which releases each environment takes is configurable per environment: for example, test instances take every release while staging and production take only releases that passed the approval gates you define. Promotion is a change of target in ReARM, and rollback is the previous feature set."
         },
         {
           "num": "05",
-          "title": "Evidence, extended to runtime",
-          "body": "The same evidence trail that covers releases now covers what actually runs.",
-          "cap": "Audit Evidence"
+          "title": "Plan versus actual, per instance or per customer",
+          "cap": "Drift Detection",
+          "body": "Every instance shows expected against observed state side by side. When a cluster drifts, a manual hotfix or a failed rollout, it is visible immediately, not at the next support call."
         },
         {
           "num": "06",
-          "title": "ReARM CD closes the loop",
-          "body": "ReARM CD, the open-source deployment controller, pulls each instance's expected state from ReARM, applies it, and reports back what actually landed. The reconcile loop that keeps plan and actual honest.",
-          "cap": "ReARM CD"
+          "title": "Evidence follows the deployment",
+          "cap": "Audit Evidence",
+          "body": "What was approved, what was targeted, what ran and when, per instance, in one immutable history. The SBOM, findings and approvals attached to a release travel with it into the deployment record."
+        },
+        {
+          "num": "07",
+          "title": "Air-gapped sites",
+          "cap": "Distribution",
+          "body": "Where nothing can connect, the release goes out instead of the agent coming in. The CLI resolves which release an environment is cleared for under your approvals, packages it with its artifacts and evidence as a bundle you carry across the gap, and ReARM records the transfer against the site, as a distribution target or a placeholder instance, so what landed there is still on record."
         }
       ],
       "img": "/screenshots/19-instance-page.png"
@@ -672,7 +806,7 @@
     {
       "name": "Enterprise",
       "price": "$75",
-      "unit": "/write user/mo",
+      "unit": "/user/mo",
       "border": "#E3E5EC",
       "bg": "#fff",
       "popular": false,

--- a/landing_site/src/data/site.ts
+++ b/landing_site/src/data/site.ts
@@ -20,9 +20,11 @@ export const productNav = [
 ];
 
 export const useCaseNav = [
+  { label: 'SBOM Aggregation', href: '/use-cases/sbom-aggregation/' },
+  { label: 'VEX Exploitability eXchange', href: '/use-cases/vex-exploitability-exchange/' },
   { label: 'Medical Devices', href: '/use-cases/medical-devices/' },
   { label: 'Field Digital Twin', href: '/use-cases/field-digital-twin/' },
-  { label: 'Deployment Governance', href: '/use-cases/deployment-governance/' },
+  { label: 'Deployment Governance, DevOps, BYOC', href: '/use-cases/deployment-governance/' },
   { label: 'EU CRA Compliance', href: '/use-cases/eu-cra/' },
 ];
 
@@ -32,9 +34,12 @@ export const pageHrefs: Record<string, string> = {
   'Findings Aggregation': '/product/findings-aggregation/',
   'Release Policies': '/product/release-policies/',
   'AI Governance': '/product/ai-governance/',
+  'SBOM Aggregation': '/use-cases/sbom-aggregation/',
+  'VEX Exploitability eXchange': '/use-cases/vex-exploitability-exchange/',
   'Medical Devices': '/use-cases/medical-devices/',
   'Field Digital Twin': '/use-cases/field-digital-twin/',
   'Deployment Governance': '/use-cases/deployment-governance/',
+  'Deployment Governance, DevOps, BYOC': '/use-cases/deployment-governance/',
   'EU CRA': '/use-cases/eu-cra/',
   'EU CRA Compliance': '/use-cases/eu-cra/',
   Pricing: '/pricing/',

--- a/landing_site/src/pages/pricing-faq.astro
+++ b/landing_site/src/pages/pricing-faq.astro
@@ -10,18 +10,17 @@ const faqs: { question: string; answer: string[]; link?: { text: string; href: s
   {
     question: 'How is the number of users calculated?',
     answer: [
-      'Each paid seat corresponds to one write user - someone who can create, modify, or manage releases, components, artifacts, and settings within ReARM.',
-      'For ReARM Pro Starter plan, for every 3 write users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes.',
-      'For ReARM Pro Standard and Enterprise plans, for every 2 write users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes.',
-      'For example, on Standard or Enterprise, if you purchase a plan for 20 write users, you get up to 10 additional read-only users (30 total).',
+      'Each paid seat corresponds to one user - someone who can create, modify, or manage releases, components, artifacts, and settings within ReARM.',
+      'On ReARM Pro Standard and Enterprise plans, for every 2 users we include one additional read-only user at no extra cost. Read-only users can view releases, artifacts, and dashboards but cannot make changes. The Starter plan does not include additional read-only users.',
+      'For example, on Standard or Enterprise, if you purchase a plan for 20 users, you get up to 10 additional read-only users (30 total).',
     ],
   },
   {
-    question: 'How many write user licenses do I need?',
+    question: 'How many user licenses do I need?',
     answer: [
-      'We recommend a write user license for every member of your cyber security organization, leads and managers in the development organization, and senior leaders in marketing, product management, and business management.',
-      'A good rule of thumb: anyone who approves releases should have a write license.',
-      'While this depends heavily on your organizational structure, in practice about 1 in every 15-20 employees across the entire organization needs a write license. For a 1000-person organization, 50-70 write licenses is usually adequate.',
+      'We recommend a user license for every member of your cyber security organization, leads and managers in the development organization, and senior leaders in marketing, product management, and business management.',
+      'A good rule of thumb: anyone who approves releases should have a license.',
+      'While this depends heavily on your organizational structure, in practice about 1 in every 15-20 employees across the entire organization needs a license. For a 1000-person organization, 50-70 licenses is usually adequate.',
     ],
   },
   {

--- a/landing_site/src/pages/pricing.astro
+++ b/landing_site/src/pages/pricing.astro
@@ -1,6 +1,6 @@
 ---
 // Full functional port of the current site's pricing: regional pricing with
-// timezone detection + localStorage persistence, write-user selectors with
+// timezone detection + localStorage persistence, user selectors with
 // live price calculation, real tier features with tooltips. Styled per the
 // 2026 design (clipped buttons, POPULAR badge, square corners).
 import Base from '../layouts/Base.astro';
@@ -99,10 +99,10 @@ const tooltipFor = (b: string) =>
         <h3>ReARM Pro - Starter</h3>
         <div class="price"><span class="amount" id="starter-price">$195</span><span class="unit">Per Month</span></div>
         <div class="selector">
-          <label for="starter-users">Number of write users (1-14):</label>
+          <label for="starter-users">1-14 users:</label>
           <div class="selector-row">
             <input type="number" id="starter-users" min="1" max="14" value="1" />
-            <input type="range" id="starter-range" min="1" max="14" value="1" aria-label="Starter write users" />
+            <input type="range" id="starter-range" min="1" max="14" value="1" aria-label="Starter users" />
           </div>
         </div>
         <ul>
@@ -113,7 +113,7 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--navy" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--navy" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
 
       <!-- Standard -->
@@ -122,10 +122,10 @@ const tooltipFor = (b: string) =>
         <h3>ReARM Pro - Standard</h3>
         <div class="price"><span class="amount" id="standard-price">$1,350</span><span class="unit">Per Month</span></div>
         <div class="selector">
-          <label for="standard-users">Number of write users (15-39):</label>
+          <label for="standard-users">15-39 users:</label>
           <div class="selector-row">
             <input type="number" id="standard-users" min="15" max="39" value="15" />
-            <input type="range" id="standard-range" min="15" max="39" value="15" aria-label="Standard write users" />
+            <input type="range" id="standard-range" min="15" max="39" value="15" aria-label="Standard users" />
           </div>
         </div>
         <ul>
@@ -136,14 +136,14 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--orange" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--orange" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
 
       <!-- Enterprise -->
       <div class="tier">
         <h3>ReARM Pro - Enterprise</h3>
-        <div class="price"><span class="amount" id="enterprise-price">$75</span><span class="unit">per write user per month</span></div>
-        <div class="selector"><span class="selector-note">40+ write users</span></div>
+        <div class="price"><span class="amount" id="enterprise-price">$75</span><span class="unit">per user per month</span></div>
+        <div class="selector"><span class="selector-note">40+ users</span></div>
         <ul>
           {enterpriseBullets.map((b) => (
             <li>
@@ -152,14 +152,14 @@ const tooltipFor = (b: string) =>
             </li>
           ))}
         </ul>
-        <a class="btn btn--navy" href="mailto:sales@reliza.io">Contact Sales</a>
+        <a class="btn btn--navy" href="https://calendly.com/pavel-reliza/30min" target="_blank" rel="noopener">Book Demo</a>
       </div>
     </div>
 
     <div class="container">
       <p class="tiers-note">
-        Each paid seat is one write user. Read-only users are included at no extra cost (1 per 3 write
-        users on Starter; 1 per 2 on Standard and Enterprise). Details in the <a href="/pricing-faq/">Pricing FAQ</a>.
+        Each paid seat is one user. On Standard and Enterprise, one additional read-only user is included
+        at no extra cost for every 2 users. Details in the <a href="/pricing-faq/">Pricing FAQ</a>.
       </p>
     </div>
   </section>

--- a/ui/src/components/BranchView.vue
+++ b/ui/src/components/BranchView.vue
@@ -377,6 +377,7 @@ import constants from '@/utils/constants'
 import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
 import VulnerabilityModal from '@/components/VulnerabilityModal.vue'
 import { isDtrackConfiguredForOrg, getReleaseScanStatus } from '@/utils/releaseScanStatus'
+import { renderVulnerabilityCells, renderViolationCells } from '@/utils/releaseScanCells'
 import Swal from 'sweetalert2'
 import { SwalData } from '@/utils/commonFunctions'
 
@@ -422,14 +423,6 @@ const myorg: ComputedRef<any> = computed((): any => store.getters.myorg)
 // of pretending those columns are pending.
 const dtrackConfigured: Ref<boolean> = ref(false)
 isDtrackConfiguredForOrg(orguuid).then((c) => { dtrackConfigured.value = c })
-
-function renderPendingBadge (status: { label: string, title: string, kind: string }) {
-    const bg = status.kind === 'rejected' ? '#d03050' : status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
-    return h('span', {
-        title: status.title,
-        style: `display: inline-block; padding: 2px 10px; border-radius: 12px; background: ${bg}; color: white; font-size: 0.8em; white-space: nowrap;`
-    }, status.label)
-}
 
 const branchUuid: Ref<string> = ref(props.branchUuidProp ? props.branchUuidProp.toString() : route.params.branchuuid ? route.params.branchuuid.toString() : '')
 
@@ -2012,38 +2005,12 @@ const releaseFields: ComputedRef<any[]>  = computed((): any[] => {
     fields.push({
         key: 'vulnerabilities',
         title: 'Vulnerabilities',
-        render: (row: any) => {
-            const status = getReleaseScanStatus(row, dtrackConfigured.value)
-            if (status.kind !== 'ready') return [renderPendingBadge(status)]
-            let els: any[] = []
-            if (row.metrics && row.metrics.lastScanned) {
-                const criticalEl = h('div', {title: 'Criticial Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.CRITICAL}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'CRITICAL', ['Vulnerability', 'Weakness'])}, row.metrics.critical)
-                const highEl = h('div', {title: 'High Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.HIGH}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'HIGH', ['Vulnerability', 'Weakness'])}, row.metrics.high)
-                const medEl = h('div', {title: 'Medium Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.MEDIUM}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'MEDIUM', ['Vulnerability', 'Weakness'])}, row.metrics.medium)
-                const lowEl = h('div', {title: 'Low Severity Vulnerabilities', class: 'circle', style: `background: ${constants.VulnerabilityColors.LOW}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'LOW', ['Vulnerability', 'Weakness'])}, row.metrics.low)
-                const unassignedEl = h('div', {title: 'Vulnerabilities with Unassigned Severity', class: 'circle', style: `background: ${constants.VulnerabilityColors.UNASSIGNED}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, 'UNASSIGNED', ['Vulnerability', 'Weakness'])}, row.metrics.unassigned)
-                els = [h(NSpace, {size: 1}, () => [criticalEl, highEl, medEl, lowEl, unassignedEl])]
-            }
-            if (!els.length) els = [h('div'), 'N/A']
-            return els
-        }
+        render: (row: any) => renderVulnerabilityCells(row, getReleaseScanStatus(row, dtrackConfigured.value), viewDetailedVulnerabilitiesForRelease)
     })
     fields.push({
         key: 'violations',
         title: 'Violations',
-        render: (row: any) => {
-            const status = getReleaseScanStatus(row, dtrackConfigured.value)
-            if (status.kind !== 'ready') return [renderPendingBadge(status)]
-            let els: any[] = []
-            if (row.metrics && row.metrics.lastScanned) {
-                const licenseEl = h('div', {title: 'Licensing Policy Violations', class: 'circle', style: `background: ${constants.ViolationColors.LICENSE}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, '', 'Violation')}, row.metrics.policyViolationsLicenseTotal)
-                const securityEl = h('div', {title: 'Security Policy Violations', class: 'circle', style: `background: ${constants.ViolationColors.SECURITY}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, '', 'Violation')}, row.metrics.policyViolationsSecurityTotal)
-                const operationalEl = h('div', {title: 'Operational Policy Violations', class: 'circle', style: `background: ${constants.ViolationColors.OPERATIONAL}; cursor: pointer;`, onClick: () => viewDetailedVulnerabilitiesForRelease(row, '', 'Violation')}, row.metrics.policyViolationsOperationalTotal)
-                els = [h(NSpace, {size: 1}, () => [licenseEl, securityEl, operationalEl])]
-            }
-            if (!els.length) els = [h('div'), 'N/A']
-            return els
-        }
+        render: (row: any) => renderViolationCells(row, getReleaseScanStatus(row, dtrackConfigured.value), viewDetailedVulnerabilitiesForRelease)
     })
 
     return fields

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -40,7 +40,7 @@
                     </n-gi>
                 </n-grid>
             </n-gi>
-            <n-gi span="3">
+            <n-gi :span="selectedTab === 'latest' ? 10 : 3">
                 <div class="componentTop">
                     <div class="componentSummary">
                         <h5 v-if="componentData">
@@ -1056,21 +1056,26 @@
                     </div>
                 </div>
                 <div class="componentDetails">
-                    <n-tabs v-if="componentData && componentData.type === 'COMPONENT'" v-model:value="selectedTab" type="segment" @update:value="handleTabChange" animated>
-                        <n-tab-pane name="branches" tab="Branches">
+                    <n-tabs v-if="componentData" v-model:value="selectedTab" type="segment" @update:value="handleTabChange" animated>
+                        <n-tab-pane name="latest" tab="Latest">
+                            <latest-releases-of-component
+                                :componentUuid="componentUuid"
+                                :orgUuid="String(route.params.orguuid)"
+                                :selectedBranchUuid="selectedBranchUuid"
+                                :featureSetLabel="words.branchFirstUpper"
+                                :refreshToken="latestRefreshToken"
+                                @selectBranch="selectBranchFromLatest" />
+                        </n-tab-pane>
+                        <n-tab-pane name="branches" :tab="componentData.type === 'COMPONENT' ? 'Branches' : words.branchFirstUpper + 's'">
                             <n-data-table :data="branches" :columns="branchFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                         </n-tab-pane>
-                        <n-tab-pane name="pull-requests" tab="Pull Requests">
-                            <n-data-table :data="pullRequests" :columns="pullRequestFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
-                        </n-tab-pane>
-                        <n-tab-pane name="tags" tab="Tags">
+                        <n-tab-pane v-if="componentData.type === 'COMPONENT'" name="tags" tab="Tags">
                             <n-data-table :data="tags" :columns="tagFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                         </n-tab-pane>
                     </n-tabs>
-                    <n-data-table v-else :data="branches" :columns="branchFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                 </div>
             </n-gi>
-            <n-gi span="7">
+            <n-gi v-if="selectedTab !== 'latest'" span="7">
                 <div v-if="marketingVersionEnabled" class="marketingReleases">
                     <mrkt-releases-of-component :component="updatedComponent.uuid" />
                 </div>
@@ -1098,6 +1103,7 @@ import commonFunctions from '../utils/commonFunctions'
 import ChangelogView from './ChangelogView.vue'
 import BranchView from './BranchView.vue'
 import MrktReleasesOfComponent from './MrktReleasesOfComponent.vue'
+import LatestReleasesOfComponent from './LatestReleasesOfComponent.vue'
 import FindingsOverTimeChart from './FindingsOverTimeChart.vue'
 import DeployedToWidget from './DeployedToWidget.vue'
 import { DashboardView } from '@/utils/dashboardView'
@@ -1447,7 +1453,9 @@ const showCreateInputTriggerModal: Ref<boolean> = ref(false)
 const branchRouteId = route.params.branchuuid ? route.params.branchuuid.toString() : ''
 const routePrnumber = route.params.prnumber ? route.params.prnumber.toString() : ''
 const selectedBranchUuid : Ref<string> = ref(branchRouteId)
-const selectedTab: Ref<string> = ref((route.query.tab as string) || 'branches')
+const selectedTab: Ref<string> = ref((route.query.tab as string) || 'latest')
+// Bumped after branch list changes so the Latest tab refetches.
+const latestRefreshToken = ref(0)
 const branchCollapseState: Ref<any> = ref({})
 const selectedPullRequest: Ref<string> = routePrnumber !== '' ? ref(branchRouteId + '-pr-' + routePrnumber) : ref('')
 branchCollapseState.value['branchCollapse' + branchRouteId] = true
@@ -1747,7 +1755,9 @@ const resourceGroupMap: ComputedRef<any> = computed((): any => {
 })
 
 const branches: ComputedRef<any> = computed((): any => {
-    const storeBranches = store.getters.branchesOfComponent(componentUuid).filter((b: any) => b.type !== 'PULL_REQUEST' && b.type !== 'TAG').map((b: any) => ({...b, key: b.uuid}))
+    // Pull-request branches (names starting with pull/ or pullrequest/, a legacy
+    // pipeline convention) stay in this list with a PR badge; tags have their own tab.
+    const storeBranches = store.getters.branchesOfComponent(componentUuid).filter((b: any) => b.type !== 'TAG').map((b: any) => ({...b, key: b.uuid}))
     if (storeBranches && storeBranches.length) {
         // sort - TODO make sort configurable
         storeBranches.sort((a: any, b: any) => {
@@ -1779,19 +1789,6 @@ const mainBranch: ComputedRef<string> = computed((): any => {
         if (!mainBranch) mainBranch = branches.value[0].uuid
     }
     return mainBranch
-})
-
-const pullRequests: ComputedRef<any> = computed((): any => {
-    const storeBranches = store.getters.branchesOfComponent(componentUuid).filter((b: any) => b.type === 'PULL_REQUEST').map((b: any) => ({...b, key: b.uuid}))
-    if (storeBranches && storeBranches.length) {
-        // Sort by creation date in descending order (newest first)
-        storeBranches.sort((a: any, b: any) => {
-            const dateA = a.createdDate ? new Date(a.createdDate).getTime() : 0
-            const dateB = b.createdDate ? new Date(b.createdDate).getTime() : 0
-            return dateB - dateA
-        })
-    }
-    return storeBranches
 })
 
 const tags: ComputedRef<any> = computed((): any => {
@@ -1847,15 +1844,39 @@ function selectBranch (uuid: string) {
     }
 }
 
+// A row in the Latest tab opens the branch in detail mode: the Latest tab
+// owns the full width, so the branch pane only exists under the Branches tab.
+function selectBranchFromLatest (uuid: string) {
+    selectedTab.value = 'branches'
+    selectedBranchUuid.value = uuid
+    router.push({
+        name: isComponent.value ? 'ComponentsOfOrg' : 'ProductsOfOrg',
+        params: {
+            orguuid: route.params.orguuid,
+            compuuid: componentUuid,
+            branchuuid: uuid
+        },
+        query: { ...route.query, tab: 'branches' }
+    })
+}
+
 function handleTabChange (tabName: string) {
-    // Clear selected branch when switching tabs
-    selectedBranchUuid.value = ''
+    // Branches / Feature Sets: open the base branch right away so the pane
+    // is never empty on the first click. Other tabs start with no selection.
+    let preselect = ''
+    if (tabName === 'branches') {
+        const list = branches.value || []
+        const base = list.find((b: any) => b.type === 'BASE') || [...list].sort((a: any, b: any) => isMain(b) - isMain(a))[0]
+        preselect = base ? base.uuid : ''
+    }
+    selectedBranchUuid.value = preselect
 
     router.push({
         name: isComponent.value ? 'ComponentsOfOrg' : 'ProductsOfOrg',
         params: {
             orguuid: route.params.orguuid,
-            compuuid: componentUuid
+            compuuid: componentUuid,
+            ...(preselect ? { branchuuid: preselect } : {})
         },
         query: { ...route.query, tab: tabName }
     })
@@ -2234,6 +2255,7 @@ const onCreateBranchSubmit = async function() {
             }
             const createBranchResp = await store.dispatch('createBranch', createBranchObject.value)
             await store.dispatch('fetchBranches', { componentId: componentUuid, forceRefresh: true })
+            latestRefreshToken.value++
             onCreateBranchReset()
             showAddBranchModal.value = false
             selectBranch(createBranchResp.uuid)
@@ -2955,6 +2977,9 @@ const branchFields: any[] = [
         key: 'name',
         render: (row: any) => {
             const children: any[] = [h('span', row.name)]
+            if (row.type === 'PULL_REQUEST') {
+                children.push(h(NTag, { size: 'small', type: 'info', bordered: false, title: 'Pull request branch' }, () => 'PR'))
+            }
             if (row.type === 'BASE') {
                 children.push(h(NTooltip, { trigger: 'hover' }, {
                     trigger: () => h(NIcon, {
@@ -3008,26 +3033,6 @@ if (!isComponent.value && isWritable){
 
 const branchTableRowKey = (row: any) => row.uuid
 
-// Pull Request fields - same as branch fields but with "Pull Request" header
-const pullRequestFields: any[] = [
-    {
-        title: 'Pull Request',
-        key: 'name'
-    },
-    {
-        title: 'Schema',
-        key: 'versionSchema',
-        render: (row: any) => row.versionSchema ? row.versionSchema : 'Not set'
-    },
-    {
-        title: '',
-        key: 'archive',
-        width: 50,
-        render: archiveActionCell,
-    }
-]
-
-// Tag fields - same as branch fields but with "Tag" header
 const tagFields: any[] = [
     {
         title: 'Tag',
@@ -3610,6 +3615,7 @@ async function loadUserGroups() {
 async function initLoad() {
     const compUuid = route.params.compuuid.toString()
     await store.dispatch('fetchBranches', compUuid)
+    latestRefreshToken.value++
     let storeComponent = store.getters.componentById(compUuid)
     if (!storeComponent || !storeComponent.versionType) {
         storeComponent = await store.dispatch('fetchComponentFull', compUuid)

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1034,11 +1034,17 @@
                                             v-model:value="cloneBrProps.name"
                                             required
                                             :placeholder="'Enter cloned ' + words.branchFirstUpper + ' name'" />
-                                            <label>Version Pin of new {{ words.branchFirstUpper }} (Defaults to Version Schema: {{ componentData.featureBranchVersioniong }} )"</label>
-                                        <n-input
+                                        <label>Version schema of new {{ words.branchFirstUpper }} (defaults to the {{ words.branchFirstUpper.toLowerCase() }} schema of {{ componentData.name }}: {{ componentData.featureBranchVersioning || 'not set' }})</label>
+                                        <n-select
                                             v-model:value="cloneBrProps.schema"
-                                            required
-                                            placeholder="Enter Version Pin" />
+                                            tag
+                                            filterable
+                                            :placeholder="'Select version schema for ' + words.branchFirstUpper"
+                                            :options="constants.BranchVersionTypes" />
+                                        <n-input
+                                            v-if="cloneBrProps.schema === 'custom_version'"
+                                            v-model:value="customCloneVersionSchema"
+                                            placeholder="Custom Version Schema" />
                                         <label>Type of new {{ words.branchFirstUpper }}</label>
                                         <n-select
                                             placeholder="Please choose type"
@@ -1067,7 +1073,7 @@
                                 @selectBranch="selectBranchFromLatest" />
                         </n-tab-pane>
                         <n-tab-pane name="branches" :tab="componentData.type === 'COMPONENT' ? 'Branches' : words.branchFirstUpper + 's'">
-                            <n-data-table :data="branches" :columns="branchFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
+                            <n-data-table :data="branches" :columns="branchColumns" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
                         </n-tab-pane>
                         <n-tab-pane v-if="componentData.type === 'COMPONENT'" name="tags" tab="Tags">
                             <n-data-table :data="tags" :columns="tagFields" :row-props="rowProps" :row-class-name="branchRowClassName" :row-key="branchTableRowKey" />
@@ -2224,24 +2230,35 @@ const defaultCloneBrProps = {
 }
 
 const cloneBrProps: Ref<any> = ref(commonFunctions.deepCopy(defaultCloneBrProps))
+const customCloneVersionSchema = ref('')
 
 const cloneBranchReset = function () {
     cloneBrProps.value.name = ''
     cloneBrProps.value.type = ''
     cloneBrProps.value.schema = componentData.value.featureBranchVersioning
+    customCloneVersionSchema.value = ''
 }
 
 const cloneBranchSubmit = async function () {
-    let brProps = {
+    if (!cloneBrProps.value.name) { notify('warning', 'Missing', `Name of the new ${words.value.branchFirstUpper} is required`); return }
+    const versionSchema = cloneBrProps.value.schema === 'custom_version' ? customCloneVersionSchema.value : cloneBrProps.value.schema
+    const brProps = {
         name: cloneBrProps.value.name,
         branchUuid: cloneBrProps.value.originalBranch.uuid,
-        versionSchema: cloneBrProps.value.schema,
-        branchType: cloneBrProps.value.type
+        versionSchema,
+        branchType: cloneBrProps.value.type || null
     }
-    const response: any = store.dispatch('cloneBranch', brProps)
-    selectBranch(response.uuid)
-    cloneBranchReset()
-    showCloneBranchModal.value = false
+    try {
+        const response: any = await store.dispatch('cloneBranch', brProps)
+        await store.dispatch('fetchBranches', { componentId: componentUuid, forceRefresh: true })
+        latestRefreshToken.value++
+        cloneBranchReset()
+        showCloneBranchModal.value = false
+        notify('success', 'Cloned', `${words.value.branchFirstUpper} ${response.name} created`)
+        selectBranch(response.uuid)
+    } catch (error: any) {
+        notify('error', 'Error', commonFunctions.parseGraphQLError(error.message))
+    }
 }
 
 const onCreateBranchSubmit = async function() {
@@ -2947,14 +2964,23 @@ async function archiveBranchFromList (row: any) {
     await commonFunctions.swalWrapper(onSwalConfirm, swalData, notify)
 }
 
+// Action cells sit on a row whose click / double-click selects or opens the
+// branch. The whole cell swallows both events so a click near the icon can't
+// switch the selection.
+const actionCell = (children: any) => h('div', {
+    style: 'display: flex; justify-content: center; align-items: center; min-height: 28px;',
+    onClick: (e: Event) => e.stopPropagation(),
+    onDblclick: (e: Event) => e.stopPropagation(),
+}, children)
+
 function archiveActionCell (row: any) {
     if (!isWritable.value || row.type === 'BASE') return null
-    return h(NIcon, {
+    return actionCell(h(NIcon, {
         title: 'Archive ' + words.value.branchFirstUpper,
         class: 'icons clickable',
         size: 22,
         onClick: (e: Event) => { e.stopPropagation(); archiveBranchFromList(row) },
-    }, () => h(Trash))
+    }, () => h(Trash)))
 }
 
 const branchFields: any[] = [
@@ -3012,24 +3038,27 @@ const branchFields: any[] = [
         render: archiveActionCell,
     },]
 
-if (!isComponent.value && isWritable){
-    branchFields.push({
-        title: '',
-        key: 'manage',
-        render: (row: any) => {
-            return h(
-                NIcon, 
-                {
-                    title: 'Clone ' + words.value.branchFirstUpper,
-                    class: 'icons clickable',
-                    size: 25,
-                    onClick: () => {cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; showCloneBranchModal.value = true}
-                }, 
-                () => h(Copy)
-            )
-        }
-    })
+// Clone lives on product feature sets for writers. isComponent / isWritable
+// only settle once the component loads, so the column is attached reactively
+// rather than pushed once at setup (which silently never ran for products).
+const cloneBranchColumn = {
+    title: '',
+    key: 'manage',
+    width: 50,
+    render: (row: any) => {
+        return actionCell(h(
+            NIcon,
+            {
+                title: 'Clone ' + words.value.branchFirstUpper,
+                class: 'icons clickable',
+                size: 25,
+                onClick: (e: Event) => { e.stopPropagation(); cloneBrProps.value.originalBranch = row; cloneBrProps.value.schema = componentData.value.featureBranchVersioning; customCloneVersionSchema.value = ''; showCloneBranchModal.value = true }
+            },
+            () => h(Copy)
+        ))
+    }
 }
+const branchColumns = computed(() => (!isComponent.value && isWritable.value) ? [...branchFields, cloneBranchColumn] : branchFields)
 
 const branchTableRowKey = (row: any) => row.uuid
 

--- a/ui/src/components/CreateRelease.vue
+++ b/ui/src/components/CreateRelease.vue
@@ -45,6 +45,8 @@
                         v-if="releaseCandidates && releaseCandidates.length"
                         v-model="release.uuid"
                         v-on:update:value="value => checkIfCreateNewRelease(value)"
+                        filterable
+                        placeholder="Select or type to filter by version"
                         :options="releaseCandidates" />
                 <div v-if="!isReleasesLoading && releaseCandidates && releaseCandidates.length === 0" style="color: #999; font-style: italic;">
                     No releases discovered.

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -73,6 +73,9 @@
                 <n-form-item label="Phone"><n-input v-model:value="clientForm.contact.phone" /></n-form-item>
                 <n-form-item label="Email"><n-input v-model:value="clientForm.contact.email" /></n-form-item>
                 <n-form-item label="Notes"><n-input v-model:value="clientForm.notes" type="textarea" /></n-form-item>
+                <n-form-item v-if="!clientForm.uuid" :show-label="false">
+                    <n-checkbox v-model:checked="createDefaultSite" data-testid="create-default-site">Create a default site named "Default" with this client's address details</n-checkbox>
+                </n-form-item>
             </n-form>
             <template #action><n-button type="primary" @click="saveClient">Save</n-button></template>
         </n-modal>
@@ -184,7 +187,7 @@ export default { name: 'DistributionOfOrg' }
 import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
+import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType, NCheckbox } from 'naive-ui'
 import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
@@ -301,6 +304,8 @@ async function onShipReleaseChange (releaseUuid: string) {
 
 const emptyContact = () => ({ address: '', phone: '', email: '' })
 const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contact: emptyContact(), notes: '' })
+// New clients get a "Default" site out of the box (address / phone / email copied from the client) unless unticked.
+const createDefaultSite = ref(true)
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
 const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
 // Shipments carry the same two-axis classification as components: nature (HARDWARE /
@@ -578,14 +583,22 @@ const deviceRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => 
 function openClientModal (c?: any) {
     clientForm.uuid = c?.uuid || ''; clientForm.name = c?.name || ''; clientForm.domain = c?.domain || 'GENERIC'
     clientForm.contact = c?.contact ? { ...c.contact } : emptyContact(); clientForm.notes = c?.notes || ''
+    createDefaultSite.value = true
     showClientModal.value = true
 }
 async function saveClient () {
     if (!clientForm.name) { notify('warning', 'Missing', 'Client name is required'); return }
     const input: any = { org: orguuid.value, name: clientForm.name, domain: clientForm.domain, notes: clientForm.notes, contact: clientForm.contact }
-    if (clientForm.uuid) input.uuid = clientForm.uuid
-    await graphqlClient.mutate({ mutation: gql`mutation upsertClient($input: ClientInput!) { upsertClient(input: $input) { uuid } }`, variables: { input } })
-    showClientModal.value = false; notify('success', 'Saved', `Client ${clientForm.name} saved`); await loadClients()
+    const creating = !clientForm.uuid
+    if (!creating) input.uuid = clientForm.uuid
+    const resp: any = await graphqlClient.mutate({ mutation: gql`mutation upsertClient($input: ClientInput!) { upsertClient(input: $input) { uuid } }`, variables: { input } })
+    let withSite = false
+    if (creating && createDefaultSite.value && resp?.data?.upsertClient?.uuid) {
+        const siteInput = { org: orguuid.value, client: resp.data.upsertClient.uuid, name: 'Default', contact: { ...clientForm.contact } }
+        await graphqlClient.mutate({ mutation: gql`mutation upsertSite($input: SiteInput!) { upsertSite(input: $input) { uuid } }`, variables: { input: siteInput } })
+        withSite = true
+    }
+    showClientModal.value = false; notify('success', 'Saved', `Client ${clientForm.name} saved${withSite ? ' with a Default site' : ''}`); await loadClients()
 }
 async function deleteClient (c: any) {
     await graphqlClient.mutate({ mutation: gql`mutation deleteClient($uuid: ID!) { deleteClient(uuid: $uuid) }`, variables: { uuid: c.uuid } })

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -24,13 +24,6 @@
                     <n-tag size="small" :type="domainTagType" style="margin-left: 6px;">{{ selectedClient.domain || 'GENERIC' }}</n-tag>
                 </h4>
                 <div v-if="selectedClient.contact" class="contactLine">{{ formatContact(selectedClient.contact) }}</div>
-                <n-space size="small" style="margin: 4px 0;">
-                    <n-button v-if="isWritable" size="tiny" @click="openClientModal(selectedClient)">Edit</n-button>
-                    <n-popconfirm v-if="isWritable" @positive-click="deleteClient(selectedClient)">
-                        <template #trigger><n-button size="tiny" type="error">Archive</n-button></template>
-                        Archive client {{ selectedClient.name }} with all its sites, shipments, and devices?
-                    </n-popconfirm>
-                </n-space>
                 <h4>Sites</h4>
                 <n-icon v-if="isWritable" @click="openSiteModal()" class="icons clickable" title="Add Site" size="22"><CirclePlus /></n-icon>
                 <n-data-table :columns="siteColumns" :data="sites" :row-class-name="siteRowClass" :row-props="siteRowProps" size="small" />
@@ -43,19 +36,26 @@
             <template v-if="selectedSite">
                 <h4>{{ selectedSite.name }}</h4>
                 <div v-if="selectedSite.contact" class="contactLine">{{ formatContact(selectedSite.contact) }}</div>
-                <n-space size="small" style="margin: 4px 0;">
-                    <n-button v-if="isWritable" size="tiny" @click="openSiteModal(selectedSite)">Edit</n-button>
-                    <n-popconfirm v-if="isWritable" @positive-click="deleteSite(selectedSite)">
-                        <template #trigger><n-button size="tiny" type="error">Archive</n-button></template>
-                        Archive site {{ selectedSite.name }} with its shipments and devices?
-                    </n-popconfirm>
-                </n-space>
                 <h4>{{ terms.shipments }} <span class="subtle">({{ terms.installedBase }})</span></h4>
                 <n-icon v-if="isWritable" @click="openShipModal()" class="icons clickable" :title="terms.shipAction" size="22"><CirclePlus /></n-icon>
-                <n-data-table :columns="shipmentColumns" :data="shipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                <n-tabs v-if="showHardwareTab || showSamdTab" v-model:value="shipmentTab" type="segment" size="small" animated data-testid="shipment-tabs">
+                    <n-tab-pane v-if="showHardwareTab" name="hardware" :tab="`Hardware (${hardwareShipments.length})`">
+                        <n-data-table :columns="shipmentColumns" :data="hardwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                    <n-tab-pane v-if="showSamdTab" name="samd" :tab="`SaMD (${samdShipments.length})`">
+                        <n-data-table :columns="shipmentColumns" :data="samdShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                    <n-tab-pane name="software" :tab="`Software (${softwareShipments.length})`">
+                        <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                    </n-tab-pane>
+                </n-tabs>
+                <!-- software-only organization: no tabs, just the software shipments -->
+                <div v-else data-testid="shipment-tabs" data-software-only="true">
+                    <n-data-table :columns="softwareShipmentColumns" :data="softwareShipments" :row-class-name="shipmentRowClass" :row-props="shipmentRowProps" size="small" />
+                </div>
 
-                <!-- Devices of selected shipment -->
-                <template v-if="selectedShipment">
+                <!-- Units of the selected HARDWARE / SAMD shipment -->
+                <template v-if="selectedShipment && !isPlainSoftware(selectedShipment)">
                     <h4 style="margin-top: 12px;">Devices <span class="subtle">of selected {{ terms.shipment.toLowerCase() }}</span></h4>
                     <n-icon v-if="isWritable" @click="openDeviceModal()" class="icons clickable" title="Add device" size="22"><CirclePlus /></n-icon>
                     <n-data-table :columns="deviceColumns" :data="devices" :row-props="deviceRowProps" size="small" />
@@ -92,21 +92,26 @@
         <!-- Ship modal -->
         <n-modal v-model:show="showShipModal" preset="dialog" :show-icon="false" :title="editingShipmentUuid ? 'Edit Shipment' : terms.shipAction" style="width: 640px;">
             <n-form>
-                <n-form-item v-if="!editingShipmentUuid" label="Product">
+                <n-form-item v-if="!editingShipmentUuid" label="Product *">
                     <n-select v-model:value="shipProductUuid" filterable :options="products" placeholder="Pick a product" @update:value="onShipProductChange" />
                 </n-form-item>
-                <n-form-item v-if="!editingShipmentUuid" label="Feature set">
+                <n-form-item v-if="!editingShipmentUuid" label="Feature set *">
                     <n-select v-model:value="shipForm.featureSet" filterable :options="featureSetOptions" :disabled="!shipProductUuid" placeholder="Pick a feature set" @update:value="onFeatureSetChange" />
                 </n-form-item>
                 <div v-if="editingShipmentUuid" class="identityBox">
-                    Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust release, dates, quantity, identifiers and choices.
+                    Editing shipment of <strong>{{ releaseLabel(shipForm.release) || shortUuid(shipForm.release) }}</strong> — product / feature set are fixed; adjust the rest. Fields marked * are required.
                 </div>
-                <div v-if="resolvedIdentity" class="identityBox">
-                    {{ terms.deviceIdentity }}:
-                    <n-tag size="small" :type="resolvedIdentity.deviceClass === 'NONE' ? 'default' : 'info'">{{ resolvedIdentity.deviceClass }}</n-tag>
-                    <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
+                <div v-if="resolvedIdentity" class="identityBox" data-testid="ship-kind-box">
+                    <n-tag size="small" :type="isSoftwareShipment ? 'success' : 'info'">{{ shipmentKindLabel(resolvedIdentity) }}</n-tag>
+                    <template v-if="resolvedIdentity.deviceClass !== 'NONE'">
+                        &middot; {{ terms.deviceIdentity }}: <n-tag size="small" type="info">{{ resolvedIdentity.deviceClass }}</n-tag>
+                        <span v-if="resolvedIdentity.udiDi"> &middot; UDI-DI: <code>{{ resolvedIdentity.udiDi }}</code></span>
+                    </template>
+                    <span v-if="isSoftwareShipment" class="subtle"> &middot; plain software: no quantity or batch facts; optionally applied to devices at this site</span>
+                    <span v-else-if="isSamd(resolvedIdentity)" class="subtle"> &middot; software as a medical device: shipped and tracked per unit like hardware</span>
                 </div>
-                <n-form-item label="Release">
+                <div v-if="!editingShipmentUuid" class="subtle" style="margin-bottom: 6px;">Fields marked * are required.</div>
+                <n-form-item label="Release *">
                     <n-select v-model:value="shipForm.release" filterable :options="shipReleases" :disabled="!shipForm.featureSet" placeholder="Pick a release / version" @update:value="onShipReleaseChange" />
                 </n-form-item>
                 <n-form-item v-if="shipDeliverables.length" label="Deliverable / lot">
@@ -127,8 +132,12 @@
                     </n-form-item>
                 </template>
                 <n-form-item label="Ship date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.shipDate" value-format="yyyy-MM-dd" placeholder="defaults to today" /></n-form-item>
-                <n-form-item label="Quantity"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
-                <n-form-item label="Batch identifiers">
+                <n-form-item v-if="isSoftwareShipment" label="Applies to devices (optional)">
+                    <n-select v-model:value="shipForm.devices" multiple filterable clearable :options="siteDeviceOptions" data-testid="ship-devices"
+                        :placeholder="siteDeviceOptions.length ? 'Pick devices from hardware or SaMD shipments at this site, or leave empty' : 'No devices at this site yet — leave empty'" />
+                </n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Quantity *"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Batch identifiers">
                     <n-dynamic-input v-model:value="shipForm.identifiers" :on-create="onCreateBatchId">
                         <template #create-button-default>Add identifier</template>
                         <template #default="{ value }">
@@ -137,8 +146,8 @@
                         </template>
                     </n-dynamic-input>
                 </n-form-item>
-                <n-form-item label="Manufacture date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.manufactureDate" value-format="yyyy-MM-dd" /></n-form-item>
-                <n-form-item label="Expiry date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.expiryDate" value-format="yyyy-MM-dd" /></n-form-item>
+                <n-form-item v-if="!isSoftwareShipment" label="Manufacture date"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.manufactureDate" value-format="yyyy-MM-dd" /></n-form-item>
+                <n-form-item :label="isSoftwareShipment ? 'Expiry / end of support date (optional)' : 'Expiry date'"><n-date-picker style="width: 100%;" type="date" clearable v-model:formatted-value="shipForm.expiryDate" value-format="yyyy-MM-dd" /></n-form-item>
             </n-form>
             <template #action><n-button type="primary" @click="shipProduct">{{ editingShipmentUuid ? 'Save changes' : terms.shipAction }}</n-button></template>
         </n-modal>
@@ -175,8 +184,8 @@ export default { name: 'DistributionOfOrg' }
 import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
-import { CirclePlus, InfoCircle, Edit as EditIcon } from '@vicons/tabler'
+import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType } from 'naive-ui'
+import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -293,7 +302,52 @@ async function onShipReleaseChange (releaseUuid: string) {
 const emptyContact = () => ({ address: '', phone: '', email: '' })
 const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contact: emptyContact(), notes: '' })
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
-const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null })
+const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
+// Shipments carry the same two-axis classification as components: nature (HARDWARE /
+// SOFTWARE, hardware if any constituent component is hardware) and deviceClass. HARDWARE =
+// physical batch; SOFTWARE + MEDICAL_* = SaMD, shipped and tracked per unit like hardware;
+// SOFTWARE + NONE = plain software that may be applied to devices at the site. The server
+// derives and stores both; this only drives the form and the tabs.
+const isHardware = (x: any) => x?.nature === 'HARDWARE'
+const isSamd = (x: any) => !isHardware(x) && !!x?.deviceClass && x.deviceClass !== 'NONE'
+const isPlainSoftware = (x: any) => !isHardware(x) && !isSamd(x)
+const isSoftwareShipment = computed(() => !!resolvedIdentity.value && isPlainSoftware(resolvedIdentity.value))
+const shipmentKindLabel = (x: any) => isHardware(x) ? 'Hardware shipment' : isSamd(x) ? 'SaMD shipment' : 'Software shipment'
+const shipmentTab = ref('hardware')
+const softwareShipments = computed(() => shipments.value.filter(isPlainSoftware))
+const samdShipments = computed(() => shipments.value.filter(isSamd))
+const hardwareShipments = computed(() => shipments.value.filter(isHardware))
+// Which tabs make sense here follows the org's component classification: no hardware
+// components -> software only; SaMD only for MEDICAL-framed clients of an org that has SaMD
+// components. A kind that already has rows stays visible so nothing is hidden by accident.
+const orgHasHardware = ref(false)
+const orgHasSamd = ref(false)
+async function loadOrgClassification () {
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query componentsClassification($o: ID!) { components(orgUuid: $o, componentType: ANY) { uuid nature deviceClass } }`, variables: { o: orguuid.value }, fetchPolicy: 'no-cache' })
+        const comps: any[] = resp.data.components || []
+        orgHasHardware.value = comps.some(isHardware)
+        orgHasSamd.value = comps.some(isSamd)
+    } catch (e) { orgHasHardware.value = false; orgHasSamd.value = false }
+}
+const showHardwareTab = computed(() => orgHasHardware.value || hardwareShipments.value.length > 0)
+const showSamdTab = computed(() => (selectedClient.value?.domain === 'MEDICAL' && orgHasSamd.value) || samdShipments.value.length > 0)
+const pickShipmentTab = () => {
+    const visible = [showHardwareTab.value ? 'hardware' : '', showSamdTab.value ? 'samd' : '', 'software'].filter(Boolean)
+    const counts: Record<string, number> = { hardware: hardwareShipments.value.length, samd: samdShipments.value.length, software: softwareShipments.value.length }
+    shipmentTab.value = visible.find(t => counts[t] > 0) || visible[0]
+}
+watch([showHardwareTab, showSamdTab], () => { if (!['hardware', 'samd', 'software'].includes(shipmentTab.value) || (shipmentTab.value === 'hardware' && !showHardwareTab.value) || (shipmentTab.value === 'samd' && !showSamdTab.value)) pickShipmentTab() })
+const siteDevices: Ref<any[]> = ref([])
+const siteDeviceOptions = computed(() => siteDevices.value.map((d: any) => ({ label: summarizeIds(d.identifiers) || shortUuid(d.uuid), value: d.uuid })))
+async function loadSiteDevices (siteUuid: string) {
+    if (!siteUuid) { siteDevices.value = []; return }
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query devicesOfSite($s: ID!, $o: ID!) { devicesOfSite(siteUuid: $s, orgUuid: $o) { uuid identifiers { idType idValue } shippedProduct } }`, variables: { s: siteUuid, o: orguuid.value }, fetchPolicy: 'no-cache' })
+        siteDevices.value = resp.data.devicesOfSite || []
+    } catch (e) { siteDevices.value = [] }
+}
+const deviceLabel = (uuid: string) => siteDeviceOptions.value.find(o => o.value === uuid)?.label || shortUuid(uuid)
 const editingShipmentUuid: Ref<string> = ref('')
 
 // Resolved display info per release uuid (product / feature set / version)
@@ -331,7 +385,7 @@ const onCreateUnitId = () => ({ idType: 'SERIAL', idValue: '' })
 // ---- GraphQL ----
 const CLIENT_FIELDS = 'uuid org name domain contact { address phone email } notes'
 const SITE_FIELDS = 'uuid org client name contact { address phone email } notes'
-const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
+const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes nature deviceClass devices identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
 const DEVICE_FIELDS = 'uuid org shippedProduct site versionDrift notes identifiers { idType idValue } plan { expectedRelease } actual { reportedRelease reportedAt source } tracking { receivedDate patientId disposition dispositionDate }'
 
 async function loadClients () {
@@ -358,7 +412,7 @@ async function resolveIdentity () {
     resolvedIdentity.value = null
     if (!shipForm.featureSet) return
     try {
-        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
+        const resp: any = await graphqlClient.query({ query: gql`query fsdi($fs: ID!, $org: ID!) { featureSetDeviceIdentity(featureSetUuid: $fs, orgUuid: $org) { deviceClass udiDi nature } }`, variables: { fs: shipForm.featureSet, org: orguuid.value }, fetchPolicy: 'no-cache' })
         resolvedIdentity.value = resp.data.featureSetDeviceIdentity
     } catch (e: any) { /* invalid uuid etc */ }
 }
@@ -383,15 +437,28 @@ watch(() => route.params.clientuuid, async (v) => {
 watch(() => route.params.siteuuid, async (v) => {
     selectedSiteUuid.value = v ? v.toString() : ''
     selectedShipmentUuid.value = ''; devices.value = []
-    await loadShipments(selectedSiteUuid.value)
+    await Promise.all([loadShipments(selectedSiteUuid.value), loadSiteDevices(selectedSiteUuid.value)])
+    pickShipmentTab()
 })
 
 // ---- columns ----
+// Edit / archive live inside the list row (no header label); clicks must not select the row.
+const rowActions = (r: any, edit: (x: any) => void, archive: (x: any) => Promise<void>, confirmText: string) => h('span', { style: 'white-space: nowrap;', onClick: (e: Event) => e.stopPropagation() }, [
+    h(NIcon, { size: 18, class: 'icons clickable', title: 'Edit', style: 'margin-right: 8px;', onClick: () => edit(r) }, { default: () => h(EditIcon) }),
+    h(NPopconfirm, { onPositiveClick: () => archive(r) }, {
+        trigger: () => h(NIcon, { size: 18, class: 'icons clickable', title: 'Archive', style: 'color: #d03050;' }, { default: () => h(ArchiveIcon) }),
+        default: () => confirmText
+    })
+])
 const clientColumns = [
     { key: 'name', title: 'Name' },
-    { key: 'domain', title: 'Framing', render: (r: any) => h(NTag, { size: 'small' }, { default: () => r.domain || 'GENERIC' }) }
+    { key: 'domain', title: 'Framing', render: (r: any) => h(NTag, { size: 'small' }, { default: () => r.domain || 'GENERIC' }) },
+    ...(isWritable ? [{ key: 'actions', title: '', width: 70, render: (r: any) => rowActions(r, openClientModal, deleteClient, `Archive client ${r.name} with all its sites, shipments, and devices?`) }] : [])
 ]
-const siteColumns = [{ key: 'name', title: 'Name' }]
+const siteColumns = [
+    { key: 'name', title: 'Name' },
+    ...(isWritable ? [{ key: 'actions', title: '', width: 70, render: (r: any) => rowActions(r, openSiteModal, deleteSite, `Archive site ${r.name} with its shipments and devices?`) }] : [])
+]
 const shipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
     {
@@ -438,6 +505,33 @@ const shipmentColumns = computed(() => [
             onClick: (e: Event) => { e.stopPropagation(); openShipModal(r) }
         }, { default: () => h(EditIcon) })
     }] : [])
+])
+const softwareShipmentColumns = computed(() => [
+    { key: 'shipDate', title: 'Date' },
+    (shipmentColumns.value as any[])[1],
+    { key: 'expiryDate', title: 'Expires', render: (r: any) => r.expiryDate || h('span', { class: 'subtle' }, '—') },
+    {
+        key: 'devices', title: 'Devices',
+        render: (r: any) => {
+            const ids: string[] = r.devices || []
+            if (!ids.length) return h('span', { class: 'subtle', title: 'Shipped without devices' }, 'none')
+            return h(NTooltip, { trigger: 'hover', placement: 'left' }, {
+                trigger: () => h(NTag, { size: 'small', type: 'info' }, { default: () => `${ids.length} device${ids.length === 1 ? '' : 's'}` }),
+                default: () => h('div', ids.map((u: string) => h('div', deviceLabel(u))))
+            })
+        }
+    },
+    {
+        key: 'info', title: '',
+        render: (r: any) => {
+            const facts: [string, any][] = [['Notes', r.notes]].filter(([, v]) => v !== null && v !== undefined && v !== '') as [string, any][]
+            return facts.length ? h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 460px;' }, {
+                trigger: () => h(NIcon, { size: 16, style: 'color: #909399; vertical-align: middle;', onClick: (e: Event) => e.stopPropagation() }, { default: () => h(InfoCircle) }),
+                default: () => h('div', facts.map(([k, v]) => h('div', { style: 'margin: 2px 0;' }, [h('strong', `${k}: `), String(v)])))
+            }) : ''
+        }
+    },
+    ...(isWritable ? [(shipmentColumns.value as any[])[(shipmentColumns.value as any[]).length - 1]] : [])
 ])
 const deviceColumns = computed(() => [
     { key: 'ids', title: 'Unit ids', render: (r: any) => summarizeIds(r.identifiers) || h('span', { class: 'subtle' }, '—') },
@@ -522,8 +616,9 @@ async function deleteSite (s: any) {
 function cleanIds (ids: any[]) { return (ids || []).filter(i => i.idType && i.idValue) }
 async function openShipModal (existing?: any) {
     shipForm.featureSet = ''; shipForm.release = ''; shipForm.deliverable = null; shipForm.shipDate = null; shipForm.quantity = 1
-    shipForm.identifiers = []; shipForm.manufactureDate = null; shipForm.expiryDate = null
+    shipForm.identifiers = []; shipForm.manufactureDate = null; shipForm.expiryDate = null; shipForm.devices = []
     shipProductUuid.value = ''; shipReleases.value = []; shipDeliverables.value = []
+    await loadSiteDevices(selectedSiteUuid.value)
     shipChoices.value = []; Object.keys(shipChoiceSelections).forEach(k => delete shipChoiceSelections[k])
     resolvedIdentity.value = null
     editingShipmentUuid.value = existing?.uuid || ''
@@ -536,6 +631,7 @@ async function openShipModal (existing?: any) {
         shipForm.identifiers = (existing.identifiers || []).map((i: any) => ({ idType: i.idType, idValue: i.idValue }))
         shipForm.manufactureDate = existing.manufactureDate || null
         shipForm.expiryDate = existing.expiryDate || null
+        shipForm.devices = [...(existing.devices || [])]
         shipReleases.value = await loadReleasesForBranch(existing.featureSet)
         await Promise.all([loadShipChoices(existing.release), resolveIdentity()])
         for (const cr of (existing.choiceResolutions || [])) {
@@ -547,7 +643,9 @@ async function openShipModal (existing?: any) {
 }
 async function shipProduct () {
     if (!shipForm.featureSet || !shipForm.release) { notify('warning', 'Missing', 'Feature set and release are required'); return }
-    const input: any = { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: shipForm.quantity, identifiers: cleanIds(shipForm.identifiers) }
+    const input: any = isSoftwareShipment.value
+        ? { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: 1, identifiers: [], devices: shipForm.devices || [] }
+        : { org: orguuid.value, site: selectedSiteUuid.value, featureSet: shipForm.featureSet, release: shipForm.release, quantity: shipForm.quantity, identifiers: cleanIds(shipForm.identifiers) }
     if (shipChoices.value.length) {
         const resolutions: any[] = []
         for (const cv of shipChoices.value) {
@@ -566,7 +664,7 @@ async function shipProduct () {
     }
     if (shipForm.deliverable) input.deliverable = shipForm.deliverable
     if (shipForm.shipDate) input.shipDate = shipForm.shipDate
-    if (shipForm.manufactureDate) input.manufactureDate = shipForm.manufactureDate
+    if (shipForm.manufactureDate && !isSoftwareShipment.value) input.manufactureDate = shipForm.manufactureDate
     if (shipForm.expiryDate) input.expiryDate = shipForm.expiryDate
     try {
         if (editingShipmentUuid.value) {
@@ -633,6 +731,7 @@ const fleetDriftColumns = [
 const driftRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device.uuid } }) })
 
 onMounted(async () => {
+    loadOrgClassification()
     store.dispatch('fetchProducts', orguuid.value)
     loadFleetDrift()
     await loadClients()

--- a/ui/src/components/InstanceHistory.vue
+++ b/ui/src/components/InstanceHistory.vue
@@ -155,6 +155,7 @@ function formatChangeType(raw: any): string {
     // Cosmetic relabeling so the table reads naturally.
     s = s.replace('PRODUCT_RELEASE', 'Product Release')
     s = s.replace('TARGET_RELEASE', 'Target Release')
+    s = s.replace('CONFIGURATION', 'Configuration')
     s = s.replace('AGENT_DATA', 'Agent Data')
     s = s.replace('PRODUCT_MATCH', 'Product Match')
     s = s.replace('DEPLOYMENT', 'Deployment')

--- a/ui/src/components/InstanceView.vue
+++ b/ui/src/components/InstanceView.vue
@@ -394,6 +394,24 @@
                             @approvalsChanged="fetchInstance" @closeRelease="showReleaseViewModal=false"/>
         </n-modal>
         <n-modal
+            v-model:show="showEditConfigurationModal"
+            preset="dialog"
+            :show-icon="false"
+            style="width: 90%;"
+            title="Edit Extra Configuration"
+        >
+            <n-form-item :label="'Extra Configuration for ' + (focusedProduct?.featureSetDetails?.name || featureSetLabel) + ' (e.g. Helm values file, optional)'">
+                <n-input
+                            type="textarea"
+                            rows="4"
+                            data-testid="product-config-input"
+                            v-model:value="updatedProductConfiguration"
+                            placeholder="Enter extra configuration" />
+            </n-form-item>
+            <n-button type="success" data-testid="product-config-save" @click="saveConfiguration()">Submit</n-button>
+            <n-button type="warning" @click="updatedProductConfiguration = focusedProduct.configuration || ''">Reset</n-button>
+        </n-modal>
+        <n-modal
             v-model:show="showEditPropertyModal"
             preset="dialog"
             :show-icon="false"
@@ -616,6 +634,7 @@ const planChangeTypeOptions = [
     { label: 'Any', key: 'ANY' },
     { label: 'Product Release', key: 'PRODUCT_RELEASE' },
     { label: 'Target Release', key: 'TARGET_RELEASE' },
+    { label: 'Configuration', key: 'CONFIGURATION' },
     { label: 'Property', key: 'PROPERTY' },
     { label: 'Environment', key: 'ENVIRONMENT' }
 ]
@@ -1355,14 +1374,19 @@ const targetReleaseSet = async function (rlz: any) {
     showSelectTargetReleaseModal.value = false
 }
 
-const updateConfiguration = async function (e: any, prl: any) {
-    const updatedProduct = updatedInstance.value.productPlans.find((product: any) => 
+const showEditConfigurationModal = ref(false)
+const updatedProductConfiguration = ref('')
+const saveConfiguration = async function () {
+    const prl = focusedProduct.value
+    const updatedProduct = updatedInstance.value.productPlans.find((product: any) =>
         product.featureSet === prl.featureSet && product.namespace === prl.namespace
     )
-    if (updatedProduct.configuration !== e.target.innerText) {
-        updatedProduct.configuration = e.target.innerText
-        await save() 
+    const newValue = updatedProductConfiguration.value.trim()
+    if (updatedProduct && (updatedProduct.configuration || '') !== newValue) {
+        updatedProduct.configuration = newValue
+        await save()
     }
+    showEditConfigurationModal.value = false
 }
 
 const clearAgentData = async function () {
@@ -1681,16 +1705,24 @@ matchedProductFields.push({
     key: 'config',
     title: 'Config',
     render: (row: any) => {
-        if(isWritable){
-            return h('span', {
-                contenteditable: true,
-                onblur: (e: Event) => {
-                    updateConfiguration(e, row)
+        // Extra configuration (e.g. Helm values file) stays editable after
+        // deployment: every save lands as a plan revision, which the Plan
+        // History tab classifies as a Configuration change.
+        const els: any[] = [h('span', { 'data-testid': 'product-config-value' }, row.configuration || '')]
+        if (isWritable) {
+            els.push(h(NIcon, {
+                title: 'Edit Extra Configuration',
+                class: 'icons clickable',
+                size: 16,
+                'data-testid': 'product-config-edit',
+                onClick: () => {
+                    focusedProduct.value = row
+                    updatedProductConfiguration.value = row.configuration || ''
+                    showEditConfigurationModal.value = true
                 }
-            }, {default: () => row.configuration})
-        }else{
-            return h('span', row.configuration)
+            }, { default: () => h(Edit24Regular) }))
         }
+        return els
     }
 })
 if(props.instanceType === InstanceType.STANDALONE_INSTANCE){

--- a/ui/src/components/LatestReleasesOfComponent.vue
+++ b/ui/src/components/LatestReleasesOfComponent.vue
@@ -1,0 +1,258 @@
+<template>
+    <div class="latestReleases">
+        <div class="latestReleasesHeader">
+            <span class="latestReleasesTitle">Most recent releases across {{ props.featureSetLabel.toLowerCase() }}es</span>
+            <n-input-number v-model:value="limit" size="small" :min="1" :max="200" :step="5" style="width: 110px;" data-testid="latest-limit" @update:value="onLimitChange" />
+            <n-icon class="clickable" size="18" title="Refresh" @click="fetchLatest"><Refresh /></n-icon>
+        </div>
+        <n-data-table
+            data-testid="latest-releases-table"
+            :data="rows"
+            :columns="columns"
+            :row-props="rowProps"
+            :row-class-name="rowClassName"
+            :row-key="(row: any) => row.uuid"
+            :loading="loading"
+            :pagination="rows.length > 50 ? { pageSize: 50 } : false" />
+        <div v-if="!loading && !rows.length && !loadError" class="latestReleasesEmpty">No releases yet.</div>
+        <div v-if="loadError" class="latestReleasesEmpty">{{ loadError }}</div>
+        <vulnerability-modal
+            v-model:show="showVulnModal"
+            :component-name="vulnModalRelease?.componentDetails?.name || ''"
+            :version="vulnModalRelease?.version || ''"
+            :data="vulnModalData"
+            :loading="vulnModalLoading"
+            :artifacts="vulnModalArtifacts"
+            :org-uuid="vulnModalOrgUuid"
+            :dtrack-project-uuids="vulnModalDtrackProjectUuids"
+            :release-uuid="vulnModalRelease?.uuid || ''"
+            :branch-uuid="vulnModalRelease?.branchDetails?.uuid || ''"
+            :branch-name="vulnModalRelease?.branchDetails?.name || ''"
+            :component-uuid="vulnModalRelease?.componentDetails?.uuid || ''"
+            :component-type="vulnModalRelease?.componentDetails?.type || ''"
+            :artifact-view-only="false"
+            :initial-severity-filter="vulnModalSeverity"
+            :initial-type-filter="vulnModalType"
+        />
+    </div>
+</template>
+
+<script lang="ts">
+export default {
+    name: 'LatestReleasesOfComponent'
+}
+</script>
+<script lang="ts" setup>
+// The N most recent releases of a component / product across all its
+// branches, newest first -- the home page's Most Recent Releases widget
+// scoped to one component. N is the user's choice, remembered in the
+// browser. The branch cell opens that branch in detail mode; the version
+// cell (or the row) opens the release. Scan status and vulnerability
+// circles mirror the home widget.
+import { ref, Ref, h, watch, onMounted } from 'vue'
+import { RouterLink, useRouter } from 'vue-router'
+import { NDataTable, NIcon, NInputNumber, NTag, NTooltip, useNotification, DataTableColumns } from 'naive-ui'
+import { Refresh, Star, CalendarTime } from '@vicons/tabler'
+import graphqlClient from '@/utils/graphql'
+import GqlQueries from '@/utils/graphqlQueries'
+import { ReleaseVulnerabilityService } from '@/utils/releaseVulnerabilityService'
+import { isDtrackConfiguredForOrg, getReleaseScanStatus } from '@/utils/releaseScanStatus'
+import { renderVulnerabilityCells, renderViolationCells } from '@/utils/releaseScanCells'
+import VulnerabilityModal from './VulnerabilityModal.vue'
+
+const props = withDefaults(defineProps<{
+    componentUuid: string
+    orgUuid: string
+    selectedBranchUuid?: string
+    featureSetLabel?: string
+    /** Bump to force a refetch from the parent (e.g. after a branch was archived). */
+    refreshToken?: number
+}>(), {
+    selectedBranchUuid: '',
+    featureSetLabel: 'Branch',
+    refreshToken: 0
+})
+const emit = defineEmits<{ (e: 'selectBranch', branchUuid: string): void }>()
+
+const router = useRouter()
+const notification = useNotification()
+const loading = ref(false)
+const loadError = ref('')
+const LIMIT_STORAGE_KEY = 'rearmLatestReleasesLimit'
+function storedLimit (): number {
+    try {
+        const v = parseInt(window.localStorage.getItem(LIMIT_STORAGE_KEY) || '', 10)
+        return Number.isFinite(v) && v > 0 ? Math.min(v, 200) : 20
+    } catch { return 20 }
+}
+const limit = ref(storedLimit())
+function onLimitChange (v: number | null) {
+    if (!v || v < 1) return
+    try { window.localStorage.setItem(LIMIT_STORAGE_KEY, String(v)) } catch {}
+    fetchLatest()
+}
+const rows: Ref<any[]> = ref([])
+const dtrackConfigured = ref(false)
+
+async function fetchLatest () {
+    loading.value = true
+    loadError.value = ''
+    try {
+        const response = await graphqlClient.query({
+            query: GqlQueries.LatestReleasesOfComponentGql,
+            variables: { componentUuid: props.componentUuid, limit: limit.value },
+            fetchPolicy: 'no-cache'
+        })
+        rows.value = (response.data as any).latestReleasesOfComponent || []
+    } catch (error: any) {
+        console.error('Error fetching latest releases per branch:', error)
+        rows.value = []
+        loadError.value = 'Could not load the latest releases (the backend may predate this view).'
+        notification.error({ content: 'Error', meta: 'Failed to load latest releases', duration: 3000 })
+    } finally {
+        loading.value = false
+    }
+}
+
+const branchTypeBadge: Record<string, { label: string, type: 'info' | 'warning' | 'success' | 'default' }> = {
+    PULL_REQUEST: { label: 'PR', type: 'info' },
+    TAG: { label: 'Tag', type: 'default' },
+    HOTFIX: { label: 'Hotfix', type: 'warning' },
+    RELEASE: { label: 'Release', type: 'success' }
+}
+
+function formatDate (dateStr: string): string {
+    return dateStr ? new Date(dateStr).toLocaleDateString('en-CA') : ''
+}
+function formatDateTime (dateStr: string): string {
+    return dateStr ? new Date(dateStr).toLocaleString('en-CA') : ''
+}
+
+const columns: DataTableColumns<any> = [
+    {
+        title: () => props.featureSetLabel,
+        key: 'branch',
+        render: (row: any) => {
+            const b = row.branchDetails || {}
+            const els: any[] = [h('span', { 'data-testid': 'latest-branch-name' }, b.name || '')]
+            if (b.type === 'BASE') {
+                els.push(h(NIcon, { size: 14, title: `Base ${props.featureSetLabel.toLowerCase()}` }, () => h(Star)))
+            }
+            const badge = branchTypeBadge[b.type]
+            if (badge) {
+                els.push(h(NTag, { size: 'small', type: badge.type, bordered: false }, () => badge.label))
+            }
+            return h('div', {
+                style: 'display: flex; align-items: center; gap: 6px; cursor: pointer;',
+                title: `Open ${props.featureSetLabel.toLowerCase()} ${b.name || ''}`,
+                onClick: (e: Event) => { e.stopPropagation(); if (b.uuid) emit('selectBranch', b.uuid) }
+            }, els)
+        }
+    },
+    {
+        title: 'Release',
+        key: 'version',
+        width: 260,
+        render: (row: any) => h(RouterLink, {
+            to: { name: 'ReleaseView', params: { uuid: row.uuid } },
+            'data-testid': 'latest-release-link',
+            onClick: (e: Event) => e.stopPropagation()
+        }, { default: () => row.version })
+    },
+    {
+        title: 'Lifecycle',
+        key: 'lifecycle',
+        width: 200,
+        render: (row: any) => row.lifecycle
+    },
+    {
+        title: 'Created',
+        key: 'createdDate',
+        width: 150,
+        render: (row: any) => h('span', { style: 'display: inline-flex; align-items: center; gap: 4px;' }, [
+            formatDate(row.createdDate),
+            h(NTooltip, { trigger: 'hover', delay: 200 }, {
+                trigger: () => h(NIcon, { size: 14, style: 'cursor: help;' }, () => h(CalendarTime)),
+                default: () => 'Release created: ' + formatDateTime(row.createdDate)
+            })
+        ])
+    },
+    {
+        title: 'Vulnerabilities',
+        key: 'vulnerabilities',
+        width: 240,
+        render: (row: any) => renderVulnerabilityCells(row, getReleaseScanStatus(row, dtrackConfigured.value), openVulnModal)
+    },
+    {
+        title: 'Violations',
+        key: 'violations',
+        width: 160,
+        render: (row: any) => renderViolationCells(row, getReleaseScanStatus(row, dtrackConfigured.value), openVulnModal)
+    }
+]
+
+const rowProps = (row: any) => ({
+    style: 'cursor: pointer;',
+    onClick: () => { if (row.uuid) router.push({ name: 'ReleaseView', params: { uuid: row.uuid } }) }
+})
+const rowClassName = (row: any) => (props.selectedBranchUuid && row.branchDetails?.uuid === props.selectedBranchUuid) ? 'selectedRow' : ''
+
+const showVulnModal = ref(false)
+const vulnModalRelease: Ref<any> = ref(null)
+const vulnModalData: Ref<any[]> = ref([])
+const vulnModalLoading = ref(false)
+const vulnModalArtifacts: Ref<any[]> = ref([])
+const vulnModalOrgUuid = ref('')
+const vulnModalDtrackProjectUuids: Ref<string[]> = ref([])
+const vulnModalSeverity = ref('')
+const vulnModalType: Ref<string | string[]> = ref('')
+async function openVulnModal (rel: any, severityFilter: string, typeFilter: string | string[]) {
+    vulnModalRelease.value = rel
+    vulnModalSeverity.value = severityFilter
+    vulnModalType.value = typeFilter
+    vulnModalLoading.value = true
+    showVulnModal.value = true
+    try {
+        const releaseData = await ReleaseVulnerabilityService.fetchReleaseVulnerabilityData(rel.uuid, rel.org)
+        vulnModalArtifacts.value = releaseData.artifacts
+        vulnModalOrgUuid.value = releaseData.orgUuid
+        vulnModalDtrackProjectUuids.value = releaseData.dtrackProjectUuids
+        vulnModalData.value = releaseData.vulnerabilityData || []
+    } catch (error) {
+        console.error('Error fetching vulnerability details:', error)
+        notification.error({ content: 'Error', meta: 'Failed to load vulnerability details', duration: 3000 })
+    } finally {
+        vulnModalLoading.value = false
+    }
+}
+
+watch(() => props.componentUuid, () => fetchLatest())
+watch(() => props.refreshToken, () => fetchLatest())
+onMounted(async () => {
+    try {
+        dtrackConfigured.value = await isDtrackConfiguredForOrg(props.orgUuid)
+    } catch {
+        dtrackConfigured.value = false
+    }
+    await fetchLatest()
+})
+</script>
+
+<style scoped lang="scss">
+.latestReleasesHeader {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 6px;
+}
+.latestReleasesTitle {
+    font-weight: 600;
+}
+.latestReleasesEmpty {
+    padding: 8px 0;
+    color: #777;
+}
+:deep(.selectedRow td) {
+    background-color: #f1f1f1 !important;
+}
+</style>

--- a/ui/src/components/LeftNavBar.vue
+++ b/ui/src/components/LeftNavBar.vue
@@ -194,8 +194,8 @@ const menuOptions = function (org : string, myuser: any) : MenuOption[] {
             key: 'instances',
             icon: renderIcon(CloudServerOutlined)
         },
-        // Distribution module is SAAS-only for now.
-        ...(myuser.installationType === 'SAAS' ? [{
+        // Distribution module: every non-OSS installation.
+        ...(myuser.installationType !== 'OSS' ? [{
             label: () =>
                 h(
                     RouterLink,

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1214,7 +1214,7 @@ async function loadTabSpecificData (tabName: string) {
             loadPerspectives(),
             store.dispatch('fetchComponents', orgResolved.value),
             store.dispatch('fetchProducts', orgResolved.value),
-            ...(myUser.value.installationType === 'SAAS' ? [store.dispatch('fetchInstances', orgResolved.value)] : [])
+            ...(myUser.value.installationType !== 'OSS' ? [store.dispatch('fetchInstances', orgResolved.value)] : [])
         ])
         loadInvitedUsers(true)
     } else if (tabName === "userGroups") {
@@ -1222,11 +1222,11 @@ async function loadTabSpecificData (tabName: string) {
         // type, so a PRODUCT/ANY rule would otherwise preview "matches 0".
         store.dispatch('fetchProducts', orgResolved.value)
         await loadUsers() // Load users for the user selection dropdown
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadUserGroups()
     } else if (tabName === "programmaticAccess") {
         await loadUsers()
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "freeFormKeys") {
         // Same as programmaticAccess — formatValuesForApiKeys() resolves
@@ -1236,7 +1236,7 @@ async function loadTabSpecificData (tabName: string) {
         // only formats when both lists are non-empty) and the column
         // ends up blank for FREEFORM rows.
         await loadUsers()
-        if (myUser.value.installationType === 'SAAS') store.dispatch('fetchInstances', orgResolved.value)
+        if (myUser.value.installationType !== 'OSS') store.dispatch('fetchInstances', orgResolved.value)
         loadProgrammaticAccessKeys(true)
     } else if (tabName === "policies") {
         fetchApprovalEntries()
@@ -1926,12 +1926,12 @@ const allComponents = computed(() => [...orgComponents.value, ...orgProducts.val
 // Instance + cluster lists used by the ScopedPermissions component to
 // expose per-instance and per-cluster permission sections (replaces
 // the old UI's userInstancePermissionColumns / userClusterPermissionColumns
-// data tables). DevOps Read/Write grants are only honored on SAAS, so we
-// short-circuit the lists to empty on other installation types — that hides
-// the corresponding sections everywhere ScopedPermissions is rendered
+// data tables). Instances and clusters exist on every non-OSS installation;
+// on OSS we short-circuit the lists to empty, which hides the corresponding
+// sections everywhere ScopedPermissions is rendered
 // (users, user groups, programmatic access, free-form keys).
 const orgInstancesAndClusters = computed(() => {
-    if (myUser.value?.installationType !== 'SAAS') return []
+    if (myUser.value?.installationType === 'OSS') return []
     const all = (store.getters.instancesOfOrg(orgResolved.value) || [])
     return all.filter((x: any) => x.revision === -1 && (x.status === 'ACTIVE' || !x.status))
 })

--- a/ui/src/components/ScopedPermissions.vue
+++ b/ui/src/components/ScopedPermissions.vue
@@ -208,14 +208,14 @@
         </div>
 
         <!-- Per-Cluster Permissions (scope=INSTANCE on a CLUSTER row). SAAS-only. -->
-        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="isSaas && orgPermission.type !== 'ADMIN' && clusters.length">
+        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="hasDevOps && orgPermission.type !== 'ADMIN' && clusters.length">
             <n-h5>
                 <n-text depth="1">
                     Per-Cluster Permissions:
                 </n-text>
             </n-h5>
         </n-space>
-        <div v-if="isSaas && orgPermission.type !== 'ADMIN' && clusters.length">
+        <div v-if="hasDevOps && orgPermission.type !== 'ADMIN' && clusters.length">
             <n-space vertical>
                 <n-card v-for="sp in scopedClusterPermissions" :key="sp.objectId" size="small" style="margin-bottom: 8px;">
                     <n-space align="center" justify="space-between" style="width: 100%;">
@@ -252,14 +252,14 @@
         </div>
 
         <!-- Per-Instance Permissions (scope=INSTANCE on a STANDALONE_INSTANCE / CLUSTER_INSTANCE row). SAAS-only. -->
-        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="isSaas && orgPermission.type !== 'ADMIN' && instances.length">
+        <n-space style="margin-top: 20px; margin-bottom: 10px;" v-if="hasDevOps && orgPermission.type !== 'ADMIN' && instances.length">
             <n-h5>
                 <n-text depth="1">
                     Per-Instance Permissions:
                 </n-text>
             </n-h5>
         </n-space>
-        <div v-if="isSaas && orgPermission.type !== 'ADMIN' && instances.length">
+        <div v-if="hasDevOps && orgPermission.type !== 'ADMIN' && instances.length">
             <n-space vertical>
                 <n-card v-for="sp in scopedInstancePermissions" :key="sp.objectId" size="small" style="margin-bottom: 8px;">
                     <n-space align="center" justify="space-between" style="width: 100%;">
@@ -370,7 +370,7 @@ const permissionTypesWithAdmin: string[] = constants.PermissionTypesWithAdmin
 const permissionTypes: string[] = constants.PermissionTypes
 const permissionFunctions: string[] = constants.PermissionFunctions
 const essentialReadPermissionFunctions: string[] = constants.EssentialReadPermissionFunctions
-const isSaas = computed(() => installationType.value === 'SAAS')
+const hasDevOps = computed(() => installationType.value !== 'OSS')
 
 const orgPermission = ref<OrgPermission>({
     type: 'NONE',
@@ -378,15 +378,15 @@ const orgPermission = ref<OrgPermission>({
     approvals: []
 })
 
-// DevOps Read/Write only make sense (and are only honored by the backend) for
-// SAAS installations; everywhere else they're hidden. At ESSENTIAL_READ we
+// DevOps Read/Write gate the instance / cluster surface, which exists on every
+// non-OSS installation (SaaS, managed service, on-prem Pro); OSS hides them. At ESSENTIAL_READ we
 // only expose the functions that explicitly support it (currently AGENT) —
 // most org-wide functions are paired with READ_ONLY / READ_WRITE.
 const orgPermissionFunctions = computed(() => permissionFunctions.filter(f =>
     f !== 'RESOURCE' &&
     (props.showSbomProbing || f !== 'SBOM_PROBING') &&
     (!props.showSbomProbing || f !== 'LIFECYCLE_UPDATE') &&
-    (isSaas.value || (f !== 'DEVOPS_READ' && f !== 'DEVOPS_WRITE')) &&
+    (hasDevOps.value || (f !== 'DEVOPS_READ' && f !== 'DEVOPS_WRITE')) &&
     (orgPermission.value.type !== 'ESSENTIAL_READ' || essentialReadPermissionFunctions.includes(f))
 ))
 

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -1703,6 +1703,21 @@ query releasesByDateRange($org: ID!, $startDate: DateTime!, $endDate: DateTime!,
     }
 }`
 
+// Most recent releases of a component across all its branches, for the
+// component page's Latest tab. branchDetails is widened beyond the shared
+// fragment so the row can show the branch type without a store lookup.
+const LATEST_RELEASES_OF_COMPONENT_GQL = gql`
+query latestReleasesOfComponent($componentUuid: ID!, $limit: Int) {
+    latestReleasesOfComponent(componentUuid: $componentUuid, limit: $limit) {
+        ${MULTI_RELEASE_GQL_DATA}
+        branchDetails {
+            uuid
+            name
+            type
+            status
+        }
+    }
+}`
 const RELEASES_BY_DATE_RANGE_AND_PERSPECTIVE_GQL = gql`
 query releasesByDateRangeAndPerspective($perspectiveUuid: ID!, $startDate: DateTime!, $endDate: DateTime!, $limit: Int, $componentType: ComponentType) {
     releasesByDateRangeAndPerspective(perspectiveUuid: $perspectiveUuid, startDate: $startDate, endDate: $endDate, limit: $limit, componentType: $componentType) {
@@ -1754,6 +1769,7 @@ export default {
     EnvironmentTypesGql: ENVIRONMENT_TYPES_GQL,
     ReleasesByDateRangeGql: RELEASES_BY_DATE_RANGE_GQL,
     ReleasesByDateRangeAndPerspectiveGql: RELEASES_BY_DATE_RANGE_AND_PERSPECTIVE_GQL,
+    LatestReleasesOfComponentGql: LATEST_RELEASES_OF_COMPONENT_GQL,
     FeatureSetsUsingComponentGql: FEATURE_SETS_USING_COMPONENT_GQL,
     FeatureSetsUsingBranchGql: FEATURE_SETS_USING_BRANCH_GQL,
 }

--- a/ui/src/utils/releaseScanCells.ts
+++ b/ui/src/utils/releaseScanCells.ts
@@ -1,0 +1,49 @@
+// Shared render functions for a release row's scan state: the pending /
+// rejected badge and the vulnerability + violation count circles. Used by
+// the branch release table and the component Latest tab so both draw the
+// exact same markup (global `.circle` from App.vue) instead of each table
+// keeping its own copy that drifts in size and font.
+import { h } from 'vue'
+import { NSpace } from 'naive-ui'
+import constants from '@/utils/constants'
+import type { ReleaseScanStatus } from '@/utils/releaseScanStatus'
+
+export type OpenVulnDetails = (row: any, severityFilter: string, typeFilter: string | string[]) => void
+
+export function renderPendingBadge (status: ReleaseScanStatus) {
+    const bg = status.kind === 'rejected' ? '#d03050' : status.kind === 'enrichment-pending' ? '#fd8c00' : '#ffc107'
+    return h('span', {
+        title: status.title,
+        style: `display: inline-block; padding: 2px 10px; border-radius: 12px; background: ${bg}; color: white; font-size: 0.8em; white-space: nowrap;`
+    }, status.label)
+}
+
+function circle (title: string, color: string, value: any, onClick: () => void) {
+    return h('div', { title, class: 'circle', style: `background: ${color}; cursor: pointer;`, onClick: (e: Event) => { e.stopPropagation(); onClick() } }, value)
+}
+
+/** Vulnerabilities cell: badge when the scan is not ready, five severity circles otherwise, 'N/A' without metrics. */
+export function renderVulnerabilityCells (row: any, status: ReleaseScanStatus, open: OpenVulnDetails) {
+    if (status.kind !== 'ready') return [renderPendingBadge(status)]
+    if (!(row.metrics && row.metrics.lastScanned)) return [h('div'), 'N/A']
+    const m = row.metrics
+    return [h(NSpace, { size: 1 }, () => [
+        circle('Critical Severity Vulnerabilities', constants.VulnerabilityColors.CRITICAL, m.critical, () => open(row, 'CRITICAL', ['Vulnerability', 'Weakness'])),
+        circle('High Severity Vulnerabilities', constants.VulnerabilityColors.HIGH, m.high, () => open(row, 'HIGH', ['Vulnerability', 'Weakness'])),
+        circle('Medium Severity Vulnerabilities', constants.VulnerabilityColors.MEDIUM, m.medium, () => open(row, 'MEDIUM', ['Vulnerability', 'Weakness'])),
+        circle('Low Severity Vulnerabilities', constants.VulnerabilityColors.LOW, m.low, () => open(row, 'LOW', ['Vulnerability', 'Weakness'])),
+        circle('Vulnerabilities with Unassigned Severity', constants.VulnerabilityColors.UNASSIGNED, m.unassigned, () => open(row, 'UNASSIGNED', ['Vulnerability', 'Weakness']))
+    ])]
+}
+
+/** Violations cell: badge when the scan is not ready, three policy circles otherwise, 'N/A' without metrics. */
+export function renderViolationCells (row: any, status: ReleaseScanStatus, open: OpenVulnDetails) {
+    if (status.kind !== 'ready') return [renderPendingBadge(status)]
+    if (!(row.metrics && row.metrics.lastScanned)) return [h('div'), 'N/A']
+    const m = row.metrics
+    return [h(NSpace, { size: 1 }, () => [
+        circle('Licensing Policy Violations', constants.ViolationColors.LICENSE, m.policyViolationsLicenseTotal, () => open(row, '', 'Violation')),
+        circle('Security Policy Violations', constants.ViolationColors.SECURITY, m.policyViolationsSecurityTotal, () => open(row, '', 'Violation')),
+        circle('Operational Policy Violations', constants.ViolationColors.OPERATIONAL, m.policyViolationsOperationalTotal, () => open(row, '', 'Violation'))
+    ])]
+}


### PR DESCRIPTION
Brings `main` into `fda-readiness-1-dev` for the UI monorepo. **A merge commit (`21510fb7`,
parents `828016de` + `2181eacf`) -- no rebase, no force-push.**

## Merged clean -- no conflicts

As expected. 18 files changed, two new: `ui/src/components/LatestReleasesOfComponent.vue` and
`ui/src/utils/releaseScanCells.ts`. `OrgSettings.vue` auto-merged despite both sides touching
it (main's changes are elsewhere in the file from the FDA toggle section).

## Gates

- **`npm run test`: 748 tests across 52 files, all passing.**
- **UI build: clean.**

Worth stating explicitly, since an unchanged count invites the question: the total is the same
as before the merge because **main added no spec files** (`git diff --name-only` across the
merge: 0 matching `spec.ts`). 52 spec files on disk, 52 executed -- nothing silently skipped.

Image build, hot-swap and the FDA probes are driven from the rearm-saas side; results on
relizaio/rearm-saas#514.
