### PR TITLE
feat(ui): Programmatic Access sub-tabs and personal API keys on the profile page

### DIFF
--- a/ui/src/components/ApiKeyPermissionsModal.vue
+++ b/ui/src/components/ApiKeyPermissionsModal.vue
@@ -1,0 +1,179 @@
+<template>
+    <n-modal
+        preset="dialog"
+        :show-icon="false"
+        style="width: 90%;"
+        :show="show"
+        @update:show="(v: boolean) => { if (!v) emit('update:show', false) }"
+    >
+        <template #header>Edit key {{ apiKey?.uuid }}</template>
+        <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
+            <p v-if="apiKey?.type === 'USER'" class="subtle" style="margin-top: 0;">
+                These permissions are a ceiling. Every call is also checked against the owner's own permissions at that moment, and the lower of the two wins.
+                Nothing is allowed until at least one permission is set.
+            </p>
+            <n-tabs v-model:value="editTab" type="segment" animated>
+                <n-tab-pane name="permissions" tab="Permissions">
+                    <n-spin :show="loading">
+                        <ScopedPermissions
+                            v-model="scoped"
+                            :org-uuid="orgUuid"
+                            :approval-roles="approvalRoles"
+                            :perspectives="perspectives"
+                            :products="orgProducts"
+                            :components="orgComponents"
+                            :instances="orgInstances"
+                            :clusters="orgClusters"
+                            :show-sbom-probing="true"
+                        />
+                    </n-spin>
+                    <n-space style="margin-top: 20px;">
+                        <n-button type="success" :disabled="loading" @click="savePermissions">Save Permissions</n-button>
+                        <n-button @click="emit('update:show', false)">Cancel</n-button>
+                    </n-space>
+                </n-tab-pane>
+                <n-tab-pane name="notes" tab="Notes">
+                    <p style="color: #555; margin-top: 0;">Free-text notes for this key: what it is used for, where it lives, expiry.</p>
+                    <n-input v-model:value="notes" type="textarea" :autosize="{ minRows: 4, maxRows: 16 }" placeholder="What this key is used for, who owns it, expiry, etc." />
+                    <n-space style="margin-top: 20px;">
+                        <n-button type="success" @click="saveNotes">Save Notes</n-button>
+                        <n-button @click="emit('update:show', false)">Cancel</n-button>
+                    </n-space>
+                </n-tab-pane>
+            </n-tabs>
+        </div>
+    </n-modal>
+</template>
+
+<script lang="ts" setup>
+/**
+ * Permissions + notes editor for an RBAC key (FREEFORM or USER). Loads the org's perspectives,
+ * components, products and instances itself, so it can be used from org settings and from the
+ * user's own keys on the profile page. Saves through setPermissionsOnFreeformApiKey / setNotesOnApiKey.
+ */
+import { NModal, NTabs, NTabPane, NSpace, NButton, NInput, NSpin } from 'naive-ui'
+import { ref, computed, watch } from 'vue'
+import { useStore } from 'vuex'
+import gql from 'graphql-tag'
+import graphqlClient from '../utils/graphql'
+import constants from '../utils/constants'
+import commonFunctions from '@/utils/commonFunctions'
+import ScopedPermissions from './ScopedPermissions.vue'
+
+const props = defineProps<{
+    show: boolean
+    apiKey: any
+    orgUuid: string
+    notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
+}>()
+const emit = defineEmits(['update:show', 'saved'])
+const store = useStore()
+
+const editTab = ref('permissions')
+const loading = ref(false)
+const notes = ref('')
+const perspectives = ref<any[]>([])
+const scoped = ref<{ orgPermission: any, scopedPermissions: any[] }>({ orgPermission: { type: 'NONE', functions: [], approvals: [] }, scopedPermissions: [] })
+
+const approvalRoles = computed(() => store.getters.orgById(props.orgUuid)?.approvalRoles || [])
+const orgComponents = computed(() => store.getters.componentsOfOrg(props.orgUuid) || [])
+const orgProducts = computed(() => store.getters.productsOfOrg(props.orgUuid) || [])
+const allComponents = computed(() => [...orgComponents.value, ...orgProducts.value])
+const orgInstancesAndClusters = computed(() => {
+    if (store.getters.myuser?.installationType === 'OSS') return []
+    const all = (store.getters.instancesOfOrg(props.orgUuid) || [])
+    return all.filter((x: any) => x.revision === -1 && (x.status === 'ACTIVE' || !x.status))
+})
+const orgInstances = computed(() => orgInstancesAndClusters.value
+    .filter((x: any) => x.instanceType === constants.InstanceType.STANDALONE_INSTANCE || x.instanceType === constants.InstanceType.CLUSTER_INSTANCE))
+const orgClusters = computed(() => orgInstancesAndClusters.value.filter((x: any) => x.instanceType === constants.InstanceType.CLUSTER))
+
+async function loadPerspectives () {
+    try {
+        const response = await graphqlClient.query({
+            query: gql`query perspectives($org: ID!) { perspectives(org: $org) { uuid name org createdDate type sidPurlOverride sidAuthoritySegments } }`,
+            variables: { org: props.orgUuid }, fetchPolicy: 'no-cache'
+        })
+        perspectives.value = response.data.perspectives || []
+    } catch (error: any) { console.error('Error loading perspectives:', error) }
+}
+
+async function resolveScopedObjectName (scope: string, objectId: string): Promise<string> {
+    if (scope === 'PERSPECTIVE') {
+        const p = perspectives.value.find((x: any) => x.uuid === objectId); return p ? p.name : objectId
+    }
+    if (scope === 'INSTANCE') {
+        const obj = orgInstancesAndClusters.value.find((x: any) => x.uuid === objectId)
+        if (!obj) return objectId
+        if (obj.instanceType === constants.InstanceType.CLUSTER_INSTANCE) {
+            const parent = orgClusters.value.find((c: any) => Array.isArray(c.instances) && c.instances.includes(obj.uuid))
+            return `${parent ? parent.name : '(cluster)'} / ${obj.namespace || obj.uuid}`
+        }
+        if (obj.instanceType === constants.InstanceType.CLUSTER) return obj.name || obj.uri || obj.uuid
+        return obj.uri || obj.name || obj.uuid
+    }
+    const known = allComponents.value.find((c: any) => c.uuid === objectId)
+    if (known) return known.name
+    try { const fetched = await store.dispatch('fetchComponent', objectId); return fetched?.name || objectId } catch { return objectId }
+}
+
+async function load () {
+    if (!props.apiKey || !props.orgUuid) return
+    loading.value = true
+    try {
+        const loads: Promise<any>[] = [loadPerspectives(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
+        if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
+        await Promise.all(loads)
+        const scopedPerms: any[] = []
+        let orgPerm = { type: 'NONE', functions: [] as string[], approvals: [] as string[] }
+        for (const up of (props.apiKey.permissions?.permissions || [])) {
+            if (up.scope === 'ORGANIZATION' && up.org === props.orgUuid) {
+                orgPerm = { type: up.type, functions: up.functions || [], approvals: up.approvals || [] }
+            } else if ((up.scope === 'PERSPECTIVE' || up.scope === 'COMPONENT' || up.scope === 'INSTANCE') && up.org === props.orgUuid) {
+                scopedPerms.push({ scope: up.scope, objectId: up.object, objectName: await resolveScopedObjectName(up.scope, up.object), type: up.type, functions: up.functions || [], approvals: up.approvals || [] })
+            }
+        }
+        scoped.value = { orgPermission: orgPerm, scopedPermissions: scopedPerms }
+        notes.value = props.apiKey.notes || ''
+        editTab.value = 'permissions'
+    } finally { loading.value = false }
+}
+watch(() => props.show, (v) => { if (v) load() })
+
+async function savePermissions () {
+    const permissions: any[] = []
+    const orgPermType = scoped.value.orgPermission.type
+    if (orgPermType && orgPermType !== 'NONE') {
+        permissions.push({ org: props.orgUuid, scope: 'ORGANIZATION', type: orgPermType, object: props.orgUuid, functions: scoped.value.orgPermission.functions || [], approvals: scoped.value.orgPermission.approvals || [] })
+    }
+    for (const sp of (scoped.value.scopedPermissions || [])) {
+        if (sp.type && sp.type !== 'NONE') permissions.push({ org: props.orgUuid, scope: sp.scope, type: sp.type, object: sp.objectId, functions: sp.functions || [], approvals: sp.approvals || [] })
+    }
+    try {
+        const resp: any = await graphqlClient.mutate({
+            mutation: gql`mutation setPermissionsOnFreeformApiKey($apiKeyUuid: ID!, $permissionType: PermissionType, $permissions: [PermissionInput]) {
+                setPermissionsOnFreeformApiKey(apiKeyUuid: $apiKeyUuid, permissionType: $permissionType, permissions: $permissions) { uuid } }`,
+            variables: { apiKeyUuid: props.apiKey.uuid, permissionType: orgPermType || 'NONE', permissions }
+        })
+        if (!resp.data.setPermissionsOnFreeformApiKey?.uuid) throw new Error('Failed to save key permissions. Please retry or contact support.')
+        props.notify('success', 'Saved', 'Saved key permissions successfully!')
+        emit('saved'); emit('update:show', false)
+    } catch (error: any) {
+        console.error(error)
+        props.notify('error', 'Error', `Failed to save key permissions: ${commonFunctions.parseGraphQLError(error.message)}`)
+    }
+}
+
+async function saveNotes () {
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`mutation setNotesOnApiKey($apiKeyUuid: ID!, $notes: String) { setNotesOnApiKey(apiKeyUuid: $apiKeyUuid, notes: $notes) { uuid notes } }`,
+            variables: { apiKeyUuid: props.apiKey.uuid, notes: notes.value }
+        })
+        props.notify('success', 'Saved', 'Saved key notes successfully!')
+        emit('saved'); emit('update:show', false)
+    } catch (error: any) {
+        props.notify('error', 'Error', `Failed to save key notes: ${commonFunctions.parseGraphQLError(error.message)}`)
+    }
+}
+</script>

--- a/ui/src/components/ApiKeyPermissionsModal.vue
+++ b/ui/src/components/ApiKeyPermissionsModal.vue
@@ -12,6 +12,11 @@
                 These permissions are a ceiling. Every call is also checked against the owner's own permissions at that moment, and the lower of the two wins.
                 Nothing is allowed until at least one permission is set.
             </p>
+            <n-alert v-if="apiKey?.type === 'USER' && ownerOrgType" :type="ceilingExceedsOwner ? 'warning' : 'info'" style="margin-bottom: 12px;">
+                Owner's own organization-wide permission right now: <strong>{{ ownerOrgType }}</strong>
+                <span v-if="ownerOrgType !== 'ADMIN'"> (plus {{ ownerScopedCount }} object-level grant{{ ownerScopedCount === 1 ? '' : 's' }})</span>.
+                <span v-if="ceilingExceedsOwner"> The organization-wide level chosen below is higher than that; it will have no effect until the owner is granted it.</span>
+            </n-alert>
             <n-tabs v-model:value="editTab" type="segment" animated>
                 <n-tab-pane name="permissions" tab="Permissions">
                     <n-spin :show="loading">
@@ -51,7 +56,7 @@
  * components, products and instances itself, so it can be used from org settings and from the
  * user's own keys on the profile page. Saves through setPermissionsOnFreeformApiKey / setNotesOnApiKey.
  */
-import { NModal, NTabs, NTabPane, NSpace, NButton, NInput, NSpin } from 'naive-ui'
+import { NModal, NTabs, NTabPane, NSpace, NButton, NInput, NSpin, NAlert } from 'naive-ui'
 import { ref, computed, watch } from 'vue'
 import { useStore } from 'vuex'
 import gql from 'graphql-tag'
@@ -76,6 +81,26 @@ const perspectives = ref<any[]>([])
 const scoped = ref<{ orgPermission: any, scopedPermissions: any[] }>({ orgPermission: { type: 'NONE', functions: [], approvals: [] }, scopedPermissions: [] })
 
 const approvalRoles = computed(() => store.getters.orgById(props.orgUuid)?.approvalRoles || [])
+// USER keys: the owner's effective permissions in this org (groups included), so the ceiling can be read against them
+const ownerPerms = ref<any[]>([])
+const PERM_ORDER = ['NONE', 'ESSENTIAL_READ', 'READ_ONLY', 'READ_WRITE', 'ADMIN']
+const ownerOrgType = computed(() => { const p = ownerPerms.value.find((x: any) => x.scope === 'ORGANIZATION' && x.object === props.orgUuid); return p ? p.type : (ownerPerms.value.length ? 'NONE' : '') })
+const ownerScopedCount = computed(() => ownerPerms.value.filter((x: any) => x.scope !== 'ORGANIZATION').length)
+const ceilingExceedsOwner = computed(() => {
+    const t = scoped.value.orgPermission?.type || 'NONE'
+    return !!ownerOrgType.value && PERM_ORDER.indexOf(t) > PERM_ORDER.indexOf(ownerOrgType.value)
+})
+async function loadOwnerPermissions () {
+    ownerPerms.value = []
+    if (props.apiKey?.type !== 'USER' || !props.apiKey?.object) return
+    try {
+        const resp: any = await graphqlClient.query({
+            query: gql`query combinedUserOrgPermissions($orgUuid: ID!, $userUuid: ID!) { combinedUserOrgPermissions(orgUuid: $orgUuid, userUuid: $userUuid) { permissions { org scope object type functions } } }`,
+            variables: { orgUuid: props.orgUuid, userUuid: props.apiKey.object }, fetchPolicy: 'no-cache'
+        })
+        ownerPerms.value = (resp.data.combinedUserOrgPermissions?.permissions || []).filter((x: any) => x.org === props.orgUuid)
+    } catch (e: any) { console.error('owner permissions unavailable', e) }
+}
 const orgComponents = computed(() => store.getters.componentsOfOrg(props.orgUuid) || [])
 const orgProducts = computed(() => store.getters.productsOfOrg(props.orgUuid) || [])
 const allComponents = computed(() => [...orgComponents.value, ...orgProducts.value])
@@ -121,7 +146,7 @@ async function load () {
     if (!props.apiKey || !props.orgUuid) return
     loading.value = true
     try {
-        const loads: Promise<any>[] = [loadPerspectives(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
+        const loads: Promise<any>[] = [loadPerspectives(), loadOwnerPermissions(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
         if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
         await Promise.all(loads)
         const scopedPerms: any[] = []

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -1589,7 +1589,7 @@ const permissionTypeswAdmin: string[] = constants.PermissionTypesWithAdmin
 
 
 // ---- API key status and secrets (kill switch + AWS-style two-secret rotation): shared controls ----
-const apiKeyControls = createApiKeyControls({ notify, reload: () => loadProgrammaticAccessKeys(false), canManage: () => isOrgAdmin.value, canMint: (row: any) => isOrgAdmin.value && !row.holder })
+const apiKeyControls = createApiKeyControls({ notify, reload: () => loadProgrammaticAccessKeys(false), canManage: () => isOrgAdmin.value, canMint: (row: any) => isOrgAdmin.value && !row.holder && row.type !== 'USER', isAdmin: () => isOrgAdmin.value })
 const apiKeyStatusColumn = { key: 'status', title: 'Status', width: 170, render: apiKeyControls.statusCell }
 const apiKeySecretsColumn = { key: 'secrets', title: 'Secrets', width: 470, render: apiKeyControls.secretsCell }
 /** Key ids are created without a secret; minting the first one is its own step, offered right after creation. */
@@ -4233,6 +4233,7 @@ async function loadProgrammaticAccessKeys(useCache: boolean) {
                                     notes
                                     status
                                     holder
+                                    adminDisabled
                                     secrets { slot active createdDate lastUsedDate expiresDate }
                                     boundAgents {
                                         uuid

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -622,98 +622,65 @@
             </n-tab-pane>
 
             <n-tab-pane name="programmaticAccess" tab="Programmatic Access" v-if="isOrgAdmin">
-                <div class="programmaticAccessBlock mt-4">
-                    <h5>Programmatic Access</h5>
-                    <n-data-table :columns="programmaticAccessFields" :data="computedProgrammaticAccessKeys" :scroll-x="2400"
-                        class="table-hover">
-                    </n-data-table>
-                    <!-- n-icon v-if="isOrgAdmin" class="clickable" @click="genApiKey"
-                        title="Create Api Key" size="24"><CirclePlus /></n-icon -->
-                    <n-modal
-                        preset="dialog"
-                        :show-icon="false"
-                        style="width: 90%;"
-                        v-model:show="showOrgSettingsProgPermissionsModal">
-                        <n-card size="huge"
-                            :title="'Set approval permissions for key: ' + selectedKey.uuid" :bordered="false" role="dialog"
-                            aria-modal="true">
-
-                            <n-form>
-                                <n-form-item label='Approval Permissions:'>
-                                    <n-checkbox-group id="modal-org-settings-programmatic-permissions-approval-checkboxes"
-                                        v-model:value="selectedKey.approvals">
-                                        <n-checkbox v-for="a in myorg.approvalRoles" :key="a.id" :value="a.id" :label="a.displayView" ></n-checkbox>
-                                    </n-checkbox-group>
-                                </n-form-item>
-                                <n-form-item label='Notes:'>
-                                    <n-input
-                                        v-model:value="selectedKey.notes"
-                                        type="textarea"
-                                        placeholder="Notes"
-                                    />
-                                </n-form-item>
-                                <n-button @click="updateKeyPermissions" type="success">Submit</n-button>
-                            </n-form>
-                        </n-card>
-                    </n-modal>
-                </div>
-            </n-tab-pane>
-
-            <n-tab-pane name="freeFormKeys" tab="Free Form Keys" v-if="isOrgAdmin">
-                <div class="programmaticAccessBlock mt-4">
-                    <h5>Free Form Keys</h5>
-                    <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2400"
-                        class="table-hover">
-                    </n-data-table>
-                    <n-icon v-if="isOrgAdmin" class="clickable" @click="genFreeFormApiKey"
-                        title="Create Free Form Key" size="24"><CirclePlus /></n-icon>
-                    <n-modal
-                        preset="dialog"
-                        :show-icon="false"
-                        style="width: 90%;"
-                        :show="showFreeFormKeyPermissionsModal"
-                        @update:show="(v) => { if (!v) showFreeFormKeyPermissionsModal = false }"
-                        @after-enter="blurActiveElement"
-                    >
-                        <template #header>Edit key {{ selectedFreeFormKey.uuid }}</template>
-                        <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
-                            <n-tabs v-model:value="freeFormKeyEditTab" type="segment" animated>
-                                <n-tab-pane name="permissions" tab="Permissions">
-                                    <ScopedPermissions
-                                        v-model="freeFormKeyScopedPermissions"
-                                        :org-uuid="orgResolved"
-                                        :approval-roles="myorg.approvalRoles || []"
-                                        :perspectives="perspectives"
-                                        :products="orgProducts"
-                                        :components="orgComponents"
-                                        :instances="orgInstances"
-                                        :clusters="orgClusters"
-                                        :show-sbom-probing="true"
-                                    />
-                                    <n-space style="margin-top: 20px;">
-                                        <n-button type="success" @click="updateFreeFormKeyPermissions">Save Permissions</n-button>
-                                        <n-button @click="showFreeFormKeyPermissionsModal = false">Cancel</n-button>
-                                    </n-space>
-                                </n-tab-pane>
-                                <n-tab-pane name="notes" tab="Notes">
-                                    <p style="color: #555; margin-top: 0;">
-                                        Free-text notes for this key. Visible only to org admins on the Free Form Keys tab.
-                                    </p>
-                                    <n-input v-model:value="freeFormKeyNotes"
-                                        type="textarea"
-                                        :autosize="{ minRows: 4, maxRows: 16 }"
-                                        placeholder="What this key is used for, who owns it, expiry, etc." />
-                                    <n-space style="margin-top: 20px;">
-                                        <n-button type="success" @click="updateFreeFormKeyNotes">Save Notes</n-button>
-                                        <n-button @click="showFreeFormKeyPermissionsModal = false">Cancel</n-button>
-                                    </n-space>
-                                </n-tab-pane>
-                            </n-tabs>
+                <n-tabs type="segment" v-model:value="programmaticSubTab" size="medium" animated style="margin-bottom: 16px;">
+                    <n-tab-pane name="freeFormKeys" tab="Free Form Keys">
+                        <div class="programmaticAccessBlock mt-4">
+                            <h5>Free Form Keys</h5>
+                            <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2400"
+                                class="table-hover">
+                            </n-data-table>
+                            <n-icon v-if="isOrgAdmin" class="clickable" @click="genFreeFormApiKey"
+                                title="Create Free Form Key" size="24"><CirclePlus /></n-icon>
                         </div>
-                    </n-modal>
-                </div>
-            </n-tab-pane>
+                    </n-tab-pane>
+                    <n-tab-pane name="userKeys" tab="User Keys">
+                        <div class="programmaticAccessBlock mt-4">
+                            <h5>User Keys</h5>
+                            <p class="subtle">Personal keys that members create for themselves on their profile page. The permissions on a key are a ceiling: every call is also checked against the owner's own permissions at that moment, and the lower of the two wins.</p>
+                            <n-data-table :columns="userKeyFields" :data="computedUserKeys" :scroll-x="2400"
+                                class="table-hover">
+                            </n-data-table>
+                        </div>
+                    </n-tab-pane>
+                    <n-tab-pane name="scopedKeys" tab="Scoped Keys">
+                        <div class="programmaticAccessBlock mt-4">
+                            <h5>Scoped Keys</h5>
+                            <p class="subtle">Keys bound to one object: component, instance, cluster, organization-wide and approval keys.</p>
+                            <n-data-table :columns="programmaticAccessFields" :data="computedProgrammaticAccessKeys" :scroll-x="2400"
+                                class="table-hover">
+                            </n-data-table>
+                            <n-modal
+                                preset="dialog"
+                                :show-icon="false"
+                                style="width: 90%;"
+                                v-model:show="showOrgSettingsProgPermissionsModal">
+                                <n-card size="huge"
+                                    :title="'Set approval permissions for key: ' + selectedKey.uuid" :bordered="false" role="dialog"
+                                    aria-modal="true">
 
+                                    <n-form>
+                                        <n-form-item label='Approval Permissions:'>
+                                            <n-checkbox-group id="modal-org-settings-programmatic-permissions-approval-checkboxes"
+                                                v-model:value="selectedKey.approvals">
+                                                <n-checkbox v-for="a in myorg.approvalRoles" :key="a.id" :value="a.id" :label="a.displayView" ></n-checkbox>
+                                            </n-checkbox-group>
+                                        </n-form-item>
+                                        <n-form-item label='Notes:'>
+                                            <n-input
+                                                v-model:value="selectedKey.notes"
+                                                type="textarea"
+                                                placeholder="Notes"
+                                            />
+                                        </n-form-item>
+                                        <n-button @click="updateKeyPermissions" type="success">Submit</n-button>
+                                    </n-form>
+                                </n-card>
+                            </n-modal>
+                        </div>
+                    </n-tab-pane>
+                </n-tabs>
+                <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="orgResolved" :notify="notify" @saved="loadProgrammaticAccessKeys(false)" />
+            </n-tab-pane>
 
             <n-tab-pane name="terminology" tab="Terminology" v-if="isOrgAdmin">
                 <div class="terminologyBlock mt-4">
@@ -1173,6 +1140,8 @@ import NotificationHistory from './NotificationHistory.vue'
 import CreateApprovalPolicy from './CreateApprovalPolicy.vue'
 import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
+import ApiKeyPermissionsModal from './ApiKeyPermissionsModal.vue'
+import { createApiKeyControls, apiKeyIdOf } from '../utils/apiKeyControls'
 import OrgIntegrations from './OrgIntegrations.vue'
 import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
 import TeamsOfOrg from './TeamsOfOrg.vue'
@@ -1260,14 +1229,13 @@ const showOrgSettingsProgPermissionsModal = ref(false)
 
 const showOrgSettingsUserPermissionsModal = ref(false)
 
-const showFreeFormKeyPermissionsModal = ref(false)
-const selectedFreeFormKey = ref<any>({})
-const freeFormKeyEditTab = ref<'permissions' | 'notes'>('permissions')
-const freeFormKeyNotes = ref<string>('')
-const freeFormKeyScopedPermissions = ref<any>({
-    orgPermission: { type: 'NONE', functions: [], approvals: [] },
-    scopedPermissions: []
-})
+const showKeyEditModal = ref(false)
+const selectedEditKey = ref<any>({})
+const programmaticSubTab = ref<'freeFormKeys' | 'userKeys' | 'scopedKeys'>('freeFormKeys')
+function editRbacKey(row: any) {
+    selectedEditKey.value = commonFunctions.deepCopy(row)
+    showKeyEditModal.value = true
+}
 
 const showUserGroupPermissionsModal = ref(false)
 
@@ -1452,6 +1420,7 @@ function isTabAccessible (t: string): boolean {
 }
 const requestedTab = (route.query.tab as string) || defaultTab
 const currentTab = ref(isTabAccessible(requestedTab) ? requestedTab : defaultTab)
+if (currentTab.value === 'freeFormKeys') currentTab.value = 'programmaticAccess'
 // Default Policies sub-tab is approvalPoliciesInner (Approval Policies) — the
 // most common entry point. Approval Roles / Entries are configuration of
 // vocabulary used inside the policies.
@@ -1612,59 +1581,10 @@ const permissionTypeSelections: ComputedRef<any[]> = computed((): any => {
 const permissionTypeswAdmin: string[] = constants.PermissionTypesWithAdmin
 
 
-// ---- API key status and secrets (kill switch + AWS-style two-secret rotation) ----
-// status: INACTIVE refuses every secret and every token of the key id. Secrets: up to two per
-// id; regenerate replaces one in place (its tokens die), retire keeps it on file but refused.
-const apiKeyStatusCell = (row: any) => {
-    const inactive = row.status === 'INACTIVE'
-    const children: any[] = [h(NTag, { size: 'small', type: inactive ? 'error' : 'success', style: 'margin-right: 6px;' }, { default: () => inactive ? 'INACTIVE' : 'ACTIVE' })]
-    if (isOrgAdmin.value) {
-        children.push(h(NButton, { size: 'tiny', type: inactive ? 'primary' : 'warning', onClick: () => setApiKeyStatus(row, inactive ? 'ACTIVE' : 'INACTIVE') },
-            { default: () => inactive ? 'Activate' : 'Deactivate' }))
-    }
-    return h('div', { style: 'display: flex; align-items: center; white-space: nowrap;' }, children)
-}
-const apiKeySecretsCell = (row: any) => {
-    const secrets: any[] = row.secrets || []
-    const lines = secrets.map((sec: any) => {
-        // a legacy slot 1 predates per-secret dates: fall back to the key's own creation date
-        const created = sec.createdDate || (sec.slot === 1 ? row.createdDate : null)
-        const meta = `created ${created ? String(created).slice(0, 10) : 'n/a'} · last used ${sec.lastUsedDate ? String(sec.lastUsedDate).slice(0, 10) : 'never'}`
-        const kids: any[] = [
-            h('strong', { style: 'margin-right: 4px;' }, `#${sec.slot}`),
-            h(NTag, { size: 'tiny', type: sec.active ? 'success' : 'default', style: 'margin-right: 6px;' }, { default: () => sec.active ? 'active' : 'retired' }),
-            h('span', { class: 'subtle', style: 'margin-right: 6px;' }, meta)
-        ]
-        if (isOrgAdmin.value) {
-            kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
-            kids.push(h(NButton, { size: 'tiny', type: sec.active ? 'warning' : 'primary', style: 'margin-right: 4px;', onClick: () => setApiKeySecretActive(row, sec.slot, !sec.active) }, { default: () => sec.active ? 'Retire' : 'Enable' }))
-            kids.push(h(NButton, { size: 'tiny', type: 'error', onClick: () => deleteApiKeySecret(row, sec.slot) }, { default: () => 'Delete' }))
-        }
-        return h('div', { style: 'display: flex; align-items: center; white-space: nowrap; margin: 2px 0;' }, kids)
-    })
-    if (isOrgAdmin.value && secrets.length < 2) {
-        lines.push(h(NButton, { size: 'tiny', dashed: true, style: 'margin-top: 2px;', onClick: () => addApiKeySecret(row) }, { default: () => secrets.length ? 'Add second secret (rotation)' : 'Add secret' }))
-    }
-    return h('div', lines)
-}
-async function confirmThen (title: string, text: string, confirmButtonText: string): Promise<boolean> {
-    const r = await Swal.fire({ title, text, icon: 'warning', showCancelButton: true, confirmButtonText, cancelButtonText: 'Cancel' })
-    return !!r.value
-}
-async function showMintedSecret (forUser: any, title: string) {
-    await Swal.fire({ title, customClass: { popup: 'swal-wide' }, html: commonFunctions.getGeneratedApiKeyHTML(forUser), icon: 'success' })
-}
-async function addApiKeySecret (row: any) {
-    const first = !(row.secrets || []).length
-    if (!first && !(await confirmThen('Add a second secret?', 'Both secrets work until you retire or regenerate one. Move your clients to the new secret, then retire the old one.', 'Add secret'))) return
-    await mintSecret(row.uuid, first ? 'Secret generated' : 'Secret added')
-}
-async function mintSecret (apiKeyUuid: string, title: string) {
-    try {
-        const resp: any = await graphqlClient.mutate({ mutation: gql`mutation addApiKeySecret($apiKeyUuid: ID!) { addApiKeySecret(apiKeyUuid: $apiKeyUuid) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid }, fetchPolicy: 'no-cache' })
-        await showMintedSecret(resp.data.addApiKeySecret, title); loadProgrammaticAccessKeys(false)
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
-}
+// ---- API key status and secrets (kill switch + AWS-style two-secret rotation): shared controls ----
+const apiKeyControls = createApiKeyControls({ notify, reload: () => loadProgrammaticAccessKeys(false), canManage: () => isOrgAdmin.value })
+const apiKeyStatusColumn = { key: 'status', title: 'Status', width: 170, render: apiKeyControls.statusCell }
+const apiKeySecretsColumn = { key: 'secrets', title: 'Secrets', width: 470, render: apiKeyControls.secretsCell }
 /** Key ids are created without a secret; minting the first one is its own step, offered right after creation. */
 async function createOrgKey (apiType: string, notes: string | null, label: string) {
     let created: any
@@ -1674,38 +1594,8 @@ async function createOrgKey (apiType: string, notes: string | null, label: strin
     } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)); return }
     loadProgrammaticAccessKeys(false)
     const r = await Swal.fire({ title: `${label} created`, text: 'The key id exists but has no secret yet. Generate its first secret now? You can also do it later from the Secrets column.', icon: 'success', showCancelButton: true, confirmButtonText: 'Generate secret', cancelButtonText: 'Later' })
-    if (r.value) await mintSecret(created.uuid, 'Secret generated')
+    if (r.value) await apiKeyControls.mintSecret(created.uuid, 'Secret generated')
 }
-async function deleteApiKeySecret (row: any, slot: number) {
-    if (!(await confirmThen(`Delete secret #${slot}?`, 'This cannot be undone. The secret and every access token exchanged with it stop working; the slot becomes free for a new secret.', 'Delete'))) return
-    try {
-        await graphqlClient.mutate({ mutation: gql`mutation deleteApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { deleteApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
-        notify('success', 'Deleted', `Secret #${slot} deleted`); loadProgrammaticAccessKeys(false)
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
-}
-async function regenerateApiKeySecret (row: any, slot: number) {
-    if (!(await confirmThen(`Regenerate secret #${slot}?`, 'The current secret in this slot stops working immediately, and so do access tokens exchanged with it. The other secret is unaffected.', 'Regenerate'))) return
-    try {
-        const resp: any = await graphqlClient.mutate({ mutation: gql`mutation regenerateApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { regenerateApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
-        await showMintedSecret(resp.data.regenerateApiKeySecret, `Secret #${slot} regenerated`); loadProgrammaticAccessKeys(false)
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
-}
-async function setApiKeySecretActive (row: any, slot: number, active: boolean) {
-    if (!active && !(await confirmThen(`Retire secret #${slot}?`, 'It stays on file and can be enabled again, but it is refused until then, and so are access tokens exchanged with it.', 'Retire'))) return
-    try {
-        await graphqlClient.mutate({ mutation: gql`mutation setApiKeySecretActive($apiKeyUuid: ID!, $slot: Int!, $active: Boolean!) { setApiKeySecretActive(apiKeyUuid: $apiKeyUuid, slot: $slot, active: $active) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot, active }, fetchPolicy: 'no-cache' })
-        notify('success', active ? 'Enabled' : 'Retired', `Secret #${slot} ${active ? 'enabled' : 'retired'}`); loadProgrammaticAccessKeys(false)
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
-}
-async function setApiKeyStatus (row: any, status: string) {
-    if (status === 'INACTIVE' && !(await confirmThen('Deactivate this key?', 'Every secret and every access token of this key id is refused until you activate it again. Nothing is deleted.', 'Deactivate'))) return
-    try {
-        await graphqlClient.mutate({ mutation: gql`mutation setApiKeyStatus($apiKeyUuid: ID!, $status: ApiKeyStatus!) { setApiKeyStatus(apiKeyUuid: $apiKeyUuid, status: $status) { uuid status } }`, variables: { apiKeyUuid: row.uuid, status }, fetchPolicy: 'no-cache' })
-        notify('success', status === 'INACTIVE' ? 'Deactivated' : 'Activated', `Key ${status.toLowerCase()}`); loadProgrammaticAccessKeys(false)
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
-}
-const apiKeyStatusColumn = { key: 'status', title: 'Status', width: 170, render: apiKeyStatusCell }
-const apiKeySecretsColumn = { key: 'secrets', title: 'Secrets', width: 470, render: apiKeySecretsCell }
 
 const programmaticAccessFields: Ref<any> = ref([
     {
@@ -1924,7 +1814,7 @@ const freeFormKeyFields: Ref<any> = ref([
                             title: 'Set Permissions For Key',
                             class: 'icons clickable',
                             size: 25,
-                            onClick: () => editFreeFormKey(row)
+                            onClick: () => editRbacKey(row)
                         }, { default: () => h(EditIcon) }
                     )
                 )
@@ -1937,6 +1827,37 @@ const freeFormKeyFields: Ref<any> = ref([
                         onClick: () => deleteKey(row.uuid)
                     }, { default: () => h(Trash) }
                 ))
+            }
+            return h('div', els)
+        }
+    }
+])
+const userKeyFields: Ref<any> = ref([
+    { key: 'uuid', width: 300, title: 'Internal ID' },
+    {
+        key: 'apiId', width: 60, title: 'API ID',
+        render: (row: any) => h(NTooltip, { trigger: 'hover' }, { trigger: () => h(NIcon, { class: 'icons', size: 25 }, { default: () => h(Info20Regular) }), default: () => apiKeyIdOf(row) })
+    },
+    { key: 'ownerName', width: 200, title: 'Owner' },
+    { key: 'createdDate', width: 180, title: 'Created' },
+    { key: 'accessDate', width: 180, title: 'Last Accessed' },
+    apiKeyStatusColumn,
+    apiKeySecretsColumn,
+    {
+        key: 'ceiling', width: 160, title: 'Ceiling',
+        render: (row: any) => {
+            const n = (row.permissions?.permissions || []).length
+            return h('span', { class: n ? '' : 'text-muted' }, n ? `${n} permission${n === 1 ? '' : 's'}` : 'none (key is inert)')
+        }
+    },
+    { key: 'notes', width: 180, title: 'Notes' },
+    {
+        key: 'controls', title: 'Manage',
+        render: (row: any) => {
+            const els: any[] = []
+            if (isOrgAdmin.value) {
+                els.push(h(NIcon, { title: 'Set Permission Ceiling For Key', class: 'icons clickable', size: 25, onClick: () => editRbacKey(row) }, { default: () => h(EditIcon) }))
+                els.push(h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => deleteKey(row.uuid) }, { default: () => h(Trash) }))
             }
             return h('div', els)
         }
@@ -3800,139 +3721,6 @@ async function genFreeFormApiKey() {
     }
 }
 
-async function editFreeFormKey(key: any) {
-    selectedFreeFormKey.value = commonFunctions.deepCopy(key)
-    await Promise.all([
-        loadPerspectives(),
-        store.dispatch('fetchComponents', orgResolved.value),
-        store.dispatch('fetchProducts', orgResolved.value)
-    ])
-    const scopedPerms: any[] = []
-    let orgPerm = { type: 'NONE', functions: [] as string[], approvals: [] as string[] }
-    for (const up of (selectedFreeFormKey.value.permissions?.permissions || [])) {
-        if (up.scope === 'ORGANIZATION' && up.org === orgResolved.value) {
-            orgPerm = { type: up.type, functions: up.functions || [], approvals: up.approvals || [] }
-        } else if ((up.scope === 'PERSPECTIVE' || up.scope === 'COMPONENT' || up.scope === 'INSTANCE') && up.org === orgResolved.value) {
-            const objectName = await resolveScopedObjectName(up.scope, up.object)
-            scopedPerms.push({
-                scope: up.scope,
-                objectId: up.object,
-                objectName,
-                type: up.type,
-                functions: up.functions || [],
-                approvals: up.approvals || []
-            })
-        }
-    }
-    freeFormKeyScopedPermissions.value = {
-        orgPermission: orgPerm,
-        scopedPermissions: scopedPerms
-    }
-    freeFormKeyNotes.value = key.notes || ''
-    freeFormKeyEditTab.value = 'permissions'
-    showFreeFormKeyPermissionsModal.value = true
-}
-
-async function updateFreeFormKeyPermissions() {
-    const permissions: any[] = []
-    const scopedData = freeFormKeyScopedPermissions.value
-    const orgPermType = scopedData.orgPermission.type
-    const orgApprovals = scopedData.orgPermission.approvals || []
-    const orgFunctions = scopedData.orgPermission.functions || []
-
-    if (orgPermType && orgPermType !== 'NONE') {
-        permissions.push({
-            org: orgResolved.value,
-            scope: 'ORGANIZATION',
-            type: orgPermType,
-            object: orgResolved.value,
-            functions: orgFunctions,
-            approvals: orgApprovals
-        })
-    }
-
-    if (scopedData.scopedPermissions && scopedData.scopedPermissions.length) {
-        for (const sp of scopedData.scopedPermissions) {
-            if (sp.type && sp.type !== 'NONE') {
-                permissions.push({
-                    org: orgResolved.value,
-                    scope: sp.scope,
-                    type: sp.type,
-                    object: sp.objectId,
-                    functions: sp.functions || [],
-                    approvals: sp.approvals || []
-                })
-            }
-        }
-    }
-
-    let isSuccess = true
-    let errorOccurred = false
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation setPermissionsOnFreeformApiKey($permissions: [PermissionInput]) {
-                    setPermissionsOnFreeformApiKey(apiKeyUuid: "${selectedFreeFormKey.value.uuid}",
-                        permissionType: ${orgPermType}, permissions: $permissions) {
-                        uuid
-                    }
-                }`,
-            variables: { permissions }
-        })
-        if (!resp.data.setPermissionsOnFreeformApiKey || !resp.data.setPermissionsOnFreeformApiKey.uuid) isSuccess = false
-    } catch (error: any) {
-        console.error(error)
-        isSuccess = false
-        errorOccurred = true
-        const errorMsg = commonFunctions.parseGraphQLError(error.message)
-        notify('error', 'Error', `Failed to save key permissions: ${errorMsg}`)
-    }
-
-    if (isSuccess) {
-        notify('success', 'Saved', 'Saved key permissions successfully!')
-        await loadProgrammaticAccessKeys(false)
-    } else if (!errorOccurred) {
-        notify('error', 'Error', 'Failed to save key permissions. Please retry or contact support.')
-    }
-
-    showFreeFormKeyPermissionsModal.value = false
-    selectedFreeFormKey.value = {}
-}
-
-async function updateFreeFormKeyNotes() {
-    if (!selectedFreeFormKey.value || !selectedFreeFormKey.value.uuid) {
-        notify('error', 'Error', 'No key selected.')
-        return
-    }
-    try {
-        const resp = await graphqlClient.mutate({
-            mutation: gql`
-                mutation setNotesOnApiKey($apiKeyUuid: ID!, $notes: String) {
-                    setNotesOnApiKey(apiKeyUuid: $apiKeyUuid, notes: $notes) {
-                        uuid notes
-                    }
-                }`,
-            variables: {
-                apiKeyUuid: selectedFreeFormKey.value.uuid,
-                notes: freeFormKeyNotes.value
-            }
-        })
-        if (!resp.data.setNotesOnApiKey || !resp.data.setNotesOnApiKey.uuid) {
-            notify('error', 'Error', 'Failed to save notes.')
-            return
-        }
-        notify('success', 'Saved', 'Saved key notes successfully!')
-        await loadProgrammaticAccessKeys(false)
-    } catch (error: any) {
-        console.error(error)
-        const errorMsg = commonFunctions.parseGraphQLError(error.message)
-        notify('error', 'Error', `Failed to save key notes: ${errorMsg}`)
-        return
-    }
-    showFreeFormKeyPermissionsModal.value = false
-    selectedFreeFormKey.value = {}
-}
-
 function extractOrgWidePermission(user: any) {
     const perm = user.permissions.permissions.filter((up: any) =>
         (up.scope === 'ORGANIZATION' && up.org === up.object && up.org === orgResolved.value)
@@ -4968,7 +4756,8 @@ const jiraIntegrationData: ComputedRef<any> = computed((): any => {
     return false
 })
 const computedProgrammaticAccessKeys: ComputedRef<any> = computed((): any => {
-    return programmaticAccessKeys.value.map((accesKey: any) => {
+    // scoped keys: everything that is not an RBAC key (FREEFORM and USER have their own sub-tabs)
+    return programmaticAccessKeys.value.filter((k: any) => k.type !== 'FREEFORM' && k.type !== 'USER').map((accesKey: any) => {
         if (accesKey.type === 'ORGANIZATION_RW' || accesKey.type === 'ORGANIZATION') {
             accesKey.object_val = store.getters.orgById(accesKey.object).name
         } else if (accesKey.type === 'COMPONENT') {
@@ -5003,6 +4792,12 @@ const computedFreeFormKeys: ComputedRef<any> = computed((): any => {
     // computed exists only so the table re-renders if the underlying
     // ref mutates (post-edit reload).
     return programmaticAccessKeys.value.filter((k: any) => k.type === 'FREEFORM')
+})
+const computedUserKeys: ComputedRef<any> = computed((): any => {
+    return programmaticAccessKeys.value.filter((k: any) => k.type === 'USER').map((k: any) => {
+        const owner = users.value.find((u: any) => u.uuid === k.object)
+        return Object.assign({}, k, { ownerName: owner ? (owner.name || owner.email) : 'Unknown user' })
+    })
 })
 const imageRegistry: ComputedRef<any> = computed((): any => {
     let content = '### OCI Container Images (Suitable for Docker and Helm):\n'

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -624,9 +624,16 @@
             <n-tab-pane name="programmaticAccess" tab="Programmatic Access" v-if="isOrgAdmin">
                 <n-tabs type="segment" v-model:value="programmaticSubTab" size="medium" animated style="margin-bottom: 16px;">
                     <n-tab-pane name="freeFormKeys" tab="Free Form Keys">
+                        <div v-if="computedKeyRequests.length" class="programmaticAccessBlock mt-4">
+                            <h5>Key Requests</h5>
+                            <p class="subtle">Free-form keys members asked for. Review the proposed permissions, then approve or deny. Once approved, only the requester (the holder) can generate its secrets.</p>
+                            <n-data-table :columns="keyRequestFields" :data="computedKeyRequests" :scroll-x="1800"
+                                class="table-hover">
+                            </n-data-table>
+                        </div>
                         <div class="programmaticAccessBlock mt-4">
                             <h5>Free Form Keys</h5>
-                            <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2400"
+                            <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2600"
                                 class="table-hover">
                             </n-data-table>
                             <n-icon v-if="isOrgAdmin" class="clickable" @click="genFreeFormApiKey"
@@ -1119,7 +1126,7 @@ import { ComputedRef, h, ref, Ref, computed, onMounted, reactive, watch } from '
 import type { SelectOption } from 'naive-ui'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import { Edit as EditIcon, Trash, CirclePlus, Eye, QuestionMark, Search, FolderPlus, Package, Clipboard } from '@vicons/tabler'
+import { Edit as EditIcon, Trash, CirclePlus, Eye, QuestionMark, Search, FolderPlus, Package, Clipboard, User as UserIcon } from '@vicons/tabler'
 import { Info20Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
@@ -1582,7 +1589,7 @@ const permissionTypeswAdmin: string[] = constants.PermissionTypesWithAdmin
 
 
 // ---- API key status and secrets (kill switch + AWS-style two-secret rotation): shared controls ----
-const apiKeyControls = createApiKeyControls({ notify, reload: () => loadProgrammaticAccessKeys(false), canManage: () => isOrgAdmin.value })
+const apiKeyControls = createApiKeyControls({ notify, reload: () => loadProgrammaticAccessKeys(false), canManage: () => isOrgAdmin.value, canMint: (row: any) => isOrgAdmin.value && !row.holder })
 const apiKeyStatusColumn = { key: 'status', title: 'Status', width: 170, render: apiKeyControls.statusCell }
 const apiKeySecretsColumn = { key: 'secrets', title: 'Secrets', width: 470, render: apiKeyControls.secretsCell }
 /** Key ids are created without a secret; minting the first one is its own step, offered right after creation. */
@@ -1773,6 +1780,15 @@ const freeFormKeyFields: Ref<any> = ref([
         width: 150,
         title: 'Updated By'
     },
+    {
+        key: 'holderName', width: 200, title: 'Holder',
+        render: (row: any) => {
+            if (!row.holder) return h('span', { class: 'text-muted' }, '—')
+            const kids: any[] = [h('span', row.holderName)]
+            if (row.holderLeft) kids.push(h(NTag, { size: 'tiny', type: 'warning', style: 'margin-left: 6px;' }, { default: () => 'reassign' }))
+            return h('div', kids)
+        }
+    },
     apiKeyStatusColumn,
     apiKeySecretsColumn,
     {
@@ -1818,6 +1834,7 @@ const freeFormKeyFields: Ref<any> = ref([
                         }, { default: () => h(EditIcon) }
                     )
                 )
+                els.push(h(NIcon, { title: 'Holder (who mints the secrets)', class: 'icons clickable', size: 25, onClick: () => reassignHolder(row) }, { default: () => h(UserIcon) }))
                 els.push(h(
                     NIcon,
                     {
@@ -4215,7 +4232,8 @@ async function loadProgrammaticAccessKeys(useCache: boolean) {
                                     createdDate
                                     notes
                                     status
-                                    secrets { slot active createdDate lastUsedDate }
+                                    holder
+                                    secrets { slot active createdDate lastUsedDate expiresDate }
                                     boundAgents {
                                         uuid
                                         name
@@ -4791,8 +4809,61 @@ const computedFreeFormKeys: ComputedRef<any> = computed((): any => {
     // updatedByName is also already resolved at load time. The
     // computed exists only so the table re-renders if the underlying
     // ref mutates (post-edit reload).
-    return programmaticAccessKeys.value.filter((k: any) => k.type === 'FREEFORM')
+    return programmaticAccessKeys.value.filter((k: any) => k.type === 'FREEFORM' && k.status !== 'REQUESTED' && k.status !== 'DENIED').map(withHolder)
 })
+function withHolder (k: any) {
+    if (!k.holder) return Object.assign({}, k, { holderName: '', holderLeft: false })
+    const u = users.value.find((x: any) => x.uuid === k.holder)
+    return Object.assign({}, k, { holderName: u ? (u.name || u.email) : 'left the organization', holderLeft: !u })
+}
+const computedKeyRequests: ComputedRef<any> = computed((): any => {
+    return programmaticAccessKeys.value.filter((k: any) => k.type === 'FREEFORM' && (k.status === 'REQUESTED' || k.status === 'DENIED')).map(withHolder)
+})
+async function resolveKeyRequest (row: any, approve: boolean) {
+    let reason: string | null = null
+    if (approve) {
+        const r = await Swal.fire({ title: 'Approve this request?', text: 'The key becomes active with the permissions shown. The requester generates its secrets; you will not see them.', icon: 'question', showCancelButton: true, confirmButtonText: 'Approve' })
+        if (!r.value) return
+    } else {
+        const r = await Swal.fire({ title: 'Deny this request?', input: 'text', inputPlaceholder: 'Reason (shown to the requester)', showCancelButton: true, confirmButtonText: 'Deny' })
+        if (!r.isConfirmed) return
+        reason = r.value || null
+    }
+    try {
+        await graphqlClient.mutate({ mutation: gql`mutation resolveApiKeyRequest($apiKeyUuid: ID!, $approve: Boolean!, $reason: String) { resolveApiKeyRequest(apiKeyUuid: $apiKeyUuid, approve: $approve, reason: $reason) { uuid status } }`, variables: { apiKeyUuid: row.uuid, approve, reason }, fetchPolicy: 'no-cache' })
+        notify('success', approve ? 'Approved' : 'Denied', approve ? 'The requester can now generate secrets for this key' : 'Request denied'); loadProgrammaticAccessKeys(false)
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+async function reassignHolder (row: any) {
+    const options: Record<string, string> = { '': '(no holder: admins mint the secrets)' }
+    for (const u of users.value) options[u.uuid] = u.name ? `${u.name} (${u.email})` : u.email
+    const r = await Swal.fire({ title: 'Holder of this key', text: 'The holder is the only one who can generate or regenerate its secrets.', input: 'select', inputOptions: options, inputValue: row.holder || '', showCancelButton: true, confirmButtonText: 'Save' })
+    if (!r.isConfirmed) return
+    try {
+        await graphqlClient.mutate({ mutation: gql`mutation setApiKeyHolder($apiKeyUuid: ID!, $holder: ID) { setApiKeyHolder(apiKeyUuid: $apiKeyUuid, holder: $holder) { uuid holder } }`, variables: { apiKeyUuid: row.uuid, holder: r.value || null }, fetchPolicy: 'no-cache' })
+        notify('success', 'Saved', 'Holder updated'); loadProgrammaticAccessKeys(false)
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+const keyRequestFields: Ref<any> = ref([
+    { key: 'uuid', width: 300, title: 'Internal ID' },
+    { key: 'holderName', width: 200, title: 'Requested By' },
+    { key: 'createdDate', width: 180, title: 'Requested' },
+    { key: 'status', width: 120, title: 'Status', render: apiKeyControls.statusCell },
+    { key: 'proposed', width: 150, title: 'Proposed', render: (row: any) => { const n = (row.permissions?.permissions || []).length; return h('span', { class: n ? '' : 'text-muted' }, n ? `${n} permission${n === 1 ? '' : 's'}` : 'none proposed') } },
+    { key: 'notes', width: 260, title: 'Purpose / Notes' },
+    {
+        key: 'controls', title: 'Manage',
+        render: (row: any) => {
+            const els: any[] = [h(NIcon, { title: 'Review / Edit Permissions', class: 'icons clickable', size: 25, onClick: () => editRbacKey(row) }, { default: () => h(EditIcon) })]
+            if (row.status === 'REQUESTED') {
+                els.push(h(NButton, { size: 'tiny', type: 'primary', style: 'margin: 0 4px;', onClick: () => resolveKeyRequest(row, true) }, { default: () => 'Approve' }))
+                els.push(h(NButton, { size: 'tiny', type: 'warning', style: 'margin-right: 4px;', onClick: () => resolveKeyRequest(row, false) }, { default: () => 'Deny' }))
+            }
+            els.push(h(NIcon, { title: 'Delete', class: 'icons clickable', size: 25, onClick: () => deleteKey(row.uuid) }, { default: () => h(Trash) }))
+            return h('div', { style: 'display: flex; align-items: center;' }, els)
+        }
+    }
+])
 const computedUserKeys: ComputedRef<any> = computed((): any => {
     return programmaticAccessKeys.value.filter((k: any) => k.type === 'USER').map((k: any) => {
         const owner = users.value.find((u: any) => u.uuid === k.object)

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -400,7 +400,7 @@ watch(orgOptions, (opts) => {
 async function loadMyKeys () {
     try {
         const resp: any = await graphqlClient.query({
-            query: gql`query myApiKeys { myApiKeys { uuid org object type keyOrder createdDate accessDate notes status holder
+            query: gql`query myApiKeys { myApiKeys { uuid org object type keyOrder createdDate accessDate notes status holder adminDisabled
                 secrets { slot active createdDate lastUsedDate expiresDate }
                 permissions { permissions { org scope object type meta approvals functions } } } }`,
             fetchPolicy: 'network-only'

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="home">
         <h2>User Profile</h2>
+        <n-tabs type="segment" v-model:value="profileTab" size="medium" animated style="margin-bottom: 16px;">
+        <n-tab-pane name="profile" tab="Profile">
 
         <div v-if="myUser" class="nameBlock mt-4">
             <n-form-item path="username" label="Your Display Name:">
@@ -85,19 +87,44 @@
             <n-button @click="submitFile">Restore</n-button>
         </n-modal>
 
+        </n-tab-pane>
+        <n-tab-pane name="apiKeys" tab="API Keys">
+            <div class="mt-4">
+                <h4>Your API Keys</h4>
+                <p class="subtle">A personal key acts as you, within the permissions you set on it. Every call is also checked against your own permissions at that moment, and the lower of the two wins. A new key has no secret and no permissions until you add them.</p>
+                <n-space align="end" style="margin-bottom: 12px;">
+                    <n-form-item label="Organization">
+                        <n-select v-model:value="newKeyOrg" :options="orgOptions" style="min-width: 280px;" />
+                    </n-form-item>
+                    <n-form-item label="Notes">
+                        <n-input v-model:value="newKeyNotes" placeholder="What this key is for" style="min-width: 280px;" />
+                    </n-form-item>
+                    <n-form-item>
+                        <n-button type="primary" :disabled="!newKeyOrg" @click="createMyKey">Create key</n-button>
+                    </n-form-item>
+                </n-space>
+                <n-data-table :columns="myKeyFields" :data="myKeys" :scroll-x="2200" class="table-hover"></n-data-table>
+                <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
+            </div>
+        </n-tab-pane>
+        </n-tabs>
     </div>
 </template>
 
 <script lang="ts" setup>
 // @ is an alias to /src
-import { NIcon, NCheckbox, NInput, NModal, NDataTable, NForm, NFormItem, NInputGroup, NButton, NotificationType, useNotification, NUpload } from 'naive-ui'
-import { ComputedRef, h, ref, Ref, computed, onMounted } from 'vue'
+import { NIcon, NCheckbox, NInput, NModal, NDataTable, NForm, NFormItem, NInputGroup, NButton, NotificationType, useNotification, NUpload, NTabs, NTabPane, NSpace, NSelect } from 'naive-ui'
+import { ComputedRef, h, ref, Ref, computed, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { Edit as EditIcon, X, Check, CirclePlus, LockOpen, Trash, ArrowDown, ArrowUp } from '@vicons/tabler'
 import commonFunctions from '@/utils/commonFunctions'
 import Swal from 'sweetalert2'
 import { OnChange } from 'naive-ui/es/upload/src/interface'
+import gql from 'graphql-tag'
+import graphqlClient from '../utils/graphql'
+import ApiKeyPermissionsModal from './ApiKeyPermissionsModal.vue'
+import { createApiKeyControls, apiKeyIdOf } from '../utils/apiKeyControls'
 
 
 const route = useRoute()
@@ -119,6 +146,7 @@ onMounted(async () => {
         notify('success', 'Success', 'Email address verified successfully!', 8000)
     }
     await initLoad()
+    loadMyKeys()
 })
 
 const apiKey = ref('')
@@ -349,6 +377,81 @@ function updateUserName() {
 // const myUser: Ref<any> = ref({})
 const organizations: ComputedRef<any> = computed((): any => store.getters.allOrganizations)
 const myUser: ComputedRef<any> = computed((): any => store.getters.myuser)
+
+// ---- personal (USER) API keys: created here, managed here; org admins also see them in org settings ----
+const profileTab = ref<'profile' | 'apiKeys'>('profile')
+const myKeys: Ref<any[]> = ref([])
+const newKeyOrg = ref<string | null>(null)
+const newKeyNotes = ref('')
+const showKeyEditModal = ref(false)
+const selectedEditKey = ref<any>({})
+const orgOptions = computed(() => (organizations.value || []).map((o: any) => ({ label: o.name, value: o.uuid })))
+watch(orgOptions, (opts) => {
+    if (newKeyOrg.value || !opts.length) return
+    let stored: string | null = null
+    try { stored = window.localStorage.getItem('relizaOrgUuid') } catch { stored = null }
+    newKeyOrg.value = opts.find((o: any) => o.value === stored)?.value || opts[0].value
+}, { immediate: true })
+
+async function loadMyKeys () {
+    try {
+        const resp: any = await graphqlClient.query({
+            query: gql`query myApiKeys { myApiKeys { uuid org object type keyOrder createdDate accessDate notes status
+                secrets { slot active createdDate lastUsedDate }
+                permissions { permissions { org scope object type meta approvals functions } } } }`,
+            fetchPolicy: 'network-only'
+        })
+        myKeys.value = (resp.data.myApiKeys || []).map((k: any) => Object.assign({}, k, {
+            orgName: store.getters.orgById(k.org)?.name || k.org,
+            createdDisplay: k.createdDate ? new Date(k.createdDate).toLocaleString('en-CA') : '',
+            accessDisplay: k.accessDate ? new Date(k.accessDate).toLocaleString('en-CA') : 'Never'
+        }))
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+const apiKeyControls = createApiKeyControls({ notify, reload: loadMyKeys, canManage: () => true })
+
+async function createMyKey () {
+    if (!newKeyOrg.value) return
+    let created: any
+    try {
+        const resp: any = await graphqlClient.mutate({
+            mutation: gql`mutation createUserApiKey($orgUuid: ID!, $notes: String) { createUserApiKey(orgUuid: $orgUuid, notes: $notes) { uuid } }`,
+            variables: { orgUuid: newKeyOrg.value, notes: newKeyNotes.value || null }, fetchPolicy: 'no-cache'
+        })
+        created = resp.data.createUserApiKey
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)); return }
+    newKeyNotes.value = ''
+    await loadMyKeys()
+    const r = await Swal.fire({ title: 'Key created', text: 'The key id exists but has no secret and no permissions yet. Generate its first secret now? Set its permissions from the Manage column; until then the key is refused everywhere.', icon: 'success', showCancelButton: true, confirmButtonText: 'Generate secret', cancelButtonText: 'Later' })
+    if (r.value) await apiKeyControls.mintSecret(created.uuid, 'Secret generated')
+}
+function editMyKey (row: any) {
+    selectedEditKey.value = commonFunctions.deepCopy(row)
+    showKeyEditModal.value = true
+}
+const myKeyFields: ComputedRef<any> = computed((): any => [
+    { key: 'orgName', width: 200, title: 'Organization' },
+    { key: 'apiId', width: 420, title: 'API ID', render: (row: any) => h('code', { style: 'word-break: break-all; font-size: 12px;' }, apiKeyIdOf(row)) },
+    { key: 'createdDisplay', width: 170, title: 'Created' },
+    { key: 'accessDisplay', width: 170, title: 'Last Accessed' },
+    { key: 'status', width: 170, title: 'Status', render: apiKeyControls.statusCell },
+    { key: 'secrets', width: 470, title: 'Secrets', render: apiKeyControls.secretsCell },
+    {
+        key: 'ceiling', width: 160, title: 'Permissions',
+        render: (row: any) => {
+            const n = (row.permissions?.permissions || []).length
+            return h('span', { class: n ? '' : 'text-muted' }, n ? `${n} permission${n === 1 ? '' : 's'}` : 'none (key is inert)')
+        }
+    },
+    { key: 'notes', width: 180, title: 'Notes' },
+    {
+        key: 'controls', title: 'Manage',
+        render: (row: any) => h('div', [
+            h(NIcon, { title: 'Set Permissions For Key', class: 'icons clickable', size: 25, onClick: () => editMyKey(row) }, { default: () => h(EditIcon) }),
+            h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => apiKeyControls.deleteApiKey(row, 'this key') }, { default: () => h(Trash) })
+        ])
+    }
+])
 </script>
 
 <style lang="scss">

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -102,7 +102,11 @@
                     <n-form-item>
                         <n-button type="primary" :disabled="!newKeyOrg" @click="createMyKey">Create key</n-button>
                     </n-form-item>
+                    <n-form-item>
+                        <n-button :disabled="!newKeyOrg" @click="requestFreeformKey">Request a free-form key</n-button>
+                    </n-form-item>
                 </n-space>
+                <p class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a free-form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
                 <n-data-table :columns="myKeyFields" :data="myKeys" :scroll-x="2200" class="table-hover"></n-data-table>
                 <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
             </div>
@@ -396,8 +400,8 @@ watch(orgOptions, (opts) => {
 async function loadMyKeys () {
     try {
         const resp: any = await graphqlClient.query({
-            query: gql`query myApiKeys { myApiKeys { uuid org object type keyOrder createdDate accessDate notes status
-                secrets { slot active createdDate lastUsedDate }
+            query: gql`query myApiKeys { myApiKeys { uuid org object type keyOrder createdDate accessDate notes status holder
+                secrets { slot active createdDate lastUsedDate expiresDate }
                 permissions { permissions { org scope object type meta approvals functions } } } }`,
             fetchPolicy: 'network-only'
         })
@@ -408,7 +412,7 @@ async function loadMyKeys () {
         }))
     } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
 }
-const apiKeyControls = createApiKeyControls({ notify, reload: loadMyKeys, canManage: () => true })
+const apiKeyControls = createApiKeyControls({ notify, reload: loadMyKeys, canManage: () => true, canMint: (row: any) => row.status === 'ACTIVE' || row.status === 'INACTIVE' })
 
 async function createMyKey () {
     if (!newKeyOrg.value) return
@@ -425,12 +429,30 @@ async function createMyKey () {
     const r = await Swal.fire({ title: 'Key created', text: 'The key id exists but has no secret and no permissions yet. Generate its first secret now? Set its permissions from the Manage column; until then the key is refused everywhere.', icon: 'success', showCancelButton: true, confirmButtonText: 'Generate secret', cancelButtonText: 'Later' })
     if (r.value) await apiKeyControls.mintSecret(created.uuid, 'Secret generated')
 }
+async function requestFreeformKey () {
+    if (!newKeyOrg.value) return
+    const r = await Swal.fire({ title: 'Request a free-form key', input: 'textarea', inputLabel: 'Purpose (what the key is for; admins see this)', inputPlaceholder: 'e.g. CI pipeline for repo X needs release write on component Y', inputValue: newKeyNotes.value, showCancelButton: true, confirmButtonText: 'Send request', inputValidator: (v: string) => v ? null : 'Please describe the purpose' })
+    if (!r.isConfirmed) return
+    let created: any
+    try {
+        const resp: any = await graphqlClient.mutate({
+            mutation: gql`mutation requestFreeformApiKey($orgUuid: ID!, $notes: String) { requestFreeformApiKey(orgUuid: $orgUuid, notes: $notes) { uuid } }`,
+            variables: { orgUuid: newKeyOrg.value, notes: r.value }, fetchPolicy: 'no-cache'
+        })
+        created = resp.data.requestFreeformApiKey
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)); return }
+    newKeyNotes.value = ''
+    await loadMyKeys()
+    const p = await Swal.fire({ title: 'Request sent', text: 'Admins of the organization will review it. Propose the permissions you need now? You can edit them until the request is decided.', icon: 'success', showCancelButton: true, confirmButtonText: 'Propose permissions', cancelButtonText: 'Later' })
+    if (p.value) { const row = myKeys.value.find((k: any) => k.uuid === created.uuid); if (row) editMyKey(row) }
+}
 function editMyKey (row: any) {
     selectedEditKey.value = commonFunctions.deepCopy(row)
     showKeyEditModal.value = true
 }
 const myKeyFields: ComputedRef<any> = computed((): any => [
     { key: 'orgName', width: 200, title: 'Organization' },
+    { key: 'kind', width: 130, title: 'Kind', render: (row: any) => row.type === 'USER' ? 'Personal' : 'Free-form (held)' },
     { key: 'apiId', width: 420, title: 'API ID', render: (row: any) => h('code', { style: 'word-break: break-all; font-size: 12px;' }, apiKeyIdOf(row)) },
     { key: 'createdDisplay', width: 170, title: 'Created' },
     { key: 'accessDisplay', width: 170, title: 'Last Accessed' },
@@ -446,10 +468,15 @@ const myKeyFields: ComputedRef<any> = computed((): any => [
     { key: 'notes', width: 180, title: 'Notes' },
     {
         key: 'controls', title: 'Manage',
-        render: (row: any) => h('div', [
-            h(NIcon, { title: 'Set Permissions For Key', class: 'icons clickable', size: 25, onClick: () => editMyKey(row) }, { default: () => h(EditIcon) }),
-            h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => apiKeyControls.deleteApiKey(row, 'this key') }, { default: () => h(Trash) })
-        ])
+        render: (row: any) => {
+            const els: any[] = []
+            // personal keys: the owner shapes the ceiling; held free-form keys: only while the request is pending
+            if (row.type === 'USER' || row.status === 'REQUESTED') {
+                els.push(h(NIcon, { title: row.type === 'USER' ? 'Set Permissions For Key' : 'Propose Permissions', class: 'icons clickable', size: 25, onClick: () => editMyKey(row) }, { default: () => h(EditIcon) }))
+            }
+            els.push(h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => apiKeyControls.deleteApiKey(row, row.status === 'REQUESTED' ? 'this request' : 'this key') }, { default: () => h(Trash) }))
+            return h('div', els)
+        }
     }
 ])
 </script>

--- a/ui/src/utils/apiKeyControls.ts
+++ b/ui/src/utils/apiKeyControls.ts
@@ -14,8 +14,34 @@ import commonFunctions from '@/utils/commonFunctions'
 export interface ApiKeyControlOptions {
     notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
     reload: () => void | Promise<void>
-    /** whether the current viewer may operate the controls (org admin, or owner of a USER key) */
+    /** whether the current viewer may operate the controls (org admin, owner of a USER key, holder of a free-form key) */
     canManage: (row: any) => boolean
+    /** whether the viewer may mint (add / regenerate), which reveals cleartext: on a held free-form key only the holder; defaults to canManage */
+    canMint?: (row: any) => boolean
+}
+
+function fmtDate (d: any): string { return d ? new Date(d).toLocaleString('en-CA', { hour12: false }).slice(0, 16) : '' }
+function isExpired (sec: any): boolean { return !!sec.expiresDate && new Date(sec.expiresDate).getTime() <= Date.now() }
+/** local datetime-local value -> ISO instant, or null when empty */
+function toIso (local: string): string | null { return local ? new Date(local).toISOString() : null }
+
+/** Confirmation that also asks for an optional expiry (date and time, local). Returns null when cancelled. */
+async function askExpiry (title: string, text: string, confirmButtonText: string, current?: string | null, allowClear: boolean = false): Promise<{ expiresDate: string | null, clear: boolean } | null> {
+    const cur = current ? new Date(current) : null
+    const curLocal = cur ? new Date(cur.getTime() - cur.getTimezoneOffset() * 60000).toISOString().slice(0, 16) : ''
+    const r = await Swal.fire({
+        title, icon: 'warning', showCancelButton: true, confirmButtonText, cancelButtonText: 'Cancel',
+        showDenyButton: allowClear, denyButtonText: 'Clear expiry',
+        html: `<p style="text-align:left">${text}</p><label style="display:block;text-align:left;margin-top:8px">Expiry (optional, local time; the secret is refused after it and its tokens end there at the latest)</label><input id="swal-expiry" type="datetime-local" class="swal2-input" style="width: 80%" value="${curLocal}">`,
+        preConfirm: () => {
+            const v = (document.getElementById('swal-expiry') as HTMLInputElement).value
+            if (v && new Date(v).getTime() <= Date.now()) { Swal.showValidationMessage('Expiry must be in the future'); return false }
+            return v
+        }
+    })
+    if (r.isDenied) return { expiresDate: null, clear: true }
+    if (!r.isConfirmed) return null
+    return { expiresDate: toIso(r.value as string), clear: false }
 }
 
 async function confirmThen (title: string, text: string, confirmButtonText: string): Promise<boolean> {
@@ -29,24 +55,36 @@ export async function showMintedSecret (forUser: any, title: string) {
 
 export function createApiKeyControls (opts: ApiKeyControlOptions) {
     const { notify, reload, canManage } = opts
+    const canMint = opts.canMint || canManage
     const fail = (e: any) => notify('error', 'Error', commonFunctions.parseGraphQLError(e.message))
 
-    async function mintSecret (apiKeyUuid: string, title: string) {
+    async function mintSecret (apiKeyUuid: string, title: string, expiresDate: string | null = null) {
         try {
-            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation addApiKeySecret($apiKeyUuid: ID!) { addApiKeySecret(apiKeyUuid: $apiKeyUuid) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid }, fetchPolicy: 'no-cache' })
+            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation addApiKeySecret($apiKeyUuid: ID!, $expiresDate: DateTime) { addApiKeySecret(apiKeyUuid: $apiKeyUuid, expiresDate: $expiresDate) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid, expiresDate }, fetchPolicy: 'no-cache' })
             await showMintedSecret(resp.data.addApiKeySecret, title); await reload()
         } catch (e: any) { fail(e) }
     }
     async function addApiKeySecret (row: any) {
         const first = !(row.secrets || []).length
-        if (!first && !(await confirmThen('Add a second secret?', 'Both secrets work until you retire or regenerate one. Move your clients to the new secret, then retire the old one.', 'Add secret'))) return
-        await mintSecret(row.uuid, first ? 'Secret generated' : 'Secret added')
+        const a = await askExpiry(first ? 'Generate the first secret?' : 'Add a second secret?', first ? 'The secret is shown once.' : 'Both secrets work until you retire or regenerate one. Move your clients to the new secret, then retire the old one.', first ? 'Generate' : 'Add secret')
+        if (!a) return
+        await mintSecret(row.uuid, first ? 'Secret generated' : 'Secret added', a.expiresDate)
     }
     async function regenerateApiKeySecret (row: any, slot: number) {
-        if (!(await confirmThen(`Regenerate secret #${slot}?`, 'The current secret in this slot stops working immediately, and so does every access token exchanged with it. The other secret, if any, is unaffected.', 'Regenerate'))) return
+        const a = await askExpiry(`Regenerate secret #${slot}?`, 'The current secret in this slot stops working immediately, and so does every access token exchanged with it. The other secret, if any, is unaffected.', 'Regenerate')
+        if (!a) return
         try {
-            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation regenerateApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { regenerateApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
+            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation regenerateApiKeySecret($apiKeyUuid: ID!, $slot: Int!, $expiresDate: DateTime) { regenerateApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot, expiresDate: $expiresDate) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid: row.uuid, slot, expiresDate: a.expiresDate }, fetchPolicy: 'no-cache' })
             await showMintedSecret(resp.data.regenerateApiKeySecret, `Secret #${slot} regenerated`); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function setApiKeySecretExpiry (row: any, slot: number) {
+        const sec = (row.secrets || []).find((x: any) => x.slot === slot)
+        const a = await askExpiry(`Expiry of secret #${slot}`, 'Change when this secret stops working. Tokens already exchanged with it end at the new expiry at the latest.', 'Save', sec?.expiresDate, !!sec?.expiresDate)
+        if (!a) return
+        try {
+            await graphqlClient.mutate({ mutation: gql`mutation setApiKeySecretExpiry($apiKeyUuid: ID!, $slot: Int!, $expiresDate: DateTime) { setApiKeySecretExpiry(apiKeyUuid: $apiKeyUuid, slot: $slot, expiresDate: $expiresDate) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot, expiresDate: a.clear ? null : a.expiresDate }, fetchPolicy: 'no-cache' })
+            notify('success', 'Saved', a.clear ? `Secret #${slot} no longer expires` : `Secret #${slot} expires ${fmtDate(a.expiresDate)}`); await reload()
         } catch (e: any) { fail(e) }
     }
     async function setApiKeySecretActive (row: any, slot: number, active: boolean) {
@@ -79,6 +117,9 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
     }
 
     const statusCell = (row: any) => {
+        if (row.status === 'REQUESTED' || row.status === 'DENIED') {
+            return h(NTag, { size: 'small', type: row.status === 'REQUESTED' ? 'warning' : 'error' }, { default: () => row.status })
+        }
         const inactive = row.status === 'INACTIVE'
         const children: any[] = [h(NTag, { size: 'small', type: inactive ? 'error' : 'success', style: 'margin-right: 6px;' }, { default: () => inactive ? 'INACTIVE' : 'ACTIVE' })]
         if (canManage(row)) {
@@ -89,30 +130,39 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
     }
     const secretsCell = (row: any) => {
         const secrets: any[] = row.secrets || []
+        if (row.status === 'REQUESTED' || row.status === 'DENIED') {
+            return h('span', { class: 'text-muted' }, row.status === 'REQUESTED' ? 'available once approved' : '—')
+        }
         const manage = canManage(row)
+        const mint = canMint(row)
         const lines = secrets.map((sec: any) => {
             // a legacy slot 1 predates per-secret dates: fall back to the key's own creation date
             const created = sec.createdDate || (sec.slot === 1 ? row.createdDate : null)
-            const meta = `created ${created ? String(created).slice(0, 10) : 'n/a'} · last used ${sec.lastUsedDate ? String(sec.lastUsedDate).slice(0, 10) : 'never'}`
+            const expired = isExpired(sec)
+            const meta = `created ${created ? String(created).slice(0, 10) : 'n/a'} · last used ${sec.lastUsedDate ? String(sec.lastUsedDate).slice(0, 10) : 'never'}` + (sec.expiresDate ? ` · expires ${fmtDate(sec.expiresDate)}` : '')
             const kids: any[] = [
                 h('strong', { style: 'margin-right: 4px;' }, `#${sec.slot}`),
-                h(NTag, { size: 'tiny', type: sec.active ? 'success' : 'default', style: 'margin-right: 6px;' }, { default: () => sec.active ? 'active' : 'retired' }),
+                h(NTag, { size: 'tiny', type: expired ? 'error' : (sec.active ? 'success' : 'default'), style: 'margin-right: 6px;' }, { default: () => expired ? 'expired' : (sec.active ? 'active' : 'retired') }),
                 h('span', { class: 'subtle', style: 'margin-right: 6px;' }, meta)
             ]
+            if (mint) kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
             if (manage) {
-                kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
+                kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => setApiKeySecretExpiry(row, sec.slot) }, { default: () => 'Expiry' }))
                 kids.push(h(NButton, { size: 'tiny', type: sec.active ? 'warning' : 'primary', style: 'margin-right: 4px;', onClick: () => setApiKeySecretActive(row, sec.slot, !sec.active) }, { default: () => sec.active ? 'Retire' : 'Enable' }))
                 kids.push(h(NButton, { size: 'tiny', type: 'error', onClick: () => deleteApiKeySecret(row, sec.slot) }, { default: () => 'Delete' }))
             }
             return h('div', { style: 'display: flex; align-items: center; white-space: nowrap; margin: 2px 0;' }, kids)
         })
-        if (manage && secrets.length < 2) {
+        if (row.holder && !mint && manage) {
+            lines.push(h('span', { class: 'subtle' }, 'held key: only the holder mints its secrets'))
+        }
+        if (mint && secrets.length < 2) {
             lines.push(h(NButton, { size: 'tiny', dashed: true, style: 'margin-top: 2px;', onClick: () => addApiKeySecret(row) }, { default: () => secrets.length ? 'Add second secret (rotation)' : 'Add secret' }))
         }
         return h('div', lines)
     }
 
-    return { statusCell, secretsCell, mintSecret, addApiKeySecret, regenerateApiKeySecret, setApiKeySecretActive, deleteApiKeySecret, setApiKeyStatus, deleteApiKey }
+    return { statusCell, secretsCell, mintSecret, addApiKeySecret, regenerateApiKeySecret, setApiKeySecretExpiry, setApiKeySecretActive, deleteApiKeySecret, setApiKeyStatus, deleteApiKey, askExpiry }
 }
 
 /** The id string a client presents for this key (Basic user name / client_id). */

--- a/ui/src/utils/apiKeyControls.ts
+++ b/ui/src/utils/apiKeyControls.ts
@@ -18,7 +18,11 @@ export interface ApiKeyControlOptions {
     canManage: (row: any) => boolean
     /** whether the viewer may mint (add / regenerate), which reveals cleartext: on a held free-form key only the holder; defaults to canManage */
     canMint?: (row: any) => boolean
+    /** whether the viewer acts as an org admin: only admins may re-activate a key an admin disabled; defaults to false */
+    isAdmin?: () => boolean
 }
+function usableSecrets (row: any): any[] { return (row.secrets || []).filter((s: any) => s.active && !isExpired(s)) }
+function deniedReason (row: any): string { const m = /Denied(?::\s*(.*))?$/.exec(row.notes || ''); return m ? (m[1] || '') : '' }
 
 function fmtDate (d: any): string { return d ? new Date(d).toLocaleString('en-CA', { hour12: false }).slice(0, 16) : '' }
 function isExpired (sec: any): boolean { return !!sec.expiresDate && new Date(sec.expiresDate).getTime() <= Date.now() }
@@ -56,6 +60,7 @@ export async function showMintedSecret (forUser: any, title: string) {
 export function createApiKeyControls (opts: ApiKeyControlOptions) {
     const { notify, reload, canManage } = opts
     const canMint = opts.canMint || canManage
+    const isAdmin = opts.isAdmin || (() => false)
     const fail = (e: any) => notify('error', 'Error', commonFunctions.parseGraphQLError(e.message))
 
     async function mintSecret (apiKeyUuid: string, title: string, expiresDate: string | null = null) {
@@ -87,15 +92,19 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
             notify('success', 'Saved', a.clear ? `Secret #${slot} no longer expires` : `Secret #${slot} expires ${fmtDate(a.expiresDate)}`); await reload()
         } catch (e: any) { fail(e) }
     }
+    function lastActiveWarning (row: any, slot: number): string {
+        const usable = usableSecrets(row)
+        return usable.length === 1 && usable[0].slot === slot ? 'This is the last active secret: the key will authenticate nothing until a new secret is added. ' : ''
+    }
     async function setApiKeySecretActive (row: any, slot: number, active: boolean) {
-        if (!active && !(await confirmThen(`Retire secret #${slot}?`, 'It stays on file and can be enabled again, but it is refused until then, and so are access tokens exchanged with it.', 'Retire'))) return
+        if (!active && !(await confirmThen(`Retire secret #${slot}?`, lastActiveWarning(row, slot) + 'It stays on file and can be enabled again, but it is refused until then, and so are access tokens exchanged with it.', 'Retire'))) return
         try {
             await graphqlClient.mutate({ mutation: gql`mutation setApiKeySecretActive($apiKeyUuid: ID!, $slot: Int!, $active: Boolean!) { setApiKeySecretActive(apiKeyUuid: $apiKeyUuid, slot: $slot, active: $active) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot, active }, fetchPolicy: 'no-cache' })
             notify('success', active ? 'Enabled' : 'Retired', `Secret #${slot} ${active ? 'enabled' : 'retired'}`); await reload()
         } catch (e: any) { fail(e) }
     }
     async function deleteApiKeySecret (row: any, slot: number) {
-        if (!(await confirmThen(`Delete secret #${slot}?`, 'This cannot be undone. The secret and every access token exchanged with it stop working; the slot becomes free for a new secret.', 'Delete'))) return
+        if (!(await confirmThen(`Delete secret #${slot}?`, lastActiveWarning(row, slot) + 'This cannot be undone. The secret and every access token exchanged with it stop working; the slot becomes free for a new secret.', 'Delete'))) return
         try {
             await graphqlClient.mutate({ mutation: gql`mutation deleteApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { deleteApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
             notify('success', 'Deleted', `Secret #${slot} deleted`); await reload()
@@ -118,13 +127,20 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
 
     const statusCell = (row: any) => {
         if (row.status === 'REQUESTED' || row.status === 'DENIED') {
-            return h(NTag, { size: 'small', type: row.status === 'REQUESTED' ? 'warning' : 'error' }, { default: () => row.status })
+            const kids: any[] = [h(NTag, { size: 'small', type: row.status === 'REQUESTED' ? 'warning' : 'error', style: 'margin-right: 6px;' }, { default: () => row.status })]
+            if (row.status === 'DENIED') kids.push(h('span', { class: 'subtle' }, deniedReason(row) ? `reason: ${deniedReason(row)}` : 'no reason given'))
+            return h('div', { style: 'display: flex; align-items: center; white-space: nowrap;' }, kids)
         }
         const inactive = row.status === 'INACTIVE'
         const children: any[] = [h(NTag, { size: 'small', type: inactive ? 'error' : 'success', style: 'margin-right: 6px;' }, { default: () => inactive ? 'INACTIVE' : 'ACTIVE' })]
         if (canManage(row)) {
-            children.push(h(NButton, { size: 'tiny', type: inactive ? 'primary' : 'warning', onClick: () => setApiKeyStatus(row, inactive ? 'ACTIVE' : 'INACTIVE') },
-                { default: () => inactive ? 'Activate' : 'Deactivate' }))
+            if (inactive && row.adminDisabled && !isAdmin()) {
+                // an admin's kill switch is authoritative: the owner or holder cannot undo it
+                children.push(h(NTag, { size: 'tiny', type: 'warning' }, { default: () => 'disabled by an admin' }))
+            } else {
+                children.push(h(NButton, { size: 'tiny', type: inactive ? 'primary' : 'warning', onClick: () => setApiKeyStatus(row, inactive ? 'ACTIVE' : 'INACTIVE') },
+                    { default: () => inactive ? 'Activate' : 'Deactivate' }))
+            }
         }
         return h('div', { style: 'display: flex; align-items: center; white-space: nowrap;' }, children)
     }
@@ -155,6 +171,8 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
         })
         if (row.holder && !mint && manage) {
             lines.push(h('span', { class: 'subtle' }, 'held key: only the holder mints its secrets'))
+        } else if (row.type === 'USER' && !mint && manage) {
+            lines.push(h('span', { class: 'subtle' }, 'personal key: only its owner mints its secrets'))
         }
         if (mint && secrets.length < 2) {
             lines.push(h(NButton, { size: 'tiny', dashed: true, style: 'margin-top: 2px;', onClick: () => addApiKeySecret(row) }, { default: () => secrets.length ? 'Add second secret (rotation)' : 'Add secret' }))

--- a/ui/src/utils/apiKeyControls.ts
+++ b/ui/src/utils/apiKeyControls.ts
@@ -1,0 +1,123 @@
+import { h } from 'vue'
+import { NButton, NTag } from 'naive-ui'
+import gql from 'graphql-tag'
+import Swal from 'sweetalert2'
+import graphqlClient from '@/utils/graphql'
+import commonFunctions from '@/utils/commonFunctions'
+
+/**
+ * Shared API key status + secrets controls (kill switch, two-secret rotation, delete).
+ * Used by the org settings key tables and by the user's own keys on the profile page.
+ * status: INACTIVE refuses every secret and every token of the key id. Secrets: up to two per id;
+ * regenerate replaces one in place (its tokens die), retire keeps it on file but refused, delete frees the slot.
+ */
+export interface ApiKeyControlOptions {
+    notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
+    reload: () => void | Promise<void>
+    /** whether the current viewer may operate the controls (org admin, or owner of a USER key) */
+    canManage: (row: any) => boolean
+}
+
+async function confirmThen (title: string, text: string, confirmButtonText: string): Promise<boolean> {
+    const r = await Swal.fire({ title, text, icon: 'warning', showCancelButton: true, confirmButtonText, cancelButtonText: 'Cancel' })
+    return !!r.value
+}
+
+export async function showMintedSecret (forUser: any, title: string) {
+    await Swal.fire({ title, customClass: { popup: 'swal-wide' }, html: commonFunctions.getGeneratedApiKeyHTML(forUser), icon: 'success' })
+}
+
+export function createApiKeyControls (opts: ApiKeyControlOptions) {
+    const { notify, reload, canManage } = opts
+    const fail = (e: any) => notify('error', 'Error', commonFunctions.parseGraphQLError(e.message))
+
+    async function mintSecret (apiKeyUuid: string, title: string) {
+        try {
+            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation addApiKeySecret($apiKeyUuid: ID!) { addApiKeySecret(apiKeyUuid: $apiKeyUuid) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid }, fetchPolicy: 'no-cache' })
+            await showMintedSecret(resp.data.addApiKeySecret, title); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function addApiKeySecret (row: any) {
+        const first = !(row.secrets || []).length
+        if (!first && !(await confirmThen('Add a second secret?', 'Both secrets work until you retire or regenerate one. Move your clients to the new secret, then retire the old one.', 'Add secret'))) return
+        await mintSecret(row.uuid, first ? 'Secret generated' : 'Secret added')
+    }
+    async function regenerateApiKeySecret (row: any, slot: number) {
+        if (!(await confirmThen(`Regenerate secret #${slot}?`, 'The current secret in this slot stops working immediately, and so does every access token exchanged with it. The other secret, if any, is unaffected.', 'Regenerate'))) return
+        try {
+            const resp: any = await graphqlClient.mutate({ mutation: gql`mutation regenerateApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { regenerateApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { id apiKey authorizationHeader } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
+            await showMintedSecret(resp.data.regenerateApiKeySecret, `Secret #${slot} regenerated`); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function setApiKeySecretActive (row: any, slot: number, active: boolean) {
+        if (!active && !(await confirmThen(`Retire secret #${slot}?`, 'It stays on file and can be enabled again, but it is refused until then, and so are access tokens exchanged with it.', 'Retire'))) return
+        try {
+            await graphqlClient.mutate({ mutation: gql`mutation setApiKeySecretActive($apiKeyUuid: ID!, $slot: Int!, $active: Boolean!) { setApiKeySecretActive(apiKeyUuid: $apiKeyUuid, slot: $slot, active: $active) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot, active }, fetchPolicy: 'no-cache' })
+            notify('success', active ? 'Enabled' : 'Retired', `Secret #${slot} ${active ? 'enabled' : 'retired'}`); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function deleteApiKeySecret (row: any, slot: number) {
+        if (!(await confirmThen(`Delete secret #${slot}?`, 'This cannot be undone. The secret and every access token exchanged with it stop working; the slot becomes free for a new secret.', 'Delete'))) return
+        try {
+            await graphqlClient.mutate({ mutation: gql`mutation deleteApiKeySecret($apiKeyUuid: ID!, $slot: Int!) { deleteApiKeySecret(apiKeyUuid: $apiKeyUuid, slot: $slot) { uuid } }`, variables: { apiKeyUuid: row.uuid, slot }, fetchPolicy: 'no-cache' })
+            notify('success', 'Deleted', `Secret #${slot} deleted`); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function setApiKeyStatus (row: any, status: string) {
+        if (status === 'INACTIVE' && !(await confirmThen('Deactivate this key?', 'Every secret and every access token of this key id are refused until you activate it again. Nothing is deleted.', 'Deactivate'))) return
+        try {
+            await graphqlClient.mutate({ mutation: gql`mutation setApiKeyStatus($apiKeyUuid: ID!, $status: ApiKeyStatus!) { setApiKeyStatus(apiKeyUuid: $apiKeyUuid, status: $status) { uuid status } }`, variables: { apiKeyUuid: row.uuid, status }, fetchPolicy: 'no-cache' })
+            notify('success', status === 'INACTIVE' ? 'Deactivated' : 'Activated', `Key ${status.toLowerCase()}`); await reload()
+        } catch (e: any) { fail(e) }
+    }
+    async function deleteApiKey (row: any, label: string = 'this key') {
+        if (!(await confirmThen(`Delete ${label}?`, 'The key id, its secrets and every access token stop working. This cannot be undone.', 'Delete'))) return
+        try {
+            await graphqlClient.mutate({ mutation: gql`mutation deleteApiKey($apiKeyUuid: ID!) { deleteApiKey(apiKeyUuid: $apiKeyUuid) }`, variables: { apiKeyUuid: row.uuid }, fetchPolicy: 'no-cache' })
+            notify('success', 'Deleted', 'Key deleted'); await reload()
+        } catch (e: any) { fail(e) }
+    }
+
+    const statusCell = (row: any) => {
+        const inactive = row.status === 'INACTIVE'
+        const children: any[] = [h(NTag, { size: 'small', type: inactive ? 'error' : 'success', style: 'margin-right: 6px;' }, { default: () => inactive ? 'INACTIVE' : 'ACTIVE' })]
+        if (canManage(row)) {
+            children.push(h(NButton, { size: 'tiny', type: inactive ? 'primary' : 'warning', onClick: () => setApiKeyStatus(row, inactive ? 'ACTIVE' : 'INACTIVE') },
+                { default: () => inactive ? 'Activate' : 'Deactivate' }))
+        }
+        return h('div', { style: 'display: flex; align-items: center; white-space: nowrap;' }, children)
+    }
+    const secretsCell = (row: any) => {
+        const secrets: any[] = row.secrets || []
+        const manage = canManage(row)
+        const lines = secrets.map((sec: any) => {
+            // a legacy slot 1 predates per-secret dates: fall back to the key's own creation date
+            const created = sec.createdDate || (sec.slot === 1 ? row.createdDate : null)
+            const meta = `created ${created ? String(created).slice(0, 10) : 'n/a'} · last used ${sec.lastUsedDate ? String(sec.lastUsedDate).slice(0, 10) : 'never'}`
+            const kids: any[] = [
+                h('strong', { style: 'margin-right: 4px;' }, `#${sec.slot}`),
+                h(NTag, { size: 'tiny', type: sec.active ? 'success' : 'default', style: 'margin-right: 6px;' }, { default: () => sec.active ? 'active' : 'retired' }),
+                h('span', { class: 'subtle', style: 'margin-right: 6px;' }, meta)
+            ]
+            if (manage) {
+                kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
+                kids.push(h(NButton, { size: 'tiny', type: sec.active ? 'warning' : 'primary', style: 'margin-right: 4px;', onClick: () => setApiKeySecretActive(row, sec.slot, !sec.active) }, { default: () => sec.active ? 'Retire' : 'Enable' }))
+                kids.push(h(NButton, { size: 'tiny', type: 'error', onClick: () => deleteApiKeySecret(row, sec.slot) }, { default: () => 'Delete' }))
+            }
+            return h('div', { style: 'display: flex; align-items: center; white-space: nowrap; margin: 2px 0;' }, kids)
+        })
+        if (manage && secrets.length < 2) {
+            lines.push(h(NButton, { size: 'tiny', dashed: true, style: 'margin-top: 2px;', onClick: () => addApiKeySecret(row) }, { default: () => secrets.length ? 'Add second secret (rotation)' : 'Add secret' }))
+        }
+        return h('div', lines)
+    }
+
+    return { statusCell, secretsCell, mintSecret, addApiKeySecret, regenerateApiKeySecret, setApiKeySecretActive, deleteApiKeySecret, setApiKeyStatus, deleteApiKey }
+}
+
+/** The id string a client presents for this key (Basic user name / client_id). */
+export function apiKeyIdOf (row: any): string {
+    let keyId = row.type + '__' + row.object
+    if (row.keyOrder) keyId += '__ord__' + row.keyOrder
+    return keyId
+}


### PR DESCRIPTION
Based on #347 (targets `2026-09-api-key-secrets-ui`). UI for personal USER keys.

## Summary
- **Org settings.** One **Programmatic Access** tab (admins) with three sub-tabs: **Free Form Keys**, **User Keys** (owner, status, secrets, permission ceiling, manage) and **Scoped Keys** (everything bound to a single object, with the existing approvals editor). The old top-level Free Form Keys tab is folded in; a deep link to it lands on its sub-tab.
- **Shared pieces.** Status and secrets controls live in one module used by both pages. The permissions/notes editor is now `ApiKeyPermissionsModal`, which loads the org's perspectives, components, products and instances itself, replacing the inline free-form modal.
- **Profile page.** New **API Keys** tab: pick an organization, create a personal key (no secret, no permissions), get offered the first secret as its own step, then manage secrets, status, permissions, notes and delete. The explanatory text states the ceiling rule: each call is also checked against the owner's own permissions, and the lower wins.

## Secret expiry and key requests
- Minting or regenerating a secret asks for an optional expiry (date and time); the secrets cell shows it, marks `expired`, and an **Expiry** action changes or clears it.
- Admins: **Key Requests** table on the Free Form Keys sub-tab (requester, proposed permissions, purpose; review, approve, deny with reason). Free-form keys show a **Holder** column, flag a holder who left the org, and offer reassignment. Mint buttons are hidden for admins on held keys.
- Profile: **Request a free-form key** with a purpose, propose permissions while pending, held keys listed next to personal ones with a Kind column.

## Review fixes
- No mint buttons for admins on personal keys (owner mints from the profile). A key an admin deactivated shows "disabled by an admin" to its owner or holder instead of Activate. Retiring or deleting the last active secret warns. Denied requests show the reason beside the status. The ceiling editor shows the owner's real org-wide permission and warns when the chosen level exceeds it.

## Test plan
- [x] psclaude: org settings shows the three sub-tabs with the expected columns; profile API Keys tab creates a key, offers the secret, lists it; permissions modal opens for a user key from both pages
- [x] psclaude build .2: mint with expiry shows it in the cell; Expiry action; request from the profile, admin sees it in Key Requests, approve → holder mints; deny shows DENIED with reason on the profile
- [x] psclaude build .3: User Keys sub-tab rows have no Regenerate / Add secret for admins; profile shows the owner-permission banner in the ceiling editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)