### PR TITLE
feat(ui): CLI browser login page and session lists

### DIFF
--- a/ui/src/components/CliLogin.vue
+++ b/ui/src/components/CliLogin.vue
@@ -98,7 +98,8 @@ onMounted(async () => {
     let stored: string | null = null
     try { stored = window.localStorage.getItem('relizaOrgUuid') } catch { stored = null }
     newKeyOrg.value = orgOptions.value.find((o: any) => o.value === stored)?.value || orgOptions.value[0]?.value || null
-    const code = (route.query.code as string) || ''
+    // the parameter is user_code: a URL carrying code= collides with the OIDC redirect through Keycloak
+    const code = (route.query.user_code as string) || ''
     if (code) { codeInput.value = code; await lookup() }
 })
 

--- a/ui/src/components/CliLogin.vue
+++ b/ui/src/components/CliLogin.vue
@@ -1,0 +1,140 @@
+<template>
+    <div class="home">
+        <h2>Sign in the ReARM CLI</h2>
+        <div v-if="phase === 'lookup'">
+            <n-form-item label="Code shown by the CLI">
+                <n-input v-model:value="codeInput" placeholder="WDJB-MJHT" style="max-width: 240px;" @keyup.enter="lookup" />
+                <n-button type="primary" style="margin-left: 8px;" @click="lookup">Continue</n-button>
+            </n-form-item>
+            <p v-if="lookupError" class="text-muted">{{ lookupError }}</p>
+        </div>
+
+        <div v-else-if="phase === 'choose'">
+            <n-alert type="info" style="margin-bottom: 16px;">
+                A CLI <strong v-if="request.requestedFrom">on {{ request.requestedFrom }}</strong> asked to sign in at {{ fmt(request.createdDate) }}
+                with code <code>{{ request.userCode }}</code>. It will act with the permissions of the key you choose. Only approve a request you started yourself.
+            </n-alert>
+            <n-radio-group v-model:value="choice" style="display: block; margin-bottom: 12px;">
+                <n-space vertical>
+                    <n-radio value="new">
+                        Create a personal key for this session
+                    </n-radio>
+                    <div v-if="choice === 'new'" style="margin-left: 26px; margin-bottom: 8px;">
+                        <n-space align="end">
+                            <n-form-item label="Organization"><n-select v-model:value="newKeyOrg" :options="orgOptions" style="min-width: 260px;" /></n-form-item>
+                            <n-form-item label="Notes"><n-input v-model:value="newKeyNotes" :placeholder="defaultNotes" style="min-width: 260px;" /></n-form-item>
+                        </n-space>
+                        <p class="subtle" style="margin: 0;">The key starts with no permissions; set them on your profile afterwards. It is deleted when the session ends.</p>
+                    </div>
+                    <n-radio value="existing" :disabled="!eligibleKeys.length">
+                        Use one of my keys <span class="subtle" v-if="!eligibleKeys.length">(no active personal or held Free Form keys)</span>
+                    </n-radio>
+                    <div v-if="choice === 'existing'" style="margin-left: 26px;">
+                        <n-radio-group v-model:value="chosenKey">
+                            <n-space vertical>
+                                <n-radio v-for="k in eligibleKeys" :key="k.uuid" :value="k.uuid">
+                                    <strong>{{ k.type === 'USER' ? 'Personal' : 'Free Form (held)' }}</strong> · {{ orgName(k.org) }}
+                                    <span class="subtle"> · {{ (k.permissions?.permissions || []).length }} permission{{ (k.permissions?.permissions || []).length === 1 ? '' : 's' }}</span>
+                                    <span class="subtle" v-if="k.notes"> · {{ k.notes }}</span>
+                                </n-radio>
+                            </n-space>
+                        </n-radio-group>
+                    </div>
+                </n-space>
+            </n-radio-group>
+            <n-space>
+                <n-button type="primary" :disabled="!canApprove" @click="approve">Approve</n-button>
+                <n-button type="error" ghost @click="deny">Deny</n-button>
+            </n-space>
+        </div>
+
+        <div v-else-if="phase === 'done'">
+            <n-alert type="success">The CLI is signed in. You can close this window.</n-alert>
+        </div>
+        <div v-else-if="phase === 'denied'">
+            <n-alert type="warning">Request denied. The CLI will report it. You can close this window.</n-alert>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+/**
+ * Browser side of `rearm login` (device authorization). The user is already signed in to ReARM
+ * (the SPA requires it); here they approve the CLI's request by choosing what the session acts as.
+ */
+import { NAlert, NButton, NFormItem, NInput, NRadio, NRadioGroup, NSelect, NSpace, useNotification, NotificationType } from 'naive-ui'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useStore } from 'vuex'
+import gql from 'graphql-tag'
+import graphqlClient from '../utils/graphql'
+import commonFunctions from '@/utils/commonFunctions'
+
+const route = useRoute()
+const store = useStore()
+const notification = useNotification()
+const notify = (type: NotificationType, title: string, content: string) => notification[type]({ content, meta: title, duration: 5000, keepAliveOnHover: true })
+
+const phase = ref<'lookup' | 'choose' | 'done' | 'denied'>('lookup')
+const codeInput = ref('')
+const lookupError = ref('')
+const request = ref<any>({})
+const myKeys = ref<any[]>([])
+const choice = ref<'new' | 'existing'>('new')
+const chosenKey = ref<string | null>(null)
+const newKeyOrg = ref<string | null>(null)
+const newKeyNotes = ref('')
+
+const organizations = computed(() => store.getters.allOrganizations || [])
+const orgOptions = computed(() => organizations.value.map((o: any) => ({ label: o.name, value: o.uuid })))
+const orgName = (uuid: string) => organizations.value.find((o: any) => o.uuid === uuid)?.name || uuid
+const eligibleKeys = computed(() => myKeys.value.filter((k: any) => k.status === 'ACTIVE' && (k.type === 'USER' || k.type === 'FREEFORM')))
+const defaultNotes = computed(() => 'CLI session' + (request.value.requestedFrom ? ' on ' + request.value.requestedFrom : ''))
+const canApprove = computed(() => choice.value === 'new' ? !!newKeyOrg.value : !!chosenKey.value)
+const fmt = (d: any) => d ? new Date(d).toLocaleString('en-CA') : ''
+
+onMounted(async () => {
+    await store.dispatch('fetchMyOrganizations')
+    let stored: string | null = null
+    try { stored = window.localStorage.getItem('relizaOrgUuid') } catch { stored = null }
+    newKeyOrg.value = orgOptions.value.find((o: any) => o.value === stored)?.value || orgOptions.value[0]?.value || null
+    const code = (route.query.code as string) || ''
+    if (code) { codeInput.value = code; await lookup() }
+})
+
+async function lookup () {
+    lookupError.value = ''
+    try {
+        const resp: any = await graphqlClient.query({
+            query: gql`query cliLoginRequest($userCode: String!) { cliLoginRequest(userCode: $userCode) { uuid status userCode requestedFrom createdDate expiresDate } }`,
+            variables: { userCode: codeInput.value }, fetchPolicy: 'no-cache'
+        })
+        if (!resp.data.cliLoginRequest) { lookupError.value = 'No pending sign-in for this code. It may have expired: run rearm login again.'; return }
+        request.value = resp.data.cliLoginRequest
+        const keys: any = await graphqlClient.query({ query: gql`query myApiKeys { myApiKeys { uuid org type status notes permissions { permissions { scope type } } } }`, fetchPolicy: 'no-cache' })
+        myKeys.value = keys.data.myApiKeys || []
+        phase.value = 'choose'
+    } catch (e: any) { lookupError.value = commonFunctions.parseGraphQLError(e.message) }
+}
+
+async function approve () {
+    try {
+        const vars: any = { userCode: request.value.userCode }
+        if (choice.value === 'existing') vars.apiKeyUuid = chosenKey.value
+        else { vars.createKeyOrgUuid = newKeyOrg.value; vars.createKeyNotes = newKeyNotes.value || defaultNotes.value }
+        await graphqlClient.mutate({
+            mutation: gql`mutation approveCliLogin($userCode: String!, $apiKeyUuid: ID, $createKeyOrgUuid: ID, $createKeyNotes: String) {
+                approveCliLogin(userCode: $userCode, apiKeyUuid: $apiKeyUuid, createKeyOrgUuid: $createKeyOrgUuid, createKeyNotes: $createKeyNotes) { uuid status } }`,
+            variables: vars, fetchPolicy: 'no-cache'
+        })
+        phase.value = 'done'
+    } catch (e: any) { notify('error', 'Could not approve', commonFunctions.parseGraphQLError(e.message)) }
+}
+
+async function deny () {
+    try {
+        await graphqlClient.mutate({ mutation: gql`mutation denyCliLogin($userCode: String!) { denyCliLogin(userCode: $userCode) }`, variables: { userCode: request.value.userCode }, fetchPolicy: 'no-cache' })
+        phase.value = 'denied'
+    } catch (e: any) { notify('error', 'Could not deny', commonFunctions.parseGraphQLError(e.message)) }
+}
+</script>

--- a/ui/src/components/OrgSettings.vue
+++ b/ui/src/components/OrgSettings.vue
@@ -687,6 +687,11 @@
                     </n-tab-pane>
                 </n-tabs>
                 <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :api-key="selectedEditKey" :org-uuid="orgResolved" :notify="notify" @saved="loadProgrammaticAccessKeys(false)" />
+                <n-modal preset="dialog" :show-icon="false" style="width: 70%;" :show="showKeySessionsModal" @update:show="(v: boolean) => { if (!v) showKeySessionsModal = false }">
+                    <template #header>CLI sessions on key {{ keySessionsKey?.uuid }}</template>
+                    <p class="subtle">Active <code>rearm login</code> sessions acting as this key. Revoking signs that CLI out at once.</p>
+                    <n-data-table :columns="keySessionFields" :data="keySessions" class="table-hover"></n-data-table>
+                </n-modal>
             </n-tab-pane>
 
             <n-tab-pane name="terminology" tab="Terminology" v-if="isOrgAdmin">
@@ -1126,7 +1131,7 @@ import { ComputedRef, h, ref, Ref, computed, onMounted, reactive, watch } from '
 import type { SelectOption } from 'naive-ui'
 import { useStore } from 'vuex'
 import { useRoute, useRouter, RouterLink } from 'vue-router'
-import { Edit as EditIcon, Trash, CirclePlus, Eye, QuestionMark, Search, FolderPlus, Package, Clipboard, User as UserIcon } from '@vicons/tabler'
+import { Edit as EditIcon, Trash, CirclePlus, Eye, QuestionMark, Search, FolderPlus, Package, Clipboard, User as UserIcon, Terminal2 as TerminalIcon } from '@vicons/tabler'
 import { Info20Regular, Power20Regular } from '@vicons/fluent'
 import { Icon } from '@vicons/utils'
 import commonFunctions, { SwalData } from '@/utils/commonFunctions'
@@ -1243,6 +1248,38 @@ function editRbacKey(row: any) {
     selectedEditKey.value = commonFunctions.deepCopy(row)
     showKeyEditModal.value = true
 }
+// ---- CLI sessions riding a key (admin view) ----
+const showKeySessionsModal = ref(false)
+const keySessionsKey = ref<any>(null)
+const keySessions: Ref<any[]> = ref([])
+async function showKeySessions (row: any) {
+    keySessionsKey.value = row
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query cliSessionsOfKey($apiKeyUuid: ID!) { cliSessionsOfKey(apiKeyUuid: $apiKeyUuid) { uuid status user requestedFrom createdDate expiresDate lastUsedDate } }`, variables: { apiKeyUuid: row.uuid }, fetchPolicy: 'network-only' })
+        keySessions.value = (resp.data.cliSessionsOfKey || []).map((s: any) => { const u = users.value.find((x: any) => x.uuid === s.user); return Object.assign({}, s, {
+            userName: u ? (u.name || u.email) : (s.user || ''),
+            createdDisplay: s.createdDate ? new Date(s.createdDate).toLocaleString('en-CA') : '',
+            lastUsedDisplay: s.lastUsedDate ? new Date(s.lastUsedDate).toLocaleString('en-CA') : 'never',
+            expiresDisplay: s.expiresDate ? new Date(s.expiresDate).toLocaleString('en-CA') : '' }) })
+        showKeySessionsModal.value = true
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+async function revokeKeySession (row: any) {
+    const r = await Swal.fire({ title: 'Sign this CLI out?', text: `The session${row.requestedFrom ? ' on ' + row.requestedFrom : ''} stops working at once.`, icon: 'warning', showCancelButton: true, confirmButtonText: 'Revoke' })
+    if (!r.value) return
+    try {
+        await graphqlClient.mutate({ mutation: gql`mutation revokeCliSession($uuid: ID!) { revokeCliSession(uuid: $uuid) }`, variables: { uuid: row.uuid }, fetchPolicy: 'no-cache' })
+        notify('success', 'Revoked', 'CLI session revoked'); await showKeySessions(keySessionsKey.value); loadProgrammaticAccessKeys(false)
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+const keySessionFields: Ref<any> = ref([
+    { key: 'userName', width: 220, title: 'User' },
+    { key: 'requestedFrom', width: 200, title: 'CLI host' },
+    { key: 'createdDisplay', width: 170, title: 'Signed in' },
+    { key: 'lastUsedDisplay', width: 170, title: 'Last used' },
+    { key: 'expiresDisplay', width: 170, title: 'Expires' },
+    { key: 'controls', title: 'Manage', render: (row: any) => h(NButton, { size: 'tiny', type: 'error', onClick: () => revokeKeySession(row) }, { default: () => 'Revoke' }) }
+])
 
 const showUserGroupPermissionsModal = ref(false)
 
@@ -1779,6 +1816,7 @@ const freeFormKeyFields: Ref<any> = ref([
                     )
                 )
                 els.push(h(NIcon, { title: 'Holder (who mints the secrets)', class: 'icons clickable', size: 25, onClick: () => reassignHolder(row) }, { default: () => h(UserIcon) }))
+                els.push(h(NIcon, { title: 'CLI sessions on this key', class: 'icons clickable', size: 25, onClick: () => showKeySessions(row) }, { default: () => h(TerminalIcon) }))
                 els.push(h(
                     NIcon,
                     {
@@ -1815,6 +1853,7 @@ const userKeyFields: Ref<any> = ref([
             const els: any[] = []
             if (isOrgAdmin.value) {
                 els.push(h(NIcon, { title: 'Set Permission Ceiling For Key', class: 'icons clickable', size: 25, onClick: () => editRbacKey(row) }, { default: () => h(EditIcon) }))
+                els.push(h(NIcon, { title: 'CLI sessions on this key', class: 'icons clickable', size: 25, onClick: () => showKeySessions(row) }, { default: () => h(TerminalIcon) }))
                 els.push(h(NIcon, { title: 'Delete Key', class: 'icons clickable', size: 25, onClick: () => deleteKey(row.uuid) }, { default: () => h(Trash) }))
             }
             return h('div', els)

--- a/ui/src/components/UserProfile.vue
+++ b/ui/src/components/UserProfile.vue
@@ -109,6 +109,9 @@
                 <p v-if="!isAdminOfSelectedOrg" class="subtle">Need more than your own permissions allow, or a key that outlives your membership? Request a Free Form key: admins approve it with the permissions they choose, and you alone generate and see its secrets.</p>
                 <ApiKeyPermissionsModal v-model:show="showRequestModal" mode="request" :api-key="null" :org-uuid="newKeyOrg || ''" :notify="notify" @saved="loadMyKeys" />
                 <n-data-table :columns="myKeyFields" :data="myKeys" :scroll-x="2200" class="table-hover"></n-data-table>
+                <h4 class="mt-4">CLI sessions</h4>
+                <p class="subtle">Where <code>rearm login</code> signed in with one of your keys. Revoking a session signs that CLI out at once; a key created for the session is deleted with it.</p>
+                <n-data-table :columns="cliSessionFields" :data="cliSessions" class="table-hover"></n-data-table>
                 <ApiKeyPermissionsModal v-model:show="showKeyEditModal" :mode="editModalMode" :api-key="selectedEditKey" :org-uuid="selectedEditKey.org || ''" :notify="notify" @saved="loadMyKeys" />
             </div>
         </n-tab-pane>
@@ -151,7 +154,8 @@ onMounted(async () => {
         notify('success', 'Success', 'Email address verified successfully!', 8000)
     }
     await initLoad()
-    loadMyKeys()
+    await loadMyKeys()
+    loadCliSessions()
 })
 
 const apiKey = ref('')
@@ -440,6 +444,37 @@ function requestFreeformKey () {
     if (!newKeyOrg.value) return
     showRequestModal.value = true
 }
+// ---- CLI browser-login sessions ----
+const cliSessions: Ref<any[]> = ref([])
+async function loadCliSessions () {
+    try {
+        const resp: any = await graphqlClient.query({ query: gql`query myCliSessions { myCliSessions { uuid status apiKey org requestedFrom createdDate expiresDate lastUsedDate } }`, fetchPolicy: 'network-only' })
+        cliSessions.value = (resp.data.myCliSessions || []).map((s: any) => Object.assign({}, s, {
+            orgName: store.getters.orgById(s.org)?.name || s.org,
+            keyLabel: (myKeys.value.find((k: any) => k.uuid === s.apiKey) || {}).type === 'FREEFORM' ? 'Free Form (held)' : 'Personal',
+            createdDisplay: s.createdDate ? new Date(s.createdDate).toLocaleString('en-CA') : '',
+            lastUsedDisplay: s.lastUsedDate ? new Date(s.lastUsedDate).toLocaleString('en-CA') : 'never',
+            expiresDisplay: s.expiresDate ? new Date(s.expiresDate).toLocaleString('en-CA') : ''
+        }))
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+async function revokeCliSession (row: any) {
+    const r = await Swal.fire({ title: 'Sign this CLI out?', text: `The session${row.requestedFrom ? ' on ' + row.requestedFrom : ''} stops working at once. A key created for it is deleted.`, icon: 'warning', showCancelButton: true, confirmButtonText: 'Revoke' })
+    if (!r.value) return
+    try {
+        await graphqlClient.mutate({ mutation: gql`mutation revokeCliSession($uuid: ID!) { revokeCliSession(uuid: $uuid) }`, variables: { uuid: row.uuid }, fetchPolicy: 'no-cache' })
+        notify('success', 'Revoked', 'CLI session revoked'); await loadMyKeys(); await loadCliSessions()
+    } catch (e: any) { notify('error', 'Error', commonFunctions.parseGraphQLError(e.message)) }
+}
+const cliSessionFields: ComputedRef<any> = computed((): any => [
+    { key: 'requestedFrom', width: 220, title: 'CLI host' },
+    { key: 'keyLabel', width: 150, title: 'Acts as' },
+    { key: 'orgName', width: 200, title: 'Organization' },
+    { key: 'createdDisplay', width: 170, title: 'Signed in' },
+    { key: 'lastUsedDisplay', width: 170, title: 'Last used' },
+    { key: 'expiresDisplay', width: 170, title: 'Expires' },
+    { key: 'controls', title: 'Manage', render: (row: any) => h(NButton, { size: 'tiny', type: 'error', onClick: () => revokeCliSession(row) }, { default: () => 'Revoke' }) }
+])
 const editModalMode = ref<'edit' | 'view'>('edit')
 function editMyKey (row: any, mode: 'edit' | 'view' = 'edit') {
     editModalMode.value = mode

--- a/ui/src/router.ts
+++ b/ui/src/router.ts
@@ -15,6 +15,11 @@ const routes : any[] = [
         component: UserProfile
     },
     {
+        path: '/cli-login',
+        name: 'cliLogin',
+        component: () => import('@/components/CliLogin.vue')
+    },
+    {
         path: '/sysSettings',
         name: 'systemSettings',
         component: () => import('@/components/SystemSettings.vue')


### PR DESCRIPTION
Based on #353 (targets `2026-09-key-tables-polish`). Browser side of the CLI login in rearm-saas #531.

## Summary
- **`/cli-login`**: shows the request behind the code `rearm login` printed (host, time). The signed-in user approves it by choosing what the session acts as: a personal key created for this session in a chosen organization (no permissions yet, deleted when the session ends), or one of their active personal or held Free Form keys, with the permission count shown. Deny is one click. Closing states for approved and denied.
- **Profile → CLI sessions**: host, acts-as, organization, signed in, last used, expiry, Revoke (signs that CLI out at once; a session-created key is deleted with it).
- **Org settings**: a CLI sessions icon on free-form and user keys opens a modal listing active sessions on the key with the user, host and dates, plus Revoke.

## Test plan
- [x] psclaude: approve a real device-code request from the page with an existing key and with a new session key; deny; sessions listed on the profile and on the key; revoke from both

🤖 Generated with [Claude Code](https://claude.com/claude-code)