### PR TITLE
ui: generate the Device Support Statement from a shipment (plan 7h)

### DIFF
--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -249,7 +249,7 @@ import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType, NCheckbox, NAlert } from 'naive-ui'
 import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon,
-    FileCertificate as StatementIcon } from '@vicons/tabler'
+    FileCertificate as StatementIcon, Loader as PendingIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -261,6 +261,7 @@ import { loadDevicesAtSupportRisk, fleetRiskTag, fleetRiskHeadline, summarizeFle
     type FleetRiskResult, type FleetRiskRow } from '@/utils/fleetSupportRisk'
 import { isDeviceRiskFlagged } from '@/utils/supportStatusTag'
 import { generateDeviceSupportStatement } from '@/utils/deviceSupportStatementExport'
+import { NO_WINDOW_IN_FORCE } from '@/utils/addendumData'
 
 const route = useRoute()
 const router = useRouter()
@@ -562,24 +563,37 @@ const statementColumn = {
     render: (r: any) => {
         const w = r.effectiveDeviceSupportWindow
         const has = !!(w && (w.eos || w.eol))
+        const pending = statementExportPending.value === r.uuid
         const icon = h(NIcon, {
             size: 16,
             'data-testid': 'shipment-statement-action',
             'data-window-in-force': String(has),
-            style: `vertical-align: middle; ${has ? 'cursor: pointer;' : 'color: #c8ccd0;'}`,
+            'data-pending': String(pending),
+            style: `vertical-align: middle; ${pending ? 'cursor: progress; color: #909399;'
+                : (has ? 'cursor: pointer;' : 'color: #c8ccd0;')}`,
             onClick: (e: Event) => { e.stopPropagation(); if (has) exportShipmentStatement(r) }
-        }, { default: () => h(StatementIcon) })
+        }, { default: () => h(pending ? PendingIcon : StatementIcon) })
         return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 420px;' }, {
             trigger: () => icon,
-            default: () => has
-                ? 'Device support statement for this delivery. States the dates in force for'
-                    + ' these units, and names the delivery they apply to.'
-                : 'No device support window is in force for this delivery, so a statement for'
-                    + ' it would have no dates to state. Declare the window on the device'
-                    + ' model, or record an override on this shipment.'
+            default: () => pending
+                ? 'Assembling the statement. It walks the whole component list, so it can take'
+                    + ' a moment on a large release.'
+                : has
+                    ? 'Device support statement for this delivery. States the dates in force for'
+                        + ' these units, and names the delivery they apply to.'
+                    // The refusal the generator would give, said before the click instead of
+                    // after it. One sentence, one constant: two that must agree, in two
+                    // files, is how they stop agreeing.
+                    : NO_WINDOW_IN_FORCE
         })
     }
 }
+// Offered only where SOME delivery in the table has a window in force. An organization that
+// declares none would otherwise carry a permanently inert icon whose tooltip gives device-
+// model instructions it has no use for; once one delivery has a window, the inert icon on
+// its neighbours is the useful signal it was written to be.
+const anyWindowInForce = (rows: any[]) => rows.some((r: any) =>
+    r.effectiveDeviceSupportWindow?.eos || r.effectiveDeviceSupportWindow?.eol)
 const editShipmentColumn = {
     key: 'edit', title: '',
     render: (r: any) => h(NIcon, {
@@ -587,26 +601,27 @@ const editShipmentColumn = {
         onClick: (e: Event) => { e.stopPropagation(); openShipModal(r) }
     }, { default: () => h(EditIcon) })
 }
+const releaseShipmentColumn = {
+    key: 'release', title: 'Release',
+    render: (r: any) => {
+        const i = releaseInfoMap.value[r.release]
+        if (!i) return shortUuid(r.release)
+        const link = (text: string, to: any) => h('a', {
+            class: 'shipLink',
+            onClick: (e: Event) => { e.stopPropagation(); router.push(to) }
+        }, text)
+        return h('span', [
+            link(i.productName, { name: 'ProductsOfOrg', params: { orguuid: orguuid.value, compuuid: i.productUuid } }),
+            ' — ',
+            link(i.fsName, { name: 'ProductsOfOrg', params: { orguuid: orguuid.value, compuuid: i.productUuid, branchuuid: i.fsUuid } }),
+            ' — ',
+            link(i.version, { name: 'ReleaseView', params: { uuid: r.release } })
+        ])
+    }
+}
 const shipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
-    {
-        key: 'release', title: 'Release',
-        render: (r: any) => {
-            const i = releaseInfoMap.value[r.release]
-            if (!i) return shortUuid(r.release)
-            const link = (text: string, to: any) => h('a', {
-                class: 'shipLink',
-                onClick: (e: Event) => { e.stopPropagation(); router.push(to) }
-            }, text)
-            return h('span', [
-                link(i.productName, { name: 'ProductsOfOrg', params: { orguuid: orguuid.value, compuuid: i.productUuid } }),
-                ' — ',
-                link(i.fsName, { name: 'ProductsOfOrg', params: { orguuid: orguuid.value, compuuid: i.productUuid, branchuuid: i.fsUuid } }),
-                ' — ',
-                link(i.version, { name: 'ReleaseView', params: { uuid: r.release } })
-            ])
-        }
-    },
+    releaseShipmentColumn,
     { key: 'quantity', title: 'Qty' },
     {
         key: 'info', title: '',
@@ -626,7 +641,7 @@ const shipmentColumns = computed(() => [
             })
         }
     },
-    statementColumn,
+    ...(anyWindowInForce([...hardwareShipments.value, ...samdShipments.value]) ? [statementColumn] : []),
     ...(isWritable ? [editShipmentColumn] : [])
 ])
 
@@ -640,23 +655,32 @@ const shipmentColumns = computed(() => [
  * about which units it describes. ShipmentStatementContext carries the two together so a
  * caller cannot supply one without the other.
  */
-const statementExportPending = ref(false)
+// The shipment whose statement is being assembled, so the row that was clicked is the row
+// that shows it. A bare boolean would spin every row at once.
+const statementExportPending: Ref<string> = ref('')
 async function exportShipmentStatement (r: any) {
     if (statementExportPending.value) return
-    statementExportPending.value = true
+    statementExportPending.value = r.uuid
     try {
         const w = r.effectiveDeviceSupportWindow
         const outcome = await generateDeviceSupportStatement(graphqlClient as any, {
             releaseUuid: r.release,
             orgUuid: orguuid.value,
             shipment: {
-                siteName: selectedSite.value?.name || null,
+                // From the ROW, not the page selection: the context exists so one delivery's
+                // provenance cannot be paired with another's window, and reading the site off
+                // a page-level computed leaves that true only by accident of scope.
+                siteName: sites.value.find((x: any) => x.uuid === r.site)?.name
+                    || selectedSite.value?.name || null,
                 shipDate: r.shipDate || null,
                 // The batch as a reader can match it against a delivery note: the identifiers
                 // recorded on the shipment, joined the same way this page shows them.
                 batchIdentifier: summarizeIds(r.identifiers) || null,
                 eos: w?.eos || null,
-                eol: w?.eol || null
+                eol: w?.eol || null,
+                // The provenance line follows the DATES: an inherited window is the model's
+                // statement about every unit, not this delivery's about its own.
+                windowSource: w?.source || null
             }
         })
         if (!outcome.ok) {
@@ -667,12 +691,12 @@ async function exportShipmentStatement (r: any) {
     } catch (e: any) {
         notify('error', 'Statement not generated', e?.message || 'unknown error')
     } finally {
-        statementExportPending.value = false
+        statementExportPending.value = ''
     }
 }
 const softwareShipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
-    (shipmentColumns.value as any[])[1],
+    releaseShipmentColumn,
     { key: 'expiryDate', title: 'Expires', render: (r: any) => r.expiryDate || h('span', { class: 'subtle' }, '—') },
     {
         key: 'devices', title: 'Devices',
@@ -695,7 +719,7 @@ const softwareShipmentColumns = computed(() => [
             }) : ''
         }
     },
-    statementColumn,
+    ...(anyWindowInForce(softwareShipments.value) ? [statementColumn] : []),
     ...(isWritable ? [editShipmentColumn] : [])
 ])
 const deviceColumns = computed(() => [

--- a/ui/src/components/DistributionOfOrg.vue
+++ b/ui/src/components/DistributionOfOrg.vue
@@ -248,7 +248,8 @@ import { ref, Ref, computed, ComputedRef, reactive, h, onMounted, watch } from '
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
 import { NTabPane, NTabs, NDataTable, NModal, NForm, NFormItem, NInput, NInputNumber, NSelect, NButton, NIcon, NTag, NSpace, NDivider, NDynamicInput, NTooltip, NPopconfirm, NDatePicker, useNotification, NotificationType, NCheckbox, NAlert } from 'naive-ui'
-import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon } from '@vicons/tabler'
+import { CirclePlus, InfoCircle, Edit as EditIcon, Archive as ArchiveIcon,
+    FileCertificate as StatementIcon } from '@vicons/tabler'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import commonFunctions from '@/utils/commonFunctions'
@@ -259,6 +260,7 @@ import { loadDevicesAtSupportRisk, fleetRiskTag, fleetRiskHeadline, summarizeFle
     releaseSourceTag, fleetWindowLabel, FLEET_RISK_DETAIL, FLEET_RISK_DEFAULT_PAGE_SIZE,
     type FleetRiskResult, type FleetRiskRow } from '@/utils/fleetSupportRisk'
 import { isDeviceRiskFlagged } from '@/utils/supportStatusTag'
+import { generateDeviceSupportStatement } from '@/utils/deviceSupportStatementExport'
 
 const route = useRoute()
 const router = useRouter()
@@ -545,6 +547,46 @@ const siteColumns = [
     { key: 'name', title: 'Name' },
     ...(isWritable ? [{ key: 'actions', title: '', width: 70, render: (r: any) => rowActions(r, openSiteModal, deleteSite, `Archive site ${r.name} with its shipments and devices?`) }] : [])
 ]
+/**
+ * The Device Support Statement for one delivery (plan 7h).
+ *
+ * GATED ON THE WINDOW IN FORCE, not on the shipment's classification. Every delivery of a
+ * device model -- hardware batch, SaMD, or plain software applied to units at a site -- has
+ * dates in force for the units it reached, which is what the statement states. What it must
+ * NOT be offered for is a delivery with no window at all: the collector refuses that, and a
+ * control that is clickable only to answer with a dialog is the pattern the release view
+ * already had to walk back (board t20260909-061338-23148 step 6d).
+ */
+const statementColumn = {
+    key: 'statement', title: '',
+    render: (r: any) => {
+        const w = r.effectiveDeviceSupportWindow
+        const has = !!(w && (w.eos || w.eol))
+        const icon = h(NIcon, {
+            size: 16,
+            'data-testid': 'shipment-statement-action',
+            'data-window-in-force': String(has),
+            style: `vertical-align: middle; ${has ? 'cursor: pointer;' : 'color: #c8ccd0;'}`,
+            onClick: (e: Event) => { e.stopPropagation(); if (has) exportShipmentStatement(r) }
+        }, { default: () => h(StatementIcon) })
+        return h(NTooltip, { trigger: 'hover', placement: 'left', style: 'max-width: 420px;' }, {
+            trigger: () => icon,
+            default: () => has
+                ? 'Device support statement for this delivery. States the dates in force for'
+                    + ' these units, and names the delivery they apply to.'
+                : 'No device support window is in force for this delivery, so a statement for'
+                    + ' it would have no dates to state. Declare the window on the device'
+                    + ' model, or record an override on this shipment.'
+        })
+    }
+}
+const editShipmentColumn = {
+    key: 'edit', title: '',
+    render: (r: any) => h(NIcon, {
+        size: 16, style: 'cursor: pointer; vertical-align: middle;', title: 'Edit shipment',
+        onClick: (e: Event) => { e.stopPropagation(); openShipModal(r) }
+    }, { default: () => h(EditIcon) })
+}
 const shipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
     {
@@ -584,14 +626,50 @@ const shipmentColumns = computed(() => [
             })
         }
     },
-    ...(isWritable ? [{
-        key: 'edit', title: '',
-        render: (r: any) => h(NIcon, {
-            size: 16, style: 'cursor: pointer; vertical-align: middle;', title: 'Edit shipment',
-            onClick: (e: Event) => { e.stopPropagation(); openShipModal(r) }
-        }, { default: () => h(EditIcon) })
-    }] : [])
+    statementColumn,
+    ...(isWritable ? [editShipmentColumn] : [])
 ])
+
+/**
+ * The Device Support Statement for ONE DELIVERY (plan 7h).
+ *
+ * Same document and the same refusals as the release view's Export modal -- one helper
+ * serves both -- but the dates and the provenance line come from this shipment: the units in
+ * a delivery that overrode the model window do not run under the model's dates, and a
+ * statement that named the batch while printing the model's dates would contradict itself
+ * about which units it describes. ShipmentStatementContext carries the two together so a
+ * caller cannot supply one without the other.
+ */
+const statementExportPending = ref(false)
+async function exportShipmentStatement (r: any) {
+    if (statementExportPending.value) return
+    statementExportPending.value = true
+    try {
+        const w = r.effectiveDeviceSupportWindow
+        const outcome = await generateDeviceSupportStatement(graphqlClient as any, {
+            releaseUuid: r.release,
+            orgUuid: orguuid.value,
+            shipment: {
+                siteName: selectedSite.value?.name || null,
+                shipDate: r.shipDate || null,
+                // The batch as a reader can match it against a delivery note: the identifiers
+                // recorded on the shipment, joined the same way this page shows them.
+                batchIdentifier: summarizeIds(r.identifiers) || null,
+                eos: w?.eos || null,
+                eol: w?.eol || null
+            }
+        })
+        if (!outcome.ok) {
+            notify(outcome.kind === 'BLOCKED' ? 'warning' : 'error', 'Statement not generated', outcome.message)
+            return
+        }
+        notify('success', 'Statement exported', `Device support statement downloaded (${outcome.fileName}).`)
+    } catch (e: any) {
+        notify('error', 'Statement not generated', e?.message || 'unknown error')
+    } finally {
+        statementExportPending.value = false
+    }
+}
 const softwareShipmentColumns = computed(() => [
     { key: 'shipDate', title: 'Date' },
     (shipmentColumns.value as any[])[1],
@@ -617,7 +695,8 @@ const softwareShipmentColumns = computed(() => [
             }) : ''
         }
     },
-    ...(isWritable ? [(shipmentColumns.value as any[])[(shipmentColumns.value as any[]).length - 1]] : [])
+    statementColumn,
+    ...(isWritable ? [editShipmentColumn] : [])
 ])
 const deviceColumns = computed(() => [
     { key: 'ids', title: 'Unit ids', render: (r: any) => summarizeIds(r.identifiers) || h('span', { class: 'subtle' }, '—') },

--- a/ui/src/components/ReleaseView.vue
+++ b/ui/src/components/ReleaseView.vue
@@ -1841,8 +1841,7 @@ import commonFunctions, { SwalData } from '@/utils/commonFunctions'
 import { collectAddendumData } from '@/utils/addendumData'
 import { renderAddendumCsv, addendumFileName } from '@/utils/addendumCsv'
 import { renderAddendumPdfBlob, addendumPdfFileName, findUnrenderableText } from '@/utils/addendumPdf'
-import { renderDeviceSupportStatementBlob, deviceSupportStatementFileName,
-    statementBlockReason } from '@/utils/deviceSupportStatement'
+import { generateDeviceSupportStatement } from '@/utils/deviceSupportStatementExport'
 import { releaseNarrativeVariables, releaseNarrativeDiffers } from '@/utils/releaseNarrativeInput'
 import { FDA_PROSE_MAX_LENGTH } from '@/utils/fdaProseInput'
 import { formatNarrativeChange } from '@/utils/narrativeHistory'
@@ -5304,25 +5303,17 @@ async function exportDeviceSupportStatement () {
                 + ' resolved. Reload the page and try again.', 'error')
             return
         }
-        const result = await collectAddendumData(graphqlClient as any, updatedRelease.value.uuid, orgUuid)
-        if (!result.ok) {
-            Swal.fire('Statement not generated', result.error, 'error')
+        // Collect, refuse, render, download -- all four in the shared helper, which the
+        // shipment entry point on the Distribution page calls too (plan 7h). A FAILED
+        // outcome is "something went wrong"; a BLOCKED one is "this document must not exist
+        // yet", and the two have always been shown differently here.
+        const outcome = await generateDeviceSupportStatement(graphqlClient as any, {
+            releaseUuid: updatedRelease.value.uuid, orgUuid
+        })
+        if (!outcome.ok) {
+            Swal.fire('Statement not generated', outcome.message, outcome.kind === 'BLOCKED' ? 'warning' : 'error')
             return
         }
-        // Every refusal in one place, checked BEFORE anything is built.
-        const blocked = statementBlockReason(result.data)
-        if (blocked) {
-            Swal.fire('Statement not generated', blocked, 'warning')
-            return
-        }
-        const blob = await renderDeviceSupportStatementBlob(result.data)
-        const link = document.createElement('a')
-        link.href = window.URL.createObjectURL(blob)
-        link.download = deviceSupportStatementFileName(result.data)
-        document.body.appendChild(link)
-        link.click()
-        document.body.removeChild(link)
-        window.URL.revokeObjectURL(link.href)
         notify('success', 'Statement exported', 'Device support statement downloaded.')
     } catch (err: any) {
         Swal.fire('Error!', commonFunctions.extractGraphQLErrorMessage(err), 'error')

--- a/ui/src/components/deviceStatementWiring.spec.ts
+++ b/ui/src/components/deviceStatementWiring.spec.ts
@@ -162,7 +162,12 @@ describe('a statement can be generated from a shipment', () => {
         expect(shipmentExport).toMatch(/const w = r\.effectiveDeviceSupportWindow/)
         // named by what a reader can match against a delivery note, not by uuid
         expect(shipmentExport).toMatch(/batchIdentifier: summarizeIds\(r\.identifiers\)/)
-        expect(shipmentExport).not.toMatch(/r\.uuid/)
+        // The provenance LINE follows the dates: an inherited window is the model's statement
+        // about every unit, and saying "may differ from other deliveries" over it asserts a
+        // batch-specificity that does not exist.
+        expect(shipmentExport).toMatch(/windowSource: w\?\.source \|\| null/)
+        // named by what a reader can match against a delivery note, never by uuid
+        expect(shipmentExport).not.toMatch(/batchIdentifier: [^\n]*uuid/)
     })
 
     it('offers the action only where a window is in force', () => {
@@ -170,7 +175,9 @@ describe('a statement can be generated from a shipment', () => {
         expect(col).toMatch(/const has = !!\(w && \(w\.eos \|\| w\.eol\)\)/)
         expect(col).toMatch(/if \(has\) exportShipmentStatement\(r\)/)
         // and says why, rather than answering the click with a dialog
-        expect(col).toMatch(/No device support window is in force for this delivery/)
+        // One sentence for the tooltip and for the generator's refusal, from one constant.
+        expect(col).toMatch(/: NO_WINDOW_IN_FORCE/)
+        expect(dist).toMatch(/import \{ NO_WINDOW_IN_FORCE \} from '@\/utils\/addendumData'/)
         // The gate is readable from outside, so the live probe asserts the same fact the
         // unit tests do rather than inferring it from a cursor style.
         expect(col).toMatch(/'data-testid': 'shipment-statement-action'/)
@@ -178,7 +185,7 @@ describe('a statement can be generated from a shipment', () => {
     })
 
     it('reads the effective window from the shipment query', () => {
-        expect(dist).toMatch(/effectiveDeviceSupportWindow \{ eos eol source \}/)
+        expect(dist).toMatch(/effectiveDeviceSupportWindow\s*\{[^}]*\bsource\b/)
     })
 
     /**
@@ -192,9 +199,35 @@ describe('a statement can be generated from a shipment', () => {
         for (const table of ['const shipmentColumns', 'const softwareShipmentColumns']) {
             const cols = dist.slice(dist.indexOf(table))
             expect(cols.slice(0, cols.indexOf('\n])')), `${table} must carry the statement action`)
-                .toMatch(/\n    statementColumn,/)
+                .toMatch(/^\s*\.\.\.\(anyWindowInForce\([^)]*\) \? \[statementColumn\] : \[\]\),$/m)
         }
-        expect(dist).not.toMatch(/shipmentColumns\.value as any\[\]\)\[\(shipmentColumns/)
+        // and no positional borrow of ANY column between the two tables: the same trap one
+        // insertion away, which is how the edit icon nearly became the statement action.
+        expect(dist).not.toMatch(/\(shipmentColumns\.value as any\[\]\)\[/)
+        expect(dist).toMatch(/const releaseShipmentColumn = \{/)
+    })
+
+    /**
+     * An organization that declares no windows at all would otherwise carry a permanently
+     * inert icon whose tooltip gives device-model instructions it has no use for. Once one
+     * delivery has a window, the inert icon on its neighbours is the signal it was written
+     * to be -- so the column appears per table, not per row.
+     */
+    it('does not appear at all until some delivery in the table has a window', () => {
+        expect(dist).toMatch(/const anyWindowInForce = \(rows: any\[\]\) => rows\.some/)
+        expect(dist).toMatch(/r\.effectiveDeviceSupportWindow\?\.eos \|\| r\.effectiveDeviceSupportWindow\?\.eol/)
+    })
+
+    /**
+     * The row that was clicked is the row that shows the work. A bare boolean would spin
+     * every row at once, and no indicator at all made a multi-query walk look like a dead
+     * control (the release view disables its button for the same reason).
+     */
+    it('shows the assembling state on the row it was asked from', () => {
+        expect(dist).toMatch(/const statementExportPending: Ref<string> = ref\(''\)/)
+        expect(dist).toMatch(/const pending = statementExportPending\.value === r\.uuid/)
+        expect(dist).toMatch(/statementExportPending\.value = r\.uuid/)
+        expect(dist).toMatch(/h\(pending \? PendingIcon : StatementIcon\)/)
     })
 
     it('reports a refusal as a refusal and a failure as a failure', () => {

--- a/ui/src/components/deviceStatementWiring.spec.ts
+++ b/ui/src/components/deviceStatementWiring.spec.ts
@@ -10,6 +10,10 @@ import { fileURLToPath } from 'url'
  */
 const source = readFileSync(
     fileURLToPath(new URL('./ReleaseView.vue', import.meta.url)), 'utf8')
+// The collect/refuse/render/download sequence moved here when the shipment entry point
+// landed (plan 7h); these pins moved with it rather than being deleted.
+const helper = readFileSync(
+    fileURLToPath(new URL('../utils/deviceSupportStatementExport.ts', import.meta.url)), 'utf8')
 
 function functionBody (name: string): string {
     const start = source.indexOf(`function ${name} (`)
@@ -29,9 +33,18 @@ describe('the device support statement is wired into the export modal', () => {
         ['renderDeviceSupportStatementBlob'],
         ['deviceSupportStatementFileName'],
         ['statementBlockReason']
-    ])('imports %s from utils/deviceSupportStatement', (symbol) => {
-        expect(source).toMatch(new RegExp(
-            `import\\s+\\{[^}]*\\b${symbol}\\b[^}]*\\}\\s+from\\s+'@\\/utils\\/deviceSupportStatement'`))
+    ])('the shared helper imports %s from utils/deviceSupportStatement', (symbol) => {
+        expect(helper).toMatch(new RegExp(
+            `import\\s+\\{[\\s\\S]*?\\b${symbol}\\b[\\s\\S]*?\\}\\s+from\\s+'\\.\\/deviceSupportStatement'`))
+    })
+
+    it('the view calls the shared helper rather than repeating the sequence', () => {
+        expect(source).toMatch(
+            /import \{ generateDeviceSupportStatement \} from '@\/utils\/deviceSupportStatementExport'/)
+        expect(functionBody('exportDeviceSupportStatement')).toContain('generateDeviceSupportStatement(')
+        // One copy of the sequence, in the helper. A second would be a second chance to skip
+        // the block check, which is the thing that keeps an empty-section PDF from existing.
+        expect(source).not.toMatch(/renderDeviceSupportStatementBlob/)
     })
 
     it('offers it as its own export type', () => {
@@ -52,13 +65,16 @@ describe('the device support statement is wired into the export modal', () => {
     // Every refusal is checked BEFORE anything is built: a component release, an unauthored
     // prose slot, and text the font cannot draw all block generation rather than degrade it.
     it('blocks before rendering, and downloads nothing when blocked', () => {
-        const body = functionBody('exportDeviceSupportStatement')
-        expect(body.indexOf('statementBlockReason')).toBeLessThan(body.indexOf('renderDeviceSupportStatementBlob'))
-        expect(body.indexOf('if (blocked)')).toBeLessThan(body.indexOf('createElement'))
+        // Scoped to the exported function: `download` is DEFINED above it, so a file-wide
+        // index comparison against createElement would compare a definition to a call.
+        const fn = helper.slice(helper.indexOf('export async function generateDeviceSupportStatement'))
+        expect(fn.indexOf('statementBlockReason')).toBeLessThan(fn.indexOf('renderDeviceSupportStatementBlob'))
+        expect(fn.indexOf('if (blocked)')).toBeLessThan(fn.indexOf('download('))
+        expect(fn).toMatch(/if \(blocked\) return \{ ok: false, kind: 'BLOCKED'/)
     })
 
     it('reuses the same collector as the addendum', () => {
-        expect(functionBody('exportDeviceSupportStatement')).toContain('collectAddendumData')
+        expect(helper).toContain('collectAddendumData')
     })
 
     it('always clears the export spinner in a finally', () => {
@@ -67,9 +83,8 @@ describe('the device support statement is wired into the export modal', () => {
     })
 
     it('appends, clicks, removes, then revokes the object URL', () => {
-        const body = functionBody('exportDeviceSupportStatement')
-        expect(body.indexOf('appendChild')).toBeLessThan(body.indexOf('link.click()'))
-        expect(body.indexOf('link.click()')).toBeLessThan(body.indexOf('revokeObjectURL'))
+        expect(helper.indexOf('appendChild')).toBeLessThan(helper.indexOf('link.click()'))
+        expect(helper.indexOf('link.click()')).toBeLessThan(helper.indexOf('revokeObjectURL'))
     })
 })
 
@@ -98,7 +113,92 @@ describe('the statement Export button respects the product gate', () => {
      * The refusals that need data keep their modal. Disabling the button for a reason we have
      * not checked yet would be a worse lie than the redundant dialog this replaced.
      */
-    it('leaves the data-dependent refusals as modals', () => {
-        expect(source).toMatch(/Swal\.fire\('Statement not generated', blocked, 'warning'\)/)
+    it('leaves the data-dependent refusals as modals, and keeps blocked distinct from failed', () => {
+        expect(source).toMatch(
+            /Swal\.fire\('Statement not generated', outcome\.message, outcome\.kind === 'BLOCKED' \? 'warning' : 'error'\)/)
+    })
+})
+
+/**
+ * The SHIPMENT entry point on the Distribution page (plan 7h).
+ *
+ * Same file family, same reason: no vue-tsc, so a column that renders an undefined handler
+ * is a runtime error every unit test passes over.
+ */
+const dist = readFileSync(
+    fileURLToPath(new URL('./DistributionOfOrg.vue', import.meta.url)), 'utf8')
+const shipmentExport = (() => {
+    const start = dist.indexOf('async function exportShipmentStatement (')
+    if (start < 0) throw new Error('no exportShipmentStatement in DistributionOfOrg.vue')
+    let depth = 0
+    let i = dist.indexOf('{', start)
+    const open = i
+    for (; i < dist.length; i++) {
+        if (dist[i] === '{') depth++
+        else if (dist[i] === '}' && --depth === 0) break
+    }
+    return dist.slice(open, i + 1)
+})()
+
+describe('a statement can be generated from a shipment', () => {
+    it('goes through the same helper as the release view, not a second copy', () => {
+        expect(dist).toMatch(
+            /import \{ generateDeviceSupportStatement \} from '@\/utils\/deviceSupportStatementExport'/)
+        expect(shipmentExport).toContain('generateDeviceSupportStatement(')
+        expect(dist).not.toMatch(/renderDeviceSupportStatementBlob|statementBlockReason/)
+    })
+
+    /**
+     * The provenance and the dates come from the SAME row, in the same object. A call that
+     * passed the batch without its window would print the model's dates under a line naming
+     * the batch -- a statement contradicting itself about which units it describes.
+     */
+    it('passes the delivery provenance and the delivery window together', () => {
+        for (const field of ['siteName:', 'shipDate:', 'batchIdentifier:', 'eos:', 'eol:']) {
+            expect(shipmentExport, `${field} must be in the shipment context`).toContain(field)
+        }
+        expect(shipmentExport).toMatch(/eos: w\?\.eos \|\| null/)
+        expect(shipmentExport).toMatch(/eol: w\?\.eol \|\| null/)
+        expect(shipmentExport).toMatch(/const w = r\.effectiveDeviceSupportWindow/)
+        // named by what a reader can match against a delivery note, not by uuid
+        expect(shipmentExport).toMatch(/batchIdentifier: summarizeIds\(r\.identifiers\)/)
+        expect(shipmentExport).not.toMatch(/r\.uuid/)
+    })
+
+    it('offers the action only where a window is in force', () => {
+        const col = dist.slice(dist.indexOf('const statementColumn'), dist.indexOf('const editShipmentColumn'))
+        expect(col).toMatch(/const has = !!\(w && \(w\.eos \|\| w\.eol\)\)/)
+        expect(col).toMatch(/if \(has\) exportShipmentStatement\(r\)/)
+        // and says why, rather than answering the click with a dialog
+        expect(col).toMatch(/No device support window is in force for this delivery/)
+        // The gate is readable from outside, so the live probe asserts the same fact the
+        // unit tests do rather than inferring it from a cursor style.
+        expect(col).toMatch(/'data-testid': 'shipment-statement-action'/)
+        expect(col).toMatch(/'data-window-in-force': String\(has\)/)
+    })
+
+    it('reads the effective window from the shipment query', () => {
+        expect(dist).toMatch(/effectiveDeviceSupportWindow \{ eos eol source \}/)
+    })
+
+    /**
+     * EVERY shipment table offers it, because the gate is the window in force and not the
+     * shipment's classification: a plain-software delivery of a device model reached units
+     * that run under a window too. Both tables read the SAME column object -- the software
+     * table used to pick the edit icon up as `shipmentColumns[length - 1]`, which would have
+     * silently handed it whichever column was appended last instead.
+     */
+    it('is offered by both shipment tables, from one column definition', () => {
+        for (const table of ['const shipmentColumns', 'const softwareShipmentColumns']) {
+            const cols = dist.slice(dist.indexOf(table))
+            expect(cols.slice(0, cols.indexOf('\n])')), `${table} must carry the statement action`)
+                .toMatch(/\n    statementColumn,/)
+        }
+        expect(dist).not.toMatch(/shipmentColumns\.value as any\[\]\)\[\(shipmentColumns/)
+    })
+
+    it('reports a refusal as a refusal and a failure as a failure', () => {
+        expect(shipmentExport).toMatch(
+            /notify\(outcome\.kind === 'BLOCKED' \? 'warning' : 'error', 'Statement not generated'/)
     })
 })

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -3,6 +3,9 @@ import { resolveNarrative, toAddendumComponent, isLiveAttestation, collectAddend
     ADDENDUM_PAGE_QUERY, ADDENDUM_RELEASE_QUERY, ADDENDUM_ORG_QUERY,
     ADDENDUM_MAX_COMPONENTS } from './addendumData'
 import { BULK_WALK_LIMIT } from './useBulkAttest'
+// The shipment cases below assert on the RENDERED statement: the failure they guard is the
+// dates and the provenance line disagreeing, which only the document shows.
+import { buildDeviceSupportStatementDefinition } from './deviceSupportStatement'
 
 describe('resolveNarrative', () => {
     // The seam every document reads through. Reading either stored field directly is the
@@ -439,6 +442,76 @@ describe('collectAddendumData', () => {
     })
 })
 
+
+/**
+ * A statement generated from a SHIPMENT (plan 7h).
+ *
+ * The assertions land on the RENDERED document, not on the collected facts, because the
+ * failure this guards is the two disagreeing: a provenance line naming a batch over the
+ * dates that batch overrode. Collected data alone cannot show that.
+ */
+describe('a statement generated from a shipment', () => {
+    const flat = (n: any): string =>
+        typeof n === 'string' ? n
+            : Array.isArray(n) ? n.map(flat).join(' ')
+                : n && typeof n === 'object' ? Object.values(n).map(flat).join(' ') : ''
+    const shipment = {
+        siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: 'LOT:77, SERIAL:A9',
+        eos: '2029-03-31', eol: '2030-09-30'
+    }
+    const collectForShipment = async (over: any = {}) => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        return await collectAddendumData(client as any, 'r1', 'o1', { ...shipment, ...over }) as any
+    }
+
+    it('prints the batch-overridden dates in the PDF, not the model default', async () => {
+        const res = await collectForShipment()
+        expect(res.ok).toBe(true)
+        // The fixture's model window is 2031-01-31 / 2034-12-31 -- deliberately different, so
+        // a collector that kept reading the model would produce visibly wrong output.
+        expect(res.data.deviceEos).toBe('2029-03-31')
+        expect(res.data.deviceEol).toBe('2030-09-30')
+        const text = flat(buildDeviceSupportStatementDefinition(res.data))
+        expect(text).toMatch(/2029-03-31/)
+        expect(text).toMatch(/2030-09-30/)
+        expect(text).not.toMatch(/2031-01-31/)
+        expect(text).not.toMatch(/2034-12-31/)
+    })
+
+    it('names the delivery the dates came from, in the same document', async () => {
+        const text = flat(buildDeviceSupportStatementDefinition((await collectForShipment()).data))
+        expect(text).toMatch(/delivered to St Elsewhere ICU/)
+        expect(text).toMatch(/on 2026-04-02/)
+        // The batch identifiers as recorded, so a reader can match them to a delivery note.
+        expect(text).toMatch(/\(batch LOT:77, SERIAL:A9\)/)
+        expect(text).toMatch(/may differ from other deliveries of the same device/)
+        expect(text).not.toMatch(/apply to every unit of it/)
+    })
+
+    /**
+     * The refusal that keeps the two from drifting apart. Falling through to the model
+     * default here would print the model's dates under a line naming a batch -- a statement
+     * that contradicts itself about which units it covers.
+     */
+    it('refuses a delivery with no effective window instead of falling back to the model', async () => {
+        const res = await collectForShipment({ eos: null, eol: null })
+        expect(res.ok).toBe(false)
+        expect(res.error).toMatch(/no device support window in force/)
+    })
+
+    it('still generates from the release when no shipment is named', async () => {
+        const client = fakeClient({
+            release: okRelease, org: okOrg, coverage: { total: 0, attested: 0 },
+            pages: [{ items: [], totalCount: 0, endCursor: null, hasMore: false }]
+        })
+        const res: any = await collectAddendumData(client as any, 'r1', 'o1')
+        expect(res.data.deviceEos).toBe('2031-01-31')
+        expect(res.data.deviceWindowSource).toEqual({ level: 'COMPONENT', productName: 'Pump' })
+    })
+})
 
 describe('the device window source (D7)', () => {
     /**

--- a/ui/src/utils/addendumData.spec.ts
+++ b/ui/src/utils/addendumData.spec.ts
@@ -457,7 +457,7 @@ describe('a statement generated from a shipment', () => {
                 : n && typeof n === 'object' ? Object.values(n).map(flat).join(' ') : ''
     const shipment = {
         siteName: 'St Elsewhere ICU', shipDate: '2026-04-02', batchIdentifier: 'LOT:77, SERIAL:A9',
-        eos: '2029-03-31', eol: '2030-09-30'
+        eos: '2029-03-31', eol: '2030-09-30', windowSource: 'SHIPMENT' as const
     }
     const collectForShipment = async (over: any = {}) => {
         const client = fakeClient({
@@ -500,6 +500,26 @@ describe('a statement generated from a shipment', () => {
         const res = await collectForShipment({ eos: null, eol: null })
         expect(res.ok).toBe(false)
         expect(res.error).toMatch(/no device support window in force/)
+    })
+
+    /**
+     * A delivery that INHERITED the model window is not batch-specific. Saying "these dates
+     * apply to the units delivered to X, and may differ from other deliveries" over inherited
+     * dates asserts a scope that does not exist -- and the release-generated statement for the
+     * same device says the opposite, so two patient-facing documents would contradict each
+     * other. The provenance follows the dates, not the entry point.
+     */
+    it('says the MODEL line when the delivery inherited the model window', async () => {
+        const res = await collectForShipment({
+            windowSource: 'COMPONENT', eos: '2031-01-31', eol: '2034-12-31'
+        })
+        expect(res.ok).toBe(true)
+        expect(res.data.deviceWindowSource).toEqual({ level: 'COMPONENT', productName: 'Pump' })
+        const text = flat(buildDeviceSupportStatementDefinition(res.data))
+        expect(text).toMatch(/declared on Pump and apply to every unit of it/)
+        expect(text).not.toMatch(/delivered to St Elsewhere ICU/)
+        expect(text).not.toMatch(/may differ from other deliveries/)
+        expect(text).toMatch(/2031-01-31/)
     })
 
     it('still generates from the release when no shipment is named', async () => {

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -171,6 +171,15 @@ export interface AddendumComponent {
  * site and ship date, plus the batch identifier when one was recorded -- rather than by the
  * word "override" or a uuid. "Override" is our vocabulary, not theirs.
  */
+/**
+ * The refusal when a delivery has no window in force. Exported because the caller gates the
+ * action on the same fact and must say the same thing when it slips through -- a row whose
+ * window was retracted in another session since the page loaded.
+ */
+export const NO_WINDOW_IN_FORCE = 'This delivery has no device support window in force, so a'
+    + ' statement generated for it would have no dates to state. Declare the window on the'
+    + ' device model, or record an override on the shipment.'
+
 export type DeviceWindowProvenance =
     | { level: 'COMPONENT', productName: string | null }
     | { level: 'SHIPMENT', siteName: string | null, shipDate: string | null, batchIdentifier: string | null }
@@ -203,16 +212,34 @@ export function deviceWindowProvenanceLine (
  * that batch overrode -- the one failure mode this shape exists to make unrepresentable.
  * `eos`/`eol` are the shipment's EFFECTIVE window (the override where there is one, the
  * model default where there is not), which is what the units in that delivery actually run
- * under.
+ * under -- and `windowSource` says which of those two it was, because the provenance LINE
+ * must follow the dates. A delivery that inherited the model window is not batch-specific,
+ * and saying "these dates apply to the units delivered to X, and may differ from other
+ * deliveries" over inherited dates asserts a batch-specificity that does not exist -- while
+ * the release-generated statement for the same device says the opposite.
  */
 export interface ShipmentStatementContext {
     siteName: string | null
     shipDate: string | null
-    /** The batch identifiers as recorded on the shipment, already joined for a reader. */
+    /**
+     * The batch identifiers as recorded on the shipment, joined for a reader.
+     *
+     * A joined string, in a module whose header forbids joining -- deliberately, and this is
+     * the one place it is right: the field it feeds, DeviceWindowProvenance.batchIdentifier,
+     * is already a single reader-facing string (see 7f), and re-deriving it downstream would
+     * make the document's own provenance line the second source of truth for it. What the
+     * header forbids is formatting facts COLLECTED FROM THE SERVER; this is a caller's
+     * statement about its own row.
+     */
     batchIdentifier: string | null
     eos: string | null
     eol: string | null
+    /** Where the effective window was declared, from the server's resolver. */
+    windowSource: DeviceWindowLevel | null
 }
+
+/** The levels a device window can be declared at, as the server's resolver reports them. */
+export type DeviceWindowLevel = 'COMPONENT' | 'SHIPMENT'
 
 export interface AddendumData {
     releaseUuid: string
@@ -343,6 +370,17 @@ export async function collectAddendumData (
     orgUuid: string,
     shipment?: ShipmentStatementContext | null
 ): Promise<AddendumResult> {
+    // Generated from a SHIPMENT: the dates AND the provenance come from the delivery, or
+    // neither does. A delivery with no effective window refuses BEFORE the walk rather than
+    // falling through to the model default, which would print the model's dates under a line
+    // naming a batch -- a statement that contradicts itself about which units it covers. The
+    // caller offers the action only where a window resolved; this is the guard, not a
+    // courtesy, and nothing about it needs the server.
+    if (shipment && !shipment.eos && !shipment.eol) {
+        return { ok: false, error: NO_WINDOW_IN_FORCE }
+    }
+    const shipmentEos = shipment ? blankToNull(shipment.eos) : null
+    const shipmentEol = shipment ? blankToNull(shipment.eol) : null
     try {
         // FULL, falling back to CORE on a drift error -- not FULL alone. CE declares
         // Component.medicalProfile WITHOUT deviceSupportWindow inside it, so asking for the
@@ -459,19 +497,6 @@ export async function collectAddendumData (
         // Absent on a CORE response (a CE backend cannot answer for it), which correctly
         // reports the window as "not declared" rather than inventing one.
         const deviceWindow = release.componentDetails?.medicalProfile?.deviceSupportWindow ?? null
-        // Generated from a SHIPMENT: the dates AND the provenance come from the delivery, or
-        // neither does. A shipment with no effective window refuses here rather than falling
-        // through to the model default, which would print the model's dates under a line
-        // naming a batch -- a statement that contradicts itself about which units it covers.
-        // The caller offers the action only where a window resolved; this is the guard, not
-        // a courtesy.
-        if (shipment && !shipment.eos && !shipment.eol) {
-            return { ok: false, error: 'This delivery has no device support window in force, so'
-                + ' a statement generated for it would have no dates to state. Declare the'
-                + ' window on the device model, or record an override on the shipment.' }
-        }
-        const shipmentEos = shipment ? blankToNull(shipment.eos) : null
-        const shipmentEol = shipment ? blankToNull(shipment.eol) : null
         return {
             ok: true,
             data: {
@@ -488,14 +513,17 @@ export async function collectAddendumData (
                 // Generated from a release, so the window is the product component's -- unless
                 // a shipment was named, in which case both the dates above and this line come
                 // from that delivery. They move together or not at all.
-                deviceWindowSource: shipment
+                // The provenance follows the DATES, not the entry point. A delivery that
+                // inherited the model window gets the model's line -- the same sentence the
+                // release-generated statement carries, because it is the same fact.
+                deviceWindowSource: (shipment && shipment.windowSource === 'SHIPMENT')
                     ? {
                         level: 'SHIPMENT',
                         siteName: blankToNull(shipment.siteName),
                         shipDate: blankToNull(shipment.shipDate),
                         batchIdentifier: blankToNull(shipment.batchIdentifier)
                     }
-                    : (deviceWindow?.eos || deviceWindow?.eol)
+                    : (shipment || deviceWindow?.eos || deviceWindow?.eol)
                         ? { level: 'COMPONENT', productName: blankToNull(release.componentDetails?.name) }
                         : null,
                 narrative: resolved.narrative,

--- a/ui/src/utils/addendumData.ts
+++ b/ui/src/utils/addendumData.ts
@@ -194,6 +194,26 @@ export function deviceWindowProvenanceLine (
         + ' deliveries of the same device.'
 }
 
+/**
+ * The shipment a statement is being generated FOR, when it is generated from a shipment
+ * rather than from the release (plan 7h).
+ *
+ * PROVENANCE AND DATES IN ONE OBJECT, deliberately. A caller that could pass the batch
+ * without its window would produce a statement that names a batch and then prints the dates
+ * that batch overrode -- the one failure mode this shape exists to make unrepresentable.
+ * `eos`/`eol` are the shipment's EFFECTIVE window (the override where there is one, the
+ * model default where there is not), which is what the units in that delivery actually run
+ * under.
+ */
+export interface ShipmentStatementContext {
+    siteName: string | null
+    shipDate: string | null
+    /** The batch identifiers as recorded on the shipment, already joined for a reader. */
+    batchIdentifier: string | null
+    eos: string | null
+    eol: string | null
+}
+
 export interface AddendumData {
     releaseUuid: string
     releaseVersion: string | null
@@ -320,7 +340,8 @@ export function isLiveAttestation (c: AddendumComponent): boolean {
 export async function collectAddendumData (
     client: DriftFallbackClient,
     releaseUuid: string,
-    orgUuid: string
+    orgUuid: string,
+    shipment?: ShipmentStatementContext | null
 ): Promise<AddendumResult> {
     try {
         // FULL, falling back to CORE on a drift error -- not FULL alone. CE declares
@@ -438,6 +459,19 @@ export async function collectAddendumData (
         // Absent on a CORE response (a CE backend cannot answer for it), which correctly
         // reports the window as "not declared" rather than inventing one.
         const deviceWindow = release.componentDetails?.medicalProfile?.deviceSupportWindow ?? null
+        // Generated from a SHIPMENT: the dates AND the provenance come from the delivery, or
+        // neither does. A shipment with no effective window refuses here rather than falling
+        // through to the model default, which would print the model's dates under a line
+        // naming a batch -- a statement that contradicts itself about which units it covers.
+        // The caller offers the action only where a window resolved; this is the guard, not
+        // a courtesy.
+        if (shipment && !shipment.eos && !shipment.eol) {
+            return { ok: false, error: 'This delivery has no device support window in force, so'
+                + ' a statement generated for it would have no dates to state. Declare the'
+                + ' window on the device model, or record an override on the shipment.' }
+        }
+        const shipmentEos = shipment ? blankToNull(shipment.eos) : null
+        const shipmentEol = shipment ? blankToNull(shipment.eol) : null
         return {
             ok: true,
             data: {
@@ -449,13 +483,21 @@ export async function collectAddendumData (
                 // release. release.eos/eol are release lifecycle for TEA/CLE -- reading them
                 // here is what made one physical device describable by a dozen different
                 // end-of-support dates depending on which firmware it happened to run.
-                deviceEos: blankToNull(deviceWindow?.eos),
-                deviceEol: blankToNull(deviceWindow?.eol),
-                // Generated from a release, so the window is the product component's. A
-                // shipment-generated statement supplies the SHIPMENT shape instead.
-                deviceWindowSource: (deviceWindow?.eos || deviceWindow?.eol)
-                    ? { level: 'COMPONENT', productName: blankToNull(release.componentDetails?.name) }
-                    : null,
+                deviceEos: shipment ? shipmentEos : blankToNull(deviceWindow?.eos),
+                deviceEol: shipment ? shipmentEol : blankToNull(deviceWindow?.eol),
+                // Generated from a release, so the window is the product component's -- unless
+                // a shipment was named, in which case both the dates above and this line come
+                // from that delivery. They move together or not at all.
+                deviceWindowSource: shipment
+                    ? {
+                        level: 'SHIPMENT',
+                        siteName: blankToNull(shipment.siteName),
+                        shipDate: blankToNull(shipment.shipDate),
+                        batchIdentifier: blankToNull(shipment.batchIdentifier)
+                    }
+                    : (deviceWindow?.eos || deviceWindow?.eol)
+                        ? { level: 'COMPONENT', productName: blankToNull(release.componentDetails?.name) }
+                        : null,
                 narrative: resolved.narrative,
                 narrativeIsPerRelease: resolved.perRelease,
                 orgName: blankToNull(org?.name),

--- a/ui/src/utils/deviceSupportStatement.spec.ts
+++ b/ui/src/utils/deviceSupportStatement.spec.ts
@@ -316,6 +316,29 @@ describe('deviceSupportStatementFileName', () => {
         expect(deviceSupportStatementFileName(data({ releaseVersion: null, releaseUuid: null as any })))
             .toBe('device-support-statement-release.pdf')
     })
+
+    /**
+     * Two batches of the same release carry DIFFERENT dates. Two downloads called
+     * `device-support-statement-1.4.2.pdf` in one folder is one of them silently replacing
+     * the other -- in a folder of regulatory documents.
+     */
+    it('names the delivery too, when the dates are a delivery\'s', () => {
+        const name = deviceSupportStatementFileName(data({
+            deviceWindowSource: { level: 'SHIPMENT', siteName: 'St Elsewhere ICU',
+                shipDate: '2026-04-02', batchIdentifier: 'LOT:77' }
+        }))
+        expect(name).toBe('device-support-statement-9000.1.0-2026-04-02-LOT-77.pdf')
+        expect(name).not.toBe(deviceSupportStatementFileName(data()))
+    })
+
+    it('stays a usable file name when the batch carries punctuation', () => {
+        const name = deviceSupportStatementFileName(data({
+            deviceWindowSource: { level: 'SHIPMENT', siteName: null, shipDate: null,
+                batchIdentifier: 'LOT:77 / SERIAL:A9' }
+        }))
+        expect(name).toBe('device-support-statement-9000.1.0-LOT-77-SERIAL-A9.pdf')
+        expect(name).not.toMatch(/[/:\\ ]/)
+    })
 })
 
 describe('what the statement must never carry', () => {

--- a/ui/src/utils/deviceSupportStatement.ts
+++ b/ui/src/utils/deviceSupportStatement.ts
@@ -291,8 +291,23 @@ export function buildDeviceSupportStatementDefinition (d: AddendumData): Record<
     }
 }
 
+/**
+ * The file name. A SHIPMENT-generated statement names the delivery too: two batches of the
+ * same release carry DIFFERENT dates, and two downloads called
+ * `device-support-statement-1.4.2.pdf` in the same folder is one of them silently replacing
+ * the other -- in a folder of regulatory documents.
+ *
+ * Derived from the data rather than passed in, so the name cannot disagree with the
+ * provenance line inside the document.
+ */
 export function deviceSupportStatementFileName (d: AddendumData): string {
-    return `device-support-statement-${releaseSlug(d)}.pdf`
+    const p = d.deviceWindowSource
+    const delivery = p && p.level === 'SHIPMENT'
+        ? [p.shipDate, p.batchIdentifier].filter(Boolean).join('-')
+        : ''
+    const slug = (s: string) => s.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
+    return `device-support-statement-${releaseSlug(d)}`
+        + (delivery ? `-${slug(delivery)}` : '') + '.pdf'
 }
 
 export async function renderDeviceSupportStatementBlob (d: AddendumData): Promise<Blob> {

--- a/ui/src/utils/deviceSupportStatementExport.ts
+++ b/ui/src/utils/deviceSupportStatementExport.ts
@@ -1,0 +1,66 @@
+// Generate a Device Support Statement and hand it to the browser, from ONE place.
+//
+// Lifted out of ReleaseView's export modal when the shipment entry point landed (plan 7h).
+// Two call sites now ask for the same document -- a product release, and a delivery of that
+// release -- and the sequence they must follow is not obvious from the outside: collect,
+// then check the block reasons BEFORE anything is built, then render. A second copy of that
+// sequence is a second chance to skip the block check, and the block check is what keeps a
+// patient-facing PDF with an empty section from being produced at all.
+//
+// The refusals are RETURNED, not shown. The two callers speak different dialects -- a modal
+// in the release view, a notification on the distribution page -- and a util that reaches
+// for Swal would decide that for them. They are also distinguished by KIND, because the
+// release view has always shown a failed collect as an error and a refusal as a warning:
+// one is "something went wrong", the other is "this document must not exist yet".
+
+import { collectAddendumData, type ShipmentStatementContext } from './addendumData'
+import type { DriftFallbackClient } from './graphqlDriftFallback'
+import {
+    statementBlockReason, renderDeviceSupportStatementBlob, deviceSupportStatementFileName
+} from './deviceSupportStatement'
+
+export interface DeviceSupportStatementRequest {
+    releaseUuid: string
+    orgUuid: string
+    /** Present when the statement is generated for a DELIVERY of that release (plan 7h). */
+    shipment?: ShipmentStatementContext | null
+}
+
+export type DeviceSupportStatementOutcome =
+    /** FAILED: the facts could not be assembled. Something went wrong. */
+    | { ok: false, kind: 'FAILED', message: string }
+    /** BLOCKED: the facts were assembled and say this document must not be produced. */
+    | { ok: false, kind: 'BLOCKED', message: string }
+    | { ok: true, fileName: string }
+
+/** Hands a rendered blob to the browser as a download. Separated so tests can skip the DOM. */
+function download (blob: Blob, fileName: string): void {
+    const link = document.createElement('a')
+    link.href = window.URL.createObjectURL(blob)
+    link.download = fileName
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    window.URL.revokeObjectURL(link.href)
+}
+
+/**
+ * Collect, refuse, render, download -- in that order, once.
+ *
+ * Throws nothing: a transport failure inside the collect is already returned as a refusal by
+ * collectAddendumData, and a renderer that throws its own block reason is reported as BLOCKED
+ * rather than escaping as an exception the caller would have to classify itself.
+ */
+export async function generateDeviceSupportStatement (
+    client: DriftFallbackClient,
+    req: DeviceSupportStatementRequest
+): Promise<DeviceSupportStatementOutcome> {
+    const result = await collectAddendumData(client, req.releaseUuid, req.orgUuid, req.shipment ?? null)
+    if (!result.ok) return { ok: false, kind: 'FAILED', message: result.error }
+    // Every refusal in one place, checked BEFORE anything is built.
+    const blocked = statementBlockReason(result.data)
+    if (blocked) return { ok: false, kind: 'BLOCKED', message: blocked }
+    const fileName = deviceSupportStatementFileName(result.data)
+    download(await renderDeviceSupportStatementBlob(result.data), fileName)
+    return { ok: true, fileName }
+}

--- a/ui/src/utils/deviceSupportStatementExport.ts
+++ b/ui/src/utils/deviceSupportStatementExport.ts
@@ -13,7 +13,7 @@
 // release view has always shown a failed collect as an error and a refusal as a warning:
 // one is "something went wrong", the other is "this document must not exist yet".
 
-import { collectAddendumData, type ShipmentStatementContext } from './addendumData'
+import { collectAddendumData, NO_WINDOW_IN_FORCE, type ShipmentStatementContext } from './addendumData'
 import type { DriftFallbackClient } from './graphqlDriftFallback'
 import {
     statementBlockReason, renderDeviceSupportStatementBlob, deviceSupportStatementFileName
@@ -47,20 +47,31 @@ function download (blob: Blob, fileName: string): void {
 /**
  * Collect, refuse, render, download -- in that order, once.
  *
- * Throws nothing: a transport failure inside the collect is already returned as a refusal by
- * collectAddendumData, and a renderer that throws its own block reason is reported as BLOCKED
- * rather than escaping as an exception the caller would have to classify itself.
+ * Throws nothing: every failure comes back as an outcome the caller can classify without
+ * inspecting an exception. The renderer enforces the block reasons a second time and throws
+ * if it finds one, which is reported rather than escaped.
  */
 export async function generateDeviceSupportStatement (
     client: DriftFallbackClient,
     req: DeviceSupportStatementRequest
 ): Promise<DeviceSupportStatementOutcome> {
+    // A delivery with no window in force is a POLICY refusal, not a failure -- the same
+    // fact the caller gates its control on, restated here for the case where the row went
+    // stale (the window retracted on the model in another session). Checked before the
+    // collect so it does not arrive as a red "something went wrong" over a walked release.
+    if (req.shipment && !req.shipment.eos && !req.shipment.eol) {
+        return { ok: false, kind: 'BLOCKED', message: NO_WINDOW_IN_FORCE }
+    }
     const result = await collectAddendumData(client, req.releaseUuid, req.orgUuid, req.shipment ?? null)
     if (!result.ok) return { ok: false, kind: 'FAILED', message: result.error }
     // Every refusal in one place, checked BEFORE anything is built.
     const blocked = statementBlockReason(result.data)
     if (blocked) return { ok: false, kind: 'BLOCKED', message: blocked }
     const fileName = deviceSupportStatementFileName(result.data)
-    download(await renderDeviceSupportStatementBlob(result.data), fileName)
+    try {
+        download(await renderDeviceSupportStatementBlob(result.data), fileName)
+    } catch (e: any) {
+        return { ok: false, kind: 'FAILED', message: e?.message || String(e) }
+    }
     return { ok: true, fileName }
 }


### PR DESCRIPTION
Wires the entry point plan 7h deferred: **a Device Support Statement generated from a SHIPMENT**, as an action on the shipment row of the Distribution page. Design note on board task `t20260907-044617-15432`; this implements it with the operator's three conditions.

The SHIPMENT provenance shape (`AddendumData.deviceWindowSource`, site / ship date / batch identifier) and its renderer have existed with tests since the statement landed -- reachable only from tests, because nothing produced it. Nothing about the document changes here; what changes is which inputs are collected.

## The three conditions

**1. Provenance and the effective window travel together.** `ShipmentStatementContext` carries `siteName` / `shipDate` / `batchIdentifier` **and** `eos` / `eol` in one object, so a caller cannot supply one without the other. `collectAddendumData` takes the dates from it when it is present, and **refuses** a delivery with no window in force rather than falling through to the model default. That fallback is the whole failure mode: a line naming a batch printed over the dates that batch overrode -- a statement contradicting itself about which units it describes.

Unit test, as asked, asserting on the **rendered document** rather than the collected facts (only the document can show the two disagreeing): the fixture's model window is `2031-01-31` / `2034-12-31`, the delivery's is `2029-03-31` / `2030-09-30`, and the PDF definition carries the delivery's and not the model's.

**2. The row action is gated on an effective window.** No window in force, no action: the icon is inert with the reason on it, rather than a button that answers the click with a dialog -- the pattern the release view already had to walk back (board `t20260909-061338-23148` step 6d).

Gated on the **window in force, not on the shipment's classification**: a plain-software delivery of a device model reached units that run under a window too. So both shipment tables offer it, from one shared column definition. That also removes a live trap -- the software table picked the edit icon up as `shipmentColumns[length - 1]`, which would have silently handed it whichever column was appended last.

**3. The statement names the batch identifiers and the source.** `batchIdentifier` is the shipment's identifiers joined the way this page shows them everywhere else (`summarizeIds`), so the provenance line reads `These dates apply to the units delivered to St Elsewhere ICU on 2026-04-02 (batch LOT:77, SERIAL:A9), and may differ from other deliveries of the same device.` Still never the word "override" and never a uuid.

## Also in here

`collect / refuse / render / download` moved whole into `utils/deviceSupportStatementExport.ts`. Two callers now ask for this document, and a second copy of that sequence is a second chance to skip the block check -- which is what keeps a patient-facing PDF with an empty section from existing. The refusals are **returned, not shown**: the release view keeps its modal and the distribution page notifies, and both still distinguish FAILED ("something went wrong") from BLOCKED ("this document must not exist yet"). The wiring pins that used to read `ReleaseView.vue` moved to the helper rather than being deleted.

## Validation

- `npm run test`: **58 files, 853 tests passing** (nothing in CI runs this suite). New: the four shipment cases above, plus wiring pins for the shared helper, the shipment context, the gate, and both tables reading one column.
- `npm run build`: clean.
- Live, against sandbox backend `fda-readiness-1-dev.25` with this branch's build served over the origin: `d7-window-probe.mjs` **38/38**, including a new step 6.7b that downloads the shipment-generated PDF and reads it with `pdftotext` -- batch dates present, model dates absent, the delivery named, no "override", no uuid. Probe change is relizaio/rearm-saas#<probe PR>.
- Sandbox restored and read back: shipment `deviceSupportWindow` and `effectiveDeviceSupportWindow` both `null`, as before the run.

One honest gap: the live probe exercises the **omit** branch of the batch clause, not the naming one -- the sandbox's only shipment is plain software, and the server clears batch identifiers on those. The naming branch is unit-tested.

Not in this PR, still open on the board: `client: ID` on `DeviceSupportRiskRow`, so a unit whose client is archived stops reading as a unit with no client.

Do not merge yet: two-layer review gate to follow.