### PR TITLE
fix(ui): key tables read left to right, request a key on one screen

### DIFF
--- a/ui/src/components/ApiKeyPermissionsModal.vue
+++ b/ui/src/components/ApiKeyPermissionsModal.vue
@@ -197,14 +197,24 @@ async function sendRequest () {
     }
 }
 
+/**
+ * Load what the editor offers to pick from. Each list is best effort: a member without
+ * instance visibility, for example, still gets components and products, and a failure here
+ * must not surface as an unhandled rejection from the watch that calls load().
+ */
+async function loadOrgObjects () {
+    const loads: Promise<any>[] = [loadPerspectives(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
+    if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
+    const results = await Promise.allSettled(loads)
+    for (const r of results) if (r.status === 'rejected') console.warn('permissions editor: an org object list is unavailable to this user', r.reason?.message || r.reason)
+}
+
 async function load () {
     if (!props.orgUuid) return
     if (isRequest.value) {
         loading.value = true
         try {
-            const loads: Promise<any>[] = [loadPerspectives(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
-            if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
-            await Promise.all(loads)
+            await loadOrgObjects()
             scoped.value = { orgPermission: { type: 'NONE', functions: [], approvals: [] }, scopedPermissions: [] }
             notes.value = ''
         } finally { loading.value = false }
@@ -213,9 +223,7 @@ async function load () {
     if (!props.apiKey) return
     loading.value = true
     try {
-        const loads: Promise<any>[] = [loadPerspectives(), loadOwnerPermissions(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
-        if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
-        await Promise.all(loads)
+        await Promise.all([loadOrgObjects(), loadOwnerPermissions()])
         const scopedPerms: any[] = []
         let orgPerm = { type: 'NONE', functions: [] as string[], approvals: [] as string[] }
         for (const up of (props.apiKey.permissions?.permissions || [])) {

--- a/ui/src/components/ApiKeyPermissionsModal.vue
+++ b/ui/src/components/ApiKeyPermissionsModal.vue
@@ -6,9 +6,34 @@
         :show="show"
         @update:show="(v: boolean) => { if (!v) emit('update:show', false) }"
     >
-        <template #header>{{ isRequest ? 'Request a free-form key' : 'Edit key ' + apiKey?.uuid }}</template>
+        <template #header>{{ isRequest ? 'Request a Free Form key' : (isView ? 'Permissions of key ' : 'Edit key ') + apiKey?.uuid }}</template>
         <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
-            <div v-if="isRequest">
+            <div v-if="isView">
+                <p class="subtle" style="margin-top: 0;">What this key may do, as set by the organization admins. Ask an admin to change it.</p>
+                <n-spin :show="loading">
+                    <h5>Organization-wide</h5>
+                    <p v-if="scoped.orgPermission.type === 'NONE'" class="text-muted">none</p>
+                    <p v-else><strong>{{ scoped.orgPermission.type }}</strong>
+                        <span v-if="scoped.orgPermission.functions?.length"> · functions: {{ scoped.orgPermission.functions.join(', ') }}</span>
+                        <span v-if="scoped.orgPermission.approvals?.length"> · approvals: {{ scoped.orgPermission.approvals.join(', ') }}</span>
+                    </p>
+                    <h5>Per object</h5>
+                    <p v-if="!scoped.scopedPermissions.length" class="text-muted">none</p>
+                    <table v-else class="table-hover" style="width: 100%; font-size: 13px;">
+                        <thead><tr><th style="text-align: left;">Scope</th><th style="text-align: left;">Object</th><th style="text-align: left;">Type</th><th style="text-align: left;">Functions</th><th style="text-align: left;">Approvals</th></tr></thead>
+                        <tbody>
+                            <tr v-for="sp in scoped.scopedPermissions" :key="sp.scope + sp.objectId">
+                                <td>{{ sp.scope }}</td><td>{{ sp.objectName || sp.objectId }}</td><td>{{ sp.type }}</td>
+                                <td>{{ (sp.functions || []).join(', ') || '—' }}</td><td>{{ (sp.approvals || []).join(', ') || '—' }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <h5 style="margin-top: 16px;">Notes</h5>
+                    <p>{{ notes || '—' }}</p>
+                </n-spin>
+                <n-space style="margin-top: 20px;"><n-button @click="emit('update:show', false)">Close</n-button></n-space>
+            </div>
+            <div v-else-if="isRequest">
                 <n-form-item label="Purpose / notes (admins see this)">
                     <n-input v-model:value="notes" type="textarea" :autosize="{ minRows: 2, maxRows: 6 }" placeholder="e.g. CI pipeline for repo X needs release write on component Y" />
                 </n-form-item>
@@ -95,10 +120,11 @@ const props = defineProps<{
     apiKey: any
     orgUuid: string
     notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
-    /** 'edit' (default) edits an existing key; 'request' asks admins for a new free-form key with purpose and proposed permissions on one screen */
-    mode?: 'edit' | 'request'
+    /** 'edit' (default) edits an existing key; 'request' asks admins for a new Free Form key with purpose and proposed permissions on one screen */
+    mode?: 'edit' | 'request' | 'view'
 }>()
 const isRequest = computed(() => props.mode === 'request')
+const isView = computed(() => props.mode === 'view')
 const emit = defineEmits(['update:show', 'saved'])
 const store = useStore()
 

--- a/ui/src/components/ApiKeyPermissionsModal.vue
+++ b/ui/src/components/ApiKeyPermissionsModal.vue
@@ -6,8 +6,31 @@
         :show="show"
         @update:show="(v: boolean) => { if (!v) emit('update:show', false) }"
     >
-        <template #header>Edit key {{ apiKey?.uuid }}</template>
+        <template #header>{{ isRequest ? 'Request a free-form key' : 'Edit key ' + apiKey?.uuid }}</template>
         <div style="height: 700px; overflow-y: auto; padding-right: 8px;">
+            <div v-if="isRequest">
+                <n-form-item label="Purpose / notes (admins see this)">
+                    <n-input v-model:value="notes" type="textarea" :autosize="{ minRows: 2, maxRows: 6 }" placeholder="e.g. CI pipeline for repo X needs release write on component Y" />
+                </n-form-item>
+                <n-spin :show="loading">
+                    <ScopedPermissions
+                        v-model="scoped"
+                        :org-uuid="orgUuid"
+                        :approval-roles="approvalRoles"
+                        :perspectives="perspectives"
+                        :products="orgProducts"
+                        :components="orgComponents"
+                        :instances="orgInstances"
+                        :clusters="orgClusters"
+                        :show-sbom-probing="true"
+                    />
+                </n-spin>
+                <n-space style="margin-top: 20px;">
+                    <n-button type="primary" :disabled="loading || !notes.trim()" @click="sendRequest">Send request</n-button>
+                    <n-button @click="emit('update:show', false)">Cancel</n-button>
+                </n-space>
+            </div>
+            <template v-else>
             <p v-if="apiKey?.type === 'USER'" class="subtle" style="margin-top: 0;">
                 These permissions are a ceiling. Every call is also checked against the owner's own permissions at that moment, and the lower of the two wins.
                 Nothing is allowed until at least one permission is set.
@@ -46,6 +69,7 @@
                     </n-space>
                 </n-tab-pane>
             </n-tabs>
+            </template>
         </div>
     </n-modal>
 </template>
@@ -56,7 +80,7 @@
  * components, products and instances itself, so it can be used from org settings and from the
  * user's own keys on the profile page. Saves through setPermissionsOnFreeformApiKey / setNotesOnApiKey.
  */
-import { NModal, NTabs, NTabPane, NSpace, NButton, NInput, NSpin, NAlert } from 'naive-ui'
+import { NModal, NTabs, NTabPane, NSpace, NButton, NInput, NSpin, NAlert, NFormItem } from 'naive-ui'
 import { ref, computed, watch } from 'vue'
 import { useStore } from 'vuex'
 import gql from 'graphql-tag'
@@ -67,10 +91,14 @@ import ScopedPermissions from './ScopedPermissions.vue'
 
 const props = defineProps<{
     show: boolean
+    /** the key being edited; null in request mode */
     apiKey: any
     orgUuid: string
     notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
+    /** 'edit' (default) edits an existing key; 'request' asks admins for a new free-form key with purpose and proposed permissions on one screen */
+    mode?: 'edit' | 'request'
 }>()
+const isRequest = computed(() => props.mode === 'request')
 const emit = defineEmits(['update:show', 'saved'])
 const store = useStore()
 
@@ -142,8 +170,47 @@ async function resolveScopedObjectName (scope: string, objectId: string): Promis
     try { const fetched = await store.dispatch('fetchComponent', objectId); return fetched?.name || objectId } catch { return objectId }
 }
 
+function permissionsPayload (): { orgPermType: string, permissions: any[] } {
+    const permissions: any[] = []
+    const orgPermType = scoped.value.orgPermission.type
+    if (orgPermType && orgPermType !== 'NONE') {
+        permissions.push({ org: props.orgUuid, scope: 'ORGANIZATION', type: orgPermType, object: props.orgUuid, functions: scoped.value.orgPermission.functions || [], approvals: scoped.value.orgPermission.approvals || [] })
+    }
+    for (const sp of (scoped.value.scopedPermissions || [])) {
+        if (sp.type && sp.type !== 'NONE') permissions.push({ org: props.orgUuid, scope: sp.scope, type: sp.type, object: sp.objectId, functions: sp.functions || [], approvals: sp.approvals || [] })
+    }
+    return { orgPermType: orgPermType || 'NONE', permissions }
+}
+
+async function sendRequest () {
+    const { orgPermType, permissions } = permissionsPayload()
+    try {
+        await graphqlClient.mutate({
+            mutation: gql`mutation requestFreeformApiKey($orgUuid: ID!, $notes: String, $permissionType: PermissionType, $permissions: [PermissionInput]) {
+                requestFreeformApiKey(orgUuid: $orgUuid, notes: $notes, permissionType: $permissionType, permissions: $permissions) { uuid status } }`,
+            variables: { orgUuid: props.orgUuid, notes: notes.value, permissionType: orgPermType, permissions }, fetchPolicy: 'no-cache'
+        })
+        props.notify('success', 'Request sent', 'Admins of the organization will review it; you can edit the proposed permissions until it is decided')
+        emit('saved'); emit('update:show', false)
+    } catch (error: any) {
+        props.notify('error', 'Error', `Failed to send the request: ${commonFunctions.parseGraphQLError(error.message)}`)
+    }
+}
+
 async function load () {
-    if (!props.apiKey || !props.orgUuid) return
+    if (!props.orgUuid) return
+    if (isRequest.value) {
+        loading.value = true
+        try {
+            const loads: Promise<any>[] = [loadPerspectives(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
+            if (store.getters.myuser?.installationType !== 'OSS') loads.push(store.dispatch('fetchInstances', props.orgUuid))
+            await Promise.all(loads)
+            scoped.value = { orgPermission: { type: 'NONE', functions: [], approvals: [] }, scopedPermissions: [] }
+            notes.value = ''
+        } finally { loading.value = false }
+        return
+    }
+    if (!props.apiKey) return
     loading.value = true
     try {
         const loads: Promise<any>[] = [loadPerspectives(), loadOwnerPermissions(), store.dispatch('fetchComponents', props.orgUuid), store.dispatch('fetchProducts', props.orgUuid)]
@@ -166,14 +233,7 @@ async function load () {
 watch(() => props.show, (v) => { if (v) load() })
 
 async function savePermissions () {
-    const permissions: any[] = []
-    const orgPermType = scoped.value.orgPermission.type
-    if (orgPermType && orgPermType !== 'NONE') {
-        permissions.push({ org: props.orgUuid, scope: 'ORGANIZATION', type: orgPermType, object: props.orgUuid, functions: scoped.value.orgPermission.functions || [], approvals: scoped.value.orgPermission.approvals || [] })
-    }
-    for (const sp of (scoped.value.scopedPermissions || [])) {
-        if (sp.type && sp.type !== 'NONE') permissions.push({ org: props.orgUuid, scope: sp.scope, type: sp.type, object: sp.objectId, functions: sp.functions || [], approvals: sp.approvals || [] })
-    }
+    const { orgPermType, permissions } = permissionsPayload()
     try {
         const resp: any = await graphqlClient.mutate({
             mutation: gql`mutation setPermissionsOnFreeformApiKey($apiKeyUuid: ID!, $permissionType: PermissionType, $permissions: [PermissionInput]) {

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -626,7 +626,7 @@
                     <n-tab-pane name="freeFormKeys" tab="Free Form Keys">
                         <div v-if="computedKeyRequests.length" class="programmaticAccessBlock mt-4">
                             <h5>Key Requests</h5>
-                            <p class="subtle">Free-form keys members asked for. Review the proposed permissions, then approve or deny. Once approved, only the requester (the holder) can generate its secrets.</p>
+                            <p class="subtle">Free Form keys members asked for. Review the proposed permissions, then approve or deny. Once approved, only the requester (the holder) can generate its secrets.</p>
                             <n-data-table :columns="keyRequestFields" :data="computedKeyRequests" :scroll-x="1800"
                                 class="table-hover">
                             </n-data-table>

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -633,7 +633,7 @@
                         </div>
                         <div class="programmaticAccessBlock mt-4">
                             <h5>Free Form Keys</h5>
-                            <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2600"
+                            <n-data-table :columns="freeFormKeyFields" :data="computedFreeFormKeys" :scroll-x="2300"
                                 class="table-hover">
                             </n-data-table>
                             <n-icon v-if="isOrgAdmin" class="clickable" @click="genFreeFormApiKey"
@@ -644,7 +644,7 @@
                         <div class="programmaticAccessBlock mt-4">
                             <h5>User Keys</h5>
                             <p class="subtle">Personal keys that members create for themselves on their profile page. The permissions on a key are a ceiling: every call is also checked against the owner's own permissions at that moment, and the lower of the two wins.</p>
-                            <n-data-table :columns="userKeyFields" :data="computedUserKeys" :scroll-x="2400"
+                            <n-data-table :columns="userKeyFields" :data="computedUserKeys" :scroll-x="2200"
                                 class="table-hover">
                             </n-data-table>
                         </div>
@@ -653,7 +653,7 @@
                         <div class="programmaticAccessBlock mt-4">
                             <h5>Scoped Keys</h5>
                             <p class="subtle">Keys bound to one object: component, instance, cluster, organization-wide and approval keys.</p>
-                            <n-data-table :columns="programmaticAccessFields" :data="computedProgrammaticAccessKeys" :scroll-x="2400"
+                            <n-data-table :columns="programmaticAccessFields" :data="computedProgrammaticAccessKeys" :scroll-x="2200"
                                 class="table-hover">
                             </n-data-table>
                             <n-modal
@@ -1148,7 +1148,7 @@ import CreateApprovalPolicy from './CreateApprovalPolicy.vue'
 import CreateApprovalEntry from './CreateApprovalEntry.vue'
 import ScopedPermissions from './ScopedPermissions.vue'
 import ApiKeyPermissionsModal from './ApiKeyPermissionsModal.vue'
-import { createApiKeyControls, apiKeyIdOf } from '../utils/apiKeyControls'
+import { createApiKeyControls, apiKeyIdOf, apiKeyIdsColumn, apiKeyTypeColumn } from '../utils/apiKeyControls'
 import OrgIntegrations from './OrgIntegrations.vue'
 import OrgGlobalApprovalPolicyRules from './OrgGlobalApprovalPolicyRules.vue'
 import TeamsOfOrg from './TeamsOfOrg.vue'
@@ -1605,34 +1605,8 @@ async function createOrgKey (apiType: string, notes: string | null, label: strin
 }
 
 const programmaticAccessFields: Ref<any> = ref([
-    {
-        key: 'uuid',
-        width: 300,
-        title: 'Internal ID'
-    },
-    {
-        key: 'apiId',
-        width: 60,
-        title: 'API ID',
-        render: (row: any) => {
-            let keyId = row.type + "__" + row.object
-            if (row.keyOrder) keyId += "__ord__" + row.keyOrder
-            const els: any[] = [
-                h(NTooltip, {
-                        trigger: 'hover'
-                    }, {trigger: () => h(NIcon,
-                            {
-                                // title: keyId,
-                                class: 'icons',
-                                size: 25,
-                            }, { default: () => h(Info20Regular) }),
-                            default: () =>  keyId
-                        }
-                )
-            ]
-            return h('div', els)
-        }
-    },
+    apiKeyTypeColumn,
+    apiKeyIdsColumn(),
     {
         key: 'createdDate',
         width: 180,
@@ -1671,11 +1645,6 @@ const programmaticAccessFields: Ref<any> = ref([
             }
             return el
         }
-    },
-    {
-        key: 'type',
-        width: 110,
-        title: 'Type'
     },
     {
         key: 'resolvedApprovals',
@@ -1738,33 +1707,8 @@ const programmaticAccessFields: Ref<any> = ref([
     }
 ])
 const freeFormKeyFields: Ref<any> = ref([
-    {
-        key: 'uuid',
-        width: 300,
-        title: 'Internal ID'
-    },
-    {
-        key: 'apiId',
-        width: 60,
-        title: 'API ID',
-        render: (row: any) => {
-            let keyId = row.type + "__" + row.object
-            if (row.keyOrder) keyId += "__ord__" + row.keyOrder
-            const els: any[] = [
-                h(NTooltip, {
-                        trigger: 'hover'
-                    }, {trigger: () => h(NIcon,
-                            {
-                                class: 'icons',
-                                size: 25,
-                            }, { default: () => h(Info20Regular) }),
-                            default: () => keyId
-                        }
-                )
-            ]
-            return h('div', els)
-        }
-    },
+    apiKeyTypeColumn,
+    apiKeyIdsColumn(),
     {
         key: 'createdDate',
         width: 180,
@@ -1850,11 +1794,8 @@ const freeFormKeyFields: Ref<any> = ref([
     }
 ])
 const userKeyFields: Ref<any> = ref([
-    { key: 'uuid', width: 300, title: 'Internal ID' },
-    {
-        key: 'apiId', width: 60, title: 'API ID',
-        render: (row: any) => h(NTooltip, { trigger: 'hover' }, { trigger: () => h(NIcon, { class: 'icons', size: 25 }, { default: () => h(Info20Regular) }), default: () => apiKeyIdOf(row) })
-    },
+    apiKeyTypeColumn,
+    apiKeyIdsColumn(),
     { key: 'ownerName', width: 200, title: 'Owner' },
     { key: 'createdDate', width: 180, title: 'Created' },
     { key: 'accessDate', width: 180, title: 'Last Accessed' },
@@ -4323,7 +4264,8 @@ function formatValuesForApiKeys (apiKeyEntry: any) {
     updEntry['createdDate'] = (new Date(apiKeyEntry['createdDate'])).toLocaleString('en-CA')
     updEntry['accessDate'] = apiKeyEntry['accessDate']? (new Date(apiKeyEntry['accessDate'])).toLocaleString('en-CA') : 'Never'
     if (apiKeyEntry['lastUpdatedBy'] && users.value.find((user) => user.uuid === apiKeyEntry['lastUpdatedBy'])) {
-        updEntry['updatedByName'] = users.value.find((user) => user.uuid === apiKeyEntry['lastUpdatedBy'])['name']
+        const updater = users.value.find((user) => user.uuid === apiKeyEntry['lastUpdatedBy'])
+        updEntry['updatedByName'] = updater['name'] || updater['email'] || ''
     } else {
         updEntry['updatedByName'] = ''
     }
@@ -4846,7 +4788,8 @@ async function reassignHolder (row: any) {
     } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
 }
 const keyRequestFields: Ref<any> = ref([
-    { key: 'uuid', width: 300, title: 'Internal ID' },
+    apiKeyTypeColumn,
+    apiKeyIdsColumn(),
     { key: 'holderName', width: 200, title: 'Requested By' },
     { key: 'createdDate', width: 180, title: 'Requested' },
     { key: 'status', width: 120, title: 'Status', render: apiKeyControls.statusCell },

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -103,13 +103,13 @@
                         <n-button type="primary" :disabled="!newKeyOrg" @click="createMyKey">Create key</n-button>
                     </n-form-item>
                     <n-form-item v-if="!isAdminOfSelectedOrg">
-                        <n-button :disabled="!newKeyOrg" @click="requestFreeformKey">Request a free-form key</n-button>
+                        <n-button :disabled="!newKeyOrg" @click="requestFreeformKey">Request a Free Form key</n-button>
                     </n-form-item>
                 </n-space>
-                <p v-if="!isAdminOfSelectedOrg" class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a free-form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
+                <p v-if="!isAdminOfSelectedOrg" class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a Free Form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
                 <ApiKeyPermissionsModal v-model:show="showRequestModal" mode="request" :api-key="null" :org-uuid="newKeyOrg || ''" :notify="notify" @saved="loadMyKeys" />
                 <n-data-table :columns="myKeyFields" :data="myKeys" :scroll-x="2200" class="table-hover"></n-data-table>
-                <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
+                <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :mode="editModalMode" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
             </div>
         </n-tab-pane>
         </n-tabs>
@@ -122,7 +122,7 @@ import { NIcon, NCheckbox, NInput, NModal, NDataTable, NForm, NFormItem, NInputG
 import { ComputedRef, h, ref, Ref, computed, onMounted, watch } from 'vue'
 import { useStore } from 'vuex'
 import { useRoute, useRouter } from 'vue-router'
-import { Edit as EditIcon, X, Check, CirclePlus, LockOpen, Trash, ArrowDown, ArrowUp } from '@vicons/tabler'
+import { Edit as EditIcon, Eye as EyeIcon, X, Check, CirclePlus, LockOpen, Trash, ArrowDown, ArrowUp } from '@vicons/tabler'
 import commonFunctions from '@/utils/commonFunctions'
 import Swal from 'sweetalert2'
 import { OnChange } from 'naive-ui/es/upload/src/interface'
@@ -392,7 +392,7 @@ const showKeyEditModal = ref(false)
 const selectedEditKey = ref<any>({})
 const orgOptions = computed(() => (organizations.value || []).map((o: any) => ({ label: o.name, value: o.uuid })))
 const showRequestModal = ref(false)
-// an org admin creates free-form keys directly in org settings; a request would only go to themselves
+// an org admin creates Free Form keys directly in org settings; a request would only go to themselves
 const isAdminOfSelectedOrg = computed(() => {
     const perms = myUser.value?.permissions?.permissions || []
     return !!newKeyOrg.value && perms.some((p: any) => p.org === newKeyOrg.value && p.object === newKeyOrg.value && p.scope === 'ORGANIZATION' && p.type === 'ADMIN')
@@ -440,12 +440,14 @@ function requestFreeformKey () {
     if (!newKeyOrg.value) return
     showRequestModal.value = true
 }
-function editMyKey (row: any) {
+const editModalMode = ref<'edit' | 'view'>('edit')
+function editMyKey (row: any, mode: 'edit' | 'view' = 'edit') {
+    editModalMode.value = mode
     selectedEditKey.value = commonFunctions.deepCopy(row)
     showKeyEditModal.value = true
 }
 const myKeyFields: ComputedRef<any> = computed((): any => [
-    { key: 'kind', width: 150, title: 'Type', render: (row: any) => row.type === 'USER' ? 'Personal' : 'Free-form (held)' },
+    { key: 'kind', width: 150, title: 'Type', render: (row: any) => row.type === 'USER' ? 'Personal' : 'Free Form (held)' },
     apiKeyIdsColumn(),
     { key: 'orgName', width: 200, title: 'Organization' },
     { key: 'createdDisplay', width: 170, title: 'Created' },
@@ -464,9 +466,12 @@ const myKeyFields: ComputedRef<any> = computed((): any => [
         key: 'controls', title: 'Manage',
         render: (row: any) => {
             const els: any[] = []
-            // personal keys: the owner shapes the ceiling; held free-form keys: only while the request is pending
+            // personal keys: the owner shapes the ceiling; held Free Form keys: only while the request is pending
             if (row.type === 'USER' || row.status === 'REQUESTED') {
                 els.push(h(NIcon, { title: row.type === 'USER' ? 'Set Permissions For Key' : 'Propose Permissions', class: 'icons clickable', size: 25, onClick: () => editMyKey(row) }, { default: () => h(EditIcon) }))
+            } else {
+                // a held Free Form key: the admins own its permissions, the holder can see them
+                els.push(h(NIcon, { title: 'View Permissions', class: 'icons clickable', size: 25, onClick: () => editMyKey(row, 'view') }, { default: () => h(EyeIcon) }))
             }
             els.push(h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => apiKeyControls.deleteApiKey(row, row.status === 'REQUESTED' ? 'this request' : 'this key') }, { default: () => h(Trash) }))
             return h('div', els)

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -102,11 +102,12 @@
                     <n-form-item>
                         <n-button type="primary" :disabled="!newKeyOrg" @click="createMyKey">Create key</n-button>
                     </n-form-item>
-                    <n-form-item>
+                    <n-form-item v-if="!isAdminOfSelectedOrg">
                         <n-button :disabled="!newKeyOrg" @click="requestFreeformKey">Request a free-form key</n-button>
                     </n-form-item>
                 </n-space>
-                <p class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a free-form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
+                <p v-if="!isAdminOfSelectedOrg" class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a free-form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
+                <ApiKeyPermissionsModal v-model:show="showRequestModal" mode="request" :api-key="null" :org-uuid="newKeyOrg || ''" :notify="notify" @saved="loadMyKeys" />
                 <n-data-table :columns="myKeyFields" :data="myKeys" :scroll-x="2200" class="table-hover"></n-data-table>
                 <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
             </div>
@@ -128,7 +129,7 @@ import { OnChange } from 'naive-ui/es/upload/src/interface'
 import gql from 'graphql-tag'
 import graphqlClient from '../utils/graphql'
 import ApiKeyPermissionsModal from './ApiKeyPermissionsModal.vue'
-import { createApiKeyControls, apiKeyIdOf } from '../utils/apiKeyControls'
+import { createApiKeyControls, apiKeyIdsColumn } from '../utils/apiKeyControls'
 
 
 const route = useRoute()
@@ -390,6 +391,12 @@ const newKeyNotes = ref('')
 const showKeyEditModal = ref(false)
 const selectedEditKey = ref<any>({})
 const orgOptions = computed(() => (organizations.value || []).map((o: any) => ({ label: o.name, value: o.uuid })))
+const showRequestModal = ref(false)
+// an org admin creates free-form keys directly in org settings; a request would only go to themselves
+const isAdminOfSelectedOrg = computed(() => {
+    const perms = myUser.value?.permissions?.permissions || []
+    return !!newKeyOrg.value && perms.some((p: any) => p.org === newKeyOrg.value && p.object === newKeyOrg.value && p.scope === 'ORGANIZATION' && p.type === 'ADMIN')
+})
 watch(orgOptions, (opts) => {
     if (newKeyOrg.value || !opts.length) return
     let stored: string | null = null
@@ -429,31 +436,18 @@ async function createMyKey () {
     const r = await Swal.fire({ title: 'Key created', text: 'The key id exists but has no secret and no permissions yet. Generate its first secret now? Set its permissions from the Manage column; until then the key is refused everywhere.', icon: 'success', showCancelButton: true, confirmButtonText: 'Generate secret', cancelButtonText: 'Later' })
     if (r.value) await apiKeyControls.mintSecret(created.uuid, 'Secret generated')
 }
-async function requestFreeformKey () {
+function requestFreeformKey () {
     if (!newKeyOrg.value) return
-    const r = await Swal.fire({ title: 'Request a free-form key', input: 'textarea', inputLabel: 'Purpose (what the key is for; admins see this)', inputPlaceholder: 'e.g. CI pipeline for repo X needs release write on component Y', inputValue: newKeyNotes.value, showCancelButton: true, confirmButtonText: 'Send request', inputValidator: (v: string) => v ? null : 'Please describe the purpose' })
-    if (!r.isConfirmed) return
-    let created: any
-    try {
-        const resp: any = await graphqlClient.mutate({
-            mutation: gql`mutation requestFreeformApiKey($orgUuid: ID!, $notes: String) { requestFreeformApiKey(orgUuid: $orgUuid, notes: $notes) { uuid } }`,
-            variables: { orgUuid: newKeyOrg.value, notes: r.value }, fetchPolicy: 'no-cache'
-        })
-        created = resp.data.requestFreeformApiKey
-    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)); return }
-    newKeyNotes.value = ''
-    await loadMyKeys()
-    const p = await Swal.fire({ title: 'Request sent', text: 'Admins of the organization will review it. Propose the permissions you need now? You can edit them until the request is decided.', icon: 'success', showCancelButton: true, confirmButtonText: 'Propose permissions', cancelButtonText: 'Later' })
-    if (p.value) { const row = myKeys.value.find((k: any) => k.uuid === created.uuid); if (row) editMyKey(row) }
+    showRequestModal.value = true
 }
 function editMyKey (row: any) {
     selectedEditKey.value = commonFunctions.deepCopy(row)
     showKeyEditModal.value = true
 }
 const myKeyFields: ComputedRef<any> = computed((): any => [
+    { key: 'kind', width: 150, title: 'Type', render: (row: any) => row.type === 'USER' ? 'Personal' : 'Free-form (held)' },
+    apiKeyIdsColumn(),
     { key: 'orgName', width: 200, title: 'Organization' },
-    { key: 'kind', width: 130, title: 'Kind', render: (row: any) => row.type === 'USER' ? 'Personal' : 'Free-form (held)' },
-    { key: 'apiId', width: 420, title: 'API ID', render: (row: any) => h('code', { style: 'word-break: break-all; font-size: 12px;' }, apiKeyIdOf(row)) },
     { key: 'createdDisplay', width: 170, title: 'Created' },
     { key: 'accessDisplay', width: 170, title: 'Last Accessed' },
     { key: 'status', width: 170, title: 'Status', render: apiKeyControls.statusCell },

--- a/ui/src/utils/apiKeyControls.ts
+++ b/ui/src/utils/apiKeyControls.ts
@@ -15,9 +15,9 @@ import commonFunctions from '@/utils/commonFunctions'
 export interface ApiKeyControlOptions {
     notify: (type: 'success' | 'error' | 'warning' | 'info', title: string, content: string) => void
     reload: () => void | Promise<void>
-    /** whether the current viewer may operate the controls (org admin, owner of a USER key, holder of a free-form key) */
+    /** whether the current viewer may operate the controls (org admin, owner of a USER key, holder of a Free Form key) */
     canManage: (row: any) => boolean
-    /** whether the viewer may mint (add / regenerate), which reveals cleartext: on a held free-form key only the holder; defaults to canManage */
+    /** whether the viewer may mint (add / regenerate), which reveals cleartext: on a held Free Form key only the holder; defaults to canManage */
     canMint?: (row: any) => boolean
     /** whether the viewer acts as an org admin: only admins may re-activate a key an admin disabled; defaults to false */
     isAdmin?: () => boolean

--- a/ui/src/utils/apiKeyControls.ts
+++ b/ui/src/utils/apiKeyControls.ts
@@ -1,5 +1,6 @@
 import { h } from 'vue'
-import { NButton, NTag } from 'naive-ui'
+import { NButton, NTag, NTooltip, NIcon } from 'naive-ui'
+import { Info20Regular } from '@vicons/fluent'
 import gql from 'graphql-tag'
 import Swal from 'sweetalert2'
 import graphqlClient from '@/utils/graphql'
@@ -161,13 +162,18 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
                 h(NTag, { size: 'tiny', type: expired ? 'error' : (sec.active ? 'success' : 'default'), style: 'margin-right: 6px;' }, { default: () => expired ? 'expired' : (sec.active ? 'active' : 'retired') }),
                 h('span', { class: 'subtle', style: 'margin-right: 6px;' }, meta)
             ]
-            if (mint) kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
+            // actions on their own line under the secret, so the column stays narrow
+            const actions: any[] = []
+            if (mint) actions.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => regenerateApiKeySecret(row, sec.slot) }, { default: () => 'Regenerate' }))
             if (manage) {
-                kids.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => setApiKeySecretExpiry(row, sec.slot) }, { default: () => 'Expiry' }))
-                kids.push(h(NButton, { size: 'tiny', type: sec.active ? 'warning' : 'primary', style: 'margin-right: 4px;', onClick: () => setApiKeySecretActive(row, sec.slot, !sec.active) }, { default: () => sec.active ? 'Retire' : 'Enable' }))
-                kids.push(h(NButton, { size: 'tiny', type: 'error', onClick: () => deleteApiKeySecret(row, sec.slot) }, { default: () => 'Delete' }))
+                actions.push(h(NButton, { size: 'tiny', style: 'margin-right: 4px;', onClick: () => setApiKeySecretExpiry(row, sec.slot) }, { default: () => 'Expiry' }))
+                actions.push(h(NButton, { size: 'tiny', type: sec.active ? 'warning' : 'primary', style: 'margin-right: 4px;', onClick: () => setApiKeySecretActive(row, sec.slot, !sec.active) }, { default: () => sec.active ? 'Retire' : 'Enable' }))
+                actions.push(h(NButton, { size: 'tiny', type: 'error', onClick: () => deleteApiKeySecret(row, sec.slot) }, { default: () => 'Delete' }))
             }
-            return h('div', { style: 'display: flex; align-items: center; white-space: nowrap; margin: 2px 0;' }, kids)
+            return h('div', { style: 'margin: 2px 0 6px 0;' }, [
+                h('div', { style: 'display: flex; align-items: center; white-space: nowrap;' }, kids),
+                actions.length ? h('div', { style: 'display: flex; align-items: center; white-space: nowrap; margin-top: 3px;' }, actions) : null
+            ])
         })
         if (row.holder && !mint && manage) {
             lines.push(h('span', { class: 'subtle' }, 'held key: only the holder mints its secrets'))
@@ -182,6 +188,23 @@ export function createApiKeyControls (opts: ApiKeyControlOptions) {
 
     return { statusCell, secretsCell, mintSecret, addApiKeySecret, regenerateApiKeySecret, setApiKeySecretExpiry, setApiKeySecretActive, deleteApiKeySecret, setApiKeyStatus, deleteApiKey, askExpiry }
 }
+
+/** One narrow "IDs" column: a tooltip carrying both the internal uuid and the API id clients present. */
+export function apiKeyIdsColumn (): any {
+    return {
+        key: 'ids', width: 60, title: 'IDs',
+        render: (row: any) => h(NTooltip, { trigger: 'hover' }, {
+            trigger: () => h(NIcon, { class: 'icons', size: 22 }, { default: () => h(Info20Regular) }),
+            default: () => h('div', { style: 'font-size: 12px;' }, [
+                h('div', [h('strong', 'Internal ID: '), h('code', row.uuid)]),
+                h('div', { style: 'margin-top: 4px;' }, [h('strong', 'API ID: '), h('code', { style: 'word-break: break-all;' }, apiKeyIdOf(row))])
+            ])
+        })
+    }
+}
+
+/** Left-most column of every key table. */
+export const apiKeyTypeColumn = { key: 'type', width: 130, title: 'Type' }
 
 /** The id string a client presents for this key (Basic user name / client_id). */
 export function apiKeyIdOf (row: any): string {


### PR DESCRIPTION
Review follow-ups on the key management UI.

## Summary
- **Type first, one IDs column.** Every key table (Scoped, Free Form, User, Key Requests, and the profile's own keys) starts with Type; Internal ID and API ID collapse into one narrow **IDs** column whose tooltip carries both.
- **Secret actions under the secret.** Regenerate, Expiry, Retire and Delete sit on their own line beneath the secret's line instead of extending the row to the right.
- **Updated By was empty** on every free-form key: the org users on the sandbox carry no display name and the column resolved only the name. It now falls back to the email. Server side the value was always there (`lastUpdatedBy` in the key record).
- **No request button for admins.** On the profile page, an admin of the selected organization does not see "Request a free-form key" (nor the prose); they create keys in org settings.
- **Request on one screen.** Requesting a free-form key opens the permissions editor in request mode with the purpose field on the same screen; Send request creates the REQUESTED key with notes and proposed permissions in one call. No prompt, no second dialog.

- **Held Free Form keys are viewable.** The holder gets a read-only View Permissions dialog on the profile (org-wide level, per-object grants with names, notes). User-facing text says "Free Form" consistently.

## Test plan
- [x] psclaude: column order and IDs tooltip on the three org tables and the profile table; actions under the secret; Updated By shows an email; admin profile shows no request button; request dialog is one screen and creates a REQUESTED key with its permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- Follow-up commit: the editor loads its org object lists best effort, so a write user without instance visibility no longer gets an unhandled "Not authorized" from the request dialog.
- [x] psclaude build .3: approved held key shows View Permissions on the profile and the dialog lists the granted permission
