### PR TITLE
D7: declare the device support window on the product component (UI)

### DIFF
--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -526,73 +526,73 @@
                                                  the field -- a CE mirror before the deferred sync.
                                                  Offering an editor whose save the server would
                                                  reject is worse than not offering it. -->
-                                            <!-- The device class itself, editable. Until this
-                                                 existed, deviceClass could ONLY be set at
-                                                 creation (CreateComponent.vue), so the window
-                                                 panel below -- which correctly renders only for
-                                                 a device -- was unreachable for every component
-                                                 that already existed. D7 puts the section 524B
-                                                 commitment on the product component, so the
-                                                 component has to be able to become a device. -->
-                                            <div v-if="deviceWindowSupported" style="margin-top: 22px;">
-                                                <h4>Device class</h4>
-                                                <n-space align="end" style="margin-bottom: 8px;">
-                                                    <n-select v-model:value="deviceClassEdit"
-                                                        :options="DEVICE_CLASS_OPTIONS" style="width: 240px;"
-                                                        :disabled="!isWritable || savingDeviceClass" />
-                                                    <n-button v-if="isWritable" size="small" type="primary"
-                                                        :disabled="deviceClassEdit === deviceClassBaseline"
-                                                        :loading="savingDeviceClass"
-                                                        @click="saveDeviceClass">Save device class</n-button>
-                                                </n-space>
-                                                <div class="text-muted" style="font-size: 12px; max-width: 720px;">
-                                                    Setting this to anything but <strong>NONE</strong> makes the
-                                                    component a device and reveals its support window below.
-                                                    Setting it back to NONE <strong>retracts any declared
-                                                    window</strong>: the window lives in the medical profile
-                                                    that NONE removes.
-                                                </div>
+                                        <!-- The device class itself, editable. Until this
+                                             existed, deviceClass could ONLY be set at
+                                             creation (CreateComponent.vue), so the window
+                                             panel below -- which correctly renders only for
+                                             a device -- was unreachable for every component
+                                             that already existed. D7 puts the section 524B
+                                             commitment on the product component, so the
+                                             component has to be able to become a device. -->
+                                        <div v-if="deviceWindowSupported" style="margin-top: 22px;">
+                                            <h4>Device class</h4>
+                                            <n-space align="end" style="margin-bottom: 8px;">
+                                                <n-select v-model:value="deviceClassEdit"
+                                                    :options="DEVICE_CLASS_OPTIONS" style="width: 240px;"
+                                                    :disabled="!isWritable || savingDeviceClass" />
+                                                <n-button v-if="isWritable" size="small" type="primary"
+                                                    :disabled="deviceClassEdit === deviceClassBaseline"
+                                                    :loading="savingDeviceClass"
+                                                    @click="saveDeviceClass">Save device class</n-button>
+                                            </n-space>
+                                            <div class="text-muted" style="font-size: 12px; max-width: 720px;">
+                                                Setting this to anything but <strong>NONE</strong> makes the
+                                                component a device and reveals its support window below.
+                                                Setting it back to NONE <strong>retracts any declared
+                                                window</strong>: the window lives in the medical profile
+                                                that NONE removes.
                                             </div>
+                                        </div>
 
-                                            <div v-if="deviceWindowSupported && isDeviceComponent"
-                                                style="margin-top: 22px;">
-                                                <h4>Device support window</h4>
-                                                <n-alert type="default" :show-icon="false"
-                                                    style="font-size: 12px; margin: 8px 0 10px; max-width: 720px;">
-                                                    Shown separately and never merged: end of support and
-                                                    end of sale are different facts, and a reader of the
-                                                    Device Support Statement is entitled to both. Blank
-                                                    means <strong>not declared</strong>, which is a fact in
-                                                    its own right &mdash; not an unknown to fill in.
-                                                    <span style="display:block; margin-top:6px;">
-                                                        This is the DEVICE's window, inherited by every
-                                                        release of this product. A release's own end-of-support
-                                                        date is release lifecycle and is set on the release.
-                                                    </span>
-                                                </n-alert>
-                                                <n-space align="end" style="margin-bottom: 8px;">
-                                                    <div>
-                                                        <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
-                                                        <n-date-picker v-model:formatted-value="deviceWindow.eos"
-                                                            value-format="yyyy-MM-dd" type="date" clearable
-                                                            @update:formatted-value="deviceWindowError = null"
-                                                            :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
-                                                    </div>
-                                                    <div>
-                                                        <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
-                                                        <n-date-picker v-model:formatted-value="deviceWindow.eol"
-                                                            value-format="yyyy-MM-dd" type="date" clearable
-                                                            @update:formatted-value="deviceWindowError = null"
-                                                            :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
-                                                    </div>
-                                                    <n-button v-if="isWritable" size="small" type="primary"
-                                                        :disabled="!deviceWindowDirty" :loading="savingDeviceWindow"
-                                                        @click="saveDeviceWindow">Save window</n-button>
-                                                </n-space>
-                                                <n-alert v-if="deviceWindowError" type="error" :show-icon="true"
-                                                    style="font-size: 12px; max-width: 720px;">
-                                                    {{ deviceWindowError }}
-                                                </n-alert>
+                                        <div v-if="deviceWindowSupported && isDeviceComponent"
+                                            style="margin-top: 22px;">
+                                            <h4>Device support window</h4>
+                                            <n-alert type="default" :show-icon="false"
+                                                style="font-size: 12px; margin: 8px 0 10px; max-width: 720px;">
+                                                Shown separately and never merged: end of support and
+                                                end of sale are different facts, and a reader of the
+                                                Device Support Statement is entitled to both. Blank
+                                                means <strong>not declared</strong>, which is a fact in
+                                                its own right &mdash; not an unknown to fill in.
+                                                <span style="display:block; margin-top:6px;">
+                                                    This is the DEVICE's window, inherited by every
+                                                    release of this product. A release's own end-of-support
+                                                    date is release lifecycle and is set on the release.
+                                                </span>
+                                            </n-alert>
+                                            <n-space align="end" style="margin-bottom: 8px;">
+                                                <div>
+                                                    <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
+                                                    <n-date-picker v-model:formatted-value="deviceWindow.eos"
+                                                        value-format="yyyy-MM-dd" type="date" clearable
+                                                        @update:formatted-value="deviceWindowError = null"
+                                                        :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                                                </div>
+                                                <div>
+                                                    <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
+                                                    <n-date-picker v-model:formatted-value="deviceWindow.eol"
+                                                        value-format="yyyy-MM-dd" type="date" clearable
+                                                        @update:formatted-value="deviceWindowError = null"
+                                                        :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                                                </div>
+                                                <n-button v-if="isWritable" size="small" type="primary"
+                                                    :disabled="!deviceWindowDirty" :loading="savingDeviceWindow"
+                                                    @click="saveDeviceWindow">Save window</n-button>
+                                            </n-space>
+                                            <n-alert v-if="deviceWindowError" type="error" :show-icon="true"
+                                                style="font-size: 12px; max-width: 720px;">
+                                                {{ deviceWindowError }}
+                                            </n-alert>
                                             </div>
                                     </n-tab-pane>
                                     <n-tab-pane name="outputTriggers" tab="Actions" v-if="myUser.installationType !== 'OSS'">
@@ -1438,7 +1438,7 @@ const deviceWindowDirty: ComputedRef<boolean> = computed((): boolean =>
 async function loadDeviceWindow (): Promise<void> {
     if (!componentUuid) return
     try {
-        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid, isSchemaDriftError)
+        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid)
         deviceWindowSupported.value = r.supported
         deviceWindow.eos = r.window.eos
         deviceWindow.eol = r.window.eol
@@ -1471,7 +1471,12 @@ async function saveDeviceWindow (): Promise<void> {
         deviceWindowBaseline.eol = deviceWindow.eol
         notify('success', 'Saved', 'Device support window updated.')
     } catch (e: any) {
-        deviceWindowError.value = commonFunctions.parseGraphQLError(e.message)
+        // extractGraphQLErrorMessage, not parseGraphQLError: the latter only strips three
+        // known BOM prefixes off e.message and never unwraps graphQLErrors[], so under
+        // Apollo's CombinedGraphQLErrors the SERVER's text -- "End of support cannot be after
+        // end of life", the device-class refusal the walkthrough quotes -- never reaches the
+        // panel. saveDeviceClass 40 lines up already uses the right one.
+        deviceWindowError.value = commonFunctions.extractGraphQLErrorMessage(e)
     } finally {
         savingDeviceWindow.value = false
     }

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -504,8 +504,17 @@
                                                     Reset Changes
                                                 </n-button>
                                             </n-space>
+                                        </div>
 
-                                            <!-- THE DEVICE SUPPORT WINDOW LIVES HERE NOW (D7).
+                                        <!-- SIBLING of coreSettingsActions, never a child. It
+                                             was nested INSIDE that div, whose v-if is
+                                             "hasCoreSettingsChanges && isWritable" -- the
+                                             unsaved-changes action bar. So the panel appeared
+                                             only after you had already edited some OTHER core
+                                             setting, and vanished the moment you saved. On a
+                                             freshly opened component, which is every reader
+                                             following the walkthrough, it did not exist.
+                                             THE DEVICE SUPPORT WINDOW LIVES HERE NOW (D7).
                                                  It was on the product RELEASE until 2026-09-10,
                                                  which meant one physical device could be described
                                                  by a dozen different end-of-support dates depending
@@ -517,6 +526,34 @@
                                                  the field -- a CE mirror before the deferred sync.
                                                  Offering an editor whose save the server would
                                                  reject is worse than not offering it. -->
+                                            <!-- The device class itself, editable. Until this
+                                                 existed, deviceClass could ONLY be set at
+                                                 creation (CreateComponent.vue), so the window
+                                                 panel below -- which correctly renders only for
+                                                 a device -- was unreachable for every component
+                                                 that already existed. D7 puts the section 524B
+                                                 commitment on the product component, so the
+                                                 component has to be able to become a device. -->
+                                            <div v-if="deviceWindowSupported" style="margin-top: 22px;">
+                                                <h4>Device class</h4>
+                                                <n-space align="end" style="margin-bottom: 8px;">
+                                                    <n-select v-model:value="deviceClassEdit"
+                                                        :options="DEVICE_CLASS_OPTIONS" style="width: 240px;"
+                                                        :disabled="!isWritable || savingDeviceClass" />
+                                                    <n-button v-if="isWritable" size="small" type="primary"
+                                                        :disabled="deviceClassEdit === deviceClassBaseline"
+                                                        :loading="savingDeviceClass"
+                                                        @click="saveDeviceClass">Save device class</n-button>
+                                                </n-space>
+                                                <div class="text-muted" style="font-size: 12px; max-width: 720px;">
+                                                    Setting this to anything but <strong>NONE</strong> makes the
+                                                    component a device and reveals its support window below.
+                                                    Setting it back to NONE <strong>retracts any declared
+                                                    window</strong>: the window lives in the medical profile
+                                                    that NONE removes.
+                                                </div>
+                                            </div>
+
                                             <div v-if="deviceWindowSupported && isDeviceComponent"
                                                 style="margin-top: 22px;">
                                                 <h4>Device support window</h4>
@@ -557,7 +594,6 @@
                                                     {{ deviceWindowError }}
                                                 </n-alert>
                                             </div>
-                                        </div>
                                     </n-tab-pane>
                                     <n-tab-pane name="outputTriggers" tab="Actions" v-if="myUser.installationType !== 'OSS'">
                                         <h4 style="margin-bottom: 8px;">{{ words.componentFirstUpper }} Local Actions</h4>
@@ -1157,7 +1193,7 @@ import { ComputedRef, ref, Ref, computed, h, onMounted, reactive, watch } from '
 import type { Component } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NAlert, NIcon, NModal, NTabs, NTabPane, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, NSpace, NRadio, NRadioGroup, NDataTable, NotificationType, useNotification, NCheckbox, NCheckboxGroup, NSwitch, NTag, NText, NTooltip, DataTableColumns, NDynamicInput, NGrid, NGi, FormInst, FormRules } from 'naive-ui'
+import { NAlert, NDatePicker, NIcon, NModal, NTabs, NTabPane, NForm, NFormItem, NInput, NInputNumber, NButton, NSelect, NSpace, NRadio, NRadioGroup, NDataTable, NotificationType, useNotification, NCheckbox, NCheckboxGroup, NSwitch, NTag, NText, NTooltip, DataTableColumns, NDynamicInput, NGrid, NGi, FormInst, FormRules } from 'naive-ui'
 import commonFunctions from '../utils/commonFunctions'
 import ChangelogView from './ChangelogView.vue'
 import BranchView from './BranchView.vue'
@@ -1194,6 +1230,8 @@ const originalComponent: Ref<any> = ref({})
 onMounted(async () => {
     await initLoad()
     // After initLoad, so componentData (and therefore isDeviceComponent) is populated.
+    deviceClassEdit.value = componentData.value?.deviceClass || 'NONE'
+    deviceClassBaseline.value = deviceClassEdit.value
     await loadDeviceWindow()
     // Initialize component settings modal from URL query parameter after data is loaded
     if (route.query.componentSettingsView === 'true') {
@@ -1340,10 +1378,59 @@ const deviceWindowSupported: Ref<boolean> = ref(false)
 const savingDeviceWindow: Ref<boolean> = ref(false)
 const deviceWindowError: Ref<string | null> = ref(null)
 
-/** Only a device declares one; the server rejects the write otherwise. */
+const DEVICE_CLASS_OPTIONS = [
+    { label: 'NONE -- not a device', value: 'NONE' },
+    { label: 'MEDICAL_UNTRACKED', value: 'MEDICAL_UNTRACKED' },
+    { label: 'MEDICAL_TRACKED', value: 'MEDICAL_TRACKED' }
+]
+const deviceClassEdit: Ref<string> = ref('NONE')
+const deviceClassBaseline: Ref<string> = ref('NONE')
+const savingDeviceClass: Ref<boolean> = ref(false)
+
+/**
+ * Only a device declares one; the server rejects the write otherwise.
+ *
+ * Reads deviceClassBaseline -- the class the SERVER last confirmed -- rather than
+ * componentData. initLoad() rehydrates from the store cache and only refetches when the entry
+ * is missing or lacks versionType, so componentData still held the old class right after a
+ * successful save, and the window panel did not appear until a full page reload. baseline is
+ * seeded from componentData on mount and advanced only after the write returns, so it is
+ * never ahead of the server.
+ */
 const isDeviceComponent: ComputedRef<boolean> = computed((): boolean =>
-    !!componentData.value && componentData.value.deviceClass
-        && componentData.value.deviceClass !== 'NONE')
+    !!deviceClassBaseline.value && deviceClassBaseline.value !== 'NONE')
+
+
+/**
+ * Writes the device class, then RE-READS the window rather than assuming it survived.
+ *
+ * Going back to NONE retracts the window server-side, because the window lives inside the
+ * medical profile that NONE removes. Keeping a stale window in the form after that would show
+ * the user dates the server no longer holds -- on a section 524B commitment, the worst
+ * possible thing to be wrong about.
+ */
+async function saveDeviceClass (): Promise<void> {
+    if (!componentUuid || deviceClassEdit.value === deviceClassBaseline.value) return
+    savingDeviceClass.value = true
+    deviceWindowError.value = null
+    try {
+        await graphqlClient.mutate({
+            mutation: graphqlQueries.ComponentMutate,
+            variables: { component: { uuid: componentUuid,
+                name: componentData.value?.name || updatedComponent.value?.name,
+                deviceClass: deviceClassEdit.value } },
+            fetchPolicy: 'no-cache'
+        })
+        await initLoad()
+        deviceClassBaseline.value = deviceClassEdit.value
+        await loadDeviceWindow()
+    } catch (e: any) {
+        deviceWindowError.value = commonFunctions.extractGraphQLErrorMessage(e)
+        deviceClassEdit.value = deviceClassBaseline.value
+    } finally {
+        savingDeviceClass.value = false
+    }
+}
 
 const deviceWindowDirty: ComputedRef<boolean> = computed((): boolean =>
     deviceWindow.eos !== deviceWindowBaseline.eos || deviceWindow.eol !== deviceWindowBaseline.eol)
@@ -1368,7 +1455,7 @@ async function saveDeviceWindow (): Promise<void> {
     // name is REQUIRED: UpdateComponentInput.name is String!, so a {uuid, window} partial is
     // rejected at variable coercion before the resolver runs.
     const input = deviceWindowMutationInput(componentUuid,
-        componentData.value?.name || updatedComponent.name, deviceWindow, deviceWindowBaseline)
+        componentData.value?.name || updatedComponent.value?.name, deviceWindow, deviceWindowBaseline)
     if (!input) return
     savingDeviceWindow.value = true
     deviceWindowError.value = null

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -504,6 +504,59 @@
                                                     Reset Changes
                                                 </n-button>
                                             </n-space>
+
+                                            <!-- THE DEVICE SUPPORT WINDOW LIVES HERE NOW (D7).
+                                                 It was on the product RELEASE until 2026-09-10,
+                                                 which meant one physical device could be described
+                                                 by a dozen different end-of-support dates depending
+                                                 on which firmware it happened to be running. A
+                                                 support commitment that changes with every build is
+                                                 not a commitment.
+
+                                                 Hidden entirely when the backend cannot answer for
+                                                 the field -- a CE mirror before the deferred sync.
+                                                 Offering an editor whose save the server would
+                                                 reject is worse than not offering it. -->
+                                            <div v-if="deviceWindowSupported && isDeviceComponent"
+                                                style="margin-top: 22px;">
+                                                <h4>Device support window</h4>
+                                                <n-alert type="default" :show-icon="false"
+                                                    style="font-size: 12px; margin: 8px 0 10px; max-width: 720px;">
+                                                    Shown separately and never merged: end of support and
+                                                    end of sale are different facts, and a reader of the
+                                                    Device Support Statement is entitled to both. Blank
+                                                    means <strong>not declared</strong>, which is a fact in
+                                                    its own right &mdash; not an unknown to fill in.
+                                                    <span style="display:block; margin-top:6px;">
+                                                        This is the DEVICE's window, inherited by every
+                                                        release of this product. A release's own end-of-support
+                                                        date is release lifecycle and is set on the release.
+                                                    </span>
+                                                </n-alert>
+                                                <n-space align="end" style="margin-bottom: 8px;">
+                                                    <div>
+                                                        <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
+                                                        <n-date-picker v-model:formatted-value="deviceWindow.eos"
+                                                            value-format="yyyy-MM-dd" type="date" clearable
+                                                            @update:formatted-value="deviceWindowError = null"
+                                                            :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                                                    </div>
+                                                    <div>
+                                                        <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
+                                                        <n-date-picker v-model:formatted-value="deviceWindow.eol"
+                                                            value-format="yyyy-MM-dd" type="date" clearable
+                                                            @update:formatted-value="deviceWindowError = null"
+                                                            :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
+                                                    </div>
+                                                    <n-button v-if="isWritable" size="small" type="primary"
+                                                        :disabled="!deviceWindowDirty" :loading="savingDeviceWindow"
+                                                        @click="saveDeviceWindow">Save window</n-button>
+                                                </n-space>
+                                                <n-alert v-if="deviceWindowError" type="error" :show-icon="true"
+                                                    style="font-size: 12px; max-width: 720px;">
+                                                    {{ deviceWindowError }}
+                                                </n-alert>
+                                            </div>
                                         </div>
                                     </n-tab-pane>
                                     <n-tab-pane name="outputTriggers" tab="Actions" v-if="myUser.installationType !== 'OSS'">
@@ -1100,7 +1153,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ComputedRef, ref, Ref, computed, h, onMounted, watch } from 'vue'
+import { ComputedRef, ref, Ref, computed, h, onMounted, reactive, watch } from 'vue'
 import type { Component } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
@@ -1131,12 +1184,17 @@ import { validateInputTrigger, validateOutputTrigger } from '../utils/triggerVal
 import { withGhosts } from '@/utils/channelOptions'
 import CelExpressionBuilder from './CelExpressionBuilder.vue'
 import graphqlQueries from '../utils/graphqlQueries'
+import { loadComponentDeviceWindow, deviceWindowMutationInput } from '@/utils/componentDeviceWindow'
+import type { DeviceWindowState } from '@/utils/deviceSupportWindowInput'
+import { isSchemaDriftError } from '@/utils/graphqlDriftFallback'
 
 const updatedComponent: Ref<any> = ref({})
 const originalComponent: Ref<any> = ref({})
 
 onMounted(async () => {
     await initLoad()
+    // After initLoad, so componentData (and therefore isDeviceComponent) is populated.
+    await loadDeviceWindow()
     // Initialize component settings modal from URL query parameter after data is loaded
     if (route.query.componentSettingsView === 'true') {
         await openComponentSettings()
@@ -1270,6 +1328,64 @@ const componentData: ComputedRef<any> = computed((): any => {
 })
 
 const isComponent : Ref<boolean> = ref(true)
+
+// ---- Device support window (D7) ---------------------------------------------------------
+// Declared on the PRODUCT COMPONENT, inherited by every release, optionally overridden per
+// shipment. Read through its own document rather than COMPONENT_FULL_DATA: that fragment is
+// the updateComponent MUTATION RESPONSE, and CE declares medicalProfile without this subfield,
+// so folding it in would invalidate the whole mutation and break EVERY component save there.
+const deviceWindow = reactive<DeviceWindowState>({ eos: null, eol: null })
+const deviceWindowBaseline = reactive<DeviceWindowState>({ eos: null, eol: null })
+const deviceWindowSupported: Ref<boolean> = ref(false)
+const savingDeviceWindow: Ref<boolean> = ref(false)
+const deviceWindowError: Ref<string | null> = ref(null)
+
+/** Only a device declares one; the server rejects the write otherwise. */
+const isDeviceComponent: ComputedRef<boolean> = computed((): boolean =>
+    !!componentData.value && componentData.value.deviceClass
+        && componentData.value.deviceClass !== 'NONE')
+
+const deviceWindowDirty: ComputedRef<boolean> = computed((): boolean =>
+    deviceWindow.eos !== deviceWindowBaseline.eos || deviceWindow.eol !== deviceWindowBaseline.eol)
+
+async function loadDeviceWindow (): Promise<void> {
+    if (!componentUuid) return
+    try {
+        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid, isSchemaDriftError)
+        deviceWindowSupported.value = r.supported
+        deviceWindow.eos = r.window.eos
+        deviceWindow.eol = r.window.eol
+        deviceWindowBaseline.eos = r.window.eos
+        deviceWindowBaseline.eol = r.window.eol
+    } catch (e: any) {
+        // A real failure hides the panel rather than showing an empty editable one: an operator
+        // must never be able to "declare" a window against a backend we could not read.
+        deviceWindowSupported.value = false
+    }
+}
+
+async function saveDeviceWindow (): Promise<void> {
+    const input = deviceWindowMutationInput(componentUuid, deviceWindow, deviceWindowBaseline)
+    if (!input) return
+    savingDeviceWindow.value = true
+    deviceWindowError.value = null
+    try {
+        await graphqlClient.mutate({
+            mutation: graphqlQueries.ComponentMutate,
+            variables: { component: input },
+            fetchPolicy: 'no-cache'
+        })
+        // Advance the baseline from what was SENT and accepted -- the mutation deliberately does
+        // not select the window back, for the CE reason above.
+        deviceWindowBaseline.eos = deviceWindow.eos
+        deviceWindowBaseline.eol = deviceWindow.eol
+        notify('success', 'Saved', 'Device support window updated.')
+    } catch (e: any) {
+        deviceWindowError.value = commonFunctions.parseGraphQLError(e.message)
+    } finally {
+        savingDeviceWindow.value = false
+    }
+}
 
 const myUser = store.getters.myuser
 const myPerspective: ComputedRef<string> = computed((): string => store.getters.myperspective)

--- a/ui/src/components/ComponentView.vue
+++ b/ui/src/components/ComponentView.vue
@@ -1365,7 +1365,10 @@ async function loadDeviceWindow (): Promise<void> {
 }
 
 async function saveDeviceWindow (): Promise<void> {
-    const input = deviceWindowMutationInput(componentUuid, deviceWindow, deviceWindowBaseline)
+    // name is REQUIRED: UpdateComponentInput.name is String!, so a {uuid, window} partial is
+    // rejected at variable coercion before the resolver runs.
+    const input = deviceWindowMutationInput(componentUuid,
+        componentData.value?.name || updatedComponent.name, deviceWindow, deviceWindowBaseline)
     if (!input) return
     savingDeviceWindow.value = true
     deviceWindowError.value = null

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -154,7 +154,12 @@
                         <template v-if="effectiveWindowLabel">
                             In force: {{ effectiveWindowLabel }}.
                         </template>
-                        <template v-else>
+                        <!-- Only claimed when we have actually READ a shipment. On create
+                             there is no shipment to resolve through yet, and the old markup
+                             fell through to "No window is declared for this device model" --
+                             a false statement about the product, made at exactly the moment
+                             it would talk someone into a batch override they do not need. -->
+                        <template v-else-if="editingShipment">
                             No window is declared for this device model.
                         </template>
                         Leave both blank to inherit from the product component; fill them to

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -229,6 +229,8 @@ import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
 import { termsFor, DISTRIBUTION_DOMAIN_OPTIONS } from '@/utils/distributionTerms'
+import { applyShipmentWindowToInput,
+    effectiveWindowLabel as buildEffectiveWindowLabel } from '@/utils/componentDeviceWindow'
 
 const route = useRoute()
 const router = useRouter()
@@ -353,12 +355,8 @@ const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null,
 const editingShipment: Ref<any> = ref(null)
 
 /** The window in force for the shipment being edited, named with where it was declared. */
-const effectiveWindowLabel: ComputedRef<string> = computed((): string => {
-    const w = (editingShipment.value as any)?.effectiveDeviceSupportWindow
-    if (!w || (!w.eos && !w.eol)) return ''
-    const where = w.source === 'SHIPMENT' ? 'this batch' : 'the product component'
-    return `EOS ${w.eos || 'not declared'}, EOL ${w.eol || 'not declared'} (from ${where})`
-})
+const effectiveWindowLabel: ComputedRef<string> = computed((): string =>
+    buildEffectiveWindowLabel((editingShipment.value as any)?.effectiveDeviceSupportWindow))
 // Shipments carry the same two-axis classification as components: nature (HARDWARE /
 // SOFTWARE, hardware if any constituent component is hardware) and deviceClass. HARDWARE =
 // physical batch; SOFTWARE + MEDICAL_* = SaMD, shipped and tracked per unit like hardware;
@@ -711,7 +709,6 @@ async function openShipModal (existing?: any) {
         shipForm.deviceWindowEol = existing.deviceSupportWindow?.eol || null
         shipForm.deviceWindowBaselineEos = shipForm.deviceWindowEos
         shipForm.deviceWindowBaselineEol = shipForm.deviceWindowEol
-        editingShipment.value = existing
         shipReleases.value = await loadReleasesForBranch(existing.featureSet)
         await Promise.all([loadShipChoices(existing.release), resolveIdentity()])
         for (const cr of (existing.choiceResolutions || [])) {
@@ -751,18 +748,9 @@ async function shipProduct () {
     // the server does not read it as a retraction, so it would leave the old override silently
     // in force while the form showed it gone.
     if (!isSoftwareShipment.value) {
-        const changed = shipForm.deviceWindowEos !== shipForm.deviceWindowBaselineEos
-            || shipForm.deviceWindowEol !== shipForm.deviceWindowBaselineEol
-        if (changed) {
-            const hasSomething = !!shipForm.deviceWindowEos || !!shipForm.deviceWindowEol
-            const hadSomething = !!shipForm.deviceWindowBaselineEos || !!shipForm.deviceWindowBaselineEol
-            if (hasSomething) {
-                input.deviceSupportWindow = {
-                    eos: shipForm.deviceWindowEos || null, eol: shipForm.deviceWindowEol || null }
-            } else if (hadSomething) {
-                input.clearDeviceSupportWindow = true
-            }
-        }
+        applyShipmentWindowToInput(input,
+            { eos: shipForm.deviceWindowEos, eol: shipForm.deviceWindowEol },
+            { eos: shipForm.deviceWindowBaselineEos, eol: shipForm.deviceWindowBaselineEol })
     }
     try {
         if (editingShipmentUuid.value) {

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -140,6 +140,37 @@
                         :placeholder="siteDeviceOptions.length ? 'Pick devices from hardware or SaMD shipments at this site, or leave empty' : 'No devices at this site yet — leave empty'" />
                 </n-form-item>
                 <n-form-item v-if="!isSoftwareShipment" label="Quantity *"><n-input-number v-model:value="shipForm.quantity" :min="1" /></n-form-item>
+
+                <!-- THE BATCH'S DEVICE SUPPORT WINDOW OVERRIDE (D7).
+                     Hardware and SaMD only: plain software is not a device and has no section
+                     524B commitment to override, so the block never renders there.
+                     Support commonly runs from SALE OR SHIPMENT ("seven years from date of
+                     sale"), which is a fact about a batch -- and the ship date it anchors to is
+                     the field directly above. -->
+                <template v-if="!isSoftwareShipment">
+                    <n-divider style="margin: 14px 0 8px;" />
+                    <div style="font-size: 13px; margin-bottom: 4px;"><strong>Device support window</strong></div>
+                    <div class="subtle" style="font-size: 12px; margin-bottom: 8px;">
+                        <template v-if="effectiveWindowLabel">
+                            In force: {{ effectiveWindowLabel }}.
+                        </template>
+                        <template v-else>
+                            No window is declared for this device model.
+                        </template>
+                        Leave both blank to inherit from the product component; fill them to
+                        override for this batch only.
+                    </div>
+                    <n-form-item label="Batch end of support">
+                        <n-date-picker style="width: 100%;" type="date" clearable
+                            v-model:formatted-value="shipForm.deviceWindowEos" value-format="yyyy-MM-dd"
+                            placeholder="inherit from the product component" />
+                    </n-form-item>
+                    <n-form-item label="Batch end of life / end of sale">
+                        <n-date-picker style="width: 100%;" type="date" clearable
+                            v-model:formatted-value="shipForm.deviceWindowEol" value-format="yyyy-MM-dd"
+                            placeholder="inherit from the product component" />
+                    </n-form-item>
+                </template>
                 <n-form-item v-if="!isSoftwareShipment" label="Batch identifiers">
                     <n-dynamic-input v-model:value="shipForm.identifiers" :on-create="onCreateBatchId">
                         <template #create-button-default>Add identifier</template>
@@ -307,7 +338,22 @@ const clientForm = reactive<any>({ uuid: '', name: '', domain: 'GENERIC', contac
 // New clients get a "Default" site out of the box (address / phone / email copied from the client) unless unticked.
 const createDefaultSite = ref(true)
 const siteForm = reactive<any>({ uuid: '', name: '', contact: emptyContact(), notes: '' })
-const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [] })
+const shipForm = reactive<any>({ featureSet: '', release: '', deliverable: null, shipDate: null, quantity: 1, identifiers: [], manufactureDate: null, expiryDate: null, devices: [],
+    // D7 batch override. Baselines so an unchanged window sends nothing -- the server stamps
+    // provenance on every write, and a no-op resend would re-attribute a claim nobody touched.
+    deviceWindowEos: null, deviceWindowEol: null,
+    deviceWindowBaselineEos: null, deviceWindowBaselineEol: null })
+
+/** The shipment row currently open in the modal, for the in-force line. */
+const editingShipment: Ref<any> = ref(null)
+
+/** The window in force for the shipment being edited, named with where it was declared. */
+const effectiveWindowLabel: ComputedRef<string> = computed((): string => {
+    const w = (editingShipment.value as any)?.effectiveDeviceSupportWindow
+    if (!w || (!w.eos && !w.eol)) return ''
+    const where = w.source === 'SHIPMENT' ? 'this batch' : 'the product component'
+    return `EOS ${w.eos || 'not declared'}, EOL ${w.eol || 'not declared'} (from ${where})`
+})
 // Shipments carry the same two-axis classification as components: nature (HARDWARE /
 // SOFTWARE, hardware if any constituent component is hardware) and deviceClass. HARDWARE =
 // physical batch; SOFTWARE + MEDICAL_* = SaMD, shipped and tracked per unit like hardware;
@@ -390,7 +436,11 @@ const onCreateUnitId = () => ({ idType: 'SERIAL', idValue: '' })
 // ---- GraphQL ----
 const CLIENT_FIELDS = 'uuid org name domain contact { address phone email } notes'
 const SITE_FIELDS = 'uuid org client name contact { address phone email } notes'
+// D7: the batch's own override plus the window that actually applies, with the level it was
+// declared at. No CORE/FULL split -- the Distribution module is SaaS-only, so this document is
+// never issued by a CE build at all, which is a stronger guarantee than a fallback.
 const SHIP_FIELDS = 'uuid org site featureSet release deliverable shipDate quantity manufactureDate expiryDate notes nature deviceClass devices identifiers { idType idValue } choiceResolutions { choiceRef selectedRefs }'
+    + ' deviceSupportWindow { eos eol } effectiveDeviceSupportWindow { eos eol source }'
 const DEVICE_FIELDS = 'uuid org shippedProduct site versionDrift notes identifiers { idType idValue } plan { expectedRelease } actual { reportedRelease reportedAt source } tracking { receivedDate patientId disposition dispositionDate }'
 
 async function loadClients () {
@@ -635,6 +685,11 @@ async function openShipModal (existing?: any) {
     shipChoices.value = []; Object.keys(shipChoiceSelections).forEach(k => delete shipChoiceSelections[k])
     resolvedIdentity.value = null
     editingShipmentUuid.value = existing?.uuid || ''
+    editingShipment.value = existing || null
+    shipForm.deviceWindowEos = null
+    shipForm.deviceWindowEol = null
+    shipForm.deviceWindowBaselineEos = null
+    shipForm.deviceWindowBaselineEol = null
     if (existing) {
         shipForm.featureSet = existing.featureSet
         shipForm.release = existing.release
@@ -645,6 +700,13 @@ async function openShipModal (existing?: any) {
         shipForm.manufactureDate = existing.manufactureDate || null
         shipForm.expiryDate = existing.expiryDate || null
         shipForm.devices = [...(existing.devices || [])]
+        // The batch's OWN override, not the effective window: seeding from the effective one
+        // would turn an inherited value into an override the moment anything else was saved.
+        shipForm.deviceWindowEos = existing.deviceSupportWindow?.eos || null
+        shipForm.deviceWindowEol = existing.deviceSupportWindow?.eol || null
+        shipForm.deviceWindowBaselineEos = shipForm.deviceWindowEos
+        shipForm.deviceWindowBaselineEol = shipForm.deviceWindowEol
+        editingShipment.value = existing
         shipReleases.value = await loadReleasesForBranch(existing.featureSet)
         await Promise.all([loadShipChoices(existing.release), resolveIdentity()])
         for (const cr of (existing.choiceResolutions || [])) {
@@ -679,6 +741,24 @@ async function shipProduct () {
     if (shipForm.shipDate) input.shipDate = shipForm.shipDate
     if (shipForm.manufactureDate && !isSoftwareShipment.value) input.manufactureDate = shipForm.manufactureDate
     if (shipForm.expiryDate) input.expiryDate = shipForm.expiryDate
+    // D7, same three rules as the component panel: unchanged sends nothing, blank-both after
+    // something was declared sends the CLEAR FLAG, and an empty window object is never sent --
+    // the server does not read it as a retraction, so it would leave the old override silently
+    // in force while the form showed it gone.
+    if (!isSoftwareShipment.value) {
+        const changed = shipForm.deviceWindowEos !== shipForm.deviceWindowBaselineEos
+            || shipForm.deviceWindowEol !== shipForm.deviceWindowBaselineEol
+        if (changed) {
+            const hasSomething = !!shipForm.deviceWindowEos || !!shipForm.deviceWindowEol
+            const hadSomething = !!shipForm.deviceWindowBaselineEos || !!shipForm.deviceWindowBaselineEol
+            if (hasSomething) {
+                input.deviceSupportWindow = {
+                    eos: shipForm.deviceWindowEos || null, eol: shipForm.deviceWindowEol || null }
+            } else if (hadSomething) {
+                input.clearDeviceSupportWindow = true
+            }
+        }
+    }
     try {
         if (editingShipmentUuid.value) {
             await graphqlClient.mutate({

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1108,9 +1108,15 @@
                         <h3>Release lifecycle dates</h3>
                         <n-alert type="default" :show-icon="false" style="font-size: 12px; margin-bottom: 10px; max-width: 720px;">
                             When this <strong>version</strong> stops being supported and sold.
-                            Consumed by TEA and CLE. <strong>This is not the device's support
-                            window</strong> &mdash; that is declared on the product component and
-                            is what FDA section 524B labeling refers to.
+                            Each date becomes a CLE lifecycle event for this release &mdash;
+                            <code>END_OF_SUPPORT</code> and <code>END_OF_LIFE</code> &mdash;
+                            served through the TEA endpoint and the CLE export, so a downstream
+                            consumer tracking your versions learns when this one lapses.
+                            <span style="display:block; margin-top:6px;">
+                                Separate from the <strong>device support window</strong> above,
+                                which is the section 524B commitment about the hardware. A device
+                                outlives many versions, so the two dates differ on purpose.
+                            </span>
                         </n-alert>
                         <n-space align="end" style="margin-bottom: 8px;">
                             <div>

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1973,25 +1973,6 @@ async function loadAcollections() {
  * an ugly one.
  */
 /**
- * The device support window, edited independently of the release body.
- *
- * NARROW PARTIAL, not the whole release: the save sends { uuid, eos, eol, clearEos,
- * clearEol } and nothing else. That matters beyond tidiness -- updateRelease treats a null
- * list as "no change" (Utils.diffUuidLists), so omitting artifacts and commits leaves them
- * attached, whereas posting a whole stale release object could detach them.
- *
- * It also sidesteps the DRAFT gate in save(), correctly. That gate protects a release's
- * CONTENTS once assembled; a support window is the opposite kind of fact -- declared after
- * assembly and revised as the device ages.
- *
- * There IS a server-side lifecycle gate -- the resolver calls the 2-arg updateRelease
- * overload, which is UpdateReleaseStrength.DRAFT_ONLY. It does not fire here only because
- * ReleaseDto.isAssemblyRequested trips on parentReleases / sourceCodeEntry / commits /
- * inbound / outboundDeliverables, none of which this narrow payload sends. That is the
- * load-bearing reason to keep the payload narrow: WIDENING IT ARMS THE GATE and an
- * assembled release stops accepting window edits.
- */
-/**
  * The DEVICE window, inherited read-only from the product component (D7).
  *
  * Separate state from `deviceWindow` below, which is this RELEASE's own lifecycle dates. They
@@ -2011,7 +1992,7 @@ async function loadInheritedDeviceWindow () {
         || (updatedRelease.value as any)?.component
     if (!componentUuid) return
     try {
-        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid, isSchemaDriftError)
+        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid)
         inheritedDeviceWindow.eos = r.window.eos
         inheritedDeviceWindow.eol = r.window.eol
     } catch (e: any) {
@@ -2021,6 +2002,25 @@ async function loadInheritedDeviceWindow () {
     }
 }
 
+/**
+ * The device support window, edited independently of the release body.
+ *
+ * NARROW PARTIAL, not the whole release: the save sends { uuid, eos, eol, clearEos,
+ * clearEol } and nothing else. That matters beyond tidiness -- updateRelease treats a null
+ * list as "no change" (Utils.diffUuidLists), so omitting artifacts and commits leaves them
+ * attached, whereas posting a whole stale release object could detach them.
+ *
+ * It also sidesteps the DRAFT gate in save(), correctly. That gate protects a release's
+ * CONTENTS once assembled; a support window is the opposite kind of fact -- declared after
+ * assembly and revised as the device ages.
+ *
+ * There IS a server-side lifecycle gate -- the resolver calls the 2-arg updateRelease
+ * overload, which is UpdateReleaseStrength.DRAFT_ONLY. It does not fire here only because
+ * ReleaseDto.isAssemblyRequested trips on parentReleases / sourceCodeEntry / commits /
+ * inbound / outboundDeliverables, none of which this narrow payload sends. That is the
+ * load-bearing reason to keep the payload narrow: WIDENING IT ARMS THE GATE and an
+ * assembled release stops accepting window edits.
+ */
 const deviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
 const deviceWindowBaseline = reactive({ eos: null as string | null, eol: null as string | null })
 const savingDeviceWindow: Ref<boolean> = ref(false)

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1065,11 +1065,14 @@
         <div class="row" v-if="release && release.orgDetails && updatedRelease && updatedRelease.orgDetails">
             <n-tabs style="padding-left:0.2%;" type="segment" @update:value="handleTabSwitch" animated>
                 <n-tab-pane name="components" tab="Components">
-                    <!-- The DEVICE support window. PRODUCT releases only: it is the device's
-                         horizon, and every component verdict (deviceSupportRisk) is measured
-                         against it. Deliberately editable after assembly -- a window is
-                         declared years after a device ships and revised as it ages, so a
-                         DRAFT-only gate would mean no shipped device could ever have one. -->
+                    <!-- TWO DIFFERENT FACTS, SIDE BY SIDE AND NEVER MERGED (D7).
+                         The DEVICE window is declared on the product component and inherited by
+                         every release of it -- a device model ships many firmware versions over
+                         its life, and a support commitment that changes with each build is not a
+                         commitment. The RELEASE's own eos/eol are release lifecycle, consumed by
+                         TEA and CLE; they predate this feature and are not a labeling claim.
+                         They were edited through one control until 2026-09-10, which is exactly
+                         the conflation this separation removes. -->
                     <div class="container" v-if="updatedRelease.componentDetails && updatedRelease.componentDetails.type === 'PRODUCT'">
                         <h3>Device support window</h3>
                         <n-alert type="default" :show-icon="false" style="font-size: 12px; margin-bottom: 10px; max-width: 720px;">
@@ -1078,16 +1081,47 @@
                             is entitled to both. Blank means <strong>not declared</strong>,
                             which is a fact in its own right &mdash; not an unknown to fill in.
                         </n-alert>
-                        <n-space align="end" style="margin-bottom: 8px;">
+                        <n-space align="center" style="margin-bottom: 6px;">
                             <div>
                                 <div class="text-muted" style="font-size: 12px;">End of support (EOS)</div>
+                                <div>{{ inheritedDeviceWindow.eos || 'not declared' }}</div>
+                            </div>
+                            <div style="margin-left: 24px;">
+                                <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
+                                <div>{{ inheritedDeviceWindow.eol || 'not declared' }}</div>
+                            </div>
+                        </n-space>
+                        <div class="text-muted" style="font-size: 12px; max-width: 720px;">
+                            Read-only here. Declared on
+                            <router-link v-if="updatedRelease.component"
+                                :to="{ name: 'ComponentView', params: { uuid: updatedRelease.component } }">
+                                {{ updatedRelease.componentDetails.name }}</router-link>
+                            <span v-else>{{ updatedRelease.componentDetails.name }}</span>
+                            and inherited by every release of it; a batch may override it on the
+                            shipment.
+                        </div>
+                    </div>
+
+                    <!-- The RELEASE's own lifecycle dates. Editable, and deliberately NOT
+                         labelled as a device window: these feed TEA and CLE. -->
+                    <div class="container">
+                        <h3>Release lifecycle dates</h3>
+                        <n-alert type="default" :show-icon="false" style="font-size: 12px; margin-bottom: 10px; max-width: 720px;">
+                            When this <strong>version</strong> stops being supported and sold.
+                            Consumed by TEA and CLE. <strong>This is not the device's support
+                            window</strong> &mdash; that is declared on the product component and
+                            is what FDA section 524B labeling refers to.
+                        </n-alert>
+                        <n-space align="end" style="margin-bottom: 8px;">
+                            <div>
+                                <div class="text-muted" style="font-size: 12px;">Release end of support</div>
                                 <n-date-picker v-model:formatted-value="deviceWindow.eos"
                                     value-format="yyyy-MM-dd" type="date" clearable
                                     @update:formatted-value="deviceWindowError = null"
                                     :disabled="!isWritable || savingDeviceWindow" style="width: 200px;" />
                             </div>
                             <div>
-                                <div class="text-muted" style="font-size: 12px;">End of life / end of sale (EOL)</div>
+                                <div class="text-muted" style="font-size: 12px;">Release end of life / end of sale</div>
                                 <n-date-picker v-model:formatted-value="deviceWindow.eol"
                                     value-format="yyyy-MM-dd" type="date" clearable
                                     @update:formatted-value="deviceWindowError = null"
@@ -1095,7 +1129,7 @@
                             </div>
                             <n-button v-if="isWritable" size="small" type="primary"
                                 :disabled="!deviceWindowDirty" :loading="savingDeviceWindow"
-                                @click="saveDeviceWindow">Save window</n-button>
+                                @click="saveDeviceWindow">Save dates</n-button>
                         </n-space>
                         <n-alert v-if="deviceWindowError" type="error" :show-icon="true"
                             style="font-size: 12px; max-width: 720px; margin-bottom: 10px;">
@@ -1801,6 +1835,8 @@ import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/rele
 import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
 import { formatSupportWindow } from '@/utils/supportWindowDisplay'
+import { loadComponentDeviceWindow } from '@/utils/componentDeviceWindow'
+import { isSchemaDriftError } from '@/utils/graphqlDriftFallback'
 import { deviceWindowVariables } from '@/utils/deviceSupportWindowInput'
 import graphqlQueries from '@/utils/graphqlQueries'
 import { coverageDisplay } from '@/utils/supportCoverageDisplay'
@@ -1943,6 +1979,29 @@ async function loadAcollections() {
  * load-bearing reason to keep the payload narrow: WIDENING IT ARMS THE GATE and an
  * assembled release stops accepting window edits.
  */
+/**
+ * The DEVICE window, inherited read-only from the product component (D7).
+ *
+ * Separate state from `deviceWindow` below, which is this RELEASE's own lifecycle dates. They
+ * were one control until 2026-09-10 and are two different facts: the device's commitment is a
+ * labeling claim about the hardware, the release's dates are TEA/CLE metadata about a version.
+ */
+const inheritedDeviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
+
+async function loadInheritedDeviceWindow () {
+    const componentUuid = (updatedRelease.value as any)?.component
+    if (!componentUuid) return
+    try {
+        const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid, isSchemaDriftError)
+        inheritedDeviceWindow.eos = r.window.eos
+        inheritedDeviceWindow.eol = r.window.eol
+    } catch (e: any) {
+        // Left as "not declared". A read-only line that cannot be loaded must not claim dates.
+        inheritedDeviceWindow.eos = null
+        inheritedDeviceWindow.eol = null
+    }
+}
+
 const deviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
 const deviceWindowBaseline = reactive({ eos: null as string | null, eol: null as string | null })
 const savingDeviceWindow: Ref<boolean> = ref(false)
@@ -1964,6 +2023,8 @@ function seedDeviceWindow () {
     deviceWindowBaseline.eos = deviceWindow.eos
     deviceWindowBaseline.eol = deviceWindow.eol
     deviceWindowError.value = null
+    // The inherited device window comes from the product component, not from this release.
+    void loadInheritedDeviceWindow()
 }
 
 /**

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -2001,7 +2001,14 @@ async function loadAcollections() {
 const inheritedDeviceWindow = reactive({ eos: null as string | null, eol: null as string | null })
 
 async function loadInheritedDeviceWindow () {
-    const componentUuid = (updatedRelease.value as any)?.component
+    // componentDetails.uuid FIRST, and it is the only one that works on the surface this
+    // panel renders on: SINGLE_RELEASE_PRODUCT_GQL -- the query used for PRODUCT releases,
+    // which is where a device window is shown -- does not select the flat `component` field
+    // at all. Reading it there returned undefined and this function returned early every
+    // time, so the read-only window said "not declared" no matter what was declared. The
+    // flat field is kept as a fallback because SINGLE_RELEASE_GQL does select it.
+    const componentUuid = (updatedRelease.value as any)?.componentDetails?.uuid
+        || (updatedRelease.value as any)?.component
     if (!componentUuid) return
     try {
         const r = await loadComponentDeviceWindow(graphqlClient as any, componentUuid, isSchemaDriftError)

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1093,10 +1093,16 @@
                         </n-space>
                         <div class="text-muted" style="font-size: 12px; max-width: 720px;">
                             Read-only here. Declared on
-                            <router-link v-if="updatedRelease.component"
-                                :to="{ name: 'ComponentView', params: { uuid: updatedRelease.component } }">
+                            <!-- ProductsOfOrg, not a 'ComponentView' route: ComponentView.vue is a
+                                 CHILD of the products/components page and has no route of its own.
+                                 The same link is built this way 180 lines above. A device window is
+                                 only ever on a PRODUCT, so this is the products surface. -->
+                            <router-link v-if="updatedRelease.componentDetails"
+                                :to="{ name: 'ProductsOfOrg', params: {
+                                    orguuid: updatedRelease.orgDetails?.uuid || updatedRelease.org,
+                                    compuuid: updatedRelease.componentDetails.uuid } }">
                                 {{ updatedRelease.componentDetails.name }}</router-link>
-                            <span v-else>{{ updatedRelease.componentDetails.name }}</span>
+                            <span v-else>the product component</span>
                             and inherited by every release of it; a batch may override it on the
                             shipment.
                         </div>

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -97,11 +97,67 @@ describe('the release page separates the device window from release lifecycle', 
     it('keeps the release lifecycle dates editable and separately labelled', () => {
         expect(releaseView).toMatch(/<h3>Release lifecycle dates<\/h3>/)
         expect(releaseView).toMatch(/v-model:formatted-value="deviceWindow\.eos"/)
-        expect(releaseView).toMatch(/This is not the device's support/)
+        // The copy says what these dates are FOR, not merely what they are not: "not the
+        // device commitment" alone reads as "ignore these".
+        expect(releaseView).toMatch(/END_OF_SUPPORT/)
+        expect(releaseView).toMatch(/CLE lifecycle event for this release/)
+        expect(releaseView).toMatch(/Separate from the <strong>device support window<\/strong>/)
     })
 
     /** Loaded from the component, not from the release's own fields. */
     it('sources the inherited window from the product component', () => {
         expect(releaseView).toMatch(/loadComponentDeviceWindow\(graphqlClient as any, componentUuid/)
+    })
+})
+
+const distribution = readFileSync(
+    fileURLToPath(new URL('./DistributionOfOrg.vue', import.meta.url)), 'utf8')
+
+/**
+ * The batch override (D7): Hardware and SaMD only, never plain software.
+ *
+ * Support commonly runs from sale or shipment ("seven years from date of sale"), which is a
+ * fact about a BATCH -- and the ship date it anchors to is on this same form. Plain software
+ * is not a device and has no section 524B commitment to override.
+ */
+describe('the shipment device-window override', () => {
+    it('never renders for a plain-software shipment', () => {
+        const block = distribution.slice(distribution.indexOf("THE BATCH'S DEVICE SUPPORT WINDOW OVERRIDE"))
+        // The gate is the <template> immediately after the comment block.
+        expect(block.slice(0, 900)).toMatch(/<template v-if="!isSoftwareShipment">/)
+        // ...and the fields themselves live inside it, not outside.
+        expect(block.indexOf('<template v-if="!isSoftwareShipment">'))
+            .toBeLessThan(block.indexOf('shipForm.deviceWindowEos'))
+    })
+
+    it('binds both override dates', () => {
+        expect(distribution).toMatch(/v-model:formatted-value="shipForm\.deviceWindowEos"/)
+        expect(distribution).toMatch(/v-model:formatted-value="shipForm\.deviceWindowEol"/)
+    })
+
+    /** The in-force line has to name WHERE the window came from, or an operator cannot tell
+     *  an inherited value from one this batch already overrode. */
+    it('names the level the effective window came from', () => {
+        expect(distribution).toMatch(/w\.source === 'SHIPMENT' \? 'this batch' : 'the product component'/)
+    })
+
+    /**
+     * Seeded from the batch's OWN window, never the effective one: seeding from the effective
+     * value would turn an inherited window into an override the moment anything else was saved.
+     */
+    it('seeds the editor from the batch override, not the effective window', () => {
+        expect(distribution).toMatch(/shipForm\.deviceWindowEos = existing\.deviceSupportWindow\?\.eos/)
+    })
+
+    /** Blank-both after something was declared is a retraction and must send the flag. */
+    it('sends the clear flag rather than an empty window object', () => {
+        const save = distribution.slice(distribution.indexOf('D7, same three rules as the component panel'))
+        expect(save.slice(0, 1200)).toMatch(/input\.clearDeviceSupportWindow = true/)
+        expect(save.slice(0, 1200)).not.toMatch(/deviceSupportWindow = \{ eos: null, eol: null \}/)
+    })
+
+    /** SaaS-only surface, so the document is simply never issued by a CE build. */
+    it('asks for the window in the shipments query', () => {
+        expect(distribution).toMatch(/effectiveDeviceSupportWindow \{ eos eol source \}/)
     })
 })

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -64,3 +64,44 @@ describe('the device window panel is wired into the component page', () => {
         expect(source).toMatch(/deviceWindowMutationInput\(componentUuid, deviceWindow, deviceWindowBaseline\)/)
     })
 })
+
+const releaseView = readFileSync(
+    fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+
+/**
+ * The release page shows TWO DIFFERENT FACTS and never merges them (D7).
+ *
+ * Until 2026-09-10 one control edited `release.eos/eol` under the heading "Device support
+ * window", which is the conflation the whole ruling removes: the device's commitment is a
+ * labeling claim about hardware, the release's dates are TEA/CLE metadata about a version.
+ */
+describe('the release page separates the device window from release lifecycle', () => {
+    it('renders the inherited device window read-only', () => {
+        expect(releaseView).toMatch(/\{\{ inheritedDeviceWindow\.eos \|\| 'not declared' \}\}/)
+        expect(releaseView).toMatch(/\{\{ inheritedDeviceWindow\.eol \|\| 'not declared' \}\}/)
+    })
+
+    /** No editor on the inherited value -- it is not this page's to change. */
+    it('does not bind the inherited window to an input', () => {
+        expect(releaseView).not.toMatch(/v-model[^\n]*inheritedDeviceWindow/)
+    })
+
+    /** A reader must be able to reach the place it IS editable. */
+    it('links to the product component that declares it', () => {
+        const section = releaseView.slice(releaseView.indexOf('<h3>Device support window</h3>'))
+        expect(section.slice(0, 2000)).toMatch(/router-link/)
+        expect(section.slice(0, 2000)).toMatch(/name: 'ComponentView'/)
+    })
+
+    /** The release's own dates stay editable, under a heading that does not claim otherwise. */
+    it('keeps the release lifecycle dates editable and separately labelled', () => {
+        expect(releaseView).toMatch(/<h3>Release lifecycle dates<\/h3>/)
+        expect(releaseView).toMatch(/v-model:formatted-value="deviceWindow\.eos"/)
+        expect(releaseView).toMatch(/This is not the device's support/)
+    })
+
+    /** Loaded from the component, not from the release's own fields. */
+    it('sources the inherited window from the product component', () => {
+        expect(releaseView).toMatch(/loadComponentDeviceWindow\(graphqlClient as any, componentUuid/)
+    })
+})

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -36,7 +36,10 @@ describe('the device window panel is wired into the component page', () => {
 
     /** Only a device declares one; the server rejects the write otherwise. */
     it('hides itself on a component that is not a device', () => {
-        expect(source).toMatch(/deviceClass !== 'NONE'/)
+        // The gate reads deviceClassBaseline -- the class the SERVER last confirmed -- not
+        // componentData, which initLoad() rehydrates from the store cache and which therefore
+        // still held the old class right after a successful save.
+        expect(source).toMatch(/deviceClassBaseline\.value !== 'NONE'/)
     })
 
     it('loads the window after the component data exists', () => {
@@ -53,9 +56,19 @@ describe('the device window panel is wired into the component page', () => {
     it('reads the window through its own document, not the mutation response', () => {
         const queries = readFileSync(
             fileURLToPath(new URL('../utils/graphqlQueries.ts', import.meta.url)), 'utf8')
+        // COMMENTS STRIPPED before the check. The claim is about the SELECTION SET -- what
+        // the server is asked for -- and a `#` comment explaining why the field is absent is
+        // the most natural place for the word to appear. Matching against comment prose made
+        // this fail on a change that documented the rule it enforces, which is the same
+        // mistake SupportEnumsSchemaEnumSyncTest made reading docstrings as enum values.
         const fragment = queries.slice(queries.indexOf('const COMPONENT_FULL_DATA'),
             queries.indexOf('const COMPONENT_MUTATE'))
+            .split('\n').filter(l => !l.trim().startsWith('#')).join('\n')
         expect(fragment).not.toMatch(/deviceSupportWindow/)
+        // deviceClass, by contrast, MUST be there: CE declares it, and the panel's gate reads
+        // it off componentData. It was absent, so isDeviceComponent was false for every
+        // component and the panel never rendered for anyone.
+        expect(fragment).toMatch(/^\s*deviceClass\s*$/m)
         expect(source).toMatch(/loadComponentDeviceWindow\(/)
     })
 
@@ -64,7 +77,10 @@ describe('the device window panel is wired into the component page', () => {
         expect(source).toMatch(/deviceWindowMutationInput\(componentUuid,/)
         // name is String! on UpdateComponentInput -- a partial without it is rejected at
         // coercion, so the panel must pass one.
-        expect(source).toMatch(/componentData\.value\?\.name \|\| updatedComponent\.name/)
+        // .value on BOTH: updatedComponent is a Ref, and `updatedComponent.name` in
+        // <script setup> is undefined rather than the name -- the template unwraps Refs, the
+        // script does not. The fallback silently sent name: undefined, which fails coercion.
+        expect(source).toMatch(/componentData\.value\?\.name \|\| updatedComponent\.value\?\.name/)
     })
 })
 
@@ -172,5 +188,98 @@ describe('the shipment device-window override', () => {
     /** SaaS-only surface, so the document is simply never issued by a CE build. */
     it('asks for the window in the shipments query', () => {
         expect(distribution).toMatch(/effectiveDeviceSupportWindow \{ eos eol source \}/)
+    })
+})
+
+/**
+ * The four defects Layer 1 found on this branch, each pinned by the property that was
+ * violated rather than by the text that fixed it.
+ *
+ * All four passed every existing gate: the UI has no vue-tsc, `src/utils/` is unlinted, and
+ * a green build plus a green suite cannot see an unregistered component, an unselected
+ * GraphQL field or a query that is never issued. They shipped a panel that could not render,
+ * a read that always returned early, and a CE protection that was documented but absent.
+ */
+describe('the D7 UI surfaces can actually render and read', () => {
+    it('ComponentView imports NDatePicker, which its pickers need to exist', () => {
+        // naive-ui is NOT globally registered in main.ts -- every component is imported per
+        // file. ReleaseView.vue imports NDatePicker for exactly this reason. Without it the
+        // two <n-date-picker> elements resolve to nothing and the panel has no date inputs.
+        const imports = source.slice(source.indexOf("from 'naive-ui'") - 900,
+            source.indexOf("from 'naive-ui'"))
+        expect(imports).toMatch(/\bNDatePicker\b/)
+        expect(source).toMatch(/<n-date-picker/)
+    })
+
+    it('ComponentView can set the device class, not only read it', () => {
+        // Before this, deviceClass could only be set at CREATE time, so the window panel --
+        // which correctly renders only for a device -- was unreachable for every component
+        // that already existed, and D7's "declare it on the product component" had no path.
+        expect(source).toMatch(/saveDeviceClass/)
+        expect(source).toMatch(/DEVICE_CLASS_OPTIONS/)
+        // Re-read after the write: NONE retracts the window server-side, and leaving stale
+        // dates in the form would show a section 524B commitment the server no longer holds.
+        const fn = source.slice(source.indexOf('async function saveDeviceClass'))
+            .slice(0, 1400)
+        expect(fn).toMatch(/loadDeviceWindow\(\)/)
+    })
+
+    it('the release page reads the component uuid from a field its query selects', () => {
+        const release = readFileSync(
+            fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+        // SINGLE_RELEASE_PRODUCT_GQL -- the query used for PRODUCT releases, which is the
+        // only surface this panel renders on -- does not select the flat `component` field.
+        // Reading it there returned undefined, so the inherited window said "not declared"
+        // regardless of what was declared.
+        const fn = release.slice(release.indexOf('async function loadInheritedDeviceWindow'))
+            .slice(0, 900)
+        expect(fn).toMatch(/componentDetails\?\.uuid/)
+        const queries = readFileSync(
+            fileURLToPath(new URL('../utils/graphqlQueries.ts', import.meta.url)), 'utf8')
+        const product = queries.slice(queries.indexOf('const SINGLE_RELEASE_PRODUCT_GQL'))
+            .slice(0, 6000)
+        expect(product).toMatch(/componentDetails/)
+    })
+
+    it('the addendum collector falls back to CORE instead of issuing FULL alone', () => {
+        const addendum = readFileSync(
+            fileURLToPath(new URL('../utils/addendumData.ts', import.meta.url)), 'utf8')
+        const fn = addendum.slice(addendum.indexOf('export async function collectAddendumData'))
+            .slice(0, 2000)
+        // Issuing FULL directly made ADDENDUM_RELEASE_QUERY_CORE dead outside its own spec,
+        // so the CE protection the split exists for was documented but not present: on CE the
+        // addendum would not generate at all, because the missing subfield invalidates the
+        // WHOLE document rather than returning null.
+        expect(fn).toMatch(/loadWithSchemaDriftFallback/)
+        expect(fn).toMatch(/ADDENDUM_RELEASE_QUERY_CORE/)
+    })
+
+    it('the statement font check covers the user-entered provenance strings', () => {
+        const stmt = readFileSync(
+            fileURLToPath(new URL('../utils/deviceSupportStatement.ts', import.meta.url)), 'utf8')
+        const fn = stmt.slice(stmt.indexOf('function statementStrings')).slice(0, 1600)
+        // A site name and a lot code are the only strings in the document a HUMAN types, and
+        // therefore the likeliest to carry a glyph the embedded font cannot draw. Omitting
+        // them let one through the refusal and into a patient-facing PDF as a blank box.
+        for (const f of ['siteName', 'shipDate', 'batchIdentifier']) expect(fn).toMatch(f)
+    })
+
+    it('the panels are siblings of coreSettingsActions, not children of it', () => {
+        // coreSettingsActions has v-if="hasCoreSettingsChanges && isWritable" -- it is the
+        // UNSAVED-CHANGES action bar. Nested inside it, the device window panel appeared only
+        // after you had edited some other core setting and vanished the moment you saved, so
+        // on a freshly opened component -- every reader following the walkthrough -- it did
+        // not exist at all. This is the defect that made the whole D7 write path unreachable,
+        // and neither the build, the suite nor a GraphQL-driven probe could see it.
+        const bar = source.indexOf('class="coreSettingsActions"')
+        const panel = source.indexOf('THE DEVICE SUPPORT WINDOW LIVES HERE NOW')
+        expect(bar).toBeGreaterThan(-1)
+        expect(panel).toBeGreaterThan(bar)
+        // Everything between the action bar and the panel, with the panel OUTSIDE: the bar's
+        // own div must have closed first. Count div depth across the gap.
+        const gap = source.slice(bar, panel)
+        const opens = (gap.match(/<div\b/g) || []).length
+        const closes = (gap.match(/<\/div>/g) || []).length
+        expect(closes).toBeGreaterThanOrEqual(opens)
     })
 })

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * The device support window panel is actually WIRED into the component page.
+ *
+ * This repo has no vue-tsc and `src/utils/` is unlinted, so a green build proves nothing about
+ * a `<script setup>` identifier or a template binding -- a deleted block, a renamed ref or a
+ * mistyped handler all build clean and fail only in a browser. That is exactly how #339 shipped
+ * a blank tab. These assertions are narrow on purpose: they pin the things whose absence makes
+ * the feature invisible while every unit test passes.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./ComponentView.vue', import.meta.url)), 'utf8')
+
+describe('the device window panel is wired into the component page', () => {
+    it('binds both date pickers to the window state', () => {
+        expect(source).toMatch(/v-model:formatted-value="deviceWindow\.eos"/)
+        expect(source).toMatch(/v-model:formatted-value="deviceWindow\.eol"/)
+    })
+
+    it('gates Save on an actual change', () => {
+        expect(source).toMatch(/:disabled="!deviceWindowDirty"/)
+        expect(source).toMatch(/@click="saveDeviceWindow"/)
+    })
+
+    /**
+     * Hidden entirely on a backend that cannot answer for the field -- a CE mirror before the
+     * deferred sync. Offering an editor whose save the server would reject is worse than not
+     * offering it, and an always-empty panel would read as "this device declares nothing".
+     */
+    it('hides itself when the backend does not support the field', () => {
+        expect(source).toMatch(/v-if="deviceWindowSupported && isDeviceComponent"/)
+    })
+
+    /** Only a device declares one; the server rejects the write otherwise. */
+    it('hides itself on a component that is not a device', () => {
+        expect(source).toMatch(/deviceClass !== 'NONE'/)
+    })
+
+    it('loads the window after the component data exists', () => {
+        const mounted = source.slice(source.indexOf('onMounted(async () => {'))
+        expect(mounted.indexOf('await initLoad()')).toBeLessThan(mounted.indexOf('await loadDeviceWindow()'))
+    })
+
+    /**
+     * The window must NOT be folded into COMPONENT_FULL_DATA: that fragment is the
+     * updateComponent mutation's response selection, and CE declares medicalProfile without
+     * this subfield, so folding it in would invalidate the whole mutation and break EVERY
+     * component save on CE. Same trap supportInjection hit in #339.
+     */
+    it('reads the window through its own document, not the mutation response', () => {
+        const queries = readFileSync(
+            fileURLToPath(new URL('../utils/graphqlQueries.ts', import.meta.url)), 'utf8')
+        const fragment = queries.slice(queries.indexOf('const COMPONENT_FULL_DATA'),
+            queries.indexOf('const COMPONENT_MUTATE'))
+        expect(fragment).not.toMatch(/deviceSupportWindow/)
+        expect(source).toMatch(/loadComponentDeviceWindow\(/)
+    })
+
+    /** The write goes through the shared builder, which owns the clear-vs-empty rule. */
+    it('builds its mutation input through deviceWindowMutationInput', () => {
+        expect(source).toMatch(/deviceWindowMutationInput\(componentUuid, deviceWindow, deviceWindowBaseline\)/)
+    })
+})

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -164,10 +164,22 @@ describe('the shipment device-window override', () => {
         expect(distribution).toMatch(/v-model:formatted-value="shipForm\.deviceWindowEol"/)
     })
 
-    /** The in-force line has to name WHERE the window came from, or an operator cannot tell
-     *  an inherited value from one this batch already overrode. */
-    it('names the level the effective window came from', () => {
-        expect(distribution).toMatch(/w\.source === 'SHIPMENT' \? 'this batch' : 'the product component'/)
+    /**
+     * WIRING only. What the label SAYS is behaviour, and is tested as behaviour in
+     * utils/shipmentDeviceWindow.spec.ts -- this used to pin the literal ternary, which meant
+     * renaming the local `w` failed the spec with the behaviour unchanged, and a genuinely
+     * wrong string would have passed as long as the shape matched.
+     */
+    it('renders the in-force line through the shared label builder', () => {
+        expect(distribution).toMatch(/buildEffectiveWindowLabel\(/)
+        expect(distribution).toMatch(/from '@\/utils\/componentDeviceWindow'/)
+    })
+
+    it('builds the shipment mutation through the shared rule, not a second copy of it', () => {
+        // The clear-vs-empty rule is identical to the component panel's. Two copies in two
+        // files are two chances to disagree about what "retract" means on a 524B commitment.
+        expect(distribution).toMatch(/applyShipmentWindowToInput\(/)
+        expect(distribution).not.toMatch(/input\.clearDeviceSupportWindow = true/)
     })
 
     /**
@@ -180,9 +192,11 @@ describe('the shipment device-window override', () => {
 
     /** Blank-both after something was declared is a retraction and must send the flag. */
     it('sends the clear flag rather than an empty window object', () => {
-        const save = distribution.slice(distribution.indexOf('D7, same three rules as the component panel'))
-        expect(save.slice(0, 1200)).toMatch(/input\.clearDeviceSupportWindow = true/)
-        expect(save.slice(0, 1200)).not.toMatch(/deviceSupportWindow = \{ eos: null, eol: null \}/)
+        // The RULE moved to utils/componentDeviceWindow.ts and is tested as behaviour in
+        // utils/shipmentDeviceWindow.spec.ts. What stays here is the wiring claim: this file
+        // delegates rather than keeping a second copy of a rule about what "retract" means.
+        expect(distribution).toMatch(/applyShipmentWindowToInput\(/)
+        expect(distribution).not.toMatch(/input\.clearDeviceSupportWindow = true/)
     })
 
     /** SaaS-only surface, so the document is simply never issued by a CE build. */

--- a/ui/src/components/deviceWindowPanelWiring.spec.ts
+++ b/ui/src/components/deviceWindowPanelWiring.spec.ts
@@ -61,7 +61,10 @@ describe('the device window panel is wired into the component page', () => {
 
     /** The write goes through the shared builder, which owns the clear-vs-empty rule. */
     it('builds its mutation input through deviceWindowMutationInput', () => {
-        expect(source).toMatch(/deviceWindowMutationInput\(componentUuid, deviceWindow, deviceWindowBaseline\)/)
+        expect(source).toMatch(/deviceWindowMutationInput\(componentUuid,/)
+        // name is String! on UpdateComponentInput -- a partial without it is rejected at
+        // coercion, so the panel must pass one.
+        expect(source).toMatch(/componentData\.value\?\.name \|\| updatedComponent\.name/)
     })
 })
 
@@ -87,10 +90,20 @@ describe('the release page separates the device window from release lifecycle', 
     })
 
     /** A reader must be able to reach the place it IS editable. */
-    it('links to the product component that declares it', () => {
+    /**
+     * A link to a route that does not exist is worse than no link: it renders, it is clickable,
+     * and it goes nowhere. The first version of this test asserted `name: 'ComponentView'` --
+     * which is the options-API COMPONENT name, not a route -- so it was green on a dead link.
+     * It now pins a route name that router.ts actually declares.
+     */
+    it('links to the product component through a route that exists', () => {
         const section = releaseView.slice(releaseView.indexOf('<h3>Device support window</h3>'))
-        expect(section.slice(0, 2000)).toMatch(/router-link/)
-        expect(section.slice(0, 2000)).toMatch(/name: 'ComponentView'/)
+        expect(section.slice(0, 2500)).toMatch(/router-link/)
+        expect(section.slice(0, 2500)).toMatch(/name: 'ProductsOfOrg'/)
+
+        const router = readFileSync(
+            fileURLToPath(new URL('../router.ts', import.meta.url)), 'utf8')
+        expect(router).toMatch(/name: 'ProductsOfOrg'/)
     })
 
     /** The release's own dates stay editable, under a heading that does not claim otherwise. */

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -115,8 +115,13 @@ function fakeClient (opts: {
     }
 }
 
+// D7: the device window is declared on the PRODUCT COMPONENT. The release's own eos/eol are
+// deliberately set to DIFFERENT dates here so that any code reading them instead would produce
+// visibly wrong output rather than an accidentally-passing test.
 const okRelease = { uuid: 'r1', version: '1.4.5', eos: '2030-06-30', eol: '2033-01-01',
-    fdaAssessmentNarrative: null, componentDetails: { name: 'Pump', type: 'PRODUCT' } }
+    fdaAssessmentNarrative: null,
+    componentDetails: { uuid: 'c1', name: 'Pump', type: 'PRODUCT',
+        medicalProfile: { deviceSupportWindow: { eos: '2031-01-31', eol: '2034-12-31' } } } }
 const okOrg = { uuid: 'o1', name: 'Acme', settings: { fdaAssessmentNarrative: 'org words' } }
 
 describe('collectAddendumData', () => {
@@ -129,8 +134,11 @@ describe('collectAddendumData', () => {
         expect(res.ok).toBe(true)
         if (!res.ok) return
         expect(res.data.components).toHaveLength(2)
-        expect(res.data.deviceEos).toBe('2030-06-30')
-        expect(res.data.deviceEol).toBe('2033-01-01')
+        // The PRODUCT COMPONENT's window, not the release's eos/eol (D7). The fixture gives
+        // the release different dates on purpose: if this ever reads them again, these two
+        // assertions fail with the release's values rather than passing by coincidence.
+        expect(res.data.deviceEos).toBe('2031-01-31')
+        expect(res.data.deviceEol).toBe('2034-12-31')
         expect(res.data.narrative).toBe('org words')
         expect(res.data.narrativeIsPerRelease).toBe(false)
         // Fetched by the query and previously discarded. The Device Support Statement is one
@@ -243,7 +251,8 @@ describe('collectAddendumData', () => {
     // PDF-READY: the next PR consumes this unchanged, so nothing here may be CSV-shaped.
     it('returns raw facts, never rendered text', async () => {
         const client = fakeClient({
-            release: { ...okRelease, eos: null, eol: null }, org: okOrg,
+            release: { ...okRelease,
+                componentDetails: { ...okRelease.componentDetails, medicalProfile: null } }, org: okOrg,
             coverage: { total: 0, attested: 0 },
             pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
         })
@@ -427,5 +436,43 @@ describe('collectAddendumData', () => {
         if (!res.ok) return
         expect(res.data.components[0].levelOfSupportEnum).toBe('ACTIVELY_MAINTAINED')
         expect(res.data.components[0].levelOfSupport).toBe('actively maintained')
+    })
+})
+
+
+describe('the device window source (D7)', () => {
+    /**
+     * A release carrying its own eos/eol whose component declares NO window must report the
+     * device window as not declared. Without this the move off the release would be cosmetic:
+     * every document would keep rendering the release's lifecycle dates as a device support
+     * commitment, and nothing would notice.
+     */
+    it('never falls back to the release lifecycle dates', async () => {
+        const client = fakeClient({
+            release: { ...okRelease, eos: '2030-06-30', eol: '2033-01-01',
+                componentDetails: { ...okRelease.componentDetails, medicalProfile: null } },
+            org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res: any = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.ok).toBe(true)
+        expect(res.data.deviceEos).toBeNull()
+        expect(res.data.deviceEol).toBeNull()
+    })
+
+    /**
+     * A CORE response -- what a CE backend can answer -- carries no medicalProfile at all.
+     * "Not declared" is the honest reading; inventing a window from the release would not be.
+     */
+    it('reports not-declared on a response that could not carry the window', async () => {
+        const client = fakeClient({
+            release: { uuid: 'r1', version: '1.4.5', eos: '2030-06-30', eol: '2033-01-01',
+                fdaAssessmentNarrative: null,
+                componentDetails: { uuid: 'c1', name: 'Pump', type: 'PRODUCT' } },
+            org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res: any = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.data.deviceEos).toBeNull()
     })
 })

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -10,6 +10,7 @@
 // them. `deviceEos` is a date string or null, never "not declared".
 
 import gql from 'graphql-tag'
+import { loadWithSchemaDriftFallback } from './graphqlDriftFallback'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
 // PAGE SIZE only. That reuse is uncontroversial: it is one server, one resolver, and the
 // same round-trip economics. The CEILING below is deliberately NOT borrowed -- see it.
@@ -322,8 +323,19 @@ export async function collectAddendumData (
     orgUuid: string
 ): Promise<AddendumResult> {
     try {
+        // FULL, falling back to CORE on a drift error -- not FULL alone. CE declares
+        // Component.medicalProfile WITHOUT deviceSupportWindow inside it, so asking for the
+        // subfield makes the WHOLE document invalid there rather than merely null: the
+        // addendum would fail to generate at all on a CE build, which is precisely what the
+        // CORE/FULL split exists to prevent. Issuing FULL directly made CORE dead code
+        // outside its own spec, so the protection was documented but not present.
         const [releaseResp, orgResp, coverageResp] = await Promise.all([
-            client.query({ query: ADDENDUM_RELEASE_QUERY, variables: { releaseUuid, orgUuid }, fetchPolicy: 'network-only' }),
+            loadWithSchemaDriftFallback(client, {
+                fullQuery: ADDENDUM_RELEASE_QUERY_FULL,
+                coreQuery: ADDENDUM_RELEASE_QUERY_CORE,
+                variables: { releaseUuid, orgUuid },
+                extractPath: (d: any) => d
+            }).then(r => ({ data: r.data })),
             client.query({ query: ADDENDUM_ORG_QUERY, variables: {}, fetchPolicy: 'network-only' }),
             loadReleaseSupportCoverage(client, orgUuid, releaseUuid)
         ])

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -57,17 +57,45 @@ export const ADDENDUM_PAGE_QUERY = gql`
         }
     }`
 
-export const ADDENDUM_RELEASE_QUERY = gql`
-    query getAddendumRelease($releaseUuid: ID!, $orgUuid: ID) {
-        release(releaseUuid: $releaseUuid, orgUuid: $orgUuid) {
+/**
+ * The addendum's release query, in two shapes (decision D7).
+ *
+ * The device support window is declared on the PRODUCT COMPONENT now, not on the release, so
+ * FULL reaches through `componentDetails` to read it. `release.eos`/`eol` are still selected
+ * and still returned -- they are release lifecycle for TEA/CLE -- but they are NO LONGER the
+ * source of `deviceEos`/`deviceEol`.
+ *
+ * **Split because CE cannot answer FULL.** CE's schema declares `Component.medicalProfile` but
+ * NOT `deviceSupportWindow` inside it, so adding the subfield to a `medicalProfile` selection
+ * makes the WHOLE DOCUMENT invalid there -- not just that field null. A CE build issuing FULL
+ * gets a validation error and renders nothing, which is the #339 defect exactly. CORE is what
+ * every backend can answer; on it the device window is simply not available and the addendum
+ * reports "not declared", which is honest rather than wrong.
+ */
+const ADDENDUM_RELEASE_CORE_SELECTION = `
             uuid
             version
             eos
             eol
             fdaAssessmentNarrative
-            componentDetails { name type }
+            componentDetails { uuid name type }`
+
+const addendumReleaseDocument = (selection: string) => `
+    query getAddendumRelease($releaseUuid: ID!, $orgUuid: ID) {
+        release(releaseUuid: $releaseUuid, orgUuid: $orgUuid) {${selection}
         }
     }`
+
+export const ADDENDUM_RELEASE_QUERY_CORE = gql`${addendumReleaseDocument(ADDENDUM_RELEASE_CORE_SELECTION)}`
+
+export const ADDENDUM_RELEASE_QUERY_FULL = gql`${addendumReleaseDocument(
+    ADDENDUM_RELEASE_CORE_SELECTION + `
+            componentDetails {
+                medicalProfile { deviceSupportWindow { eos eol } }
+            }`)}`
+
+/** Back-compat alias: the FULL shape is what a Pro build wants. */
+export const ADDENDUM_RELEASE_QUERY = ADDENDUM_RELEASE_QUERY_FULL
 
 /**
  * The ORGANIZATIONS LIST, filtered client-side -- not organization(orgUuid:).
@@ -357,6 +385,9 @@ export async function collectAddendumData (
 
         const settings = org?.settings || null
         const resolved = resolveNarrative(release, settings)
+        // Absent on a CORE response (a CE backend cannot answer for it), which correctly
+        // reports the window as "not declared" rather than inventing one.
+        const deviceWindow = release.componentDetails?.medicalProfile?.deviceSupportWindow ?? null
         return {
             ok: true,
             data: {
@@ -364,8 +395,12 @@ export async function collectAddendumData (
                 releaseVersion: blankToNull(release.version),
                 componentName: blankToNull(release.componentDetails?.name),
                 componentType: blankToNull(release.componentDetails?.type),
-                deviceEos: blankToNull(release.eos),
-                deviceEol: blankToNull(release.eol),
+                // D7: the DEVICE window comes from the product component, never from the
+                // release. release.eos/eol are release lifecycle for TEA/CLE -- reading them
+                // here is what made one physical device describable by a dozen different
+                // end-of-support dates depending on which firmware it happened to run.
+                deviceEos: blankToNull(deviceWindow?.eos),
+                deviceEol: blankToNull(deviceWindow?.eol),
                 narrative: resolved.narrative,
                 narrativeIsPerRelease: resolved.perRelease,
                 orgName: blankToNull(org?.name),

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -163,6 +163,32 @@ export interface AddendumComponent {
     assessedAt: string | null
 }
 
+/**
+ * Where a device support window was declared, in the terms a lay reader can act on.
+ *
+ * The SHIPMENT case names the batch by things a person can match against a delivery note --
+ * site and ship date, plus the batch identifier when one was recorded -- rather than by the
+ * word "override" or a uuid. "Override" is our vocabulary, not theirs.
+ */
+export type DeviceWindowProvenance =
+    | { level: 'COMPONENT', productName: string | null }
+    | { level: 'SHIPMENT', siteName: string | null, shipDate: string | null, batchIdentifier: string | null }
+
+/** The statement's provenance line, or null when no window is declared. */
+export function deviceWindowProvenanceLine (p: DeviceWindowProvenance | null): string | null {
+    if (!p) return null
+    if (p.level === 'COMPONENT') {
+        return p.productName
+            ? `These dates are declared on ${p.productName} and apply to every unit of it.`
+            : 'These dates are declared on the product and apply to every unit of it.'
+    }
+    const where = p.siteName ? ` delivered to ${p.siteName}` : ''
+    const when = p.shipDate ? ` on ${p.shipDate}` : ''
+    const batch = p.batchIdentifier ? ` (batch ${p.batchIdentifier})` : ''
+    return `These dates apply to the units${where}${when}${batch}, and may differ from other`
+        + ' deliveries of the same device.'
+}
+
 export interface AddendumData {
     releaseUuid: string
     releaseVersion: string | null
@@ -183,6 +209,14 @@ export interface AddendumData {
      */
     deviceEos: string | null
     deviceEol: string | null
+    /**
+     * WHERE the device window was declared, for the statement's one-line provenance (D7).
+     *
+     * A reader comparing two statements for the same device model needs to know why the dates
+     * differ, and "a different batch declared its own" is the answer. Null when no window is
+     * declared at all -- there is no provenance for a fact that does not exist.
+     */
+    deviceWindowSource: DeviceWindowProvenance | null
     /** Resolved through resolveNarrative: release override else org default, else null. */
     narrative: string | null
     /** True when the narrative came from the release rather than the org. */
@@ -401,6 +435,11 @@ export async function collectAddendumData (
                 // end-of-support dates depending on which firmware it happened to run.
                 deviceEos: blankToNull(deviceWindow?.eos),
                 deviceEol: blankToNull(deviceWindow?.eol),
+                // Generated from a release, so the window is the product component's. A
+                // shipment-generated statement supplies the SHIPMENT shape instead.
+                deviceWindowSource: (deviceWindow?.eos || deviceWindow?.eol)
+                    ? { level: 'COMPONENT', productName: blankToNull(release.componentDetails?.name) }
+                    : null,
                 narrative: resolved.narrative,
                 narrativeIsPerRelease: resolved.perRelease,
                 orgName: blankToNull(org?.name),

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -175,7 +175,11 @@ export type DeviceWindowProvenance =
     | { level: 'SHIPMENT', siteName: string | null, shipDate: string | null, batchIdentifier: string | null }
 
 /** The statement's provenance line, or null when no window is declared. */
-export function deviceWindowProvenanceLine (p: DeviceWindowProvenance | null): string | null {
+export function deviceWindowProvenanceLine (
+    p: DeviceWindowProvenance | null | undefined
+): string | null {
+    // Optional on AddendumData, so undefined reaches here from any fixture or caller that
+    // predates D7. Same answer as null: no window declared, so no provenance to state.
     if (!p) return null
     if (p.level === 'COMPONENT') {
         return p.productName
@@ -216,7 +220,7 @@ export interface AddendumData {
      * differ, and "a different batch declared its own" is the answer. Null when no window is
      * declared at all -- there is no provenance for a fact that does not exist.
      */
-    deviceWindowSource: DeviceWindowProvenance | null
+    deviceWindowSource?: DeviceWindowProvenance | null
     /** Resolved through resolveNarrative: release override else org default, else null. */
     narrative: string | null
     /** True when the narrative came from the release rather than the org. */

--- a/ui/src/utils/componentDeviceWindow.spec.ts
+++ b/ui/src/utils/componentDeviceWindow.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { loadComponentDeviceWindow, deviceWindowMutationInput,
+    COMPONENT_DEVICE_WINDOW_QUERY } from './componentDeviceWindow'
+import { print } from 'graphql'
+
+const drift = (e: any) => e?.driftLike === true
+
+function client (result: any, throws?: any) {
+    return { query: async () => { if (throws) throw throws; return result } }
+}
+
+describe('reading the declared window', () => {
+    it('reads the component-level window', async () => {
+        const r = await loadComponentDeviceWindow(client({
+            data: { component: { uuid: 'c1', medicalProfile: {
+                deviceSupportWindow: { eos: '2031-01-31', eol: null, assertedBy: 'u1', assessedAt: 'i' } } } }
+        }), 'c1', drift)
+        expect(r.supported).toBe(true)
+        expect(r.window).toEqual({ eos: '2031-01-31', eol: null })
+        expect(r.assertedBy).toBe('u1')
+    })
+
+    it('reports not-declared when the component declares nothing', async () => {
+        const r = await loadComponentDeviceWindow(client({
+            data: { component: { uuid: 'c1', medicalProfile: null } } }), 'c1', drift)
+        expect(r.supported).toBe(true)
+        expect(r.window).toEqual({ eos: null, eol: null })
+    })
+
+    /**
+     * CE declares Component.medicalProfile WITHOUT deviceSupportWindow, so this document is a
+     * VALIDATION ERROR there -- not a null field. "This build cannot show the window" and "this
+     * device has no window declared" are different facts, and collapsing them would put an
+     * editable, always-empty panel in front of a CE operator whose saves would all fail.
+     */
+    it('reports unsupported, not not-declared, on a schema-drift error', async () => {
+        const r = await loadComponentDeviceWindow(client(null, { driftLike: true }), 'c1', drift)
+        expect(r.supported).toBe(false)
+        expect(r.window).toEqual({ eos: null, eol: null })
+    })
+
+    /** A real failure must not be swallowed as "unsupported" -- that would hide an outage. */
+    it('rethrows a non-drift error', async () => {
+        await expect(loadComponentDeviceWindow(client(null, new Error('boom')), 'c1', drift))
+            .rejects.toThrow('boom')
+    })
+})
+
+describe('writing the window', () => {
+    const none = { eos: null, eol: null }
+
+    it('sends the dates when they change', () => {
+        expect(deviceWindowMutationInput('c1', { eos: '2031-01-31', eol: null }, none))
+            .toEqual({ uuid: 'c1', deviceSupportWindow: { eos: '2031-01-31', eol: null } })
+    })
+
+    /**
+     * Blanking both pickers is a RETRACTION and must send the flag. An empty window object is
+     * deliberately not a clear on the server, so sending one would leave the old commitment
+     * silently in force while the screen showed it gone.
+     */
+    it('sends the clear flag when both dates are emptied', () => {
+        expect(deviceWindowMutationInput('c1', none, { eos: '2031-01-31', eol: null }))
+            .toEqual({ uuid: 'c1', clearDeviceSupportWindow: true })
+    })
+
+    /** Nothing declared and nothing entered is not a retraction of anything. */
+    it('sends nothing when there was nothing to clear', () => {
+        expect(deviceWindowMutationInput('c1', none, none)).toBeNull()
+    })
+
+    /**
+     * An unrelated save must not rewrite the window: the server stamps assertedBy/assessedAt on
+     * every write, so a no-op resend would re-attribute a claim nobody touched.
+     */
+    it('sends nothing when the dates are unchanged', () => {
+        const w = { eos: '2031-01-31', eol: '2033-06-30' }
+        expect(deviceWindowMutationInput('c1', { ...w }, { ...w })).toBeNull()
+    })
+})
+
+describe('the document itself', () => {
+    /** It must not be folded into COMPONENT_FULL_DATA -- see the module javadoc. */
+    it('is a standalone query, not part of the mutation response', () => {
+        const text = print(COMPONENT_DEVICE_WINDOW_QUERY)
+        expect(text).toMatch(/query componentDeviceWindow/)
+        expect(text).toMatch(/deviceSupportWindow/)
+    })
+})

--- a/ui/src/utils/componentDeviceWindow.spec.ts
+++ b/ui/src/utils/componentDeviceWindow.spec.ts
@@ -3,7 +3,15 @@ import { loadComponentDeviceWindow, deviceWindowMutationInput,
     COMPONENT_DEVICE_WINDOW_QUERY } from './componentDeviceWindow'
 import { print } from 'graphql'
 
-const drift = (e: any) => e?.driftLike === true
+// A REAL drift error, shaped the way graphql-java actually returns one, rather than a fake
+// predicate the module was handed. isSchemaDriftError is imported by the module now, so this
+// spec exercises the same classification the running app does -- a fake predicate would have
+// gone on passing even if the real one stopped recognising a validation error.
+const driftError = () => Object.assign(new Error('Validation error'), {
+    graphQLErrors: [{ message: "Validation error (FieldUndefined@[component/medicalProfile/"
+        + "deviceSupportWindow]) : Field 'deviceSupportWindow' in type 'MedicalProfile' is"
+        + " undefined", extensions: { classification: 'ValidationError' } }]
+})
 
 function client (result: any, throws?: any) {
     return { query: async () => { if (throws) throw throws; return result } }
@@ -14,7 +22,7 @@ describe('reading the declared window', () => {
         const r = await loadComponentDeviceWindow(client({
             data: { component: { uuid: 'c1', medicalProfile: {
                 deviceSupportWindow: { eos: '2031-01-31', eol: null, assertedBy: 'u1', assessedAt: 'i' } } } }
-        }), 'c1', drift)
+        }), 'c1')
         expect(r.supported).toBe(true)
         expect(r.window).toEqual({ eos: '2031-01-31', eol: null })
         expect(r.assertedBy).toBe('u1')
@@ -22,7 +30,7 @@ describe('reading the declared window', () => {
 
     it('reports not-declared when the component declares nothing', async () => {
         const r = await loadComponentDeviceWindow(client({
-            data: { component: { uuid: 'c1', medicalProfile: null } } }), 'c1', drift)
+            data: { component: { uuid: 'c1', medicalProfile: null } } }), 'c1')
         expect(r.supported).toBe(true)
         expect(r.window).toEqual({ eos: null, eol: null })
     })
@@ -34,14 +42,14 @@ describe('reading the declared window', () => {
      * editable, always-empty panel in front of a CE operator whose saves would all fail.
      */
     it('reports unsupported, not not-declared, on a schema-drift error', async () => {
-        const r = await loadComponentDeviceWindow(client(null, { driftLike: true }), 'c1', drift)
+        const r = await loadComponentDeviceWindow(client(null, driftError()), 'c1')
         expect(r.supported).toBe(false)
         expect(r.window).toEqual({ eos: null, eol: null })
     })
 
     /** A real failure must not be swallowed as "unsupported" -- that would hide an outage. */
     it('rethrows a non-drift error', async () => {
-        await expect(loadComponentDeviceWindow(client(null, new Error('boom')), 'c1', drift))
+        await expect(loadComponentDeviceWindow(client(null, new Error('boom')), 'c1'))
             .rejects.toThrow('boom')
     })
 })

--- a/ui/src/utils/componentDeviceWindow.spec.ts
+++ b/ui/src/utils/componentDeviceWindow.spec.ts
@@ -50,8 +50,8 @@ describe('writing the window', () => {
     const none = { eos: null, eol: null }
 
     it('sends the dates when they change', () => {
-        expect(deviceWindowMutationInput('c1', { eos: '2031-01-31', eol: null }, none))
-            .toEqual({ uuid: 'c1', deviceSupportWindow: { eos: '2031-01-31', eol: null } })
+        expect(deviceWindowMutationInput('c1', 'Pump', { eos: '2031-01-31', eol: null }, none))
+            .toEqual({ uuid: 'c1', name: 'Pump', deviceSupportWindow: { eos: '2031-01-31', eol: null } })
     })
 
     /**
@@ -60,13 +60,13 @@ describe('writing the window', () => {
      * silently in force while the screen showed it gone.
      */
     it('sends the clear flag when both dates are emptied', () => {
-        expect(deviceWindowMutationInput('c1', none, { eos: '2031-01-31', eol: null }))
-            .toEqual({ uuid: 'c1', clearDeviceSupportWindow: true })
+        expect(deviceWindowMutationInput('c1', 'Pump', none, { eos: '2031-01-31', eol: null }))
+            .toEqual({ uuid: 'c1', name: 'Pump', clearDeviceSupportWindow: true })
     })
 
     /** Nothing declared and nothing entered is not a retraction of anything. */
     it('sends nothing when there was nothing to clear', () => {
-        expect(deviceWindowMutationInput('c1', none, none)).toBeNull()
+        expect(deviceWindowMutationInput('c1', 'Pump', none, none)).toBeNull()
     })
 
     /**
@@ -75,7 +75,27 @@ describe('writing the window', () => {
      */
     it('sends nothing when the dates are unchanged', () => {
         const w = { eos: '2031-01-31', eol: '2033-06-30' }
-        expect(deviceWindowMutationInput('c1', { ...w }, { ...w })).toBeNull()
+        expect(deviceWindowMutationInput('c1', 'Pump', { ...w }, { ...w })).toBeNull()
+    })
+})
+
+/**
+ * UpdateComponentInput.name is String!, so a {uuid, window} partial is rejected at variable
+ * COERCION -- before the resolver, with no server-side log explaining it. The panel's Save then
+ * fails every single time. Layer 2 caught this; nothing here did, because every assertion
+ * checked the fields I remembered to send rather than the ones the schema demands.
+ */
+describe('the mutation input satisfies the required fields', () => {
+    const none = { eos: null, eol: null }
+
+    it('always carries name on a set', () => {
+        expect(deviceWindowMutationInput('c1', 'Pump', { eos: '2031-01-31', eol: null }, none))
+            .toHaveProperty('name', 'Pump')
+    })
+
+    it('always carries name on a clear', () => {
+        expect(deviceWindowMutationInput('c1', 'Pump', none, { eos: '2031-01-31', eol: null }))
+            .toHaveProperty('name', 'Pump')
     })
 })
 

--- a/ui/src/utils/componentDeviceWindow.ts
+++ b/ui/src/utils/componentDeviceWindow.ts
@@ -79,8 +79,16 @@ export async function loadComponentDeviceWindow (
  * Returns null when nothing changed, so an unrelated save cannot rewrite the window and stamp
  * fresh provenance on a claim nobody touched.
  */
+/**
+ * @param componentName REQUIRED. `UpdateComponentInput.name` is `String!`, so even the
+ *   narrowest partial must carry it or graphql-java rejects the whole mutation at variable
+ *   coercion, BEFORE the resolver is reached -- the save then fails every time, for a reason
+ *   no server-side log explains. `deviceSupportWindowInput.ts` documents the identical trap
+ *   for `org` on `ReleaseInput`; this module missed it despite being modelled on that one.
+ */
 export function deviceWindowMutationInput (
     componentUuid: string,
+    componentName: string,
     edited: DeviceWindowState,
     baseline: DeviceWindowState
 ): Record<string, unknown> | null {
@@ -90,11 +98,12 @@ export function deviceWindowMutationInput (
     const hasSomething = !!edited.eos || !!edited.eol
     if (!hasSomething) {
         return hadSomething
-            ? { uuid: componentUuid, clearDeviceSupportWindow: true }
+            ? { uuid: componentUuid, name: componentName, clearDeviceSupportWindow: true }
             : null
     }
     return {
         uuid: componentUuid,
+        name: componentName,
         deviceSupportWindow: { eos: edited.eos || null, eol: edited.eol || null }
     }
 }

--- a/ui/src/utils/componentDeviceWindow.ts
+++ b/ui/src/utils/componentDeviceWindow.ts
@@ -1,5 +1,11 @@
 import gql from 'graphql-tag'
 import type { DeviceWindowState } from './deviceSupportWindowInput'
+// DriftFallbackClient and isSchemaDriftError imported rather than restated: an inline
+// structural client type and an injected predicate are a seam this module does not need --
+// both call sites passed the same function, so it bought nothing but a fake predicate in the
+// spec. Every neighbour that reads a drift-guarded document (notificationInboxQuery.ts,
+// changelogQueries.ts, useBulkAttest.ts) imports these directly.
+import { isSchemaDriftError, type DriftFallbackClient } from './graphqlDriftFallback'
 
 /**
  * The device support window on a PRODUCT COMPONENT (decision D7).
@@ -43,9 +49,8 @@ export const NOT_DECLARED: ComponentWindowResult = {
  * second is a statement about the device.
  */
 export async function loadComponentDeviceWindow (
-    client: { query: (opts: any) => Promise<any> },
-    componentUuid: string,
-    isDriftError: (e: any) => boolean
+    client: DriftFallbackClient,
+    componentUuid: string
 ): Promise<ComponentWindowResult> {
     try {
         const resp = await client.query({
@@ -61,7 +66,7 @@ export async function loadComponentDeviceWindow (
             assessedAt: w?.assessedAt ?? null
         }
     } catch (e: any) {
-        if (isDriftError(e)) {
+        if (isSchemaDriftError(e)) {
             return { ...NOT_DECLARED, supported: false }
         }
         throw e
@@ -78,8 +83,7 @@ export async function loadComponentDeviceWindow (
  *
  * Returns null when nothing changed, so an unrelated save cannot rewrite the window and stamp
  * fresh provenance on a claim nobody touched.
- */
-/**
+ *
  * @param componentName REQUIRED. `UpdateComponentInput.name` is `String!`, so even the
  *   narrowest partial must carry it or graphql-java rejects the whole mutation at variable
  *   coercion, BEFORE the resolver is reached -- the save then fails every time, for a reason
@@ -106,4 +110,53 @@ export function deviceWindowMutationInput (
         name: componentName,
         deviceSupportWindow: { eos: edited.eos || null, eol: edited.eol || null }
     }
+}
+
+/**
+ * The same three rules as `deviceWindowMutationInput`, for the SHIPMENT override.
+ *
+ * Extracted rather than left inline in `DistributionOfOrg.vue` because it IS the same rule --
+ * unchanged sends nothing, blank-both-after-something sends the clear flag, and an empty
+ * window object is never sent because the server does not read one as a retraction. Two copies
+ * of that in two files is two chances for them to disagree about what "retract" means, on a
+ * section 524B commitment. The inline copy was covered only by a spec that regex-matched the
+ * `.vue` source, which cannot tell whether the rule is right -- only whether the text moved.
+ *
+ * Mutates `input` and returns it, matching how the surrounding shipment builder is written.
+ */
+export function applyShipmentWindowToInput (
+    input: Record<string, unknown>,
+    edited: DeviceWindowState,
+    baseline: DeviceWindowState
+): Record<string, unknown> {
+    const changed = edited.eos !== baseline.eos || edited.eol !== baseline.eol
+    if (!changed) return input
+    const hasSomething = !!edited.eos || !!edited.eol
+    const hadSomething = !!baseline.eos || !!baseline.eol
+    if (hasSomething) {
+        input.deviceSupportWindow = { eos: edited.eos || null, eol: edited.eol || null }
+    } else if (hadSomething) {
+        input.clearDeviceSupportWindow = true
+    }
+    return input
+}
+
+/**
+ * The window in force for a shipment, named by WHERE it was declared rather than by whether
+ * it is an override.
+ *
+ * "this batch" / "the product component" is the whole point: two shipments of the same device
+ * model can legitimately carry different dates, and a reader with no way to tell why would
+ * reasonably conclude one of them is wrong. Returns '' when nothing is declared, which the
+ * caller must distinguish from "we have not loaded a shipment yet" -- on a NEW shipment there
+ * is nothing to resolve through, and saying "no window is declared for this device model"
+ * there is a false claim about the product made exactly when it would invite a needless
+ * override.
+ */
+export function effectiveWindowLabel (
+    w: { eos?: string | null, eol?: string | null, source?: string | null } | null | undefined
+): string {
+    if (!w || (!w.eos && !w.eol)) return ''
+    const where = w.source === 'SHIPMENT' ? 'this batch' : 'the product component'
+    return `EOS ${w.eos || 'not declared'}, EOL ${w.eol || 'not declared'} (from ${where})`
 }

--- a/ui/src/utils/componentDeviceWindow.ts
+++ b/ui/src/utils/componentDeviceWindow.ts
@@ -1,0 +1,100 @@
+import gql from 'graphql-tag'
+import type { DeviceWindowState } from './deviceSupportWindowInput'
+
+/**
+ * The device support window on a PRODUCT COMPONENT (decision D7).
+ *
+ * <p>Its own small document, deliberately NOT part of `COMPONENT_FULL_DATA`. That fragment is
+ * the response selection of the `updateComponent` MUTATION, and CE's schema declares
+ * `Component.medicalProfile` without `deviceSupportWindow` inside it -- so adding the subfield
+ * there would make the whole mutation document invalid on CE and break EVERY component save,
+ * not just this field. That is the same trap `supportInjection` hit in #339, and the same
+ * answer: read it separately, write it without selecting it back.
+ */
+export const COMPONENT_DEVICE_WINDOW_QUERY = gql`
+    query componentDeviceWindow($componentUuid: ID!) {
+        component(componentUuid: $componentUuid) {
+            uuid
+            medicalProfile {
+                deviceSupportWindow { eos eol assertedBy assessedAt source }
+            }
+        }
+    }`
+
+/** What the panel needs to render, plus whether this backend can answer at all. */
+export interface ComponentWindowResult {
+    /** False on a backend whose schema lacks the field -- the panel must hide, not error. */
+    supported: boolean
+    window: DeviceWindowState
+    assertedBy: string | null
+    assessedAt: string | null
+}
+
+export const NOT_DECLARED: ComponentWindowResult = {
+    supported: true, window: { eos: null, eol: null }, assertedBy: null, assessedAt: null
+}
+
+/**
+ * Read the declared window, tolerating a backend that does not know the field.
+ *
+ * A CE build issuing this document gets a VALIDATION error, not a null field, so the failure
+ * has to be caught and reported as "unsupported" rather than as "not declared". Those are
+ * different facts: the first means this build cannot show or edit the window at all, the
+ * second is a statement about the device.
+ */
+export async function loadComponentDeviceWindow (
+    client: { query: (opts: any) => Promise<any> },
+    componentUuid: string,
+    isDriftError: (e: any) => boolean
+): Promise<ComponentWindowResult> {
+    try {
+        const resp = await client.query({
+            query: COMPONENT_DEVICE_WINDOW_QUERY,
+            variables: { componentUuid },
+            fetchPolicy: 'no-cache'
+        })
+        const w = resp?.data?.component?.medicalProfile?.deviceSupportWindow ?? null
+        return {
+            supported: true,
+            window: { eos: w?.eos ?? null, eol: w?.eol ?? null },
+            assertedBy: w?.assertedBy ?? null,
+            assessedAt: w?.assessedAt ?? null
+        }
+    } catch (e: any) {
+        if (isDriftError(e)) {
+            return { ...NOT_DECLARED, supported: false }
+        }
+        throw e
+    }
+}
+
+/**
+ * The `updateComponent` input for a window edit.
+ *
+ * Returns `clearDeviceSupportWindow` when BOTH dates have been emptied and something was
+ * declared before -- an operator blanking both pickers means "retract", and the flag is the
+ * only way to say it. An empty window object is deliberately NOT a clear on the server, so
+ * sending one here would silently leave the old value in force.
+ *
+ * Returns null when nothing changed, so an unrelated save cannot rewrite the window and stamp
+ * fresh provenance on a claim nobody touched.
+ */
+export function deviceWindowMutationInput (
+    componentUuid: string,
+    edited: DeviceWindowState,
+    baseline: DeviceWindowState
+): Record<string, unknown> | null {
+    const changed = edited.eos !== baseline.eos || edited.eol !== baseline.eol
+    if (!changed) return null
+    const hadSomething = !!baseline.eos || !!baseline.eol
+    const hasSomething = !!edited.eos || !!edited.eol
+    if (!hasSomething) {
+        return hadSomething
+            ? { uuid: componentUuid, clearDeviceSupportWindow: true }
+            : null
+    }
+    return {
+        uuid: componentUuid,
+        deviceSupportWindow: { eos: edited.eos || null, eol: edited.eol || null }
+    }
+}

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -435,3 +435,55 @@ describe('the ends-sooner section is a statement, not an inventory', () => {
         expect(text).not.toMatch(/Software components whose support ends sooner/)
     })
 })
+
+/**
+ * WHERE THE DATES CAME FROM, in one line under them (D7).
+ *
+ * A reader comparing two statements for the same device model needs to know why the dates
+ * differ, and "a different batch declared its own" is the answer. The line names the batch by
+ * things a person can match against a delivery note -- site, ship date, batch identifier --
+ * never by the word "override" or a uuid.
+ */
+describe('the device window provenance line', () => {
+    const flat = (n: any): string =>
+        typeof n === 'string' ? n
+            : Array.isArray(n) ? n.map(flat).join(' ')
+                : n && typeof n === 'object' ? Object.values(n).map(flat).join(' ') : ''
+    const render = (over: any) => flat(buildDeviceSupportStatementDefinition(data(over)))
+
+    it('names the product when the window is the model default', () => {
+        const text = render({ deviceWindowSource: { level: 'COMPONENT', productName: 'Infusion Pump 9000' } })
+        expect(text).toMatch(/declared on Infusion Pump 9000 and apply to every unit of it/)
+    })
+
+    it('names the site, ship date and batch when it came from a shipment', () => {
+        const text = render({ deviceWindowSource: {
+            level: 'SHIPMENT', siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: 'LOT-77' } })
+        expect(text).toMatch(/delivered to St Elsewhere ICU/)
+        expect(text).toMatch(/on 2026-04-02/)
+        expect(text).toMatch(/\(batch LOT-77\)/)
+        expect(text).toMatch(/may differ from other deliveries of the same device/)
+    })
+
+    it('omits the batch identifier when none was recorded', () => {
+        const text = render({ deviceWindowSource: {
+            level: 'SHIPMENT', siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: null } })
+        expect(text).toMatch(/delivered to St Elsewhere ICU/)
+        expect(text).not.toMatch(/batch/)
+    })
+
+    /** "Override" is our vocabulary, not a patient's; a uuid is not something anyone can check. */
+    it('never uses the word override or prints an identifier a reader cannot match', () => {
+        const text = render({ deviceWindowSource: {
+            level: 'SHIPMENT', siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: 'LOT-77' } })
+        expect(text.toLowerCase()).not.toMatch(/override/)
+        expect(text).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
+    })
+
+    /** No provenance for a fact that does not exist. */
+    it('prints no line at all when no window is declared', () => {
+        const text = render({ deviceWindowSource: null })
+        expect(text).not.toMatch(/apply to every unit of it/)
+        expect(text).not.toMatch(/may differ from other deliveries/)
+    })
+})

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -474,10 +474,30 @@ describe('the device window provenance line', () => {
 
     /** "Override" is our vocabulary, not a patient's; a uuid is not something anyone can check. */
     it('never uses the word override or prints an identifier a reader cannot match', () => {
-        const text = render({ deviceWindowSource: {
-            level: 'SHIPMENT', siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: 'LOT-77' } })
-        expect(text.toLowerCase()).not.toMatch(/override/)
-        expect(text).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
+        // A REAL uuid in the fixture. With 'r-1' this assertion was green for the wrong
+        // reason: the page footer prints d.releaseUuid and always has, so a document-wide
+        // "no uuid" claim is false by design and only passed because the fixture had nothing
+        // uuid-shaped in it. Scoped to the provenance LINE, which is the claim
+        // buildDeviceSupportStatementDefinition's provenance block actually makes -- and the
+        // scope d7-window-probe.mjs already uses against the real PDF.
+        const text = render({
+            releaseUuid: '277c971c-687d-46eb-bded-74a55149a978',
+            deviceWindowSource: {
+                level: 'SHIPMENT', siteName: 'St Elsewhere ICU', shipDate: '2026-04-02',
+                batchIdentifier: 'LOT-77' }
+        })
+        // The CONTENT carries no uuid, and the FOOTER deliberately does -- they are different
+        // claims, and `flat()` only walks content, so the old document-wide assertion was
+        // never testing the footer at all. Both stated here so neither can quietly change.
+        expect(text).not.toMatch(/277c971c/)
+        const footerText = (buildDeviceSupportStatementDefinition(
+            data({ releaseUuid: '277c971c-687d-46eb-bded-74a55149a978' })).footer as any)(1, 1)
+            .columns.map((c: any) => c.text).join(' | ')
+        expect(footerText).toMatch(/277c971c/)
+        const line = text.split('\n').find(l => /delivered to/.test(l)) || ''
+        expect(line).not.toBe('')
+        expect(line.toLowerCase()).not.toMatch(/override/)
+        expect(line).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-/)
     })
 
     /** No provenance for a fact that does not exist. */

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -135,7 +135,16 @@ function statementStrings (d: AddendumData): Array<string | null | undefined> {
         // states is "every string the document prints", and the next field added to the
         // footer would otherwise escape the whitelist silently.
         d.deviceEos, d.deviceEol, d.releaseUuid, d.generatedAt,
-        d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice
+        d.patchesMayCeaseStatement, d.riskTransferProcessRef, d.riskIncreasesNotice,
+        // The SHIPMENT provenance line's three fields. These are USER-ENTERED -- a site name,
+        // a lot code -- which makes them the likeliest strings in the whole document to carry
+        // a glyph the embedded font cannot draw, and the only ones here that are not
+        // server-generated. Omitting them let an unrenderable site name through the refusal
+        // and into a patient-facing PDF as a blank or a tofu box.
+        ...(d.deviceWindowSource && d.deviceWindowSource.level === 'SHIPMENT'
+            ? [d.deviceWindowSource.siteName, d.deviceWindowSource.shipDate,
+                d.deviceWindowSource.batchIdentifier]
+            : [d.deviceWindowSource?.productName])
         // NO component names or dates. They were listed here when the ends-sooner section
         // printed them; it now prints one fixed sentence and no component text at all. Left in
         // place, this made an unrenderable glyph in a component NAME a HARD REFUSAL of the

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -23,7 +23,7 @@
 import pdfMake from 'pdfmake/build/pdfmake'
 import pdfFonts from 'pdfmake/build/vfs_fonts'
 import type { AddendumComponent, AddendumData } from './addendumData'
-import { isLiveAttestation } from './addendumData'
+import { isLiveAttestation, deviceWindowProvenanceLine } from './addendumData'
 import { releaseSlug, PROSE_SLOT_LABELS } from './addendumDocument'
 import { fontCoverageRefusal } from './pdfFontCoverage'
 
@@ -211,6 +211,21 @@ export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<
             margin: [0, 0, 0, 14]
         }
     ]
+
+    // WHERE THE DATES COME FROM, in one plain line, immediately under them (D7).
+    //
+    // A reader comparing two statements for the same device model needs to know why the dates
+    // differ, and "a different batch declared its own" is the answer. The shipment case names
+    // the batch by things a person can match against a delivery note -- site, ship date, batch
+    // identifier -- never by the word "override" or a uuid: "override" is our vocabulary, not
+    // theirs, and a uuid is not something anyone can check.
+    //
+    // Omitted entirely when no window is declared: there is no provenance for a fact that does
+    // not exist, and a line explaining the origin of two blanks would be noise.
+    const provenance = deviceWindowProvenanceLine(d.deviceWindowSource)
+    if (provenance) {
+        content.push({ text: provenance, style: 'body', margin: [0, 0, 0, 14] })
+    }
 
     if (early.length) {
         content.push({ text: 'Software components whose support ends sooner', style: 'h2' })

--- a/ui/src/utils/deviceWindowSchemaDrift.spec.ts
+++ b/ui/src/utils/deviceWindowSchemaDrift.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
-import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { buildSchema, validate, parse, type GraphQLSchema } from 'graphql'
 import { ADDENDUM_RELEASE_QUERY_CORE, ADDENDUM_RELEASE_QUERY_FULL } from './addendumData'
 import { COMPONENT_DEVICE_WINDOW_QUERY } from './componentDeviceWindow'
 
@@ -57,10 +57,11 @@ describe('the addendum release query', () => {
         expect(errs.join(' ')).toMatch(/deviceSupportWindow/)
     })
 
-    it('both validate against the Pro schema', () => {
-        if (!proSchema) return
-        expect(errorsAgainst(proSchema, ADDENDUM_RELEASE_QUERY_CORE)).toEqual([])
-        expect(errorsAgainst(proSchema, ADDENDUM_RELEASE_QUERY_FULL)).toEqual([])
+    // it.runIf, not an early return: a silent green when rearm-core is absent is how a drift
+    // spec stops covering anything without anyone noticing. Skipped is reported; green is not.
+    it.runIf(proSchema)('both validate against the Pro schema', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, ADDENDUM_RELEASE_QUERY_CORE)).toEqual([])
+        expect(errorsAgainst(proSchema as GraphQLSchema, ADDENDUM_RELEASE_QUERY_FULL)).toEqual([])
     })
 })
 
@@ -79,9 +80,28 @@ describe('the component device-window query (the panel and the release read-only
         expect(errs.join(' ')).toMatch(/deviceSupportWindow/)
     })
 
-    it('validates against the Pro schema', () => {
-        if (!proSchema) return
-        expect(errorsAgainst(proSchema, COMPONENT_DEVICE_WINDOW_QUERY)).toEqual([])
+    it.runIf(proSchema)('validates against the Pro schema', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, COMPONENT_DEVICE_WINDOW_QUERY)).toEqual([])
+    })
+})
+
+/**
+ * The shipments document is built by string interpolation, so `npm run validate:graphql` skips
+ * it ("dynamic/non-operation skipped") and no other spec covers it. The repo's own convention
+ * for that case -- validate-graphql.mjs says so in as many words -- is a vitest drift spec.
+ *
+ * Distribution is SaaS-only, so there is no CE half to check. What needs pinning is that the
+ * fields it asks for EXIST on Pro: nothing else would tell us if they moved.
+ */
+describe('the shipments query (SaaS-only, interpolated, skipped by validate-graphql)', () => {
+    it.runIf(proSchema)('asks only for fields Pro declares on ShippedProduct', () => {
+        const source = readFileSync(
+            fileURLToPath(new URL('../components/DistributionOfOrg.vue', import.meta.url)), 'utf8')
+        const m = source.match(/const SHIP_FIELDS = '([^']+)'\s*\n\s*\+ '([^']+)'/)
+        expect(m, 'SHIP_FIELDS changed shape -- update this spec rather than deleting it').toBeTruthy()
+        const doc = parse(`query shippedProductsOfSite($siteUuid: ID!) {
+            shippedProductsOfSite(siteUuid: $siteUuid) { ${(m as RegExpMatchArray)[1]}${(m as RegExpMatchArray)[2]} } }`)
+        expect(errorsAgainst(proSchema as GraphQLSchema, doc)).toEqual([])
     })
 })
 

--- a/ui/src/utils/deviceWindowSchemaDrift.spec.ts
+++ b/ui/src/utils/deviceWindowSchemaDrift.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, type GraphQLSchema } from 'graphql'
+import { ADDENDUM_RELEASE_QUERY_CORE, ADDENDUM_RELEASE_QUERY_FULL } from './addendumData'
+import { COMPONENT_DEVICE_WINDOW_QUERY } from './componentDeviceWindow'
+
+/**
+ * Every document that gained a device-window selection, validated against BOTH schemas (D7).
+ *
+ * CE declares `Component.medicalProfile` but NOT `deviceSupportWindow` inside it. That makes
+ * the subfield a WHOLE-DOCUMENT failure on CE rather than a null field: graphql rejects the
+ * query at validation and the caller renders nothing. It is the #339 defect exactly -- a UI
+ * build meeting a backend one field behind and blanking.
+ *
+ * So this asserts the split is real in both directions: CORE must validate against CE, FULL
+ * must NOT (if it did, the split would be unnecessary and someone would rightly delete it),
+ * and both must validate against Pro.
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+const proSchema: GraphQLSchema | null = existsSync(PRO_SCHEMA_PATH)
+    ? buildSchema(readFileSync(PRO_SCHEMA_PATH, 'utf8'))
+    : null
+
+const errorsAgainst = (schema: GraphQLSchema, doc: any) => validate(schema, doc).map(e => e.message)
+
+describe('the addendum release query', () => {
+    /**
+     * CORE's ONLY CE failure is the pre-existing `Release.fdaAssessmentNarrative` gap, which
+     * predates D7 and is already on the CE sync list (board t20260904-041253-3993). What this
+     * asserts is the property the split actually guarantees: CORE does not fail on the DEVICE
+     * WINDOW. Asserting `toEqual([])` here would be asserting something false about this repo
+     * today, and would go green for the wrong reason the moment CE syncs.
+     */
+    it('CORE does not fail on the device window against the CE mirror', () => {
+        const errs = errorsAgainst(ceSchema, ADDENDUM_RELEASE_QUERY_CORE)
+        expect(errs.join(' ')).not.toMatch(/deviceSupportWindow/)
+        expect(errs.filter(e => !e.includes('fdaAssessmentNarrative')),
+            'CORE gained a CE-invalid field other than the known fdaAssessmentNarrative gap')
+            .toEqual([])
+    })
+
+    /**
+     * The load-bearing half. If FULL ever validates on CE the split has become pointless and
+     * should be removed -- but far more likely is that someone moved the subfield into CORE,
+     * which this catches from the other side.
+     */
+    it('FULL does NOT validate against the CE mirror', () => {
+        const errs = errorsAgainst(ceSchema, ADDENDUM_RELEASE_QUERY_FULL)
+        expect(errs.length, 'FULL validated on CE -- either CE gained the field (delete the'
+            + ' split) or the split stopped covering it').toBeGreaterThan(0)
+        expect(errs.join(' ')).toMatch(/deviceSupportWindow/)
+    })
+
+    it('both validate against the Pro schema', () => {
+        if (!proSchema) return
+        expect(errorsAgainst(proSchema, ADDENDUM_RELEASE_QUERY_CORE)).toEqual([])
+        expect(errorsAgainst(proSchema, ADDENDUM_RELEASE_QUERY_FULL)).toEqual([])
+    })
+})
+
+describe('the component device-window query (the panel and the release read-only view)', () => {
+    /**
+     * One document serves both surfaces: the editable panel on the component page and the
+     * read-only inherited line on the release page. It is FULL-only by nature -- there is no
+     * CORE shape of "read the window", because the whole document exists to read it. The panel
+     * and the line handle a CE backend by HIDING, via loadComponentDeviceWindow's drift branch,
+     * not by falling back to a narrower query.
+     */
+    it('does NOT validate against the CE mirror', () => {
+        const errs = errorsAgainst(ceSchema, COMPONENT_DEVICE_WINDOW_QUERY)
+        expect(errs.length, 'CE gained deviceSupportWindow -- the panel can stop hiding')
+            .toBeGreaterThan(0)
+        expect(errs.join(' ')).toMatch(/deviceSupportWindow/)
+    })
+
+    it('validates against the Pro schema', () => {
+        if (!proSchema) return
+        expect(errorsAgainst(proSchema, COMPONENT_DEVICE_WINDOW_QUERY)).toEqual([])
+    })
+})
+
+describe('what CE actually declares', () => {
+    /**
+     * Pinned as a FACT rather than inferred from a validation failure. If CE gains the field,
+     * this is the test that says so in one line, and the three "does not validate" assertions
+     * above stop being mysterious.
+     */
+    it('has medicalProfile but not deviceSupportWindow inside it', () => {
+        const ce = readFileSync(CE_SCHEMA_PATH, 'utf8')
+        const medicalProfile = ce.slice(ce.indexOf('type MedicalProfile {'))
+        expect(medicalProfile.slice(0, medicalProfile.indexOf('}'))).not.toMatch(/deviceSupportWindow/)
+    })
+})

--- a/ui/src/utils/graphqlQueries.ts
+++ b/ui/src/utils/graphqlQueries.ts
@@ -1016,6 +1016,11 @@ const COMPONENT_FULL_DATA = `
     org
     resourceGroup
     type
+    # Read by ComponentView to decide whether the device support window panel applies (D7).
+    # CE declares Component.deviceClass too, so this needs no CORE/FULL split -- unlike
+    # medicalProfile.deviceSupportWindow, which CE does not declare and which therefore has
+    # its own drift-guarded document in utils/componentDeviceWindow.ts.
+    deviceClass
     kind
     versionSchema
     marketingVersionSchema

--- a/ui/src/utils/shipmentDeviceWindow.spec.ts
+++ b/ui/src/utils/shipmentDeviceWindow.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { applyShipmentWindowToInput, effectiveWindowLabel } from './componentDeviceWindow'
+
+/**
+ * The shipment override's rules, tested as BEHAVIOUR.
+ *
+ * They lived inline in DistributionOfOrg.vue and were covered only by a spec that
+ * regex-matched the .vue source, which can tell you the text moved but not whether the rule is
+ * right. That matters most for the clear flag: an empty window object is NOT a retraction on
+ * the server, so sending one leaves the old override silently in force while the form shows it
+ * gone -- on a section 524B commitment, a wrong answer that looks like a right one.
+ */
+describe('applyShipmentWindowToInput', () => {
+    const w = (eos: string | null, eol: string | null) => ({ eos, eol })
+
+    it('sends nothing at all when neither date changed', () => {
+        expect(applyShipmentWindowToInput({ uuid: 's' }, w('2031-01-31', null), w('2031-01-31', null)))
+            .toEqual({ uuid: 's' })
+    })
+
+    it('sends the window when a date is set', () => {
+        expect(applyShipmentWindowToInput({}, w('2031-01-31', '2033-06-30'), w(null, null)))
+            .toEqual({ deviceSupportWindow: { eos: '2031-01-31', eol: '2033-06-30' } })
+    })
+
+    it('sends the CLEAR FLAG, never an empty window, when both are blanked', () => {
+        const out = applyShipmentWindowToInput({}, w(null, null), w('2031-01-31', '2033-06-30'))
+        expect(out).toEqual({ clearDeviceSupportWindow: true })
+        expect(out.deviceSupportWindow).toBeUndefined()
+    })
+
+    it('sends nothing when both are blank and nothing was declared before', () => {
+        // Not a retraction: there is nothing to retract, and sending the flag would stamp a
+        // write -- and fresh provenance -- on a claim nobody touched.
+        expect(applyShipmentWindowToInput({}, w(null, null), w(null, null))).toEqual({})
+    })
+
+    it('treats the empty string as blank, the way a cleared picker reports it', () => {
+        expect(applyShipmentWindowToInput({}, w('', ''), w('2031-01-31', null)))
+            .toEqual({ clearDeviceSupportWindow: true })
+    })
+})
+
+describe('effectiveWindowLabel', () => {
+    it('names the batch when the shipment overrides', () => {
+        expect(effectiveWindowLabel({ eos: '2030-01-01', eol: null, source: 'SHIPMENT' }))
+            .toContain('from this batch')
+    })
+
+    it('names the product component when the window is inherited', () => {
+        expect(effectiveWindowLabel({ eos: '2030-01-01', eol: null, source: 'COMPONENT' }))
+            .toContain('from the product component')
+    })
+
+    it('never says "override": that is our vocabulary, not the reader\'s', () => {
+        expect(effectiveWindowLabel({ eos: '2030-01-01', eol: '2031-01-01', source: 'SHIPMENT' }))
+            .not.toMatch(/override/i)
+    })
+
+    it('names each missing date rather than dropping it', () => {
+        expect(effectiveWindowLabel({ eos: '2030-01-01', eol: null, source: 'COMPONENT' }))
+            .toContain('EOL not declared')
+    })
+
+    it('returns empty for no window, and for a null shipment', () => {
+        expect(effectiveWindowLabel({ eos: null, eol: null, source: 'COMPONENT' })).toBe('')
+        expect(effectiveWindowLabel(null)).toBe('')
+        expect(effectiveWindowLabel(undefined)).toBe('')
+    })
+})


### PR DESCRIPTION
UI half of PR 2, for operator decision D7: the section 524B support window is declared on the
**product component** (the device model), optionally overridden per **shipment** (the batch),
and evaluated per **device** (the unit). Backend is rearm-saas #515 (+ #516 for the walkthrough).

**Merge order: rearm-saas #515, then rearm-saas #516, then this, in one sitting.** Dev must
never sit with the backend resolving through the component while the documents still read the
release.

## What moved

| Surface | Before | After |
|---|---|---|
| Product component, Core Settings | -- | **Declares** the window. Renders only when the component has a device class. |
| Release page | Editable `eos`/`eol`, labelled as the device window | Window shown **read-only** with a link to where it was declared; the release's own dates are a **separate, editable** block that says outright it feeds TEA/CLE `END_OF_SUPPORT` / `END_OF_LIFE` events |
| Shipment (Distribution) | -- | Batch **override**, on Hardware/SaMD tabs only |
| Addendum + Device Support Statement | Read the release | Read the component window, and **say where the dates came from** |

`ReleaseData.eos/eol` are untouched and are not renamed or re-documented beyond one line saying
they are no longer the device window. **Nothing is migrated**: copying a release lifecycle date
into a device support window would turn a version's metadata into a labeling claim the
manufacturer never made.

## The CE constraint

CE declares `Component.medicalProfile` **without** `deviceSupportWindow` inside it, so asking
for the subfield makes the **whole document invalid** on CE rather than merely null. Every
document that gained the selection is therefore split CORE/FULL, with a drift spec per
document. `ShippedProduct`/`Device` are SaaS-only and exempt.

`deviceWindowSchemaDrift.spec.ts` also now covers the **shipments** query, which
`validate:graphql` skips because it is built by string interpolation and which nothing else
covered. It uses `it.runIf(proSchema)` rather than an early `return`: a silent green when
rearm-core is absent is how a drift spec stops covering anything without anyone noticing.

## The statement's provenance line

Two statements for the same device model can legitimately carry different dates -- a batch may
override the model default -- and a reader with no way to tell why would reasonably conclude
one of them is wrong. So the statement says, in one plain line under the dates, where they came
from: the product for a model-level window, and site + ship date + lot for a shipment. Never
the word "override", never a uuid: neither is something a patient or a biomed engineer can
check. The shipment form is built and tested but has no entry point yet; that arrives with the
fleet UI, and plan 7h records it so it is not rediscovered as dead code.

## Gates

- `npm run test`: **790 passing, 55 files** (nothing in CI runs this suite; it is part of my
  validation step)
- `npm run build`: clean
- Hot-swapped as `rearm-ui:t7806-d7` and verified live: `d7-window-probe.mjs` **22/22**, driving
  this UI for the release page and downloading the real statement PDF; `toggle-probe.mjs` pass
  with 0 page exceptions.

The live probe matters more than usual here: `ui/` has no `vue-tsc` and `src/utils/` is
unlinted, so a green build and a green suite cannot catch an undefined `<script setup>`
identifier, an invalid GraphQL document or a dead router link. Two of the three Layer 2
blocking findings on this branch were exactly that -- a mutation that would have failed
coercion on **every** save, and a `router-link` to a route `router.ts` does not declare, whose
spec had **pinned the broken form**.

## Out of scope

The fleet UI, shipment-date-anchored windows, `dev -> main`, the CE sync, `5f0daff8`.