### PR TITLE
ui: read-only "Devices at support risk" panel on the Distribution page (D7 fleet view)

### DIFF
--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -8,6 +8,22 @@
             </n-space>
             <n-data-table :columns="fleetDriftColumns" :data="fleetDrift" size="small" :row-props="driftRowProps" :pagination="fleetDrift.length > 5 ? { pageSize: 5 } : false" />
         </div>
+        <!-- D7 fleet question, read-only: which in-field units outlive their software.
+             Hidden entirely on a backend whose schema lacks the query (CE before the sync);
+             follows the client / site selected below. -->
+        <div v-if="fleetRisk.supported" class="fleetRiskPanel" data-testid="fleet-risk-panel">
+            <n-space align="center" size="small" style="margin-bottom: 6px;">
+                <n-tag :type="fleetRiskPageSummary.atRisk > 0 ? 'error' : 'default'" size="small">SUPPORT RISK</n-tag>
+                <strong data-testid="fleet-risk-headline">{{ fleetRiskHeadlineText }}</strong>
+                <span class="subtle">{{ fleetRiskScopeLabel }}</span>
+            </n-space>
+            <n-alert v-if="fleetRisk.degraded" type="warning" :show-icon="false" size="small" style="margin-bottom: 6px;" data-testid="fleet-risk-degraded-alert">
+                This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support). Those columns are blank, not empty.
+            </n-alert>
+            <n-data-table remote :columns="fleetRiskColumns" :data="fleetRisk.rows" :loading="fleetRiskLoading" size="small"
+                :row-props="fleetRiskRowProps" :row-key="(r: any) => r.device"
+                :pagination="fleetRiskPagination" @update:page="loadFleetRisk" />
+        </div>
     <div class="distWrapper">
         <!-- Clients column -->
         <div class="distColumn">
@@ -223,7 +239,7 @@ export default { name: 'DistributionOfOrg' }
 import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType, NCheckbox } from 'naive-ui'
+import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType, NCheckbox, NAlert } from 'naive-ui'
 import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
@@ -231,6 +247,9 @@ import commonFunctions from '@/utils/commonFunctions'
 import { termsFor, DISTRIBUTION_DOMAIN_OPTIONS } from '@/utils/distributionTerms'
 import { applyShipmentWindowToInput,
     effectiveWindowLabel as buildEffectiveWindowLabel } from '@/utils/componentDeviceWindow'
+import { loadDevicesAtSupportRisk, fleetRiskTag, fleetRiskHeadline, summarizeFleetRiskPage,
+    FLEET_RISK_DEFAULT_PAGE_SIZE, FLEET_RISK_UNSUPPORTED, type FleetRiskResult, type FleetRiskRow } from '@/utils/fleetSupportRisk'
+import { DEVICE_RISK_DETAIL, isDeviceRiskFlagged } from '@/utils/supportStatusTag'
 
 const route = useRoute()
 const router = useRouter()
@@ -816,10 +835,127 @@ const fleetDriftColumns = [
 ]
 const driftRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device.uuid } }) })
 
+// ---- fleet support risk (D7, read-only, paged, follows the client / site selection) ----
+// Starts as "supported" so the first load decides: a panel that defaults to hidden and is
+// then shown on success flashes; one that defaults to shown and hides on an unsupported
+// backend shows an empty frame for one round-trip. Neither is great; the second is honest
+// about what is being asked, and the loading spinner covers it.
+const fleetRisk: Ref<FleetRiskResult> = ref({ supported: true, degraded: false, rows: [], total: 0 })
+const fleetRiskLoading = ref(false)
+const fleetRiskPage = ref(1)  // one-based for n-data-table; the server is zero-based
+const fleetRiskFullRejected = ref(false)
+const fleetRiskPageSummary = computed(() => summarizeFleetRiskPage(fleetRisk.value.rows))
+const fleetRiskHeadlineText = computed(() => fleetRiskHeadline(fleetRisk.value.total, fleetRisk.value.rows))
+const fleetRiskScopeLabel = computed(() => selectedSite.value
+    ? `at site ${selectedSite.value.name}`
+    : (selectedClient.value ? `for client ${selectedClient.value.name}` : 'org-wide'))
+const fleetRiskPagination = computed(() => ({
+    page: fleetRiskPage.value,
+    pageSize: FLEET_RISK_DEFAULT_PAGE_SIZE,
+    itemCount: fleetRisk.value.total
+}))
+// Site names for the rows come from the org-wide site list (rows carry ids only); device
+// identifiers come from the per-site device list, one read per DISTINCT site on the page.
+const siteInfoMap: Ref<Record<string, { name: string, client: string }>> = ref({})
+const siteDevicesMap: Ref<Record<string, Record<string, any>>> = ref({})
+async function resolveSiteInfos () {
+    if (Object.keys(siteInfoMap.value).length) return
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query sitesOfOrg($o: ID!) { sitesOfOrg(orgUuid: $o) { uuid name client } }`, variables: { o: orguuid.value }, fetchPolicy: 'no-cache' })
+        const m: Record<string, { name: string, client: string }> = {}
+        for (const s of resp.data.sitesOfOrg || []) m[s.uuid] = { name: s.name, client: s.client }
+        siteInfoMap.value = m
+    } catch (e) { /* names stay as short uuids */ }
+}
+async function resolveSiteDevices (siteUuids: string[]) {
+    const missing = [...new Set(siteUuids)].filter(u => u && !siteDevicesMap.value[u])
+    await Promise.all(missing.map(async (u) => {
+        try {
+            const resp: any = await graphqlClient.query({ query: gql`query devicesOfSite($s: ID!, $o: ID!) { devicesOfSite(siteUuid: $s, orgUuid: $o) { uuid identifiers { idType idValue } } }`, variables: { s: u, o: orguuid.value }, fetchPolicy: 'no-cache' })
+            const m: Record<string, any> = {}
+            for (const d of resp.data.devicesOfSite || []) m[d.uuid] = d
+            siteDevicesMap.value[u] = m
+        } catch (e) { /* identifiers stay as short uuids */ }
+    }))
+}
+const fleetRiskUnitLabel = (r: FleetRiskRow) => summarizeIds(r.site ? siteDevicesMap.value[r.site]?.[r.device]?.identifiers : null) || shortUuid(r.device)
+const fleetRiskSiteName = (r: FleetRiskRow) => (r.site && siteInfoMap.value[r.site]?.name) || (r.site ? shortUuid(r.site) : '')
+const fleetRiskClientName = (r: FleetRiskRow) => {
+    const c = r.site ? siteInfoMap.value[r.site]?.client : null
+    return (c && clients.value.find(x => x.uuid === c)?.name) || (c ? shortUuid(c) : '')
+}
+// `page` is one-based (from n-data-table); the server counts from zero.
+async function loadFleetRisk (page: number = 1) {
+    fleetRiskLoading.value = true
+    try {
+        const result = await loadDevicesAtSupportRisk(graphqlClient, {
+            orgUuid: orguuid.value,
+            clientUuid: selectedClientUuid.value || null,
+            siteUuid: selectedSiteUuid.value || null,
+            page: Math.max(0, page - 1),
+            size: FLEET_RISK_DEFAULT_PAGE_SIZE
+        }, { skipFull: fleetRiskFullRejected.value })
+        if (result.supported && result.degraded) fleetRiskFullRejected.value = true
+        fleetRisk.value = result
+        fleetRiskPage.value = page
+        if (result.supported && result.rows.length) {
+            await Promise.all([
+                resolveSiteInfos(),
+                resolveSiteDevices(result.rows.map(r => r.site || '')),
+                resolveReleaseInfos(result.rows.map(r => r.release || ''))
+            ])
+        }
+    } catch (e: any) {
+        // Not schema drift (that is `supported: false`): a real failure the operator must see.
+        fleetRisk.value = FLEET_RISK_UNSUPPORTED
+        notify('error', 'Fleet support risk', e?.message || 'Could not load the fleet support risk view')
+    } finally {
+        fleetRiskLoading.value = false
+    }
+}
+const fleetRiskColumns = computed(() => [
+    { key: 'unit', title: 'Unit', minWidth: 220, render: (r: FleetRiskRow) => fleetRiskUnitLabel(r) },
+    { key: 'client', title: 'Client', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskClientName(r) || h('span', { class: 'subtle' }, '—') },
+    { key: 'site', title: 'Site', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskSiteName(r) || h('span', { class: 'subtle' }, '—') },
+    {
+        key: 'release', title: 'Release judged',
+        render: (r: FleetRiskRow) => {
+            if (!r.release) return h('span', { class: 'subtle' }, 'none')
+            const label = releaseLabel(r.release) || shortUuid(r.release)
+            // Presence-guarded: absent on a CORE-served page, and a plan is not ground truth.
+            const source = 'releaseSource' in r && r.releaseSource
+                ? h(NTag, { size: 'tiny', type: r.releaseSource === 'REPORTED' ? 'success' : 'default', style: 'margin-left: 6px;' }, { default: () => r.releaseSource === 'REPORTED' ? 'reported' : 'expected' })
+                : null
+            return h('span', [label, source])
+        }
+    },
+    {
+        key: 'window', title: 'Device window',
+        render: (r: FleetRiskRow) => ('window' in r ? buildEffectiveWindowLabel(r.window) : '') || h('span', { class: 'subtle' }, '—')
+    },
+    {
+        key: 'risk', title: 'Risk',
+        render: (r: FleetRiskRow) => {
+            const t = fleetRiskTag(r.risk)
+            const tag = h(NTag, { size: 'small', type: t.type }, { default: () => t.label })
+            if (!isDeviceRiskFlagged(r.risk)) return tag
+            return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 420px;' }, {
+                trigger: () => tag, default: () => DEVICE_RISK_DETAIL[r.risk]
+            })
+        }
+    },
+    { key: 'eos', title: 'Earliest component EOS', render: (r: FleetRiskRow) => ('earliestComponentEos' in r && r.earliestComponentEos) || h('span', { class: 'subtle' }, '—') },
+    { key: 'driving', title: 'Components driving risk', render: (r: FleetRiskRow) => ('componentsDrivingRisk' in r && typeof r.componentsDrivingRisk === 'number') ? String(r.componentsDrivingRisk) : h('span', { class: 'subtle' }, '—') }
+])
+const fleetRiskRowProps = (r: FleetRiskRow) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device } }) })
+// The selection is the filter: a client or site change re-asks from page 1.
+watch([selectedClientUuid, selectedSiteUuid], () => { if (fleetRisk.value.supported) loadFleetRisk(1) })
+
 onMounted(async () => {
     loadOrgClassification()
     store.dispatch('fetchProducts', orguuid.value)
     loadFleetDrift()
+    loadFleetRisk(1)
     await loadClients()
     if (selectedClientUuid.value) await loadSites(selectedClientUuid.value)
     if (selectedSiteUuid.value) await loadShipments(selectedSiteUuid.value)
@@ -833,6 +969,7 @@ onMounted(async () => {
 .placeholder { color: #999; padding-top: 24px; font-style: italic; }
 .subtle { color: #999; font-size: 12px; }
 .fleetDriftPanel { margin: 8px 1% 4px 1%; padding: 8px 10px; border: 1px solid #f0a020; border-radius: 6px; background: #fffaf0; }
+.fleetRiskPanel { margin: 8px 1% 4px 1%; padding: 8px 10px; border: 1px solid #d9dde1; border-radius: 6px; background: #fafbfc; }
 .identityBox { background: #f4f8fb; border-radius: 6px; padding: 6px 8px; margin-bottom: 8px; font-size: 13px; }
 .icons { margin: 4px; vertical-align: middle; }
 .clickable { cursor: pointer; }

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -9,14 +9,21 @@
             <n-data-table :columns="fleetDriftColumns" :data="fleetDrift" size="small" :row-props="driftRowProps" :pagination="fleetDrift.length > 5 ? { pageSize: 5 } : false" />
         </div>
         <!-- D7 fleet question, read-only: which in-field units outlive their software.
-             Hidden entirely on a backend whose schema lacks the query (CE before the sync);
-             follows the client / site selected below. -->
-        <div v-if="fleetRisk.supported" class="fleetRiskPanel" data-testid="fleet-risk-panel">
+             Hidden entirely on a backend whose schema lacks the query (CE before the sync),
+             and not shown at all until the first answer is in, so an empty frame never reads
+             as "no risk"; follows the client / site selected below. -->
+        <div v-if="fleetRiskLoaded && fleetRisk.supported" class="fleetRiskPanel" data-testid="fleet-risk-panel">
             <n-space align="center" size="small" style="margin-bottom: 6px;">
                 <n-tag :type="fleetRiskPageSummary.atRisk > 0 ? 'error' : 'default'" size="small">SUPPORT RISK</n-tag>
                 <strong data-testid="fleet-risk-headline">{{ fleetRiskHeadlineText }}</strong>
                 <span class="subtle">{{ fleetRiskScopeLabel }}</span>
             </n-space>
+            <n-alert v-if="fleetRiskError" type="error" :show-icon="false" size="small" style="margin-bottom: 6px;" data-testid="fleet-risk-error-alert">
+                <n-space align="center" size="small">
+                    <span>Could not load the fleet support risk view: {{ fleetRiskError }}. The rows below are the last answer, not the current one.</span>
+                    <n-button size="tiny" @click="loadFleetRisk(fleetRiskPage)">Retry</n-button>
+                </n-space>
+            </n-alert>
             <n-alert v-if="fleetRisk.degraded" type="warning" :show-icon="false" size="small" style="margin-bottom: 6px;" data-testid="fleet-risk-degraded-alert">
                 This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support). Those columns are blank, not empty.
             </n-alert>
@@ -248,8 +255,9 @@ import { termsFor, DISTRIBUTION_DOMAIN_OPTIONS } from '@/utils/distributionTerms
 import { applyShipmentWindowToInput,
     effectiveWindowLabel as buildEffectiveWindowLabel } from '@/utils/componentDeviceWindow'
 import { loadDevicesAtSupportRisk, fleetRiskTag, fleetRiskHeadline, summarizeFleetRiskPage,
-    FLEET_RISK_DEFAULT_PAGE_SIZE, FLEET_RISK_UNSUPPORTED, type FleetRiskResult, type FleetRiskRow } from '@/utils/fleetSupportRisk'
-import { DEVICE_RISK_DETAIL, isDeviceRiskFlagged } from '@/utils/supportStatusTag'
+    releaseSourceTag, fleetWindowLabel, FLEET_RISK_DETAIL, FLEET_RISK_DEFAULT_PAGE_SIZE,
+    type FleetRiskResult, type FleetRiskRow } from '@/utils/fleetSupportRisk'
+import { isDeviceRiskFlagged } from '@/utils/supportStatusTag'
 
 const route = useRoute()
 const router = useRouter()
@@ -689,12 +697,14 @@ async function saveSite () {
     if (siteForm.uuid) input.uuid = siteForm.uuid
     await graphqlClient.mutate({ mutation: gql`mutation upsertSite($input: SiteInput!) { upsertSite(input: $input) { uuid } }`, variables: { input } })
     showSiteModal.value = false; notify('success', 'Saved', `Site ${siteForm.name} saved`); await loadSites(selectedClientUuid.value)
+    siteInfoLoaded.value = false
 }
 async function deleteSite (s: any) {
     await graphqlClient.mutate({ mutation: gql`mutation deleteSite($uuid: ID!) { deleteSite(uuid: $uuid) }`, variables: { uuid: s.uuid } })
     notify('info', 'Archived', `Site ${s.name} archived`)
     if (selectedSiteUuid.value === s.uuid) router.push({ name: 'DistributionOfOrg', params: { orguuid: orguuid.value, clientuuid: selectedClientUuid.value } })
     await loadSites(selectedClientUuid.value)
+    siteInfoLoaded.value = false
 }
 
 // ---- shipment ----
@@ -836,14 +846,16 @@ const fleetDriftColumns = [
 const driftRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device.uuid } }) })
 
 // ---- fleet support risk (D7, read-only, paged, follows the client / site selection) ----
-// Starts as "supported" so the first load decides: a panel that defaults to hidden and is
-// then shown on success flashes; one that defaults to shown and hides on an unsupported
-// backend shows an empty frame for one round-trip. Neither is great; the second is honest
-// about what is being asked, and the loading spinner covers it.
+// Three facts the template needs kept apart: has ANY answer arrived (`fleetRiskLoaded`, gates
+// the whole panel so an empty frame never reads as "no risk"), does the backend have the
+// query at all (`fleetRisk.supported`, hides it for good on CE), and did the LAST request
+// fail for some other reason (`fleetRiskError`, shown over the previous rows with a retry --
+// a 403 or a timeout is not a reason to make the panel disappear).
 const fleetRisk: Ref<FleetRiskResult> = ref({ supported: true, degraded: false, rows: [], total: 0 })
+const fleetRiskLoaded = ref(false)
 const fleetRiskLoading = ref(false)
+const fleetRiskError: Ref<string> = ref('')
 const fleetRiskPage = ref(1)  // one-based for n-data-table; the server is zero-based
-const fleetRiskFullRejected = ref(false)
 const fleetRiskPageSummary = computed(() => summarizeFleetRiskPage(fleetRisk.value.rows))
 const fleetRiskHeadlineText = computed(() => fleetRiskHeadline(fleetRisk.value.total, fleetRisk.value.rows))
 const fleetRiskScopeLabel = computed(() => selectedSite.value
@@ -856,15 +868,18 @@ const fleetRiskPagination = computed(() => ({
 }))
 // Site names for the rows come from the org-wide site list (rows carry ids only); device
 // identifiers come from the per-site device list, one read per DISTINCT site on the page.
+// The site list is read once and invalidated when this page saves or archives a site.
 const siteInfoMap: Ref<Record<string, { name: string, client: string }>> = ref({})
+const siteInfoLoaded = ref(false)
 const siteDevicesMap: Ref<Record<string, Record<string, any>>> = ref({})
 async function resolveSiteInfos () {
-    if (Object.keys(siteInfoMap.value).length) return
+    if (siteInfoLoaded.value) return
     try {
         const resp: any = await graphqlClient.query({ query: gql`query sitesOfOrg($o: ID!) { sitesOfOrg(orgUuid: $o) { uuid name client } }`, variables: { o: orguuid.value }, fetchPolicy: 'no-cache' })
         const m: Record<string, { name: string, client: string }> = {}
         for (const s of resp.data.sitesOfOrg || []) m[s.uuid] = { name: s.name, client: s.client }
         siteInfoMap.value = m
+        siteInfoLoaded.value = true
     } catch (e) { /* names stay as short uuids */ }
 }
 async function resolveSiteDevices (siteUuids: string[]) {
@@ -884,8 +899,13 @@ const fleetRiskClientName = (r: FleetRiskRow) => {
     const c = r.site ? siteInfoMap.value[r.site]?.client : null
     return (c && clients.value.find(x => x.uuid === c)?.name) || (c ? shortUuid(c) : '')
 }
+// Every load takes a ticket; only the newest ticket may write. A client switch while a
+// slow org-wide page is in flight would otherwise land the org-wide rows under the client's
+// scope label -- a wrong roster with a confident heading.
+let fleetRiskTicket = 0
 // `page` is one-based (from n-data-table); the server counts from zero.
 async function loadFleetRisk (page: number = 1) {
+    const ticket = ++fleetRiskTicket
     fleetRiskLoading.value = true
     try {
         const result = await loadDevicesAtSupportRisk(graphqlClient, {
@@ -894,10 +914,11 @@ async function loadFleetRisk (page: number = 1) {
             siteUuid: selectedSiteUuid.value || null,
             page: Math.max(0, page - 1),
             size: FLEET_RISK_DEFAULT_PAGE_SIZE
-        }, { skipFull: fleetRiskFullRejected.value })
-        if (result.supported && result.degraded) fleetRiskFullRejected.value = true
+        }, { skipFull: fleetRisk.value.degraded })  // once FULL is rejected, stop asking
+        if (ticket !== fleetRiskTicket) return
         fleetRisk.value = result
         fleetRiskPage.value = page
+        fleetRiskError.value = ''
         if (result.supported && result.rows.length) {
             await Promise.all([
                 resolveSiteInfos(),
@@ -906,32 +927,39 @@ async function loadFleetRisk (page: number = 1) {
             ])
         }
     } catch (e: any) {
-        // Not schema drift (that is `supported: false`): a real failure the operator must see.
-        fleetRisk.value = FLEET_RISK_UNSUPPORTED
-        notify('error', 'Fleet support risk', e?.message || 'Could not load the fleet support risk view')
+        if (ticket !== fleetRiskTicket) return
+        // Not schema drift (that is `supported: false`): a real failure the operator must
+        // see, over the rows that were there, with a way to ask again.
+        fleetRiskError.value = e?.message || 'unknown error'
+        notify('error', 'Failed', `Could not load the fleet support risk view: ${fleetRiskError.value}`)
     } finally {
-        fleetRiskLoading.value = false
+        if (ticket === fleetRiskTicket) {
+            fleetRiskLoading.value = false
+            fleetRiskLoaded.value = true
+        }
     }
 }
-const fleetRiskColumns = computed(() => [
+const blankCell = () => h('span', { class: 'subtle' }, '\u2014')
+const fleetRiskColumns = [
     { key: 'unit', title: 'Unit', minWidth: 220, render: (r: FleetRiskRow) => fleetRiskUnitLabel(r) },
-    { key: 'client', title: 'Client', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskClientName(r) || h('span', { class: 'subtle' }, '—') },
-    { key: 'site', title: 'Site', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskSiteName(r) || h('span', { class: 'subtle' }, '—') },
+    { key: 'client', title: 'Client', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskClientName(r) || blankCell() },
+    { key: 'site', title: 'Site', minWidth: 110, render: (r: FleetRiskRow) => fleetRiskSiteName(r) || blankCell() },
     {
         key: 'release', title: 'Release judged',
         render: (r: FleetRiskRow) => {
             if (!r.release) return h('span', { class: 'subtle' }, 'none')
             const label = releaseLabel(r.release) || shortUuid(r.release)
             // Presence-guarded: absent on a CORE-served page, and a plan is not ground truth.
-            const source = 'releaseSource' in r && r.releaseSource
-                ? h(NTag, { size: 'tiny', type: r.releaseSource === 'REPORTED' ? 'success' : 'default', style: 'margin-left: 6px;' }, { default: () => r.releaseSource === 'REPORTED' ? 'reported' : 'expected' })
+            const st = 'releaseSource' in r ? releaseSourceTag(r.releaseSource) : null
+            const source = st
+                ? h(NTag, { size: 'tiny', type: st.type, style: 'margin-left: 6px;' }, { default: () => st.label })
                 : null
             return h('span', [label, source])
         }
     },
     {
         key: 'window', title: 'Device window',
-        render: (r: FleetRiskRow) => ('window' in r ? buildEffectiveWindowLabel(r.window) : '') || h('span', { class: 'subtle' }, '—')
+        render: (r: FleetRiskRow) => ('window' in r ? fleetWindowLabel(r.window) : '') || blankCell()
     },
     {
         key: 'risk', title: 'Risk',
@@ -940,15 +968,16 @@ const fleetRiskColumns = computed(() => [
             const tag = h(NTag, { size: 'small', type: t.type }, { default: () => t.label })
             if (!isDeviceRiskFlagged(r.risk)) return tag
             return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 420px;' }, {
-                trigger: () => tag, default: () => DEVICE_RISK_DETAIL[r.risk]
+                trigger: () => tag, default: () => FLEET_RISK_DETAIL[r.risk]
             })
         }
     },
-    { key: 'eos', title: 'Earliest component EOS', render: (r: FleetRiskRow) => ('earliestComponentEos' in r && r.earliestComponentEos) || h('span', { class: 'subtle' }, '—') },
-    { key: 'driving', title: 'Components driving risk', render: (r: FleetRiskRow) => ('componentsDrivingRisk' in r && typeof r.componentsDrivingRisk === 'number') ? String(r.componentsDrivingRisk) : h('span', { class: 'subtle' }, '—') }
-])
+    { key: 'eos', title: 'Earliest component EOS', render: (r: FleetRiskRow) => ('earliestComponentEos' in r && r.earliestComponentEos) || blankCell() },
+    { key: 'driving', title: 'Components driving risk', render: (r: FleetRiskRow) => ('componentsDrivingRisk' in r && typeof r.componentsDrivingRisk === 'number') ? String(r.componentsDrivingRisk) : blankCell() }
+]
 const fleetRiskRowProps = (r: FleetRiskRow) => ({ style: 'cursor: pointer;', onClick: () => router.push({ name: 'DeviceView', params: { deviceuuid: r.device } }) })
-// The selection is the filter: a client or site change re-asks from page 1.
+// The selection is the filter: a client or site change re-asks from page 1. Only a backend
+// without the query stops the asking; a failed load is retried on the next selection.
 watch([selectedClientUuid, selectedSiteUuid], () => { if (fleetRisk.value.supported) loadFleetRisk(1) })
 
 onMounted(async () => {

--- a/ui/src/components/fleetRiskPanelWiring.spec.ts
+++ b/ui/src/components/fleetRiskPanelWiring.spec.ts
@@ -13,8 +13,11 @@ const source = readFileSync(
     fileURLToPath(new URL('./DistributionOfOrg.vue', import.meta.url)), 'utf8')
 
 describe('the fleet support-risk panel', () => {
-    it('hides itself when the backend does not support the query', () => {
-        expect(source).toMatch(/<div v-if="fleetRisk\.supported" class="fleetRiskPanel"/)
+    it('hides itself until the first answer, and for good when the backend lacks the query', () => {
+        expect(source).toMatch(/v-if="fleetRiskLoaded && fleetRisk\.supported"/)
+        // Only an unsupported backend stops the re-asking; a failed load must not.
+        expect(source).toMatch(/if \(fleetRisk\.value\.supported\) loadFleetRisk\(1\)/)
+        expect(source).not.toMatch(/fleetRisk\.value = FLEET_RISK_UNSUPPORTED/)
     })
 
     it('reads through the shared loader, not an inline document', () => {
@@ -25,11 +28,25 @@ describe('the fleet support-risk panel', () => {
 
     /**
      * A panel that swallowed every error would read "no risk" on a 403. The loader already
-     * turns schema drift into `supported: false`; anything else must reach the operator.
+     * turns schema drift into `supported: false`; anything else must reach the operator --
+     * and must NOT hide the panel, or a transient failure erases the report.
      */
-    it('notifies on a real load failure instead of swallowing it', () => {
-        const fn = source.slice(source.indexOf('async function loadFleetRisk'), source.indexOf('const fleetRiskColumns'))
-        expect(fn).toMatch(/notify\('error', 'Fleet support risk'/)
+    it('shows a real load failure over the last rows, with a retry, instead of hiding', () => {
+        const fn = source.slice(source.indexOf('async function loadFleetRisk'), source.indexOf('const blankCell'))
+        expect(fn).toMatch(/fleetRiskError\.value = e\?\.message/)
+        expect(fn).toMatch(/notify\('error', 'Failed'/)
+        expect(source).toMatch(/<n-alert v-if="fleetRiskError" type="error"/)
+        expect(source).toMatch(/@click="loadFleetRisk\(fleetRiskPage\)">Retry</)
+    })
+
+    /**
+     * Two loads in flight (client switched while the org-wide page was slow) must resolve to
+     * the NEWER scope, whichever answers last. Pinned on the ticket check after the await.
+     */
+    it('lets only the newest request write its result', () => {
+        const fn = source.slice(source.indexOf('async function loadFleetRisk'), source.indexOf('const blankCell'))
+        expect(fn).toMatch(/const ticket = \+\+fleetRiskTicket/)
+        expect(fn).toMatch(/if \(ticket !== fleetRiskTicket\) return\s+fleetRisk\.value = result/)
     })
 
     it('is paged remotely with the server total, and the page change reloads', () => {
@@ -46,10 +63,24 @@ describe('the fleet support-risk panel', () => {
         expect(source).toMatch(/watch\(\[selectedClientUuid, selectedSiteUuid\]/)
     })
 
-    it('shows the degraded alert only on a CORE-served page and remembers the rejection', () => {
+    it('shows the degraded alert only on a CORE-served page and stops asking for FULL after a rejection', () => {
         expect(source).toMatch(/<n-alert v-if="fleetRisk\.degraded"/)
-        expect(source).toMatch(/if \(result\.supported && result\.degraded\) fleetRiskFullRejected\.value = true/)
-        expect(source).toMatch(/skipFull: fleetRiskFullRejected\.value/)
+        expect(source).toMatch(/skipFull: fleetRisk\.value\.degraded/)
+    })
+
+    /**
+     * The row window must not carry the provenance clause effectiveWindowLabel adds: this
+     * query does not select `source` (the backend serialises it as null here), so the
+     * shipment-form helper would attribute every row's window to the product component.
+     */
+    it('labels the row window without a provenance clause', () => {
+        expect(source).toMatch(/'window' in r \? fleetWindowLabel\(r\.window\)/)
+        const fleet = source.slice(source.indexOf('// ---- fleet support risk'))
+        expect(fleet).not.toMatch(/buildEffectiveWindowLabel/)
+        // and the flagged tooltip is the roster wording, not the per-component one
+        expect(fleet).toMatch(/FLEET_RISK_DETAIL\[r\.risk\]/)
+        expect(fleet).not.toMatch(/DEVICE_RISK_DETAIL/)
+        expect(fleet).not.toMatch(/=== 'REPORTED'/)
     })
 
     it('reads enrichment fields behind a presence guard', () => {
@@ -60,13 +91,16 @@ describe('the fleet support-risk panel', () => {
 
     it('imports the naive-ui components it renders', () => {
         const imp = source.match(/import \{([^}]*)\} from 'naive-ui'/)?.[1] || ''
-        for (const c of ['NAlert', 'NDataTable', 'NTag', 'NTooltip', 'NSpace']) expect(imp).toContain(c)
+        for (const c of ['NAlert', 'NDataTable', 'NTag', 'NTooltip', 'NSpace', 'NButton']) expect(imp).toContain(c)
     })
 
     it('loads on mount and links each row to the device twin', () => {
         const mounted = source.slice(source.indexOf('onMounted(async () => {'))
         expect(mounted).toMatch(/loadFleetRisk\(1\)/)
-        expect(source).toMatch(/const fleetRiskRowProps = \(r: FleetRiskRow\) => \(\{ style: 'cursor: pointer;', onClick: \(\) => router\.push\(\{ name: 'DeviceView', params: \{ deviceuuid: r\.device \} \}\) \}\)/)
+        const rowProps = source.match(/const fleetRiskRowProps = [^\n]*/)?.[0] || ''
+        expect(rowProps).toMatch(/name: 'DeviceView'/)
+        expect(rowProps).toMatch(/deviceuuid: r\.device\b/)
+        expect(source).toMatch(/:row-props="fleetRiskRowProps"/)
     })
 
     it('sits above the three-column grid as a sibling of the drift panel, not inside it', () => {

--- a/ui/src/components/fleetRiskPanelWiring.spec.ts
+++ b/ui/src/components/fleetRiskPanelWiring.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+/**
+ * The fleet support-risk panel is actually WIRED into the distribution page.
+ *
+ * Same reasoning as deviceWindowPanelWiring.spec.ts: no vue-tsc, unlinted utils, so a green
+ * build proves nothing about a template binding or a `<script setup>` identifier. These pin
+ * the things whose absence makes the panel invisible while every unit test passes.
+ */
+const source = readFileSync(
+    fileURLToPath(new URL('./DistributionOfOrg.vue', import.meta.url)), 'utf8')
+
+describe('the fleet support-risk panel', () => {
+    it('hides itself when the backend does not support the query', () => {
+        expect(source).toMatch(/<div v-if="fleetRisk\.supported" class="fleetRiskPanel"/)
+    })
+
+    it('reads through the shared loader, not an inline document', () => {
+        expect(source).toMatch(/import \{[^}]*loadDevicesAtSupportRisk[^}]*\} from '@\/utils\/fleetSupportRisk'/)
+        expect(source).toMatch(/await loadDevicesAtSupportRisk\(graphqlClient, \{/)
+        expect(source).not.toMatch(/gql`[^`]*devicesAtSupportRisk/)
+    })
+
+    /**
+     * A panel that swallowed every error would read "no risk" on a 403. The loader already
+     * turns schema drift into `supported: false`; anything else must reach the operator.
+     */
+    it('notifies on a real load failure instead of swallowing it', () => {
+        const fn = source.slice(source.indexOf('async function loadFleetRisk'), source.indexOf('const fleetRiskColumns'))
+        expect(fn).toMatch(/notify\('error', 'Fleet support risk'/)
+    })
+
+    it('is paged remotely with the server total, and the page change reloads', () => {
+        expect(source).toMatch(/<n-data-table remote :columns="fleetRiskColumns"/)
+        expect(source).toMatch(/:pagination="fleetRiskPagination" @update:page="loadFleetRisk"/)
+        expect(source).toMatch(/itemCount: fleetRisk\.value\.total/)
+        // one-based in the table, zero-based on the wire
+        expect(source).toMatch(/page: Math\.max\(0, page - 1\)/)
+    })
+
+    it('follows the client / site selection as its filter', () => {
+        expect(source).toMatch(/clientUuid: selectedClientUuid\.value \|\| null/)
+        expect(source).toMatch(/siteUuid: selectedSiteUuid\.value \|\| null/)
+        expect(source).toMatch(/watch\(\[selectedClientUuid, selectedSiteUuid\]/)
+    })
+
+    it('shows the degraded alert only on a CORE-served page and remembers the rejection', () => {
+        expect(source).toMatch(/<n-alert v-if="fleetRisk\.degraded"/)
+        expect(source).toMatch(/if \(result\.supported && result\.degraded\) fleetRiskFullRejected\.value = true/)
+        expect(source).toMatch(/skipFull: fleetRiskFullRejected\.value/)
+    })
+
+    it('reads enrichment fields behind a presence guard', () => {
+        for (const f of ['releaseSource', 'window', 'earliestComponentEos', 'componentsDrivingRisk']) {
+            expect(source, `${f} must be presence-guarded`).toMatch(new RegExp(`'${f}' in r`))
+        }
+    })
+
+    it('imports the naive-ui components it renders', () => {
+        const imp = source.match(/import \{([^}]*)\} from 'naive-ui'/)?.[1] || ''
+        for (const c of ['NAlert', 'NDataTable', 'NTag', 'NTooltip', 'NSpace']) expect(imp).toContain(c)
+    })
+
+    it('loads on mount and links each row to the device twin', () => {
+        const mounted = source.slice(source.indexOf('onMounted(async () => {'))
+        expect(mounted).toMatch(/loadFleetRisk\(1\)/)
+        expect(source).toMatch(/const fleetRiskRowProps = \(r: FleetRiskRow\) => \(\{ style: 'cursor: pointer;', onClick: \(\) => router\.push\(\{ name: 'DeviceView', params: \{ deviceuuid: r\.device \} \}\) \}\)/)
+    })
+
+    it('sits above the three-column grid as a sibling of the drift panel, not inside it', () => {
+        const drift = source.indexOf('class="fleetDriftPanel"')
+        const driftClose = source.indexOf('</div>', drift)
+        const risk = source.indexOf('class="fleetRiskPanel"')
+        const grid = source.indexOf('<div class="distWrapper">')
+        expect(drift).toBeGreaterThan(-1)
+        expect(risk).toBeGreaterThan(driftClose)
+        expect(grid).toBeGreaterThan(risk)
+    })
+})

--- a/ui/src/utils/fleetSupportRisk.ts
+++ b/ui/src/utils/fleetSupportRisk.ts
@@ -1,0 +1,163 @@
+import gql from 'graphql-tag'
+import type { DocumentNode } from 'graphql'
+import { isSchemaDriftError, loadWithSchemaDriftFallback, type DriftFallbackClient } from './graphqlDriftFallback'
+import { DEVICE_RISK_LABEL, isDeviceRiskFlagged, type SupportTagType } from './supportStatusTag'
+
+/**
+ * THE FLEET QUESTION (D7), read-only: which in-field units outlive their software.
+ *
+ * <p>`devicesAtSupportRisk` is Pro-only today -- CE declares the Distribution surface but not
+ * this query -- so the panel that renders it must be able to HIDE, not just degrade. The
+ * document is still split CORE/FULL the way every other Pro-leading read is: CORE selects the
+ * verdict and the ids, FULL adds the evidence (which release was judged, the window in force,
+ * the soonest component EOS, how many components drive the verdict). When CE gains the query
+ * it will gain the CORE shape first; the panel then renders rows with the evidence columns
+ * blank instead of blanking outright.
+ *
+ * <p>Enrichment fields are read behind a presence guard by the caller, same rule as
+ * notificationInboxQuery.ts: on a CORE-served page they are absent, not null.
+ */
+export const FLEET_RISK_CORE_ROW_FIELDS = ['device', 'shippedProduct', 'site', 'release', 'risk']
+
+export const FLEET_RISK_ENRICHMENT_ROW_FIELDS = [
+    'releaseSource', 'window { eos eol source }', 'earliestComponentEos', 'componentsDrivingRisk'
+]
+
+function buildFleetRiskQuery (rowFields: string[]): DocumentNode {
+    return gql`
+        query devicesAtSupportRisk($orgUuid: ID!, $clientUuid: ID, $siteUuid: ID, $page: Int, $size: Int) {
+            devicesAtSupportRisk(orgUuid: $orgUuid, clientUuid: $clientUuid, siteUuid: $siteUuid, page: $page, size: $size) {
+                total
+                rows { ${rowFields.join(' ')} }
+            }
+        }`
+}
+
+export const FLEET_RISK_QUERY_CORE = buildFleetRiskQuery(FLEET_RISK_CORE_ROW_FIELDS)
+export const FLEET_RISK_QUERY_FULL = buildFleetRiskQuery([...FLEET_RISK_CORE_ROW_FIELDS, ...FLEET_RISK_ENRICHMENT_ROW_FIELDS])
+
+/** The server's page size cap; asking for more is silently clamped, so do not pretend otherwise. */
+export const FLEET_RISK_MAX_PAGE_SIZE = 200
+export const FLEET_RISK_DEFAULT_PAGE_SIZE = 20
+
+export type DeviceSupportRisk = 'OK' | 'EOS_BEFORE_DEVICE' | 'UNKNOWN'
+export type EvaluatedRelease = 'REPORTED' | 'EXPECTED'
+
+export interface FleetRiskRow {
+    device: string
+    shippedProduct: string | null
+    site: string | null
+    release: string | null
+    risk: DeviceSupportRisk
+    // Enrichment (FULL only): absent on a CORE-served page.
+    releaseSource?: EvaluatedRelease | null
+    window?: { eos?: string | null, eol?: string | null, source?: string | null } | null
+    earliestComponentEos?: string | null
+    componentsDrivingRisk?: number | null
+}
+
+export interface FleetRiskFilter {
+    orgUuid: string
+    clientUuid?: string | null
+    siteUuid?: string | null
+    /** Zero-based, as the server counts. */
+    page?: number
+    size?: number
+}
+
+export interface FleetRiskResult {
+    /** False on a backend whose schema lacks the query -- the panel must hide, not error. */
+    supported: boolean
+    /** True when only the CORE selection was served: rows render, evidence columns are blank. */
+    degraded: boolean
+    rows: FleetRiskRow[]
+    /** The whole in-field fleet matching the filter, not this page. */
+    total: number
+}
+
+export const FLEET_RISK_UNSUPPORTED: FleetRiskResult = { supported: false, degraded: false, rows: [], total: 0 }
+
+/**
+ * Load one page, tolerating a backend that trails the schema.
+ *
+ * FULL first; a validation rejection retries CORE (flagged `degraded`); a validation
+ * rejection of CORE too means the query itself is absent and the result is `unsupported`.
+ * Transport, auth and server errors are NOT swallowed -- a 403 on a fleet roster is a fact
+ * the operator must see, not a reason to quietly show an empty panel.
+ */
+export async function loadDevicesAtSupportRisk (
+    client: DriftFallbackClient,
+    filter: FleetRiskFilter,
+    opts: { skipFull?: boolean } = {}
+): Promise<FleetRiskResult> {
+    const size = Math.min(filter.size ?? FLEET_RISK_DEFAULT_PAGE_SIZE, FLEET_RISK_MAX_PAGE_SIZE)
+    const variables = {
+        orgUuid: filter.orgUuid,
+        clientUuid: filter.clientUuid || null,
+        siteUuid: filter.siteUuid || null,
+        page: Math.max(0, filter.page ?? 0),
+        size
+    }
+    try {
+        const { data, degraded } = await loadWithSchemaDriftFallback(client, {
+            fullQuery: FLEET_RISK_QUERY_FULL,
+            coreQuery: FLEET_RISK_QUERY_CORE,
+            variables,
+            extractPath: d => d?.devicesAtSupportRisk,
+            skipFull: opts.skipFull
+        })
+        return {
+            supported: true,
+            degraded,
+            rows: (data?.rows ?? []).filter(Boolean),
+            total: typeof data?.total === 'number' ? data.total : 0
+        }
+    } catch (e: any) {
+        if (isSchemaDriftError(e)) return FLEET_RISK_UNSUPPORTED
+        throw e
+    }
+}
+
+/**
+ * The tag for one unit's verdict. Unlike the per-component badge on the release page, a fleet
+ * roster shows EVERY verdict: an operator scanning a page of units needs OK and "not assessed"
+ * to be visibly different, because a unit with no window declared is not a safe unit -- it is
+ * one nobody has looked at.
+ */
+export function fleetRiskTag (risk: unknown): { type: SupportTagType, label: string } {
+    if (isDeviceRiskFlagged(risk)) return { type: 'error', label: DEVICE_RISK_LABEL[risk] }
+    if (risk === 'OK') return { type: 'success', label: 'OK' }
+    return { type: 'warning', label: 'Not assessed' }
+}
+
+export interface FleetRiskPageSummary {
+    atRisk: number
+    unknown: number
+    ok: number
+}
+
+/** Counts over the rows in hand -- one PAGE, which the caller must label as such. */
+export function summarizeFleetRiskPage (rows: FleetRiskRow[]): FleetRiskPageSummary {
+    const s: FleetRiskPageSummary = { atRisk: 0, unknown: 0, ok: 0 }
+    for (const r of rows) {
+        if (isDeviceRiskFlagged(r.risk)) s.atRisk++
+        else if (r.risk === 'OK') s.ok++
+        else s.unknown++
+    }
+    return s
+}
+
+/**
+ * The one-line headline above the table. Says how many units were evaluated in total and,
+ * when the page is the whole population, the exact at-risk count; otherwise it names the
+ * count as a page count so a partial view never reads as a fleet total.
+ */
+export function fleetRiskHeadline (total: number, rows: FleetRiskRow[]): string {
+    if (total === 0) return 'No in-field units to evaluate'
+    const s = summarizeFleetRiskPage(rows)
+    const units = `${total} in-field unit${total === 1 ? '' : 's'} evaluated`
+    const verdicts = `${s.atRisk} at risk, ${s.unknown} not assessed, ${s.ok} OK`
+    return rows.length >= total
+        ? `${units}: ${verdicts}`
+        : `${units}; this page: ${verdicts}`
+}

--- a/ui/src/utils/fleetSupportRisk.ts
+++ b/ui/src/utils/fleetSupportRisk.ts
@@ -1,7 +1,10 @@
 import gql from 'graphql-tag'
 import type { DocumentNode } from 'graphql'
 import { isSchemaDriftError, loadWithSchemaDriftFallback, type DriftFallbackClient } from './graphqlDriftFallback'
-import { DEVICE_RISK_LABEL, isDeviceRiskFlagged, type SupportTagType } from './supportStatusTag'
+import {
+    DEVICE_RISK_LABEL, UNRECOGNISED_TAG, isDeviceRiskFlagged,
+    type FlaggedDeviceRisk, type SupportTagType
+} from './supportStatusTag'
 
 /**
  * THE FLEET QUESTION (D7), read-only: which in-field units outlive their software.
@@ -17,10 +20,13 @@ import { DEVICE_RISK_LABEL, isDeviceRiskFlagged, type SupportTagType } from './s
  * <p>Enrichment fields are read behind a presence guard by the caller, same rule as
  * notificationInboxQuery.ts: on a CORE-served page they are absent, not null.
  */
-export const FLEET_RISK_CORE_ROW_FIELDS = ['device', 'shippedProduct', 'site', 'release', 'risk']
+export const FLEET_RISK_CORE_ROW_FIELDS: string[] = ['device', 'shippedProduct', 'site', 'release', 'risk']
 
-export const FLEET_RISK_ENRICHMENT_ROW_FIELDS = [
-    'releaseSource', 'window { eos eol source }', 'earliestComponentEos', 'componentsDrivingRisk'
+// `window` deliberately selects no `source`: Pro's resolver serialises it as null for this
+// query (the level a window was declared at lives on the unit, not the row), and a label
+// that attributes a null source to "the product component" is a false provenance claim.
+export const FLEET_RISK_ENRICHMENT_ROW_FIELDS: string[] = [
+    'releaseSource', 'window { eos eol }', 'earliestComponentEos', 'componentsDrivingRisk'
 ]
 
 function buildFleetRiskQuery (rowFields: string[]): DocumentNode {
@@ -33,15 +39,32 @@ function buildFleetRiskQuery (rowFields: string[]): DocumentNode {
         }`
 }
 
-export const FLEET_RISK_QUERY_CORE = buildFleetRiskQuery(FLEET_RISK_CORE_ROW_FIELDS)
-export const FLEET_RISK_QUERY_FULL = buildFleetRiskQuery([...FLEET_RISK_CORE_ROW_FIELDS, ...FLEET_RISK_ENRICHMENT_ROW_FIELDS])
+export const FLEET_RISK_QUERY_CORE: DocumentNode = buildFleetRiskQuery(FLEET_RISK_CORE_ROW_FIELDS)
+export const FLEET_RISK_QUERY_FULL: DocumentNode = buildFleetRiskQuery([...FLEET_RISK_CORE_ROW_FIELDS, ...FLEET_RISK_ENRICHMENT_ROW_FIELDS])
 
 /** The server's page size cap; asking for more is silently clamped, so do not pretend otherwise. */
 export const FLEET_RISK_MAX_PAGE_SIZE = 200
 export const FLEET_RISK_DEFAULT_PAGE_SIZE = 20
 
-export type DeviceSupportRisk = 'OK' | 'EOS_BEFORE_DEVICE' | 'UNKNOWN'
+// Derived from the flagged set, not re-listed: supportStatusTag.ts owns which verdicts flag.
+export type DeviceSupportRisk = FlaggedDeviceRisk | 'OK' | 'UNKNOWN'
 export type EvaluatedRelease = 'REPORTED' | 'EXPECTED'
+
+/**
+ * Which release the verdict was computed against, as a tag. Keyed on the union so the
+ * comparison never happens on a string literal in an un-type-checked .vue render.
+ */
+export const RELEASE_SOURCE_TAG: Record<EvaluatedRelease, { type: SupportTagType, label: string }> = {
+    REPORTED: { type: 'success', label: 'reported' },
+    EXPECTED: { type: 'default', label: 'expected' }
+}
+export function releaseSourceTag (source: unknown): { type: SupportTagType, label: string } | null {
+    if (typeof source === 'string' && Object.prototype.hasOwnProperty.call(RELEASE_SOURCE_TAG, source)) {
+        return RELEASE_SOURCE_TAG[source as EvaluatedRelease]
+    }
+    if (source != null) console.error('unrecognised EvaluatedRelease from the server:', source)
+    return null
+}
 
 export interface FleetRiskRow {
     device: string
@@ -51,7 +74,7 @@ export interface FleetRiskRow {
     risk: DeviceSupportRisk
     // Enrichment (FULL only): absent on a CORE-served page.
     releaseSource?: EvaluatedRelease | null
-    window?: { eos?: string | null, eol?: string | null, source?: string | null } | null
+    window?: { eos?: string | null, eol?: string | null } | null
     earliestComponentEos?: string | null
     componentsDrivingRisk?: number | null
 }
@@ -123,40 +146,74 @@ export async function loadDevicesAtSupportRisk (
  * roster shows EVERY verdict: an operator scanning a page of units needs OK and "not assessed"
  * to be visibly different, because a unit with no window declared is not a safe unit -- it is
  * one nobody has looked at.
+ *
+ * A verdict this build does not know is NOT "not assessed" either -- same rule as supportTag:
+ * the server stated something, and rendering it as the absence of a statement is the UI
+ * asserting a disclosure fact. Loud tag, console error, the other rows still render.
  */
 export function fleetRiskTag (risk: unknown): { type: SupportTagType, label: string } {
     if (isDeviceRiskFlagged(risk)) return { type: 'error', label: DEVICE_RISK_LABEL[risk] }
     if (risk === 'OK') return { type: 'success', label: 'OK' }
-    return { type: 'warning', label: 'Not assessed' }
+    if (risk === 'UNKNOWN') return { type: 'warning', label: 'Not assessed' }
+    console.error('unrecognised DeviceSupportRisk from the server:', risk,
+        '- rendering it as "Not assessed" would assert nobody looked.')
+    return UNRECOGNISED_TAG
+}
+
+/**
+ * Why a UNIT is flagged. DEVICE_RISK_DETAIL is written for the per-component badge ("this
+ * component stops receiving support..."); on a roster row there is no single component in
+ * view, so the sentence has to speak of the release the unit runs. Keyed on the same union
+ * so a second flagged verdict cannot ship without roster wording.
+ */
+export const FLEET_RISK_DETAIL: Record<FlaggedDeviceRisk, string> = {
+    EOS_BEFORE_DEVICE: 'At least one attested component in the release this unit runs stops'
+        + ' receiving support before the unit\'s declared support window ends. "Components'
+        + ' driving risk" counts them; "Earliest component EOS" is the date that decided it.'
+}
+
+/**
+ * The window that applied to a unit, WITHOUT a provenance clause: this query does not say
+ * where the window came from, and effectiveWindowLabel would attribute it to the product
+ * component by default. See FLEET_RISK_ENRICHMENT_ROW_FIELDS.
+ */
+export function fleetWindowLabel (w: { eos?: string | null, eol?: string | null } | null | undefined): string {
+    if (!w || (!w.eos && !w.eol)) return ''
+    return `EOS ${w.eos || 'not declared'}, EOL ${w.eol || 'not declared'}`
 }
 
 export interface FleetRiskPageSummary {
     atRisk: number
     unknown: number
     ok: number
+    /** Verdicts this build does not know; never folded into `unknown` (see fleetRiskTag). */
+    unrecognised: number
 }
 
 /** Counts over the rows in hand -- one PAGE, which the caller must label as such. */
 export function summarizeFleetRiskPage (rows: FleetRiskRow[]): FleetRiskPageSummary {
-    const s: FleetRiskPageSummary = { atRisk: 0, unknown: 0, ok: 0 }
+    const s: FleetRiskPageSummary = { atRisk: 0, unknown: 0, ok: 0, unrecognised: 0 }
     for (const r of rows) {
         if (isDeviceRiskFlagged(r.risk)) s.atRisk++
         else if (r.risk === 'OK') s.ok++
-        else s.unknown++
+        else if (r.risk === 'UNKNOWN') s.unknown++
+        else s.unrecognised++
     }
     return s
 }
 
 /**
- * The one-line headline above the table. Says how many units were evaluated in total and,
- * when the page is the whole population, the exact at-risk count; otherwise it names the
- * count as a page count so a partial view never reads as a fleet total.
+ * The one-line headline above the table. Says how many units are in scope and, when the
+ * page is the whole population, the exact verdict counts; otherwise it names the counts as
+ * page counts so a partial view never reads as a fleet total. "In scope", not "evaluated":
+ * the server evaluates only the page it returns, sorted by unit, not by verdict.
  */
 export function fleetRiskHeadline (total: number, rows: FleetRiskRow[]): string {
     if (total === 0) return 'No in-field units to evaluate'
     const s = summarizeFleetRiskPage(rows)
-    const units = `${total} in-field unit${total === 1 ? '' : 's'} evaluated`
+    const units = `${total} in-field unit${total === 1 ? '' : 's'} in scope`
     const verdicts = `${s.atRisk} at risk, ${s.unknown} not assessed, ${s.ok} OK`
+        + (s.unrecognised ? `, ${s.unrecognised} unrecognised` : '')
     return rows.length >= total
         ? `${units}: ${verdicts}`
         : `${units}; this page: ${verdicts}`

--- a/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
+++ b/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { buildSchema, validate, print, type GraphQLSchema } from 'graphql'
+import {
+    FLEET_RISK_QUERY_CORE, FLEET_RISK_QUERY_FULL, FLEET_RISK_ENRICHMENT_ROW_FIELDS,
+    FLEET_RISK_CORE_ROW_FIELDS, FLEET_RISK_UNSUPPORTED, loadDevicesAtSupportRisk,
+    fleetRiskTag, summarizeFleetRiskPage, fleetRiskHeadline, type FleetRiskRow
+} from './fleetSupportRisk'
+
+/**
+ * The fleet-risk documents against BOTH schemas (D7).
+ *
+ * Unlike the other drift specs, the honest CE assertion here is not "CORE validates": CE has
+ * no `devicesAtSupportRisk` at all, so BOTH documents fail on CE today and the panel hides.
+ * What this pins is the shape of that failure -- the query is what is missing, not a field
+ * inside it -- because that is the fact the runtime relies on to tell "hide" (query absent,
+ * CORE rejected too) from "degrade" (query present, an enrichment field rejected). The day
+ * CE syncs the query, the CE test below flips and must be rewritten as the usual
+ * CORE-validates / FULL-does-not pair.
+ */
+const CE_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+const PRO_SCHEMA_PATH = fileURLToPath(new URL(
+    '../../../../rearm-core/backend/src/main/resources/schema/schema.graphqls', import.meta.url))
+
+const ceSchema = buildSchema(readFileSync(CE_SCHEMA_PATH, 'utf8'))
+const proSchema: GraphQLSchema | null = existsSync(PRO_SCHEMA_PATH)
+    ? buildSchema(readFileSync(PRO_SCHEMA_PATH, 'utf8'))
+    : null
+
+const errorsAgainst = (schema: GraphQLSchema, doc: any) => validate(schema, doc).map(e => e.message)
+
+describe('the devicesAtSupportRisk documents', () => {
+    it('CE does not declare the query at all, and that is why the panel hides', () => {
+        const ceText = readFileSync(CE_SCHEMA_PATH, 'utf8')
+        expect(ceText).not.toMatch(/devicesAtSupportRisk/)
+        for (const doc of [FLEET_RISK_QUERY_CORE, FLEET_RISK_QUERY_FULL]) {
+            const errs = errorsAgainst(ceSchema, doc)
+            expect(errs.length).toBeGreaterThan(0)
+            // The QUERY is what CE lacks. If this ever fails on a row field instead, CE has
+            // gained the query and this spec must become the CORE-validates / FULL-fails pair.
+            expect(errs.join(' ')).toMatch(/Cannot query field "devicesAtSupportRisk"/)
+        }
+    })
+
+    it('FULL selects every enrichment field and CORE none of them', () => {
+        const full = print(FLEET_RISK_QUERY_FULL)
+        const core = print(FLEET_RISK_QUERY_CORE)
+        for (const f of FLEET_RISK_ENRICHMENT_ROW_FIELDS) {
+            const name = f.split(' ')[0]
+            expect(full).toMatch(new RegExp(`\\b${name}\\b`))
+            expect(core).not.toMatch(new RegExp(`\\b${name}\\b`))
+        }
+        for (const f of FLEET_RISK_CORE_ROW_FIELDS) {
+            expect(core).toMatch(new RegExp(`\\b${f}\\b`))
+        }
+        // The verdict is CORE: a page without it is not a fleet-risk page.
+        expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('risk')
+        expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('device')
+    })
+
+    // it.runIf, not an early return: a silent green when rearm-core is absent is how a drift
+    // spec stops covering anything without anyone noticing. Skipped is reported; green is not.
+    it.runIf(proSchema)('both validate against the Pro schema', () => {
+        expect(errorsAgainst(proSchema as GraphQLSchema, FLEET_RISK_QUERY_CORE)).toEqual([])
+        expect(errorsAgainst(proSchema as GraphQLSchema, FLEET_RISK_QUERY_FULL)).toEqual([])
+    })
+})
+
+// A client whose FULL and CORE outcomes are scripted, so each branch of the loader is
+// exercised without a backend.
+function scriptedClient (full: () => any, core: () => any) {
+    const calls: string[] = []
+    return {
+        calls,
+        query: async ({ query }: any) => {
+            const isFull = print(query).includes('componentsDrivingRisk')
+            calls.push(isFull ? 'FULL' : 'CORE')
+            const out = isFull ? full() : core()
+            return { data: { devicesAtSupportRisk: out } }
+        }
+    }
+}
+const validationError = () => {
+    const e: any = new Error('Validation error (FieldUndefined@[devicesAtSupportRisk]) : Field \'devicesAtSupportRisk\' in type \'Query\' is undefined')
+    e.errors = [{ message: e.message, extensions: { classification: 'ValidationError' } }]
+    return e
+}
+const row = (over: Partial<FleetRiskRow> = {}): FleetRiskRow => ({
+    device: 'd1', shippedProduct: 's1', site: 'site1', release: 'r1', risk: 'OK', ...over
+})
+
+describe('loadDevicesAtSupportRisk', () => {
+    it('serves FULL when the backend accepts it', async () => {
+        const c = scriptedClient(() => ({ total: 1, rows: [row({ componentsDrivingRisk: 2 })] }), () => { throw new Error('unreachable') })
+        const r = await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })
+        expect(r).toMatchObject({ supported: true, degraded: false, total: 1 })
+        expect(r.rows[0].componentsDrivingRisk).toBe(2)
+        expect(c.calls).toEqual(['FULL'])
+    })
+
+    it('degrades to CORE when only an enrichment field is rejected', async () => {
+        const c = scriptedClient(() => { throw validationError() }, () => ({ total: 1, rows: [row()] }))
+        const r = await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })
+        expect(r).toMatchObject({ supported: true, degraded: true, total: 1 })
+        expect('componentsDrivingRisk' in r.rows[0]).toBe(false)
+        expect(c.calls).toEqual(['FULL', 'CORE'])
+    })
+
+    it('reports unsupported, not empty, when CORE is rejected too', async () => {
+        const c = scriptedClient(() => { throw validationError() }, () => { throw validationError() })
+        const r = await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })
+        expect(r).toEqual(FLEET_RISK_UNSUPPORTED)
+        expect(r.supported).toBe(false)
+    })
+
+    /**
+     * A 403 on a fleet roster is a fact the operator must see. Swallowing it into an empty
+     * panel is how the fleet-drift panel above it already behaves, and it is the wrong call
+     * for a report whose absence reads as "no risk".
+     */
+    it('surfaces auth and server errors unchanged', async () => {
+        const forbidden: any = new Error('Forbidden'); forbidden.statusCode = 403
+        const c = scriptedClient(() => { throw forbidden }, () => { throw new Error('unreachable') })
+        await expect(loadDevicesAtSupportRisk(c, { orgUuid: 'o' })).rejects.toBe(forbidden)
+        expect(c.calls).toEqual(['FULL'])
+    })
+
+    it('skips FULL once told the backend rejected it, and sends zero-based paging', async () => {
+        let seen: any = null
+        const c = {
+            query: async ({ query, variables }: any) => { seen = { doc: print(query), variables }; return { data: { devicesAtSupportRisk: { total: 0, rows: [] } } } }
+        }
+        await loadDevicesAtSupportRisk(c, { orgUuid: 'o', clientUuid: '', siteUuid: 'x', page: 3, size: 999 }, { skipFull: true })
+        expect(seen.doc).not.toContain('componentsDrivingRisk')
+        expect(seen.variables).toEqual({ orgUuid: 'o', clientUuid: null, siteUuid: 'x', page: 3, size: 200 })
+    })
+})
+
+describe('fleet-risk presentation helpers', () => {
+    it('gives every verdict a visibly different tag, and never renders UNKNOWN as OK', () => {
+        expect(fleetRiskTag('EOS_BEFORE_DEVICE')).toEqual({ type: 'error', label: 'EOS before device' })
+        expect(fleetRiskTag('OK')).toEqual({ type: 'success', label: 'OK' })
+        expect(fleetRiskTag('UNKNOWN').type).not.toBe('success')
+        expect(fleetRiskTag(undefined).type).not.toBe('success')
+    })
+
+    it('counts a page by verdict', () => {
+        const s = summarizeFleetRiskPage([row(), row({ risk: 'EOS_BEFORE_DEVICE' }), row({ risk: 'UNKNOWN' }), row({ risk: 'EOS_BEFORE_DEVICE' })])
+        expect(s).toEqual({ atRisk: 2, unknown: 1, ok: 1 })
+    })
+
+    /**
+     * A partial page must never read as a fleet total: the server sorts by unit, not by
+     * verdict, so "0 at risk" on page 1 says nothing about page 2.
+     */
+    it('labels counts as page counts unless the page is the whole population', () => {
+        expect(fleetRiskHeadline(0, [])).toBe('No in-field units to evaluate')
+        expect(fleetRiskHeadline(2, [row(), row({ risk: 'EOS_BEFORE_DEVICE' })]))
+            .toBe('2 in-field units evaluated: 1 at risk, 0 not assessed, 1 OK')
+        expect(fleetRiskHeadline(57, [row()]))
+            .toBe('57 in-field units evaluated; this page: 0 at risk, 0 not assessed, 1 OK')
+        expect(fleetRiskHeadline(1, [row()])).toMatch(/^1 in-field unit evaluated:/)
+    })
+})

--- a/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
+++ b/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { buildSchema, validate, print, type GraphQLSchema } from 'graphql'
 import {
     FLEET_RISK_QUERY_CORE, FLEET_RISK_QUERY_FULL, FLEET_RISK_ENRICHMENT_ROW_FIELDS,
     FLEET_RISK_CORE_ROW_FIELDS, FLEET_RISK_UNSUPPORTED, loadDevicesAtSupportRisk,
-    fleetRiskTag, summarizeFleetRiskPage, fleetRiskHeadline, type FleetRiskRow
+    fleetRiskTag, releaseSourceTag, fleetWindowLabel, summarizeFleetRiskPage, fleetRiskHeadline,
+    type FleetRiskRow
 } from './fleetSupportRisk'
+import { UNRECOGNISED_TAG } from './supportStatusTag'
 
 /**
  * The fleet-risk documents against BOTH schemas (D7).
@@ -58,6 +60,9 @@ describe('the devicesAtSupportRisk documents', () => {
         // The verdict is CORE: a page without it is not a fleet-risk page.
         expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('risk')
         expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('device')
+        // The backend serialises window.source as null for this query; selecting it would
+        // only feed a false "(from the product component)" clause. Pinned so nobody adds it.
+        expect(full).not.toMatch(/\bsource\b/)
     })
 
     // it.runIf, not an early return: a silent green when rearm-core is absent is how a drift
@@ -142,13 +147,50 @@ describe('fleet-risk presentation helpers', () => {
     it('gives every verdict a visibly different tag, and never renders UNKNOWN as OK', () => {
         expect(fleetRiskTag('EOS_BEFORE_DEVICE')).toEqual({ type: 'error', label: 'EOS before device' })
         expect(fleetRiskTag('OK')).toEqual({ type: 'success', label: 'OK' })
-        expect(fleetRiskTag('UNKNOWN').type).not.toBe('success')
-        expect(fleetRiskTag(undefined).type).not.toBe('success')
+        expect(fleetRiskTag('UNKNOWN')).toEqual({ type: 'warning', label: 'Not assessed' })
     })
 
-    it('counts a page by verdict', () => {
-        const s = summarizeFleetRiskPage([row(), row({ risk: 'EOS_BEFORE_DEVICE' }), row({ risk: 'UNKNOWN' }), row({ risk: 'EOS_BEFORE_DEVICE' })])
-        expect(s).toEqual({ atRisk: 2, unknown: 1, ok: 1 })
+    /**
+     * A verdict this build does not know is a statement the server made; "Not assessed"
+     * would say nobody looked. Same rule as supportTag: loud tag, console error.
+     */
+    it('renders an unrecognised verdict as unrecognised, not as "not assessed"', () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            for (const v of ['EOL_BEFORE_DEVICE', '', undefined, null, 42]) {
+                expect(fleetRiskTag(v)).toEqual(UNRECOGNISED_TAG)
+                expect(fleetRiskTag(v).label).not.toBe('Not assessed')
+            }
+            expect(err).toHaveBeenCalled()
+        } finally { err.mockRestore() }
+    })
+
+    it('tags the release source off the enum, and rejects what it does not know', () => {
+        expect(releaseSourceTag('REPORTED')).toEqual({ type: 'success', label: 'reported' })
+        expect(releaseSourceTag('EXPECTED')).toEqual({ type: 'default', label: 'expected' })
+        expect(releaseSourceTag(undefined)).toBeNull()
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            expect(releaseSourceTag('PLANNED')).toBeNull()
+            expect(err).toHaveBeenCalledOnce()
+        } finally { err.mockRestore() }
+    })
+
+    it('labels the window without saying where it came from', () => {
+        expect(fleetWindowLabel({ eos: '2031-01-31', eol: '2033-06-30' })).toBe('EOS 2031-01-31, EOL 2033-06-30')
+        expect(fleetWindowLabel({ eos: '2031-01-31', eol: null })).toBe('EOS 2031-01-31, EOL not declared')
+        expect(fleetWindowLabel({ eos: null, eol: null })).toBe('')
+        expect(fleetWindowLabel(null)).toBe('')
+        expect(fleetWindowLabel(undefined)).toBe('')
+        expect(fleetWindowLabel({ eos: '2031-01-31', eol: '2033-06-30' })).not.toMatch(/from the/)
+    })
+
+    it('counts a page by verdict, keeping unrecognised verdicts out of "not assessed"', () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            const s = summarizeFleetRiskPage([row(), row({ risk: 'EOS_BEFORE_DEVICE' }), row({ risk: 'UNKNOWN' }), row({ risk: 'EOS_BEFORE_DEVICE' }), row({ risk: 'WHAT' as any })])
+            expect(s).toEqual({ atRisk: 2, unknown: 1, ok: 1, unrecognised: 1 })
+        } finally { err.mockRestore() }
     })
 
     /**
@@ -158,9 +200,20 @@ describe('fleet-risk presentation helpers', () => {
     it('labels counts as page counts unless the page is the whole population', () => {
         expect(fleetRiskHeadline(0, [])).toBe('No in-field units to evaluate')
         expect(fleetRiskHeadline(2, [row(), row({ risk: 'EOS_BEFORE_DEVICE' })]))
-            .toBe('2 in-field units evaluated: 1 at risk, 0 not assessed, 1 OK')
+            .toBe('2 in-field units in scope: 1 at risk, 0 not assessed, 1 OK')
         expect(fleetRiskHeadline(57, [row()]))
-            .toBe('57 in-field units evaluated; this page: 0 at risk, 0 not assessed, 1 OK')
-        expect(fleetRiskHeadline(1, [row()])).toMatch(/^1 in-field unit evaluated:/)
+            .toBe('57 in-field units in scope; this page: 0 at risk, 0 not assessed, 1 OK')
+        expect(fleetRiskHeadline(1, [row()])).toMatch(/^1 in-field unit in scope:/)
+        // "in scope", never "evaluated": the server evaluates only the page it returns
+        expect(fleetRiskHeadline(57, [row()])).not.toMatch(/evaluated/)
+    })
+
+    it('names unrecognised verdicts in the headline only when there are any', () => {
+        expect(fleetRiskHeadline(1, [row()])).not.toMatch(/unrecognised/)
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            expect(fleetRiskHeadline(1, [row({ risk: 'WHAT' as any })]))
+                .toBe('1 in-field unit in scope: 0 at risk, 0 not assessed, 0 OK, 1 unrecognised')
+        } finally { err.mockRestore() }
     })
 })


### PR DESCRIPTION
## What

A read-only **Devices at support risk** panel at the top of `DistributionOfOrg`, consuming `devicesAtSupportRisk`: unit by identifier, client, site, release judged (+ `expected`/`reported` tag), device window with provenance, verdict tag (red verdict / green OK / amber "Not assessed" -- never rendered as OK), earliest component EOS, components driving risk. Follows the client / site selected below it; remote paging on the server total; row click opens the device twin.

## Schema drift (CORE/FULL)

`ui/src/utils/fleetSupportRisk.ts` splits the document: CORE = ids + verdict, FULL = + evidence. Because CE does not declare the query at all today, the loader distinguishes **hide** (query absent: CORE rejected too -> `supported: false`, panel not rendered) from **degrade** (enrichment rejected -> CORE served, evidence columns blank + amber notice). Non-drift errors (403, 5xx) are surfaced via `notify`, not swallowed. `fleetSupportRiskSchemaDrift.spec.ts` validates both documents against the CE schema (pins that the QUERY is what CE lacks) and, when `rearm-core` is checked out alongside, against the Pro schema (`it.runIf`).

## Verification

- `npm run test`: **58 files / 829 tests** pass (11 drift/loader/helper + 10 source-wiring specs added); `npm run build` exit 0; `validate:graphql` 0 Pro failures; no invisible unicode.
- **UI-driven probe** `fleet-risk-probe.mjs` (rearm-core PR, `ai-agents/probes/fda-readiness-1/`) ran this branch's `ui/dist` over the live sandbox backend (`rearm-backend:fda-readiness-1-dev.24`): **16/16** -- panel/headline/row values compared to the server's own `devicesAtSupportRisk` answer, client and site rows *clicked*, empty client reads "No in-field units to evaluate", row click lands on `/device/show/<uuid>`. Sandbox restored (`reset-baseline.mjs` all OK).
- Walkthrough step 12 written from the probe run (same rearm-core PR).

## Not in this PR

Backend follow-up worth considering: the service sorts by device uuid, so on a large fleet an at-risk unit can sit on page 3 -- sorting at-risk first server-side would make the headline's "this page" caveat unnecessary.

Do not merge yet -- two-layer review gate outcomes will be noted below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
