### PR TITLE
feat(permissions): Configuration Read / Write functions in the editor

### DIFF
--- a/ui/src/utils/commonFunctions.ts
+++ b/ui/src/utils/commonFunctions.ts
@@ -27,6 +27,8 @@ function translateFunctionName(fn: string): string {
         case 'VERSION_FEATURESET': return 'Version Feature Set'
         case 'AGENT': return 'AI Agent'
         case 'DISTRIBUTION': return 'Distribution'
+        case 'CONFIGURATION_READ': return 'Configuration Read'
+        case 'CONFIGURATION_WRITE': return 'Configuration Write'
         default: return fn
     }
 }
@@ -58,6 +60,10 @@ const PERMISSION_FUNCTION_DESCRIPTIONS: Record<string, string> = {
         'Carve-out: a key with this function (even Read Only) can also enrol its own SSH/GPG public signing key via "rearm agent enrollkey" - needed so an agent can sign its first commit without operator intervention. The backend enforces that the key being enrolled targets the calling key\'s own agent identity; cross-agent enrolment is rejected.',
     DISTRIBUTION:
         'Access the Distribution module - clients, sites, shipments, devices, and device events. Organization admins have this implicitly.',
+    CONFIGURATION_READ:
+        'Export declarative configuration (components, products, branches, feature sets) as spec files through the programmatic API. Organization admins have this implicitly.',
+    CONFIGURATION_WRITE:
+        'Apply declarative configuration spec files through the programmatic API - what a GitOps pipeline or the Terraform provider needs. Implies Configuration Read. Requires Read & Write permission to take effect.',
 }
 
 function translateFunctionDescription(fn: string): string | null {

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -180,7 +180,11 @@ const PERMISSION_FUNCTIONS: string[] = [
     'AGENT',
     // Gates the Distribution module surface (clients, sites, shipments,
     // devices, device events) for non-admin users and FREEFORM keys.
-    'DISTRIBUTION'
+    'DISTRIBUTION',
+    // Gate the declarative configuration surface (export / apply of spec
+    // files through the programmatic API). WRITE implies READ.
+    'CONFIGURATION_READ',
+    'CONFIGURATION_WRITE'
 ]
 // Functions that are grantable at the ESSENTIAL_READ permission type.
 // Most org-wide functions only make sense alongside READ_ONLY/READ_WRITE


### PR DESCRIPTION
## Summary
- Adds `CONFIGURATION_READ` and `CONFIGURATION_WRITE` to the permission function list, with labels and descriptions, so they can be granted to users and FREEFORM keys in the permissions editor.
- They gate the declarative configuration surface (export and apply of spec files through the programmatic API). Write implies Read. Organization admins pass implicitly, as for every function.
- Needs the backend that declares the two functions (Pro backend PR in flight).

## Test plan
- [x] `vite build`
- [ ] sandbox: the two functions appear under Organization-Wide Functions; granting Configuration Write to a FREEFORM key lets it apply a spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)