### PR TITLE
ui: fleet-risk rows carry their own labels and the fleet-wide at-risk count

### DIFF
--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -25,7 +25,7 @@
                 </n-space>
             </n-alert>
             <n-alert v-if="fleetRisk.degraded" type="warning" :show-icon="false" size="small" style="margin-bottom: 6px;" data-testid="fleet-risk-degraded-alert">
-                This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support) nor the unit labels (identifiers, site and client names) or the fleet-wide at-risk count. Those columns are blank, not empty; units are named by id and the headline counts this page only.
+                This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support) nor the unit labels (identifiers, site and client names) or the fleet-wide at-risk count. Those columns are blank, not empty; units are named by id, and the headline counts the rows in hand rather than the fleet.
             </n-alert>
             <!-- Served at-risk-first across the whole fleet; rendered in that order, never re-sorted. -->
             <n-data-table remote :columns="fleetRiskColumns" :data="fleetRisk.rows" :loading="fleetRiskLoading" size="small"
@@ -874,6 +874,9 @@ const fleetRiskPagination = computed(() => ({
 // FULL page with a null name is a unit at an archived site, shown by id so it is not lost.
 const fleetRiskUnitLabel = (r: FleetRiskRow) => summarizeIds('identifiers' in r ? (r.identifiers || []) : []) || shortUuid(r.device)
 const fleetRiskSiteName = (r: FleetRiskRow) => ('siteName' in r && r.siteName) || (r.site ? shortUuid(r.site) : '')
+// No id fallback, unlike the site: the row carries no client uuid, so a unit whose CLIENT was
+// archived reads the same as a site with no client at all. The panel will not invent a
+// distinction it was not given; closing it needs `client: ID` on the row, backend-side.
 const fleetRiskClientName = (r: FleetRiskRow) => ('clientName' in r && r.clientName) || ''
 // Every load takes a ticket; only the newest ticket may write. A client switch while a
 // slow org-wide page is in flight would otherwise land the org-wide rows under the client's

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -14,7 +14,7 @@
              as "no risk"; follows the client / site selected below. -->
         <div v-if="fleetRiskLoaded && fleetRisk.supported" class="fleetRiskPanel" data-testid="fleet-risk-panel">
             <n-space align="center" size="small" style="margin-bottom: 6px;">
-                <n-tag :type="fleetRiskPageSummary.atRisk > 0 ? 'error' : 'default'" size="small">SUPPORT RISK</n-tag>
+                <n-tag :type="fleetRiskAnyAtRisk ? 'error' : 'default'" size="small">SUPPORT RISK</n-tag>
                 <strong data-testid="fleet-risk-headline">{{ fleetRiskHeadlineText }}</strong>
                 <span class="subtle">{{ fleetRiskScopeLabel }}</span>
             </n-space>
@@ -25,8 +25,9 @@
                 </n-space>
             </n-alert>
             <n-alert v-if="fleetRisk.degraded" type="warning" :show-icon="false" size="small" style="margin-bottom: 6px;" data-testid="fleet-risk-degraded-alert">
-                This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support). Those columns are blank, not empty.
+                This backend serves the verdict per unit but not the evidence behind it (release judged, window in force, component end-of-support) nor the unit labels (identifiers, site and client names) or the fleet-wide at-risk count. Those columns are blank, not empty; units are named by id and the headline counts this page only.
             </n-alert>
+            <!-- Served at-risk-first across the whole fleet; rendered in that order, never re-sorted. -->
             <n-data-table remote :columns="fleetRiskColumns" :data="fleetRisk.rows" :loading="fleetRiskLoading" size="small"
                 :row-props="fleetRiskRowProps" :row-key="(r: any) => r.device"
                 :pagination="fleetRiskPagination" @update:page="loadFleetRisk" />
@@ -697,14 +698,12 @@ async function saveSite () {
     if (siteForm.uuid) input.uuid = siteForm.uuid
     await graphqlClient.mutate({ mutation: gql`mutation upsertSite($input: SiteInput!) { upsertSite(input: $input) { uuid } }`, variables: { input } })
     showSiteModal.value = false; notify('success', 'Saved', `Site ${siteForm.name} saved`); await loadSites(selectedClientUuid.value)
-    siteInfoLoaded.value = false
 }
 async function deleteSite (s: any) {
     await graphqlClient.mutate({ mutation: gql`mutation deleteSite($uuid: ID!) { deleteSite(uuid: $uuid) }`, variables: { uuid: s.uuid } })
     notify('info', 'Archived', `Site ${s.name} archived`)
     if (selectedSiteUuid.value === s.uuid) router.push({ name: 'DistributionOfOrg', params: { orguuid: orguuid.value, clientuuid: selectedClientUuid.value } })
     await loadSites(selectedClientUuid.value)
-    siteInfoLoaded.value = false
 }
 
 // ---- shipment ----
@@ -851,13 +850,17 @@ const driftRowProps = (r: any) => ({ style: 'cursor: pointer;', onClick: () => r
 // query at all (`fleetRisk.supported`, hides it for good on CE), and did the LAST request
 // fail for some other reason (`fleetRiskError`, shown over the previous rows with a retry --
 // a 403 or a timeout is not a reason to make the panel disappear).
-const fleetRisk: Ref<FleetRiskResult> = ref({ supported: true, degraded: false, rows: [], total: 0 })
+const fleetRisk: Ref<FleetRiskResult> = ref({ supported: true, degraded: false, rows: [], total: 0, atRiskTotal: null })
 const fleetRiskLoaded = ref(false)
 const fleetRiskLoading = ref(false)
 const fleetRiskError: Ref<string> = ref('')
 const fleetRiskPage = ref(1)  // one-based for n-data-table; the server is zero-based
 const fleetRiskPageSummary = computed(() => summarizeFleetRiskPage(fleetRisk.value.rows))
-const fleetRiskHeadlineText = computed(() => fleetRiskHeadline(fleetRisk.value.total, fleetRisk.value.rows))
+const fleetRiskHeadlineText = computed(() => fleetRiskHeadline(fleetRisk.value.total, fleetRisk.value.rows, fleetRisk.value.atRiskTotal))
+// The fleet-wide count when the server gave one; the page's when it did not (CORE).
+const fleetRiskAnyAtRisk = computed(() => fleetRisk.value.atRiskTotal !== null
+    ? fleetRisk.value.atRiskTotal > 0
+    : fleetRiskPageSummary.value.atRisk > 0)
 const fleetRiskScopeLabel = computed(() => selectedSite.value
     ? `at site ${selectedSite.value.name}`
     : (selectedClient.value ? `for client ${selectedClient.value.name}` : 'org-wide'))
@@ -866,39 +869,12 @@ const fleetRiskPagination = computed(() => ({
     pageSize: FLEET_RISK_DEFAULT_PAGE_SIZE,
     itemCount: fleetRisk.value.total
 }))
-// Site names for the rows come from the org-wide site list (rows carry ids only); device
-// identifiers come from the per-site device list, one read per DISTINCT site on the page.
-// The site list is read once and invalidated when this page saves or archives a site.
-const siteInfoMap: Ref<Record<string, { name: string, client: string }>> = ref({})
-const siteInfoLoaded = ref(false)
-const siteDevicesMap: Ref<Record<string, Record<string, any>>> = ref({})
-async function resolveSiteInfos () {
-    if (siteInfoLoaded.value) return
-    try {
-        const resp: any = await graphqlClient.query({ query: gql`query sitesOfOrg($o: ID!) { sitesOfOrg(orgUuid: $o) { uuid name client } }`, variables: { o: orguuid.value }, fetchPolicy: 'no-cache' })
-        const m: Record<string, { name: string, client: string }> = {}
-        for (const s of resp.data.sitesOfOrg || []) m[s.uuid] = { name: s.name, client: s.client }
-        siteInfoMap.value = m
-        siteInfoLoaded.value = true
-    } catch (e) { /* names stay as short uuids */ }
-}
-async function resolveSiteDevices (siteUuids: string[]) {
-    const missing = [...new Set(siteUuids)].filter(u => u && !siteDevicesMap.value[u])
-    await Promise.all(missing.map(async (u) => {
-        try {
-            const resp: any = await graphqlClient.query({ query: gql`query devicesOfSite($s: ID!, $o: ID!) { devicesOfSite(siteUuid: $s, orgUuid: $o) { uuid identifiers { idType idValue } } }`, variables: { s: u, o: orguuid.value }, fetchPolicy: 'no-cache' })
-            const m: Record<string, any> = {}
-            for (const d of resp.data.devicesOfSite || []) m[d.uuid] = d
-            siteDevicesMap.value[u] = m
-        } catch (e) { /* identifiers stay as short uuids */ }
-    }))
-}
-const fleetRiskUnitLabel = (r: FleetRiskRow) => summarizeIds(r.site ? siteDevicesMap.value[r.site]?.[r.device]?.identifiers : null) || shortUuid(r.device)
-const fleetRiskSiteName = (r: FleetRiskRow) => (r.site && siteInfoMap.value[r.site]?.name) || (r.site ? shortUuid(r.site) : '')
-const fleetRiskClientName = (r: FleetRiskRow) => {
-    const c = r.site ? siteInfoMap.value[r.site]?.client : null
-    return (c && clients.value.find(x => x.uuid === c)?.name) || (c ? shortUuid(c) : '')
-}
+// Unit identifiers and the site / client names ride on the row (FULL). Behind a presence
+// guard like the evidence fields: a CORE-served page names the unit by its short id, and a
+// FULL page with a null name is a unit at an archived site, shown by id so it is not lost.
+const fleetRiskUnitLabel = (r: FleetRiskRow) => summarizeIds('identifiers' in r ? (r.identifiers || []) : []) || shortUuid(r.device)
+const fleetRiskSiteName = (r: FleetRiskRow) => ('siteName' in r && r.siteName) || (r.site ? shortUuid(r.site) : '')
+const fleetRiskClientName = (r: FleetRiskRow) => ('clientName' in r && r.clientName) || ''
 // Every load takes a ticket; only the newest ticket may write. A client switch while a
 // slow org-wide page is in flight would otherwise land the org-wide rows under the client's
 // scope label -- a wrong roster with a confident heading.
@@ -920,11 +896,7 @@ async function loadFleetRisk (page: number = 1) {
         fleetRiskPage.value = page
         fleetRiskError.value = ''
         if (result.supported && result.rows.length) {
-            await Promise.all([
-                resolveSiteInfos(),
-                resolveSiteDevices(result.rows.map(r => r.site || '')),
-                resolveReleaseInfos(result.rows.map(r => r.release || ''))
-            ])
+            await resolveReleaseInfos(result.rows.map(r => r.release || ''))
         }
     } catch (e: any) {
         if (ticket !== fleetRiskTicket) return

--- a/ui/src/components/fleetRiskPanelWiring.spec.ts
+++ b/ui/src/components/fleetRiskPanelWiring.spec.ts
@@ -96,7 +96,8 @@ describe('the fleet support-risk panel', () => {
      */
     it('labels rows from the row itself, with no per-site side reads', () => {
         const fleet = source.slice(source.indexOf('// ---- fleet support risk'))
-        expect(fleet).toMatch(/summarizeIds\('identifiers' in r \? \(r\.identifiers \|\| \[\]\) : \[\]\) \|\| shortUuid\(r\.device\)/)
+        expect(fleet).toMatch(/summarizeIds\('identifiers' in r \?[^)]*r\.identifiers/)
+        expect(fleet).toMatch(/\|\| shortUuid\(r\.device\)/)
         expect(fleet).toMatch(/'siteName' in r && r\.siteName/)
         expect(fleet).toMatch(/'clientName' in r && r\.clientName/)
         expect(fleet).not.toMatch(/devicesOfSite/)
@@ -111,10 +112,13 @@ describe('the fleet support-risk panel', () => {
     it('headlines the fleet-wide at-risk count and never re-sorts the served rows', () => {
         expect(source).toMatch(/fleetRiskHeadline\(fleetRisk\.value\.total, fleetRisk\.value\.rows, fleetRisk\.value\.atRiskTotal\)/)
         expect(source).toMatch(/fleetRisk\.value\.atRiskTotal !== null\s*\?\s*fleetRisk\.value\.atRiskTotal > 0\s*:\s*fleetRiskPageSummary\.value\.atRisk > 0/)
-        expect(source).toMatch(/<n-tag :type="fleetRiskAnyAtRisk \? 'error' : 'default'" size="small">SUPPORT RISK<\/n-tag>/)
+        expect(source).toMatch(/:type="fleetRiskAnyAtRisk \? 'error' : 'default'"/)
         // Rows are served at-risk-first across the whole fleet; the table shows them as served.
         expect(source).toMatch(/:data="fleetRisk\.rows"/)
         const fleet = source.slice(source.indexOf('// ---- fleet support risk'), source.indexOf('onMounted(async'))
+        // Positive pin first: a reworded section marker would otherwise slice to '' and let
+        // the two anti-assertions below pass while covering nothing.
+        expect(fleet).toMatch(/const fleetRiskColumns = \[/)
         expect(fleet).not.toMatch(/\.sort\(/)
         expect(fleet).not.toMatch(/sorter/)
     })

--- a/ui/src/components/fleetRiskPanelWiring.spec.ts
+++ b/ui/src/components/fleetRiskPanelWiring.spec.ts
@@ -84,9 +84,39 @@ describe('the fleet support-risk panel', () => {
     })
 
     it('reads enrichment fields behind a presence guard', () => {
-        for (const f of ['releaseSource', 'window', 'earliestComponentEos', 'componentsDrivingRisk']) {
+        for (const f of ['releaseSource', 'window', 'earliestComponentEos', 'componentsDrivingRisk', 'identifiers', 'siteName', 'clientName']) {
             expect(source, `${f} must be presence-guarded`).toMatch(new RegExp(`'${f}' in r`))
         }
+    })
+
+    /**
+     * #524 put the unit identifiers and the site / client names ON the row. The panel must
+     * label rows from them, not from the per-site device reads it used to fan out (one
+     * `devicesOfSite` per distinct site on the page) nor from an org-wide site list.
+     */
+    it('labels rows from the row itself, with no per-site side reads', () => {
+        const fleet = source.slice(source.indexOf('// ---- fleet support risk'))
+        expect(fleet).toMatch(/summarizeIds\('identifiers' in r \? \(r\.identifiers \|\| \[\]\) : \[\]\) \|\| shortUuid\(r\.device\)/)
+        expect(fleet).toMatch(/'siteName' in r && r\.siteName/)
+        expect(fleet).toMatch(/'clientName' in r && r\.clientName/)
+        expect(fleet).not.toMatch(/devicesOfSite/)
+        expect(fleet).not.toMatch(/sitesOfOrg/)
+        expect(source).not.toMatch(/siteInfoLoaded|siteDevicesMap|resolveSiteInfos|resolveSiteDevices/)
+    })
+
+    /**
+     * The headline and the tag colour come from the server's fleet-wide count, falling back
+     * to the page's own count only when the server did not state one (CORE).
+     */
+    it('headlines the fleet-wide at-risk count and never re-sorts the served rows', () => {
+        expect(source).toMatch(/fleetRiskHeadline\(fleetRisk\.value\.total, fleetRisk\.value\.rows, fleetRisk\.value\.atRiskTotal\)/)
+        expect(source).toMatch(/fleetRisk\.value\.atRiskTotal !== null\s*\?\s*fleetRisk\.value\.atRiskTotal > 0\s*:\s*fleetRiskPageSummary\.value\.atRisk > 0/)
+        expect(source).toMatch(/<n-tag :type="fleetRiskAnyAtRisk \? 'error' : 'default'" size="small">SUPPORT RISK<\/n-tag>/)
+        // Rows are served at-risk-first across the whole fleet; the table shows them as served.
+        expect(source).toMatch(/:data="fleetRisk\.rows"/)
+        const fleet = source.slice(source.indexOf('// ---- fleet support risk'), source.indexOf('onMounted(async'))
+        expect(fleet).not.toMatch(/\.sort\(/)
+        expect(fleet).not.toMatch(/sorter/)
     })
 
     it('imports the naive-ui components it renders', () => {

--- a/ui/src/utils/fleetSupportRisk.ts
+++ b/ui/src/utils/fleetSupportRisk.ts
@@ -21,6 +21,13 @@ import {
  * <p>Enrichment fields are read behind a presence guard by the caller, same rule as
  * notificationInboxQuery.ts: on a CORE-served page they are absent, not null.
  *
+ * <p>The labels and the at-risk count joined the SAME FULL document rather than a third
+ * tier: a Pro backend that has the query but not those fields (mid-roll, UI ahead of
+ * backend) therefore degrades all the way to CORE and blanks the evidence columns it could
+ * have served, until the page is reloaded against the rolled backend. A third document
+ * would buy that window a partial answer at the cost of an extra round trip on every
+ * fallback, for a state that lasts one deploy.
+ *
  * <p>Rows arrive at-risk-first (flagged, then not assessed, then OK; unit id as tie-break)
  * from the server, across the WHOLE filtered fleet, not just the page: the panel renders
  * them in the order served and must not re-sort.

--- a/ui/src/utils/fleetSupportRisk.ts
+++ b/ui/src/utils/fleetSupportRisk.ts
@@ -13,12 +13,17 @@ import {
  * this query -- so the panel that renders it must be able to HIDE, not just degrade. The
  * document is still split CORE/FULL the way every other Pro-leading read is: CORE selects the
  * verdict and the ids, FULL adds the evidence (which release was judged, the window in force,
- * the soonest component EOS, how many components drive the verdict). When CE gains the query
- * it will gain the CORE shape first; the panel then renders rows with the evidence columns
- * blank instead of blanking outright.
+ * the soonest component EOS, how many components drive the verdict) and the labels (the
+ * unit's identifiers, the site and client names) plus the fleet-wide at-risk count. When CE
+ * gains the query it will gain the CORE shape first; the panel then renders rows with the
+ * evidence and label columns blank instead of blanking outright.
  *
  * <p>Enrichment fields are read behind a presence guard by the caller, same rule as
  * notificationInboxQuery.ts: on a CORE-served page they are absent, not null.
+ *
+ * <p>Rows arrive at-risk-first (flagged, then not assessed, then OK; unit id as tie-break)
+ * from the server, across the WHOLE filtered fleet, not just the page: the panel renders
+ * them in the order served and must not re-sort.
  */
 export const FLEET_RISK_CORE_ROW_FIELDS: string[] = ['device', 'shippedProduct', 'site', 'release', 'risk']
 
@@ -26,21 +31,28 @@ export const FLEET_RISK_CORE_ROW_FIELDS: string[] = ['device', 'shippedProduct',
 // query (the level a window was declared at lives on the unit, not the row), and a label
 // that attributes a null source to "the product component" is a false provenance claim.
 export const FLEET_RISK_ENRICHMENT_ROW_FIELDS: string[] = [
-    'releaseSource', 'window { eos eol }', 'earliestComponentEos', 'componentsDrivingRisk'
+    'releaseSource', 'window { eos eol }', 'earliestComponentEos', 'componentsDrivingRisk',
+    'identifiers { idType idValue }', 'siteName', 'clientName'
 ]
 
-function buildFleetRiskQuery (rowFields: string[]): DocumentNode {
+/** Page-level fields. CORE has the population size only; FULL adds the fleet-wide at-risk count. */
+export const FLEET_RISK_CORE_PAGE_FIELDS: string[] = ['total']
+export const FLEET_RISK_ENRICHMENT_PAGE_FIELDS: string[] = ['atRiskTotal']
+
+function buildFleetRiskQuery (pageFields: string[], rowFields: string[]): DocumentNode {
     return gql`
         query devicesAtSupportRisk($orgUuid: ID!, $clientUuid: ID, $siteUuid: ID, $page: Int, $size: Int) {
             devicesAtSupportRisk(orgUuid: $orgUuid, clientUuid: $clientUuid, siteUuid: $siteUuid, page: $page, size: $size) {
-                total
+                ${pageFields.join(' ')}
                 rows { ${rowFields.join(' ')} }
             }
         }`
 }
 
-export const FLEET_RISK_QUERY_CORE: DocumentNode = buildFleetRiskQuery(FLEET_RISK_CORE_ROW_FIELDS)
-export const FLEET_RISK_QUERY_FULL: DocumentNode = buildFleetRiskQuery([...FLEET_RISK_CORE_ROW_FIELDS, ...FLEET_RISK_ENRICHMENT_ROW_FIELDS])
+export const FLEET_RISK_QUERY_CORE: DocumentNode = buildFleetRiskQuery(FLEET_RISK_CORE_PAGE_FIELDS, FLEET_RISK_CORE_ROW_FIELDS)
+export const FLEET_RISK_QUERY_FULL: DocumentNode = buildFleetRiskQuery(
+    [...FLEET_RISK_CORE_PAGE_FIELDS, ...FLEET_RISK_ENRICHMENT_PAGE_FIELDS],
+    [...FLEET_RISK_CORE_ROW_FIELDS, ...FLEET_RISK_ENRICHMENT_ROW_FIELDS])
 
 /** The server's page size cap; asking for more is silently clamped, so do not pretend otherwise. */
 export const FLEET_RISK_MAX_PAGE_SIZE = 200
@@ -77,6 +89,16 @@ export interface FleetRiskRow {
     window?: { eos?: string | null, eol?: string | null } | null
     earliestComponentEos?: string | null
     componentsDrivingRisk?: number | null
+    // Labels (FULL only): the unit's own identifiers, and the names of the site / client the
+    // unit is placed at. Name fields are null when the unit has none OR when it is archived.
+    identifiers?: FleetRiskIdentifier[] | null
+    siteName?: string | null
+    clientName?: string | null
+}
+
+export interface FleetRiskIdentifier {
+    idType: string
+    idValue: string
 }
 
 export interface FleetRiskFilter {
@@ -96,9 +118,15 @@ export interface FleetRiskResult {
     rows: FleetRiskRow[]
     /** The whole in-field fleet matching the filter, not this page. */
     total: number
+    /**
+     * Flagged units across the whole filtered fleet, not this page. Null when unknown: a
+     * CORE-served page, or a server that omitted it. Never 0 by default -- an unknown count
+     * rendered as "0 at risk" is the panel asserting a fleet fact it was not told.
+     */
+    atRiskTotal: number | null
 }
 
-export const FLEET_RISK_UNSUPPORTED: FleetRiskResult = { supported: false, degraded: false, rows: [], total: 0 }
+export const FLEET_RISK_UNSUPPORTED: FleetRiskResult = { supported: false, degraded: false, rows: [], total: 0, atRiskTotal: null }
 
 /**
  * Load one page, tolerating a backend that trails the schema.
@@ -133,7 +161,8 @@ export async function loadDevicesAtSupportRisk (
             supported: true,
             degraded,
             rows: (data?.rows ?? []).filter(Boolean),
-            total: typeof data?.total === 'number' ? data.total : 0
+            total: typeof data?.total === 'number' ? data.total : 0,
+            atRiskTotal: !degraded && typeof data?.atRiskTotal === 'number' ? data.atRiskTotal : null
         }
     } catch (e: any) {
         if (isSchemaDriftError(e)) return FLEET_RISK_UNSUPPORTED
@@ -203,15 +232,22 @@ export function summarizeFleetRiskPage (rows: FleetRiskRow[]): FleetRiskPageSumm
 }
 
 /**
- * The one-line headline above the table. Says how many units are in scope and, when the
- * page is the whole population, the exact verdict counts; otherwise it names the counts as
- * page counts so a partial view never reads as a fleet total. "In scope", not "evaluated":
- * the server evaluates only the page it returns, sorted by unit, not by verdict.
+ * The one-line headline above the table: "K at risk of M in-field units", where K is the
+ * server's count over the WHOLE filtered fleet (it evaluates every unit in scope on each
+ * request and serves them at-risk-first, so K is a fleet fact, not a page fact).
+ *
+ * When K is unknown -- a CORE-served page -- falls back to page counts: says how many units
+ * are in scope and, when the page is the whole population, the exact verdict counts;
+ * otherwise names the counts as page counts so a partial view never reads as a fleet total.
  */
-export function fleetRiskHeadline (total: number, rows: FleetRiskRow[]): string {
+export function fleetRiskHeadline (total: number, rows: FleetRiskRow[], atRiskTotal: number | null = null): string {
     if (total === 0) return 'No in-field units to evaluate'
     const s = summarizeFleetRiskPage(rows)
     const units = `${total} in-field unit${total === 1 ? '' : 's'} in scope`
+    if (typeof atRiskTotal === 'number') {
+        return `${atRiskTotal} at risk of ${units}`
+            + (s.unrecognised ? `; ${s.unrecognised} unrecognised on this page` : '')
+    }
     const verdicts = `${s.atRisk} at risk, ${s.unknown} not assessed, ${s.ok} OK`
         + (s.unrecognised ? `, ${s.unrecognised} unrecognised` : '')
     return rows.length >= total

--- a/ui/src/utils/fleetSupportRisk.ts
+++ b/ui/src/utils/fleetSupportRisk.ts
@@ -96,8 +96,29 @@ export interface FleetRiskRow {
     clientName?: string | null
 }
 
+/**
+ * The wire enum `IdentifierType`, mirrored as a union for the same reason as
+ * `DeviceSupportRisk` above: a `.vue` render comparing `idType` to the DISPLAY spelling
+ * ('UDI-DI', as the shipment form labels it) instead of the wire spelling ('UDI_DI') is a
+ * silent no-match with no compiler and no linter to catch it. Pinned against both schemas
+ * by fleetSupportRiskSchemaDrift.spec.ts, so a new identifier type cannot land unmirrored.
+ */
+export type IdentifierType =
+    | 'PURL' | 'CPE' | 'TEI' | 'COMPLIANCE_DOCUMENT'
+    | 'UDI' | 'UDI_DI' | 'UDI_PI' | 'SERIAL' | 'LOT'
+    | 'SWID' | 'SWHID' | 'OMNIBORID' | 'GTIN' | 'GMN' | 'MPN'
+    | 'PART_NUMBER' | 'MODEL_NUMBER' | 'SKU' | 'ASSET_TAG'
+    | 'FCC_ID' | 'IMEI' | 'MAC_ADDRESS'
+export const IDENTIFIER_TYPES: IdentifierType[] = [
+    'PURL', 'CPE', 'TEI', 'COMPLIANCE_DOCUMENT',
+    'UDI', 'UDI_DI', 'UDI_PI', 'SERIAL', 'LOT',
+    'SWID', 'SWHID', 'OMNIBORID', 'GTIN', 'GMN', 'MPN',
+    'PART_NUMBER', 'MODEL_NUMBER', 'SKU', 'ASSET_TAG',
+    'FCC_ID', 'IMEI', 'MAC_ADDRESS'
+]
+
 export interface FleetRiskIdentifier {
-    idType: string
+    idType: IdentifierType
     idValue: string
 }
 
@@ -245,8 +266,16 @@ export function fleetRiskHeadline (total: number, rows: FleetRiskRow[], atRiskTo
     const s = summarizeFleetRiskPage(rows)
     const units = `${total} in-field unit${total === 1 ? '' : 's'} in scope`
     if (typeof atRiskTotal === 'number') {
+        // "0 at risk" is not "clean": a unit with no declared window is one nobody has
+        // looked at (see fleetRiskTag). The server does not count those fleet-wide, so they
+        // are named as the page fact they are -- and the page is at-risk-first, so a page
+        // carrying unassessed units is a page that has run out of flagged ones.
+        const caveats = [
+            s.unknown ? `${s.unknown} not assessed` : '',
+            s.unrecognised ? `${s.unrecognised} unrecognised` : ''
+        ].filter(Boolean)
         return `${atRiskTotal} at risk of ${units}`
-            + (s.unrecognised ? `; ${s.unrecognised} unrecognised on this page` : '')
+            + (caveats.length ? `; ${caveats.join(', ')} on this page` : '')
     }
     const verdicts = `${s.atRisk} at risk, ${s.unknown} not assessed, ${s.ok} OK`
         + (s.unrecognised ? `, ${s.unrecognised} unrecognised` : '')

--- a/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
+++ b/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from 'url'
 import { buildSchema, validate, print, type GraphQLSchema } from 'graphql'
 import {
     FLEET_RISK_QUERY_CORE, FLEET_RISK_QUERY_FULL, FLEET_RISK_ENRICHMENT_ROW_FIELDS,
-    FLEET_RISK_CORE_ROW_FIELDS, FLEET_RISK_UNSUPPORTED, loadDevicesAtSupportRisk,
+    FLEET_RISK_CORE_ROW_FIELDS, FLEET_RISK_CORE_PAGE_FIELDS, FLEET_RISK_ENRICHMENT_PAGE_FIELDS,
+    FLEET_RISK_UNSUPPORTED, loadDevicesAtSupportRisk,
     fleetRiskTag, releaseSourceTag, fleetWindowLabel, summarizeFleetRiskPage, fleetRiskHeadline,
     type FleetRiskRow
 } from './fleetSupportRisk'
@@ -57,6 +58,17 @@ describe('the devicesAtSupportRisk documents', () => {
         for (const f of FLEET_RISK_CORE_ROW_FIELDS) {
             expect(core).toMatch(new RegExp(`\\b${f}\\b`))
         }
+        // Same split at page level: the fleet-wide at-risk count is FULL-only (#524), the
+        // population size is CORE. And the #524 labels ride with the evidence, not the verdict.
+        for (const f of FLEET_RISK_ENRICHMENT_PAGE_FIELDS) {
+            expect(full).toMatch(new RegExp(`\\b${f}\\b`))
+            expect(core).not.toMatch(new RegExp(`\\b${f}\\b`))
+        }
+        for (const f of FLEET_RISK_CORE_PAGE_FIELDS) expect(core).toMatch(new RegExp(`\\b${f}\\b`))
+        expect(FLEET_RISK_ENRICHMENT_PAGE_FIELDS).toContain('atRiskTotal')
+        expect(FLEET_RISK_ENRICHMENT_ROW_FIELDS).toContain('identifiers { idType idValue }')
+        expect(FLEET_RISK_ENRICHMENT_ROW_FIELDS).toContain('siteName')
+        expect(FLEET_RISK_ENRICHMENT_ROW_FIELDS).toContain('clientName')
         // The verdict is CORE: a page without it is not a fleet-risk page.
         expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('risk')
         expect(FLEET_RISK_CORE_ROW_FIELDS).toContain('device')
@@ -97,20 +109,40 @@ const row = (over: Partial<FleetRiskRow> = {}): FleetRiskRow => ({
 })
 
 describe('loadDevicesAtSupportRisk', () => {
-    it('serves FULL when the backend accepts it', async () => {
-        const c = scriptedClient(() => ({ total: 1, rows: [row({ componentsDrivingRisk: 2 })] }), () => { throw new Error('unreachable') })
+    it('serves FULL when the backend accepts it, with the fleet-wide at-risk count and labels', async () => {
+        const full = row({ componentsDrivingRisk: 2, identifiers: [{ idType: 'SERIAL', idValue: 'SN-1' }], siteName: 'Ward 3', clientName: 'Mercy' })
+        const c = scriptedClient(() => ({ total: 1, atRiskTotal: 1, rows: [full] }), () => { throw new Error('unreachable') })
         const r = await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })
-        expect(r).toMatchObject({ supported: true, degraded: false, total: 1 })
+        expect(r).toMatchObject({ supported: true, degraded: false, total: 1, atRiskTotal: 1 })
         expect(r.rows[0].componentsDrivingRisk).toBe(2)
+        expect(r.rows[0]).toMatchObject({ identifiers: [{ idType: 'SERIAL', idValue: 'SN-1' }], siteName: 'Ward 3', clientName: 'Mercy' })
         expect(c.calls).toEqual(['FULL'])
+    })
+
+    /**
+     * A FULL server that omits the count (or serves it as null) leaves it UNKNOWN. Coercing
+     * to 0 would put "0 at risk" over a fleet the panel was never told about.
+     */
+    it('keeps atRiskTotal null when the server did not state it', async () => {
+        const c = scriptedClient(() => ({ total: 3, rows: [row()] }), () => { throw new Error('unreachable') })
+        expect((await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })).atRiskTotal).toBeNull()
+        const nulled = scriptedClient(() => ({ total: 3, atRiskTotal: null, rows: [row()] }), () => { throw new Error('unreachable') })
+        expect((await loadDevicesAtSupportRisk(nulled, { orgUuid: 'o' })).atRiskTotal).toBeNull()
     })
 
     it('degrades to CORE when only an enrichment field is rejected', async () => {
         const c = scriptedClient(() => { throw validationError() }, () => ({ total: 1, rows: [row()] }))
         const r = await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })
-        expect(r).toMatchObject({ supported: true, degraded: true, total: 1 })
+        expect(r).toMatchObject({ supported: true, degraded: true, total: 1, atRiskTotal: null })
         expect('componentsDrivingRisk' in r.rows[0]).toBe(false)
+        expect('identifiers' in r.rows[0]).toBe(false)
         expect(c.calls).toEqual(['FULL', 'CORE'])
+    })
+
+    /** CORE never selects atRiskTotal; a server that echoes one anyway is not believed on a degraded page. */
+    it('ignores an atRiskTotal on a degraded page', async () => {
+        const c = scriptedClient(() => { throw validationError() }, () => ({ total: 1, atRiskTotal: 1, rows: [row()] }))
+        expect((await loadDevicesAtSupportRisk(c, { orgUuid: 'o' })).atRiskTotal).toBeNull()
     })
 
     it('reports unsupported, not empty, when CORE is rejected too', async () => {
@@ -194,11 +226,32 @@ describe('fleet-risk presentation helpers', () => {
     })
 
     /**
-     * A partial page must never read as a fleet total: the server sorts by unit, not by
-     * verdict, so "0 at risk" on page 1 says nothing about page 2.
+     * With the server's fleet-wide count (#524) the headline is "K at risk of M" -- K counts
+     * the whole filtered fleet, whatever page is showing, so the page's own verdicts are not
+     * repeated as if they were news. Unrecognised verdicts still get named, as a page fact.
      */
-    it('labels counts as page counts unless the page is the whole population', () => {
+    it('says "K at risk of M" from the fleet-wide count when the server gave one', () => {
+        expect(fleetRiskHeadline(57, [row()], 3)).toBe('3 at risk of 57 in-field units in scope')
+        expect(fleetRiskHeadline(1, [row({ risk: 'EOS_BEFORE_DEVICE' })], 1)).toBe('1 at risk of 1 in-field unit in scope')
+        expect(fleetRiskHeadline(57, [row()], 0)).toBe('0 at risk of 57 in-field units in scope')
+        expect(fleetRiskHeadline(0, [], 0)).toBe('No in-field units to evaluate')
+        // the fleet count wins over what this page happens to show
+        expect(fleetRiskHeadline(57, [row({ risk: 'EOS_BEFORE_DEVICE' })], 0)).toMatch(/^0 at risk of 57/)
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            expect(fleetRiskHeadline(2, [row({ risk: 'WHAT' as any })], 1))
+                .toBe('1 at risk of 2 in-field units in scope; 1 unrecognised on this page')
+        } finally { err.mockRestore() }
+    })
+
+    /**
+     * Without the fleet-wide count (a CORE-served page) a partial page must never read as a
+     * fleet total, so the counts are named as page counts. (Pre-#524 servers also sorted by
+     * unit, not verdict, so "0 at risk" on page 1 said nothing about page 2.)
+     */
+    it('falls back to page counts, labelled as such, when the fleet-wide count is unknown', () => {
         expect(fleetRiskHeadline(0, [])).toBe('No in-field units to evaluate')
+        expect(fleetRiskHeadline(57, [row()], null)).toMatch(/this page:/)
         expect(fleetRiskHeadline(2, [row(), row({ risk: 'EOS_BEFORE_DEVICE' })]))
             .toBe('2 in-field units in scope: 1 at risk, 0 not assessed, 1 OK')
         expect(fleetRiskHeadline(57, [row()]))

--- a/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
+++ b/ui/src/utils/fleetSupportRiskSchemaDrift.spec.ts
@@ -5,7 +5,7 @@ import { buildSchema, validate, print, type GraphQLSchema } from 'graphql'
 import {
     FLEET_RISK_QUERY_CORE, FLEET_RISK_QUERY_FULL, FLEET_RISK_ENRICHMENT_ROW_FIELDS,
     FLEET_RISK_CORE_ROW_FIELDS, FLEET_RISK_CORE_PAGE_FIELDS, FLEET_RISK_ENRICHMENT_PAGE_FIELDS,
-    FLEET_RISK_UNSUPPORTED, loadDevicesAtSupportRisk,
+    FLEET_RISK_UNSUPPORTED, IDENTIFIER_TYPES, loadDevicesAtSupportRisk,
     fleetRiskTag, releaseSourceTag, fleetWindowLabel, summarizeFleetRiskPage, fleetRiskHeadline,
     type FleetRiskRow
 } from './fleetSupportRisk'
@@ -75,6 +75,20 @@ describe('the devicesAtSupportRisk documents', () => {
         // The backend serialises window.source as null for this query; selecting it would
         // only feed a false "(from the product component)" clause. Pinned so nobody adds it.
         expect(full).not.toMatch(/\bsource\b/)
+    })
+
+    /**
+     * The mirrored IdentifierType union is the whole wire enum, not a device-facing subset:
+     * a roster row can carry any identifier the unit was given. Pinned against the schema so
+     * a new type cannot land in the backend and leave the union quietly short.
+     */
+    it.runIf(proSchema)('mirrors every IdentifierType the schema declares', () => {
+        for (const text of [readFileSync(CE_SCHEMA_PATH, 'utf8'), readFileSync(PRO_SCHEMA_PATH, 'utf8')]) {
+            const body = text.slice(text.indexOf('enum IdentifierType {'))
+            const declared = body.slice(0, body.indexOf('}')).split('\n').slice(1)
+                .map(l => l.replace(/#.*/, '').trim()).filter(Boolean)
+            expect([...declared].sort()).toEqual([...IDENTIFIER_TYPES].sort())
+        }
     })
 
     // it.runIf, not an early return: a silent green when rearm-core is absent is how a drift
@@ -241,6 +255,23 @@ describe('fleet-risk presentation helpers', () => {
         try {
             expect(fleetRiskHeadline(2, [row({ risk: 'WHAT' as any })], 1))
                 .toBe('1 at risk of 2 in-field units in scope; 1 unrecognised on this page')
+        } finally { err.mockRestore() }
+    })
+
+    /**
+     * "0 at risk" must not read as "clean fleet": a unit with no declared window is one
+     * nobody has looked at. The server counts only the flagged ones fleet-wide, so the
+     * unassessed are named as the page fact they are -- never dropped.
+     */
+    it('still names the unassessed units, as a page fact, under the fleet-wide count', () => {
+        expect(fleetRiskHeadline(57, [row({ risk: 'UNKNOWN' }), row({ risk: 'UNKNOWN' }), row()], 0))
+            .toBe('0 at risk of 57 in-field units in scope; 2 not assessed on this page')
+        // a page of nothing but assessed, OK units says nothing extra
+        expect(fleetRiskHeadline(57, [row(), row()], 0)).toBe('0 at risk of 57 in-field units in scope')
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+        try {
+            expect(fleetRiskHeadline(9, [row({ risk: 'UNKNOWN' }), row({ risk: 'WHAT' as any })], 2))
+                .toBe('2 at risk of 9 in-field units in scope; 1 not assessed, 1 unrecognised on this page')
         } finally { err.mockRestore() }
     })
 


### PR DESCRIPTION
Consumes the row fields relizaio/rearm-saas#524 added, on the Distribution page's "Devices at support risk" panel (D7).

## What changes

| | before | after |
|---|---|---|
| Unit column | `devicesOfSite` per DISTINCT site on the page, then look the unit up | `identifiers` on the row |
| Client / Site | org-wide `sitesOfOrg` + the loaded client list | `siteName` / `clientName` on the row |
| Headline | `M in-field units in scope; this page: A at risk, B not assessed, C OK` | `K at risk of M in-field units in scope`, K = `atRiskTotal` over the whole filtered fleet |
| Order | server sorted by unit | server sorts at-risk-first across the fleet; rendered as served, never re-sorted |

Rendering the org-wide panel is now **one** roster read instead of one plus N site reads.

## Drift pattern kept

The new fields are FULL-only, alongside the evidence columns, read behind the same `'field' in r` presence guard. A CORE-served page still renders the roster (units named by short id) and falls back to the page-count headline. `atRiskTotal` is `number | null`, never coerced to 0: an unknown fleet count rendered as "0 at risk" would be the panel asserting a disclosure fact it was not told. The degraded alert now names the labels and the count among what that backend does not serve.

Null `siteName` / `clientName` on a FULL page means no placement **or an archived site** (backend behaviour); the row still renders, with an em dash.

## Validation

- `npm run test`: **58 files, 840 tests, all passing** (no CI runs this suite). New coverage: FULL carries `atRiskTotal` + labels; `atRiskTotal` stays null when the server omits it, nulls it, or the page is degraded; the "K at risk of M" headline including the fleet count overriding what the page shows; the page-count fallback; and wiring pins for the row-sourced labels, the absence of `devicesOfSite` / `sitesOfOrg`, and the absence of any client-side sort.
- `npm run build`: clean.
- Browser-render check, branch build served over the sandbox (`DIST=ui/dist`, backend `fda-readiness-1-dev.25`, i.e. post-#524): `fleet-risk-probe.mjs` **22/22**, including three new assertions that fail against the deployed UI by design. Probe change is relizaio/rearm-saas (branch `probe/fleet-risk-ui-labels-headline`).

Do not merge yet: two-layer review gate to follow.